### PR TITLE
fixes [decorate and adds timestamp to world save

### DIFF
--- a/ModernUO.sln
+++ b/ModernUO.sln
@@ -1,11 +1,10 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29102.190
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "Projects\Server\Server.csproj", "{5E93BB35-3661-4822-9A8A-859726BAD87F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Server", "Projects\Server\Server.csproj", "{5E93BB35-3661-4822-9A8A-859726BAD87F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scripts", "Projects\Scripts\Scripts.csproj", "{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scripts", "Projects\Scripts\Scripts.csproj", "{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,12 +12,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5E93BB35-3661-4822-9A8A-859726BAD87F}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{5E93BB35-3661-4822-9A8A-859726BAD87F}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{5E93BB35-3661-4822-9A8A-859726BAD87F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E93BB35-3661-4822-9A8A-859726BAD87F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E93BB35-3661-4822-9A8A-859726BAD87F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5E93BB35-3661-4822-9A8A-859726BAD87F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{83CF2484-BCCB-4B7C-9C5F-7AB43AEA5E8F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/Projects/Scripts/Commands/Decorate.cs
+++ b/Projects/Scripts/Commands/Decorate.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Server.Engines.Quests.Haven;
 using Server.Engines.Quests.Necro;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Commands
 {
@@ -339,9 +342,9 @@ namespace Server.Commands
             }
 
           if (fill)
-            item = (Item)Activator.CreateInstance(m_Type, content);
+            item = (Item)ActivatorUtil.CreateInstance(m_Type, content);
           else
-            item = (Item)Activator.CreateInstance(m_Type);
+            item = (Item)ActivatorUtil.CreateInstance(m_Type);
         }
         else if (m_Type.IsSubclassOf(typeofBaseDoor))
         {
@@ -359,16 +362,16 @@ namespace Server.Commands
               }
             }
 
-          item = (Item)Activator.CreateInstance(m_Type, facing);
+          item = (Item)ActivatorUtil.CreateInstance(m_Type, facing);
         }
         else
         {
-          item = (Item)Activator.CreateInstance(m_Type);
+          item = (Item)ActivatorUtil.CreateInstance(m_Type);
         }
       }
       catch (Exception e)
       {
-        throw new Exception($"Bad type: {m_Type}", e);
+        throw new TypeInitializationException(m_Type.ToString(), e);
       }
 
       if (item is BaseAddon addon)
@@ -931,7 +934,16 @@ namespace Server.Commands
 
         for (int j = 0; j < maps.Length; ++j)
         {
-          item ??= Construct();
+
+          try
+          {
+            item ??= Construct();
+          }
+          catch(TypeInitializationException e)
+          {
+            Console.WriteLine($"{nameof(Generate)}() failed to load type: {e.TypeName}: {e.InnerException.Message}");
+            continue;
+          }
 
           if (item == null)
             continue;

--- a/Projects/Scripts/Commands/DecorateMag.cs
+++ b/Projects/Scripts/Commands/DecorateMag.cs
@@ -7,6 +7,7 @@ using Server.Engines.Quests.Haven;
 using Server.Engines.Quests.Necro;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Commands
 {
@@ -337,9 +338,9 @@ namespace Server.Commands
             }
 
           if (fill)
-            item = (Item)Activator.CreateInstance(m_Type, content);
+            item = (Item)ActivatorUtil.CreateInstance(m_Type, content);
           else
-            item = (Item)Activator.CreateInstance(m_Type);
+            item = (Item)ActivatorUtil.CreateInstance(m_Type);
         }
         else if (m_Type.IsSubclassOf(typeofBaseDoor))
         {
@@ -357,11 +358,11 @@ namespace Server.Commands
               }
             }
 
-          item = (Item)Activator.CreateInstance(m_Type, facing);
+          item = (Item)ActivatorUtil.CreateInstance(m_Type, facing);
         }
         else
         {
-          item = (Item)Activator.CreateInstance(m_Type);
+          item = (Item)ActivatorUtil.CreateInstance(m_Type);
         }
       }
       catch (Exception e)

--- a/Projects/Scripts/Commands/GenCategorization.cs
+++ b/Projects/Scripts/Commands/GenCategorization.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Xml;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Commands
 {
@@ -271,7 +272,7 @@ namespace Server.Commands
     public CategoryTypeEntry(Type type)
     {
       Type = type;
-      Object = Activator.CreateInstance(type);
+      Object = ActivatorUtil.CreateInstance(type);
     }
 
     public Type Type{ get; }

--- a/Projects/Scripts/Commands/Generic/Extensions/Compilers/ConditionalCompiler.cs
+++ b/Projects/Scripts/Commands/Generic/Extensions/Compilers/ConditionalCompiler.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Globalization;
 using System.Reflection;
@@ -543,7 +544,7 @@ namespace Server.Commands.Generic
 
       Type conditionalType = typeBuilder.CreateType();
 
-      return (IConditional)Activator.CreateInstance(conditionalType);
+      return (IConditional)ActivatorUtil.CreateInstance(conditionalType);
     }
   }
 }

--- a/Projects/Scripts/Commands/Generic/Extensions/Compilers/DistinctCompiler.cs
+++ b/Projects/Scripts/Commands/Generic/Extensions/Compilers/DistinctCompiler.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -252,7 +253,7 @@ namespace Server.Commands.Generic
 
       Type comparerType = typeBuilder.CreateType();
 
-      return (IComparer<T>)Activator.CreateInstance(comparerType);
+      return (IComparer<T>)ActivatorUtil.CreateInstance(comparerType);
     }
   }
 }

--- a/Projects/Scripts/Commands/Generic/Extensions/Compilers/SortCompiler.cs
+++ b/Projects/Scripts/Commands/Generic/Extensions/Compilers/SortCompiler.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -159,7 +160,7 @@ namespace Server.Commands.Generic
       #endregion
 
       Type comparerType = typeBuilder.CreateType();
-      return (IComparer<T>)Activator.CreateInstance(comparerType);
+      return (IComparer<T>)ActivatorUtil.CreateInstance(comparerType);
     }
   }
 }

--- a/Projects/Scripts/Engines/CannedEvil/ChampionSpawn.cs
+++ b/Projects/Scripts/Engines/CannedEvil/ChampionSpawn.cs
@@ -4,6 +4,7 @@ using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 using Server.Regions;
+using Server.Utilities;
 
 namespace Server.Engines.CannedEvil
 {
@@ -363,7 +364,7 @@ namespace Server.Engines.CannedEvil
           {
             prot.SendLocalizedMessage(1049368); // You have been rewarded for your dedication to Justice!
 
-            if (Activator.CreateInstance(scroll.GetType()) is SpecialScroll scrollDupe)
+            if (ActivatorUtil.CreateInstance(scroll.GetType()) is SpecialScroll scrollDupe)
             {
               scrollDupe.Skill = scroll.Skill;
               scrollDupe.Value = scroll.Value;
@@ -552,7 +553,7 @@ namespace Server.Engines.CannedEvil
 
       try
       {
-        Champion = Activator.CreateInstance(ChampionSpawnInfo.GetInfo(m_Type).Champion) as Mobile;
+        Champion = ActivatorUtil.CreateInstance(ChampionSpawnInfo.GetInfo(m_Type).Champion) as Mobile;
       }
       catch
       {
@@ -689,7 +690,7 @@ namespace Server.Engines.CannedEvil
     {
       try
       {
-        return Activator.CreateInstance(types[Utility.Random(types.Length)]) as Mobile;
+        return ActivatorUtil.CreateInstance(types[Utility.Random(types.Length)]) as Mobile;
       }
       catch
       {

--- a/Projects/Scripts/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/Scripts/Engines/Craft/Core/CraftItem.cs
@@ -5,6 +5,7 @@ using Server.Commands;
 using Server.Factions;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Engines.Craft
 {
@@ -139,7 +140,7 @@ namespace Server.Engines.Craft
 
         try
         {
-          item = Activator.CreateInstance(type) as Item;
+          item = ActivatorUtil.CreateInstance(type) as Item;
         }
         catch
         {
@@ -930,7 +931,7 @@ namespace Server.Engines.Craft
         }
         else
         {
-          item = Activator.CreateInstance(ItemType) as Item;
+          item = ActivatorUtil.CreateInstance(ItemType) as Item;
         }
 
         if (item != null)
@@ -1113,7 +1114,7 @@ namespace Server.Engines.Craft
 
             try
             {
-              cc = Activator.CreateInstance(m_CraftItem.ItemType, m_From, m_CraftItem, m_CraftSystem,
+              cc = ActivatorUtil.CreateInstance(m_CraftItem.ItemType, m_From, m_CraftItem, m_CraftSystem,
                 m_TypeRes, m_Tool, quality) as CustomCraft;
             }
             catch

--- a/Projects/Scripts/Engines/Craft/Core/Resmelt.cs
+++ b/Projects/Scripts/Engines/Craft/Core/Resmelt.cs
@@ -2,6 +2,7 @@ using System;
 using Server.Ethics;
 using Server.Items;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Engines.Craft
 {
@@ -82,7 +83,7 @@ namespace Server.Engines.Craft
             return SmeltResult.NoSkill;
 
           Type resourceType = info.ResourceTypes[0];
-          Item ingot = (Item)Activator.CreateInstance(resourceType);
+          Item ingot = (Item)ActivatorUtil.CreateInstance(resourceType);
 
           if (item is DragonBardingDeed || item is BaseArmor armor && armor.PlayerConstructed ||
               item is BaseWeapon weapon && weapon.PlayerConstructed ||

--- a/Projects/Scripts/Engines/Craft/DefInscription.cs
+++ b/Projects/Scripts/Engines/Craft/DefInscription.cs
@@ -2,6 +2,7 @@ using System;
 using Server.Engines.BulkOrders;
 using Server.Items;
 using Server.Spells;
+using Server.Utilities;
 
 namespace Server.Engines.Craft
 {
@@ -49,7 +50,7 @@ namespace Server.Engines.Craft
 
       if (typeItem != null)
       {
-        object o = Activator.CreateInstance(typeItem);
+        object o = ActivatorUtil.CreateInstance(typeItem);
 
         if (o is SpellScroll scroll)
         {

--- a/Projects/Scripts/Engines/Doom/GauntletSpawner.cs
+++ b/Projects/Scripts/Engines/Doom/GauntletSpawner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Server.Items;
 using Server.Mobiles;
 using Server.Regions;
+using Server.Utilities;
 
 namespace Server.Engines.Doom
 {
@@ -298,7 +299,7 @@ namespace Server.Engines.Doom
         if (type == null)
           return;
 
-        object obj = Activator.CreateInstance(type);
+        object obj = ActivatorUtil.CreateInstance(type);
 
         if (obj is Item item)
         {

--- a/Projects/Scripts/Engines/Factions/Core/GuardList.cs
+++ b/Projects/Scripts/Engines/Factions/Core/GuardList.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 
@@ -19,7 +20,7 @@ namespace Server.Factions
     {
       try
       {
-        return Activator.CreateInstance(Definition.Type) as BaseFactionGuard;
+        return ActivatorUtil.CreateInstance(Definition.Type) as BaseFactionGuard;
       }
       catch
       {

--- a/Projects/Scripts/Engines/Factions/Core/Reflector.cs
+++ b/Projects/Scripts/Engines/Factions/Core/Reflector.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -36,7 +37,7 @@ namespace Server.Factions
     {
       try
       {
-        return Activator.CreateInstance(type);
+        return ActivatorUtil.CreateInstance(type);
       }
       catch
       {

--- a/Projects/Scripts/Engines/Factions/Core/VendorList.cs
+++ b/Projects/Scripts/Engines/Factions/Core/VendorList.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 
@@ -19,7 +20,7 @@ namespace Server.Factions
     {
       try
       {
-        return Activator.CreateInstance(Definition.Type, town, faction) as BaseFactionVendor;
+        return ActivatorUtil.CreateInstance(Definition.Type, town, faction) as BaseFactionVendor;
       }
       catch
       {

--- a/Projects/Scripts/Engines/Factions/Items/Power Faction Items/PowerFactionItem.cs
+++ b/Projects/Scripts/Engines/Factions/Items/Power Faction Items/PowerFactionItem.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Server.Factions;
 using Server.Mobiles;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server
 {
@@ -174,7 +175,7 @@ namespace Server
 
       public Type Type{ get; }
 
-      public Item Construct() => Activator.CreateInstance(Type) as Item;
+      public Item Construct() => ActivatorUtil.CreateInstance(Type) as Item;
     }
   }
 }

--- a/Projects/Scripts/Engines/Factions/Items/Traps/BaseFactionTrapDeed.cs
+++ b/Projects/Scripts/Engines/Factions/Items/Traps/BaseFactionTrapDeed.cs
@@ -1,6 +1,7 @@
 using System;
 using Server.Engines.Craft;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Factions
 {
@@ -50,7 +51,7 @@ namespace Server.Factions
     {
       try
       {
-        return Activator.CreateInstance(TrapType, m_Faction, from) as BaseFactionTrap;
+        return ActivatorUtil.CreateInstance(TrapType, m_Faction, from) as BaseFactionTrap;
       }
       catch
       {

--- a/Projects/Scripts/Engines/Factions/Mobiles/Guards/GuardAI.cs
+++ b/Projects/Scripts/Engines/Factions/Mobiles/Guards/GuardAI.cs
@@ -12,6 +12,7 @@ using Server.Spells.Seventh;
 using Server.Spells.Sixth;
 using Server.Spells.Third;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Factions
 {
@@ -86,7 +87,7 @@ namespace Server.Factions
         if (entry.Chance > Utility.Random(100))
         {
           releaseTime = DateTime.UtcNow + entry.Hold;
-          return (Spell)Activator.CreateInstance(entry.Spell, mob, null);
+          return (Spell)ActivatorUtil.CreateInstance(entry.Spell, mob, null);
         }
       }
 
@@ -656,7 +657,7 @@ namespace Server.Factions
               if (types.Count > 1)
                 spell = new BlessSpell(m_Guard);
               else if (types.Count == 1)
-                spell = Activator.CreateInstance(types[0], m_Guard, null) as Spell;
+                spell = ActivatorUtil.CreateInstance(types[0], m_Guard, null) as Spell;
             }
             else if (types.Count > 0)
             {
@@ -694,7 +695,7 @@ namespace Server.Factions
               if (types.Count > 1)
                 spell = new CurseSpell(m_Guard);
               else if (types.Count == 1)
-                spell = (Spell)Activator.CreateInstance(types[0], m_Guard, null);
+                spell = (Spell)ActivatorUtil.CreateInstance(types[0], m_Guard, null);
             }
           }
         }

--- a/Projects/Scripts/Engines/Harvest/Core/HarvestSystem.cs
+++ b/Projects/Scripts/Engines/Harvest/Core/HarvestSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Server.Items;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Engines.Harvest
 {
@@ -220,7 +221,7 @@ namespace Server.Engines.Harvest
     {
       try
       {
-        return Activator.CreateInstance(type) as Item;
+        return ActivatorUtil.CreateInstance(type) as Item;
       }
       catch
       {

--- a/Projects/Scripts/Engines/Harvest/Mining.cs
+++ b/Projects/Scripts/Engines/Harvest/Mining.cs
@@ -2,6 +2,7 @@ using System;
 using Server.Items;
 using Server.Mobiles;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Engines.Harvest
 {
@@ -258,7 +259,7 @@ namespace Server.Engines.Harvest
             if (map == null)
               return;
 
-            if (Activator.CreateInstance(res.Types[2], 25) is BaseCreature spawned)
+            if (ActivatorUtil.CreateInstance(res.Types[2], 25) is BaseCreature spawned)
             {
               int offset = Utility.Random(8) * 2;
 

--- a/Projects/Scripts/Engines/MLQuests/MLQuestSystem.cs
+++ b/Projects/Scripts/Engines/MLQuests/MLQuestSystem.cs
@@ -9,6 +9,7 @@ using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Engines.MLQuests
 {
@@ -62,7 +63,7 @@ namespace Server.Engines.MLQuests
 
           try
           {
-            quest = Activator.CreateInstance(type) as MLQuest;
+            quest = ActivatorUtil.CreateInstance(type) as MLQuest;
           }
           catch
           {

--- a/Projects/Scripts/Engines/MLQuests/Objectives/DeliverObjective.cs
+++ b/Projects/Scripts/Engines/MLQuests/Objectives/DeliverObjective.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Engines.MLQuests.Objectives
 {
@@ -45,7 +46,7 @@ namespace Server.Engines.MLQuests.Objectives
 
       for (int i = 0; i < Amount; ++i)
       {
-        if (!(Activator.CreateInstance(Delivery) is Item item))
+        if (!(ActivatorUtil.CreateInstance(Delivery) is Item item))
           continue;
 
         delivery.Add(item);

--- a/Projects/Scripts/Engines/MLQuests/Rewards/ItemReward.cs
+++ b/Projects/Scripts/Engines/MLQuests/Rewards/ItemReward.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Server.Engines.MLQuests.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Engines.MLQuests.Rewards
 {
@@ -53,7 +54,7 @@ namespace Server.Engines.MLQuests.Rewards
 
       try
       {
-        spawnedItem = Activator.CreateInstance(m_Type) as Item;
+        spawnedItem = ActivatorUtil.CreateInstance(m_Type) as Item;
       }
       catch (Exception e)
       {

--- a/Projects/Scripts/Engines/Plants/MiscItems/GreenThorns.cs
+++ b/Projects/Scripts/Engines/Plants/MiscItems/GreenThorns.cs
@@ -2,6 +2,7 @@ using System;
 using Server.Mobiles;
 using Server.Network;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -280,7 +281,7 @@ namespace Server.Items
         if (contains)
         {
           GreenThornsEffect effect =
-            (GreenThornsEffect)Activator.CreateInstance(taep.Effect, land.Location, from.Map, from);
+            (GreenThornsEffect)ActivatorUtil.CreateInstance(taep.Effect, land.Location, from.Map, from);
           return effect;
         }
       }

--- a/Projects/Scripts/Engines/Plants/PlantResources.cs
+++ b/Projects/Scripts/Engines/Plants/PlantResources.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Engines.Plants
 {
@@ -40,6 +41,6 @@ namespace Server.Engines.Plants
       return null;
     }
 
-    public Item CreateResource() => (Item)Activator.CreateInstance(ResourceType);
+    public Item CreateResource() => (Item)ActivatorUtil.CreateInstance(ResourceType);
   }
 }

--- a/Projects/Scripts/Engines/Quests/Core/QuestSerializer.cs
+++ b/Projects/Scripts/Engines/Quests/Core/QuestSerializer.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 
 namespace Server.Engines.Quests
@@ -8,7 +9,7 @@ namespace Server.Engines.Quests
     {
       try
       {
-        return Activator.CreateInstance(type);
+        return ActivatorUtil.CreateInstance(type);
       }
       catch
       {

--- a/Projects/Scripts/Engines/Quests/Core/Regions/QuestOfferRegion.cs
+++ b/Projects/Scripts/Engines/Quests/Core/Regions/QuestOfferRegion.cs
@@ -2,6 +2,7 @@ using System;
 using System.Xml;
 using Server.Mobiles;
 using Server.Regions;
+using Server.Utilities;
 
 namespace Server.Engines.Quests
 {
@@ -26,7 +27,7 @@ namespace Server.Engines.Quests
       if (m is PlayerMobile player && player.Quest == null && QuestSystem.CanOfferQuest(m, m_Quest))
         try
         {
-          QuestSystem qs = (QuestSystem)Activator.CreateInstance(m_Quest, player);
+          QuestSystem qs = (QuestSystem)ActivatorUtil.CreateInstance(m_Quest, player);
           qs.SendOffer();
         }
         catch (Exception ex)

--- a/Projects/Scripts/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
+++ b/Projects/Scripts/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
@@ -8,6 +8,7 @@ using Server.Mobiles;
 using Server.Multis;
 using Server.Network;
 using Server.Regions;
+using Server.Utilities;
 
 namespace Server.Misc
 {
@@ -152,7 +153,7 @@ namespace Server.Misc
 
         try
         {
-          i = Activator.CreateInstance(
+          i = ActivatorUtil.CreateInstance(
               m_LesserArtifacts[(int)DropEra - 1][Utility.Random(m_LesserArtifacts[(int)DropEra - 1].Length)])
             as
             Item;
@@ -528,7 +529,7 @@ namespace Server.Gumps
 
         try
         {
-          item = (Item)Activator.CreateInstance(t.Type);
+          item = (Item)ActivatorUtil.CreateInstance(t.Type);
         }
         catch
         {

--- a/Projects/Scripts/Engines/VeteranRewards/RewardEntry.cs
+++ b/Projects/Scripts/Engines/VeteranRewards/RewardEntry.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 
 namespace Server.Engines.VeteranRewards
@@ -64,7 +65,7 @@ namespace Server.Engines.VeteranRewards
     {
       try
       {
-        Item item = Activator.CreateInstance(ItemType, Args) as Item;
+        Item item = ActivatorUtil.CreateInstance(ItemType, Args) as Item;
 
         if (item is IRewardItem rewardItem)
           rewardItem.IsRewardItem = true;

--- a/Projects/Scripts/Gumps/ConfirmHeritageGump.cs
+++ b/Projects/Scripts/Gumps/ConfirmHeritageGump.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Server.Items;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Gumps
 {
@@ -42,7 +43,7 @@ namespace Server.Gumps
           {
             try
             {
-              item = Activator.CreateInstance(type) as Item;
+              item = ActivatorUtil.CreateInstance(type) as Item;
             }
             catch (Exception ex)
             {

--- a/Projects/Scripts/Holiday Stuff/Halloween/HolidaySettings.cs
+++ b/Projects/Scripts/Holiday Stuff/Halloween/HolidaySettings.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Events.Halloween
 {
@@ -35,8 +36,8 @@ namespace Server.Events.Halloween
     public static DateTime FinishHalloween => new DateTime(2012, 11, 15);
 
     public static Item RandomGMBeggerItem =>
-      (Item)Activator.CreateInstance(m_GMBeggarTreats[Utility.Random(m_GMBeggarTreats.Length)]);
+      (Item)ActivatorUtil.CreateInstance(m_GMBeggarTreats[Utility.Random(m_GMBeggarTreats.Length)]);
 
-    public static Item RandomTreat => (Item)Activator.CreateInstance(m_Treats[Utility.Random(m_Treats.Length)]);
+    public static Item RandomTreat => (Item)ActivatorUtil.CreateInstance(m_Treats[Utility.Random(m_Treats.Length)]);
   }
 }

--- a/Projects/Scripts/Items/Aquarium/Aquarium.cs
+++ b/Projects/Scripts/Items/Aquarium/Aquarium.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Server.ContextMenus;
 using Server.Multis;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -692,7 +693,7 @@ namespace Server.Items
 
       try
       {
-        item = Activator.CreateInstance(m_Decorations[random]) as Item;
+        item = ActivatorUtil.CreateInstance(m_Decorations[random]) as Item;
       }
       catch
       {

--- a/Projects/Scripts/Items/Armor/BaseArmor.cs
+++ b/Projects/Scripts/Items/Armor/BaseArmor.cs
@@ -4,6 +4,7 @@ using Server.Engines.Craft;
 using Server.Ethics;
 using Server.Factions;
 using Server.Network;
+using Server.Utilities;
 using AMA = Server.Items.ArmorMeditationAllowance;
 using AMT = Server.Items.ArmorMaterialType;
 
@@ -560,7 +561,7 @@ namespace Server.Items
       if (item?.Resources.Count == 1 && item.Resources.GetAt(0).Amount >= 2)
         try
         {
-          Item res = (Item)Activator.CreateInstance(CraftResources.GetInfo(m_Resource).ResourceTypes[0]);
+          Item res = (Item)ActivatorUtil.CreateInstance(CraftResources.GetInfo(m_Resource).ResourceTypes[0]);
 
           ScissorHelper(from, res, PlayerConstructed ? item.Resources.GetAt(0).Amount / 2 : 1);
           return true;

--- a/Projects/Scripts/Items/Clothing/BaseClothing.cs
+++ b/Projects/Scripts/Items/Clothing/BaseClothing.cs
@@ -4,6 +4,7 @@ using Server.Engines.Craft;
 using Server.Ethics;
 using Server.Factions;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -210,7 +211,7 @@ namespace Server.Items
 
           Type resourceType = info.ResourceTypes?[0] ?? item.Resources.GetAt(0).ItemType;
 
-          Item res = (Item)Activator.CreateInstance(resourceType);
+          Item res = (Item)ActivatorUtil.CreateInstance(resourceType);
 
           ScissorHelper(from, res, PlayerConstructed ? item.Resources.GetAt(0).Amount / 2 : 1);
 

--- a/Projects/Scripts/Items/Containers/SalvageBag.cs
+++ b/Projects/Scripts/Items/Containers/SalvageBag.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Server.ContextMenus;
 using Server.Engines.Craft;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -77,7 +78,7 @@ namespace Server.Items
         };
 
         Type resourceType = info.ResourceTypes[0];
-        Item ingot = (Item)Activator.CreateInstance(resourceType);
+        Item ingot = (Item)ActivatorUtil.CreateInstance(resourceType);
 
         if (item is DragonBardingDeed || item is BaseArmor armor && armor.PlayerConstructed ||
             item is BaseWeapon weapon && weapon.PlayerConstructed ||

--- a/Projects/Scripts/Items/Containers/TreasureMapChest.cs
+++ b/Projects/Scripts/Items/Containers/TreasureMapChest.cs
@@ -4,6 +4,7 @@ using Server.ContextMenus;
 using Server.Engines.PartySystem;
 using Server.Gumps;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -286,7 +287,7 @@ namespace Server.Items
       }
 
       if (level == 6 && Core.AOS)
-        cont.DropItem((Item)Activator.CreateInstance(Artifacts[Utility.Random(Artifacts.Length)]));
+        cont.DropItem((Item)ActivatorUtil.CreateInstance(Artifacts[Utility.Random(Artifacts.Length)]));
     }
 
     public override bool CheckLocked(Mobile from)

--- a/Projects/Scripts/Items/Decoration Artifacts/StealableArtifactsSpawner.cs
+++ b/Projects/Scripts/Items/Decoration Artifacts/StealableArtifactsSpawner.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 
@@ -316,7 +317,7 @@ namespace Server.Items
 
       public Item CreateInstance()
       {
-        Item item = (Item)Activator.CreateInstance(Type);
+        Item item = (Item)ActivatorUtil.CreateInstance(Type);
 
         if (Hue > 0)
           item.Hue = Hue;

--- a/Projects/Scripts/Items/Maps/TreasureMap.cs
+++ b/Projects/Scripts/Items/Maps/TreasureMap.cs
@@ -7,6 +7,7 @@ using Server.Engines.Harvest;
 using Server.Mobiles;
 using Server.Network;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -224,7 +225,7 @@ namespace Server.Items
 
         try
         {
-          bc = (BaseCreature)Activator.CreateInstance(
+          bc = (BaseCreature)ActivatorUtil.CreateInstance(
             m_SpawnTypes[level][Utility.Random(m_SpawnTypes[level].Length)]);
         }
         catch

--- a/Projects/Scripts/Items/Misc/DeceitBrazier.cs
+++ b/Projects/Scripts/Items/Misc/DeceitBrazier.cs
@@ -1,6 +1,7 @@
 using System;
 using Server.Mobiles;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -195,7 +196,7 @@ namespace Server.Items
           {
             Map map = Map;
             BaseCreature bc =
-              (BaseCreature)Activator.CreateInstance(Creatures[Utility.Random(Creatures.Length)]);
+              (BaseCreature)ActivatorUtil.CreateInstance(Creatures[Utility.Random(Creatures.Length)]);
 
             Point3D spawnLoc = GetSpawnPosition();
 

--- a/Projects/Scripts/Items/Skill Items/Magical/Potions/BasePotion.cs
+++ b/Projects/Scripts/Items/Skill Items/Magical/Potions/BasePotion.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Server.Engines.ConPVP;
 using Server.Engines.Craft;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -141,7 +142,7 @@ namespace Server.Items
         {
           if (this is BaseExplosionPotion && Amount > 1)
           {
-            BasePotion pot = (BasePotion)Activator.CreateInstance(GetType());
+            BasePotion pot = (BasePotion)ActivatorUtil.CreateInstance(GetType());
 
             Amount--;
 

--- a/Projects/Scripts/Items/Skill Items/Ninjitsu/NinjaWeapons.cs
+++ b/Projects/Scripts/Items/Skill Items/Ninjitsu/NinjaWeapons.cs
@@ -6,6 +6,7 @@ using Server.Spells.Chivalry;
 using Server.Spells.Necromancy;
 using Server.Spells.Ninjitsu;
 using Server.Targeting;
+using Server.Utilities;
 
 /*
  * There really was no prettier way to do this,  other than the one
@@ -85,7 +86,7 @@ namespace Server.Items
     {
       if (weapon.UsesRemaining > 0)
       {
-        INinjaAmmo ammo = Activator.CreateInstance(weapon.AmmoType, weapon.UsesRemaining) as INinjaAmmo;
+        INinjaAmmo ammo = ActivatorUtil.CreateInstance(weapon.AmmoType, weapon.UsesRemaining) as INinjaAmmo;
 
         ammo.Poison = weapon.Poison;
         ammo.PoisonCharges = weapon.PoisonCharges;

--- a/Projects/Scripts/Items/Talismans/BaseTalisman.cs
+++ b/Projects/Scripts/Items/Talismans/BaseTalisman.cs
@@ -6,6 +6,7 @@ using Server.Spells.Fourth;
 using Server.Spells.Necromancy;
 using Server.Spells.Second;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -228,7 +229,7 @@ namespace Server.Items
 
         try
         {
-          obj = Activator.CreateInstance(type);
+          obj = ActivatorUtil.CreateInstance(type);
         }
         catch
         {
@@ -260,7 +261,7 @@ namespace Server.Items
             from.PlaceInBackpack(item);
 
             if (i + 1 < count)
-              item = Activator.CreateInstance(type) as Item;
+              item = ActivatorUtil.CreateInstance(type) as Item;
           }
 
           if (item is Board)

--- a/Projects/Scripts/Misc/Loot.cs
+++ b/Projects/Scripts/Misc/Loot.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server
 {
@@ -689,7 +690,7 @@ namespace Server
     {
       try
       {
-        return Activator.CreateInstance(type) as Item;
+        return ActivatorUtil.CreateInstance(type) as Item;
       }
       catch
       {

--- a/Projects/Scripts/Misc/LootPack.cs
+++ b/Projects/Scripts/Misc/LootPack.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server
 {
@@ -886,7 +887,7 @@ namespace Server
         else if (Type == typeof(SummonAirElementalScroll)) // high scroll
           item = RandomScroll(2, 8, 8);
         else
-          item = Activator.CreateInstance(Type) as Item;
+          item = ActivatorUtil.CreateInstance(Type) as Item;
 
         return item;
       }

--- a/Projects/Scripts/Misc/MondainsLegacy.cs
+++ b/Projects/Scripts/Misc/MondainsLegacy.cs
@@ -1,6 +1,7 @@
 using System;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server
 {
@@ -26,7 +27,7 @@ namespace Server
 
     public static void GiveArtifactTo(Mobile m)
     {
-      if (!(Activator.CreateInstance(Artifacts[Utility.Random(Artifacts.Length)]) is Item item))
+      if (!(ActivatorUtil.CreateInstance(Artifacts[Utility.Random(Artifacts.Length)]) is Item item))
         return;
 
       if (m.AddToBackpack(item))

--- a/Projects/Scripts/Mobiles/BaseCreature.cs
+++ b/Projects/Scripts/Mobiles/BaseCreature.cs
@@ -23,6 +23,7 @@ using Server.Spells.Necromancy;
 using Server.Spells.Sixth;
 using Server.Spells.Spellweaving;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Mobiles
 {
@@ -2170,7 +2171,7 @@ namespace Server.Mobiles
         return null;
 
       Type type = m_SpellAttack[Utility.Random(m_SpellAttack.Count)];
-      return Activator.CreateInstance(type, this, null) as Spell;
+      return ActivatorUtil.CreateInstance(type, this, null) as Spell;
     }
 
     public Spell GetDefenseSpellRandom()
@@ -2179,7 +2180,7 @@ namespace Server.Mobiles
         return null;
 
       Type type = m_SpellDefense[Utility.Random(m_SpellDefense.Count)];
-      return Activator.CreateInstance(type, this, null) as Spell;
+      return ActivatorUtil.CreateInstance(type, this, null) as Spell;
     }
 
     public Spell GetSpellSpecific(Type type)
@@ -2188,11 +2189,11 @@ namespace Server.Mobiles
 
       for (i = 0; i < m_SpellAttack.Count; i++)
         if (m_SpellAttack[i] == type)
-          return Activator.CreateInstance(type, this, null) as Spell;
+          return ActivatorUtil.CreateInstance(type, this, null) as Spell;
 
       for (i = 0; i < m_SpellDefense.Count; i++)
         if (m_SpellDefense[i] == type)
-          return Activator.CreateInstance(type, this, null) as Spell;
+          return ActivatorUtil.CreateInstance(type, this, null) as Spell;
 
       return null;
     }

--- a/Projects/Scripts/Mobiles/PlayerMobile.cs
+++ b/Projects/Scripts/Mobiles/PlayerMobile.cs
@@ -33,6 +33,7 @@ using Server.Spells.Seventh;
 using Server.Spells.Sixth;
 using Server.Spells.Spellweaving;
 using Server.Targeting;
+using Server.Utilities;
 using BaseQuestGump = Server.Engines.MLQuests.Gumps.BaseQuestGump;
 using QuestOfferGump = Server.Engines.MLQuests.Gumps.QuestOfferGump;
 using RankDefinition = Server.Guilds.RankDefinition;
@@ -3080,7 +3081,7 @@ namespace Server.Mobiles
 
           try
           {
-            ammo = Activator.CreateInstance(kvp.Key) as Item;
+            ammo = ActivatorUtil.CreateInstance(kvp.Key) as Item;
           }
           catch
           {

--- a/Projects/Scripts/Mobiles/Special/Paragon.cs
+++ b/Projects/Scripts/Mobiles/Special/Paragon.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Mobiles
 {
@@ -179,7 +180,7 @@ namespace Server.Mobiles
 
     public static void GiveArtifactTo(Mobile m)
     {
-      Item item = (Item)Activator.CreateInstance(Artifacts[Utility.Random(Artifacts.Length)]);
+      Item item = (Item)ActivatorUtil.CreateInstance(Artifacts[Utility.Random(Artifacts.Length)]);
 
       if (m.AddToBackpack(item))
         m.SendMessage("As a reward for slaying the mighty paragon, an artifact has been placed in your backpack.");

--- a/Projects/Scripts/Mobiles/Vendors/BeverageBuy.cs
+++ b/Projects/Scripts/Mobiles/Vendors/BeverageBuy.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Mobiles
 {
@@ -27,6 +28,6 @@ namespace Server.Mobiles
 
     public override bool CanCacheDisplay => false;
 
-    public override IEntity GetEntity() => (IEntity)Activator.CreateInstance(Type, m_Content);
+    public override IEntity GetEntity() => (IEntity)ActivatorUtil.CreateInstance(Type, m_Content);
   }
 }

--- a/Projects/Scripts/Mobiles/Vendors/GenericBuy.cs
+++ b/Projects/Scripts/Mobiles/Vendors/GenericBuy.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Mobiles
 {
@@ -94,10 +95,10 @@ namespace Server.Mobiles
     public virtual IEntity GetEntity()
     {
       if (Args == null || Args.Length == 0)
-        return (IEntity)Activator.CreateInstance(Type);
+        return (IEntity)ActivatorUtil.CreateInstance(Type);
 
-      return (IEntity)Activator.CreateInstance(Type, Args);
-      //return (Item)Activator.CreateInstance( m_Type );
+      return (IEntity)ActivatorUtil.CreateInstance(Type, Args);
+      //return (Item)ActivatorUtil.CreateInstance( m_Type );
     }
 
     //Attempt to restock with item, (return true if restock successful)

--- a/Projects/Scripts/Mobiles/Vendors/NPC/CustomHairstylist.cs
+++ b/Projects/Scripts/Mobiles/Vendors/NPC/CustomHairstylist.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Server.Gumps;
 using Server.Items;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Mobiles
 {
@@ -193,7 +194,7 @@ namespace Server.Mobiles
               else
                 args[i] = origArgs[i];
 
-            Gump g = Activator.CreateInstance(buyInfo.GumpType, args) as Gump;
+            Gump g = ActivatorUtil.CreateInstance(buyInfo.GumpType, args) as Gump;
 
             m_From.SendGump(g);
           }

--- a/Projects/Scripts/Multis/HousePlacementTool.cs
+++ b/Projects/Scripts/Multis/HousePlacementTool.cs
@@ -7,6 +7,7 @@ using Server.Multis;
 using Server.Network;
 using Server.Regions;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Items
 {
@@ -568,7 +569,7 @@ namespace Server.Items
         else
           args = new object[] { from };
 
-        return Activator.CreateInstance(Type, args) as BaseHouse;
+        return ActivatorUtil.CreateInstance(Type, args) as BaseHouse;
       }
       catch
       {

--- a/Projects/Scripts/Regions/GuardedRegion.cs
+++ b/Projects/Scripts/Regions/GuardedRegion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Regions
 {
@@ -171,7 +172,7 @@ namespace Server.Regions
 
         try
         {
-          Activator.CreateInstance(m_GuardType, m_GuardParams);
+          ActivatorUtil.CreateInstance(m_GuardType, m_GuardParams);
         }
         catch
         {

--- a/Projects/Scripts/Regions/Spawning/SpawnDefinition.cs
+++ b/Projects/Scripts/Regions/Spawning/SpawnDefinition.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Xml;
 using Server.Items;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Regions
 {
@@ -157,7 +158,7 @@ namespace Server.Regions
 
     protected override void Init()
     {
-      Mobile mob = (Mobile)Activator.CreateInstance(Type);
+      Mobile mob = (Mobile)ActivatorUtil.CreateInstance(Type);
 
       m_Land = !mob.CantWalk;
       m_Water = mob.CanSwim;
@@ -186,7 +187,7 @@ namespace Server.Regions
       return mobile;
     }
 
-    protected virtual Mobile CreateMobile() => (Mobile)Activator.CreateInstance(Type);
+    protected virtual Mobile CreateMobile() => (Mobile)ActivatorUtil.CreateInstance(Type);
   }
 
   public class SpawnItem : SpawnType
@@ -221,7 +222,7 @@ namespace Server.Regions
 
     protected override void Init()
     {
-      Item item = (Item)Activator.CreateInstance(Type);
+      Item item = (Item)ActivatorUtil.CreateInstance(Type);
 
       m_Height = item.ItemData.Height;
 
@@ -239,7 +240,7 @@ namespace Server.Regions
       return item;
     }
 
-    protected virtual Item CreateItem() => (Item)Activator.CreateInstance(Type);
+    protected virtual Item CreateItem() => (Item)ActivatorUtil.CreateInstance(Type);
   }
 
   public class SpawnTreasureChest : SpawnItem

--- a/Projects/Scripts/Spells/Base/SpellRegistry.cs
+++ b/Projects/Scripts/Spells/Base/SpellRegistry.cs
@@ -1,3 +1,4 @@
+using Server.Utilities;
 using System;
 using System.Collections.Generic;
 
@@ -83,7 +84,7 @@ namespace Server.Spells
 
         try
         {
-          spm = Activator.CreateInstance(type) as SpecialMove;
+          spm = ActivatorUtil.CreateInstance(type) as SpecialMove;
         }
         catch
         {
@@ -123,7 +124,7 @@ namespace Server.Spells
 
         try
         {
-          return (Spell)Activator.CreateInstance(t, m_Params);
+          return (Spell)ActivatorUtil.CreateInstance(t, m_Params);
         }
         catch
         {
@@ -147,7 +148,7 @@ namespace Server.Spells
 
           try
           {
-            return (Spell)Activator.CreateInstance(t, m_Params);
+            return (Spell)ActivatorUtil.CreateInstance(t, m_Params);
           }
           catch
           {

--- a/Projects/Scripts/Spells/Fifth/SummonCreature.cs
+++ b/Projects/Scripts/Spells/Fifth/SummonCreature.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Spells.Fifth
 {
@@ -63,7 +64,7 @@ namespace Server.Spells.Fifth
       if (CheckSequence())
         try
         {
-          BaseCreature creature = (BaseCreature)Activator.CreateInstance(m_Types[Utility.Random(m_Types.Length)]);
+          BaseCreature creature = (BaseCreature)ActivatorUtil.CreateInstance(m_Types[Utility.Random(m_Types.Length)]);
 
           //creature.ControlSlots = 2;
 

--- a/Projects/Scripts/Spells/First/CreateFood.cs
+++ b/Projects/Scripts/Spells/First/CreateFood.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Items;
+using Server.Utilities;
 
 namespace Server.Spells.First
 {
@@ -75,7 +76,7 @@ namespace Server.Spells.First
 
       try
       {
-        item = (Item)Activator.CreateInstance(Type);
+        item = (Item)ActivatorUtil.CreateInstance(Type);
       }
       catch
       {

--- a/Projects/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Projects/Scripts/Spells/Necromancy/AnimateDeadSpell.cs
@@ -5,6 +5,7 @@ using Server.Engines.Quests.Necro;
 using Server.Items;
 using Server.Mobiles;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server.Spells.Necromancy
 {
@@ -298,7 +299,7 @@ namespace Server.Spells.Necromancy
 
       try
       {
-        summoned = Activator.CreateInstance(toSummon) as Mobile;
+        summoned = ActivatorUtil.CreateInstance(toSummon) as Mobile;
       }
       catch
       {

--- a/Projects/Scripts/Spells/Necromancy/SummonFamiliar.cs
+++ b/Projects/Scripts/Spells/Necromancy/SummonFamiliar.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Server.Gumps;
 using Server.Mobiles;
 using Server.Network;
+using Server.Utilities;
 
 namespace Server.Spells.Necromancy
 {
@@ -170,7 +171,7 @@ namespace Server.Spells.Necromancy
         {
           try
           {
-            BaseCreature bc = (BaseCreature)Activator.CreateInstance(entry.Type);
+            BaseCreature bc = (BaseCreature)ActivatorUtil.CreateInstance(entry.Type);
 
             // TODO: Is this right?
             bc.Skills.MagicResist.Base = m_From.Skills.MagicResist.Base;

--- a/Projects/Scripts/Spells/Spellweaving/ArcaneSummon.cs
+++ b/Projects/Scripts/Spells/Spellweaving/ArcaneSummon.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Mobiles;
+using Server.Utilities;
 
 namespace Server.Spells.Spellweaving
 {
@@ -39,7 +40,7 @@ namespace Server.Spells.Spellweaving
 
           try
           {
-            bc = Activator.CreateInstance<T>();
+            bc = ActivatorUtil.CreateInstance<T>();
           }
           catch
           {

--- a/Projects/Server/Mobile.cs
+++ b/Projects/Server/Mobile.cs
@@ -36,6 +36,7 @@ using Server.Mobiles;
 using Server.Network;
 using Server.Prompts;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server
 {
@@ -4690,7 +4691,7 @@ namespace Server
       Item item;
       try
       {
-        item = (Item)Activator.CreateInstance(oldItem.GetType());
+        item = (Item)ActivatorUtil.CreateInstance(oldItem.GetType());
       }
       catch
       {

--- a/Projects/Server/Region.cs
+++ b/Projects/Server/Region.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.Xml;
 using Server.Network;
 using Server.Targeting;
+using Server.Utilities;
 
 namespace Server
 {
@@ -780,7 +781,7 @@ namespace Server
         Region region = null;
         try
         {
-          region = (Region)Activator.CreateInstance(type, xmlReg, map, parent);
+          region = (Region)ActivatorUtil.CreateInstance(type, xmlReg, map, parent);
         }
         catch (Exception ex)
         {

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationIcon>MUO.ico</ApplicationIcon>
-    <StartupObject>
-    </StartupObject>
+    <StartupObject>Server.Core</StartupObject>
     <AssemblyName>ModernUO</AssemblyName>
     <Win32Resource />
     <Version>0.2.1</Version>

--- a/Projects/Server/Utilities/ActivatorUtil.cs
+++ b/Projects/Server/Utilities/ActivatorUtil.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Server.Utilities
+{
+  public static class ActivatorUtil
+  {
+    public static object CreateInstance(Type type)
+    {
+      try
+      {
+        if (type.GetConstructor(Type.EmptyTypes) != null)
+          return Activator.CreateInstance(type);
+        else
+        {
+          var emptyConstructor = type.GetConstructors().Single(info =>
+          {
+            var paramList = info.GetParameters();
+            return paramList.Length == 1 && paramList[0].IsOptional;
+          });
+          if (emptyConstructor != null)
+            return emptyConstructor.Invoke(new object[] { Type.Missing });
+          else
+            throw new TypeInitializationException(type.ToString(), new Exception($"There is no empty/default constructor for {type}"));
+        }
+      }
+      catch (NullReferenceException e)
+      {
+        throw new TypeInitializationException(type.ToString(), new Exception($"There is no empty/default constructor for {type}", e));
+      }
+    }
+    public static object CreateInstance(Type type, params object[] args)
+    {
+      if (args == null || args.Length == 0)
+        return CreateInstance(type);
+      try
+      {
+        return Activator.CreateInstance(type, args);
+      }
+      catch (NullReferenceException e)
+      {
+        throw new TypeInitializationException(type.ToString(), new Exception($"There is no constructor for {type} with the given parameter types", e));
+      }
+      throw new TypeInitializationException(type.ToString(), new Exception($"There is no constructor for {type} with the given parameter types"));
+    }
+
+    public static T CreateInstance<T>() => (T)CreateInstance(typeof(T));
+  }
+}

--- a/Projects/Server/Utilities/ActivatorUtil.cs
+++ b/Projects/Server/Utilities/ActivatorUtil.cs
@@ -1,51 +1,89 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Reflection;
 
 namespace Server.Utilities
 {
   public static class ActivatorUtil
   {
-    public static object CreateInstance(Type type)
+
+    public static ConstructorInfo GetConstructor(Type type)
     {
       try
       {
-        if (type.GetConstructor(Type.EmptyTypes) != null)
-          return Activator.CreateInstance(type);
-        else
-        {
-          var emptyConstructor = type.GetConstructors().Single(info =>
-          {
-            var paramList = info.GetParameters();
-            return paramList.Length == 1 && paramList[0].IsOptional;
-          });
-          if (emptyConstructor != null)
-            return emptyConstructor.Invoke(new object[] { Type.Missing });
-          else
-            throw new TypeInitializationException(type.ToString(), new Exception($"There is no empty/default constructor for {type}"));
-        }
+        return type.GetConstructor(Type.EmptyTypes)
+          ?? type.GetConstructors().Single(info => info.GetParameters().All(x => x.IsOptional))
+          ?? throw new TypeInitializationException(type.ToString(), new Exception($"There is no empty/default constructor for {type}"));
       }
-      catch (NullReferenceException e)
+      catch (Exception e)
       {
-        throw new TypeInitializationException(type.ToString(), new Exception($"There is no empty/default constructor for {type}", e));
+        throw new TypeInitializationException(type.ToString(), e);
+      }
+    }
+    public static ConstructorInfo GetConstructor(Type type, params Type[] args)
+    {
+      try
+      {
+        ConstructorInfo cctor = null;
+        if (args.All(x => x != null))
+          cctor = type.GetConstructor(args);
+        if (cctor == null)
+          cctor = type.GetConstructors().Single(info =>
+          {
+            var paramList = info.GetParameters().ToList();
+            // If more args are given than parameters, skip.
+            if (args.Length > paramList.Count)
+              return false;
+            // check all given args map to params.
+            for (int i = 0; i < args.Length; i++)
+            {
+              // if a null reference is passed, but the type is not nullable, skip.
+              if (args[i] == null)
+              {
+                if (paramList[i].ParameterType.IsValueType) return false;
+              }
+              // If an arg is not assignable to the parameter type, skip.
+              else if (!paramList[i].ParameterType.IsAssignableFrom(args[i]))
+                return false;
+            }
+            // If there are more parameters, check if they any are not optional, if any are not, skip.
+            if (args.Length < paramList.Count && paramList.GetRange(args.Length, paramList.Count - args.Length).Any(x => !x.IsOptional))
+              return false;
+            // All checks have passed. We have found a match.
+            return true;
+          });
+        if (cctor == null)
+          throw new TypeInitializationException(type.ToString(), new Exception($"There is no empty/default constructor for {type}"));
+        else
+          return cctor;
+      }
+      catch (Exception e)
+      {
+        throw new TypeInitializationException(type.ToString(), e);
+      }
+    }
+    public static object CreateInstance(Type type)
+    {
+      var cctor = GetConstructor(type);
+      var args = cctor.GetParameters();
+      if (args.Length == 0)
+        return cctor.Invoke(Type.EmptyTypes);
+      else
+      {
+        var argList = new object[args.Length];
+        Array.Fill(argList, Type.Missing);
+        return cctor.Invoke(argList);
       }
     }
     public static object CreateInstance(Type type, params object[] args)
     {
       if (args == null || args.Length == 0)
         return CreateInstance(type);
-      try
-      {
-        return Activator.CreateInstance(type, args);
-      }
-      catch (NullReferenceException e)
-      {
-        throw new TypeInitializationException(type.ToString(), new Exception($"There is no constructor for {type} with the given parameter types", e));
-      }
-      throw new TypeInitializationException(type.ToString(), new Exception($"There is no constructor for {type} with the given parameter types"));
+      var cctor = GetConstructor(type, args.Select(x => x?.GetType()).ToArray());
+      return cctor.Invoke(args);
     }
 
     public static T CreateInstance<T>() => (T)CreateInstance(typeof(T));
+    public static T CreateInstance<T>(params object[] args) => (T)CreateInstance(typeof(T), args);
   }
 }

--- a/Projects/Server/Utilities/ActivatorUtil.cs
+++ b/Projects/Server/Utilities/ActivatorUtil.cs
@@ -55,12 +55,9 @@ namespace Server.Utilities
       var args = cctor.GetParameters();
       if (args.Length == 0)
         return cctor.Invoke(Type.EmptyTypes);
-      else
-      {
-        var argList = new object[args.Length];
-        Array.Fill(argList, Type.Missing);
-        return cctor.Invoke(argList);
-      }
+      var argList = new object[args.Length];
+      Array.Fill(argList, Type.Missing);
+      return cctor.Invoke(argList);
     }
     public static object CreateInstance(Type type, params object[] args)
     {

--- a/Projects/Server/World.cs
+++ b/Projects/Server/World.cs
@@ -629,7 +629,7 @@ namespace Server
       SaveStrategy strategy = SaveStrategy.Acquire();
       Console.WriteLine("Core: Using {0} save strategy", strategy.Name.ToLowerInvariant());
 
-      Console.Write($"[{DateTime.Now.ToLongTimeString()}] World: Saving...");
+      Console.Write($"[{DateTime.UtcNow.ToLongTimeString()}] World: Saving...");
 
       Stopwatch watch = Stopwatch.StartNew();
 

--- a/Projects/Server/World.cs
+++ b/Projects/Server/World.cs
@@ -629,7 +629,7 @@ namespace Server
       SaveStrategy strategy = SaveStrategy.Acquire();
       Console.WriteLine("Core: Using {0} save strategy", strategy.Name.ToLowerInvariant());
 
-      Console.Write("World: Saving...");
+      Console.Write($"[{DateTime.Now.ToLongTimeString()}] World: Saving...");
 
       Stopwatch watch = Stopwatch.StartNew();
 


### PR DESCRIPTION
Spawning systems such as the `[decorate` command would often use the raw `Activator.CreateInstance(type)` function with no additional parameters. This causes Activator to look for a class constructor in the type that has NO parameters. This will fail as many models do not have a parameterless constructor. Instead, those models contain exactly one constructor that takes exactly 1 optional parameter. The ActivatorUtil manages this by searching for a parameterless constructor first, if none are found, then it searches for a constructor with one optional parameter. It then performs the correct instantiation execution by passing it the `Type.Missing` value to the optional parameter.

All of the Activator references have been replaced with the ActivatorUtil, which will also make future fixes much more easy as they will all go through the util wrapper.