### PR TITLE
Restore Gump.AddTextEntry overload without size parameter

### DIFF
--- a/Projects/Server/Gumps/Gump.cs
+++ b/Projects/Server/Gumps/Gump.cs
@@ -262,7 +262,12 @@ namespace Server.Gumps
       Add(new GumpRadio(x, y, inactiveID, activeID, initialState, switchID));
     }
 
-    public void AddTextEntry(int x, int y, int width, int height, int hue, int entryID, string initialText, int size = 0)
+    public void AddTextEntry(int x, int y, int width, int height, int hue, int entryID, string initialText)
+    {
+      Add( new GumpTextEntry(x, y, width, height, hue, entryID, initialText));
+    }
+
+    public void AddTextEntry(int x, int y, int width, int height, int hue, int entryID, string initialText, int size)
     {
       Add(new GumpTextEntryLimited(x, y, width, height, hue, entryID, initialText, size));
     }


### PR DESCRIPTION
Restore Gump.AddTextEntry overload without size parameter as sending GumpTextEntryLimited with size = 0 makes it unusable in standard client.