### PR TITLE
Fixes uint to ushort truncation issue for Amount

### DIFF
--- a/Projects/Server/Network/Packets.cs
+++ b/Projects/Server/Network/Packets.cs
@@ -1839,7 +1839,7 @@ namespace Server.Network
       m_Stream.Write(item.Serial);
       m_Stream.Write((ushort)item.ItemID);
       m_Stream.Write((byte)0); // signed, itemID offset
-      m_Stream.Write((ushort)item.Amount);
+      m_Stream.Write((ushort)Math.Min(item.Amount, ushort.MaxValue));
       m_Stream.Write((short)item.X);
       m_Stream.Write((short)item.Y);
       m_Stream.Write(parentSerial);
@@ -1866,7 +1866,7 @@ namespace Server.Network
       m_Stream.Write(item.Serial);
       m_Stream.Write((ushort)item.ItemID);
       m_Stream.Write((byte)0); // signed, itemID offset
-      m_Stream.Write((ushort)item.Amount);
+      m_Stream.Write((ushort)Math.Min(item.Amount, ushort.MaxValue));
       m_Stream.Write((short)item.X);
       m_Stream.Write((short)item.Y);
       m_Stream.Write((byte)0); // Grid Location?
@@ -1901,7 +1901,7 @@ namespace Server.Network
           m_Stream.Write(child.Serial);
           m_Stream.Write((ushort)child.ItemID);
           m_Stream.Write((byte)0); // signed, itemID offset
-          m_Stream.Write((ushort)child.Amount);
+          m_Stream.Write((ushort)Math.Min(child.Amount, ushort.MaxValue));
           m_Stream.Write((short)loc.m_X);
           m_Stream.Write((short)loc.m_Y);
           m_Stream.Write(beheld.Serial);
@@ -1942,7 +1942,7 @@ namespace Server.Network
           m_Stream.Write(child.Serial);
           m_Stream.Write((ushort)child.ItemID);
           m_Stream.Write((byte)0); // signed, itemID offset
-          m_Stream.Write((ushort)child.Amount);
+          m_Stream.Write((ushort)Math.Min(child.Amount, ushort.MaxValue));
           m_Stream.Write((short)loc.m_X);
           m_Stream.Write((short)loc.m_Y);
           m_Stream.Write((byte)0); // Grid Location?


### PR DESCRIPTION
Currently the server tracks item amounts via an int or uint. The network packets, however, expect this value to be transmitted in a 2 byte ushort. The casting truncates the 16 high order bits, causing the client to receive a bizare number. This fix is simple in that it will just pass the max ushort value if the server side Amount field is too high. This really only is an issue when dealing with currencies such as Gold or Tokens.

Scenario: Spawn a large pile of 1M gold and attempt to move it. Only a max of 16960 (Amount & 0xFFFF) can be moved and this value changes each time the Amount changes. It can also cause unpredictable behaviour in the Client if the gold Amount gets truncated to `0` (i.e. 1M-16960 & 0xFFFF).