### PR TITLE
Adds a new [location command for easy display of target XYZ

### DIFF
--- a/Projects/Scripts/Commands/Generic/Commands/Commands.cs
+++ b/Projects/Scripts/Commands/Generic/Commands/Commands.cs
@@ -59,6 +59,7 @@ namespace Server.Commands.Generic
       Register(new FactionKickCommand(FactionKickType.Unban));
       Register(new BringToPackCommand());
       Register(new TraceLockdownCommand());
+      Register(new LocationCommand());
     }
 
     public static void Register(BaseCommand command)
@@ -751,7 +752,7 @@ namespace Server.Commands.Generic
     {
       AccessLevel = AccessLevel.GameMaster;
       Supports = CommandSupport.AllNPCs | CommandSupport.AllItems;
-      Commands = new[] { "Delete", "Remove" };
+      Commands = new[] { "Delete", "Remove", "Rm" };
       ObjectTypes = ObjectTypes.Both;
       Usage = "Delete";
       Description = "Deletes a targeted item or mobile. Does not delete players.";

--- a/Projects/Scripts/Commands/LocationCommand.cs
+++ b/Projects/Scripts/Commands/LocationCommand.cs
@@ -1,0 +1,56 @@
+using Server.Commands.Generic;
+using Server.Items;
+using Server.Targeting;
+using System.Globalization;
+using System.Linq;
+
+namespace Server.Commands
+{
+  public class LocationCommand : BaseCommand
+  {
+    public LocationCommand() : base()
+    {
+      AccessLevel = AccessLevel.Counselor;
+      Commands = new[] { "Location", "Loc", "Pos" };
+      ObjectTypes = ObjectTypes.All;
+      Supports = CommandSupport.Single | CommandSupport.Multi;
+      Usage = "Location [itemIds ...]";
+      Description = "Retrieves the positional coordinates of a target. Displaying a message above the item, mobile, or environment. Environment targets will also have a graphic temporarily displayed on the tile. This graphic can be changed to the provided list of itemIds.";
+    }
+
+    public override void Execute(CommandEventArgs e, object obj)
+    {
+      int[] graphics = new[] { 0x17AF, 0X17B0, 0X17B1, 0X17B2 };
+      if (e.Arguments.Length > 0)
+        graphics = e.Arguments
+          .Select(x =>
+          {
+            int result;
+            if (x.StartsWith("0x"))
+              return int.TryParse(x.Substring(2), NumberStyles.HexNumber, CultureInfo.CurrentCulture, out result) ? result : (int?)null;
+            return int.TryParse(x, out result) ? result : (int?)null;
+          })
+          .Where(x => x.HasValue)
+          .Select(x => x.Value)
+          .ToArray();
+      if (obj is IPoint3D point)
+      {
+        var label = $"(x:{point.X}, y:{point.Y}, z:{point.Z})";
+        if (obj is LandTarget || obj is StaticTarget)
+        {
+          var item = EffectItem.Create(new Point3D(point), e.Mobile.Map, EffectItem.DefaultDuration);
+          foreach (int graphic in graphics)
+            Effects.SendLocationParticles(item, graphic, 10, 50, 2023);
+          item.LabelTo(e.Mobile, label);
+        }
+        else if (obj is Mobile entity) entity.SayTo(e.Mobile, label);
+        else if (obj is Item item) item.LabelTo(e.Mobile, label);
+        AddResponse($"Location: (x:{point.X}, y:{point.Y}, z:{point.Z})");
+      }
+      else
+      {
+        LogFailure("That is not locatable.");
+      }
+    }
+  }
+}

--- a/Projects/Scripts/Commands/LocationCommand.cs
+++ b/Projects/Scripts/Commands/LocationCommand.cs
@@ -15,7 +15,9 @@ namespace Server.Commands
       ObjectTypes = ObjectTypes.All;
       Supports = CommandSupport.Single | CommandSupport.Multi;
       Usage = "Location [itemIds ...]";
-      Description = "Retrieves the positional coordinates of a target. Displaying a message above the item, mobile, or environment. Environment targets will also have a graphic temporarily displayed on the tile. This graphic can be changed to the provided list of itemIds.";
+      Description = "Retrieves the positional coordinates of a target. Displaying a message above the item, "
+                  + "mobile, or environment. Environment targets will also have a graphic temporarily displayed "
+                  + "on the tile. This graphic can be changed to the provided list of itemIds.";
     }
 
     public override void Execute(CommandEventArgs e, object obj)
@@ -23,13 +25,9 @@ namespace Server.Commands
       int[] graphics = new[] { 0x17AF, 0X17B0, 0X17B1, 0X17B2 };
       if (e.Arguments.Length > 0)
         graphics = e.Arguments
-          .Select(x =>
-          {
-            int result;
-            if (x.StartsWith("0x"))
-              return int.TryParse(x.Substring(2), NumberStyles.HexNumber, CultureInfo.CurrentCulture, out result) ? result : (int?)null;
-            return int.TryParse(x, out result) ? result : (int?)null;
-          })
+          .Select(x => int.TryParse(x, out int result)
+                     ? result : int.TryParse(x.Substring(2), NumberStyles.HexNumber, CultureInfo.CurrentCulture, out result)
+                     ? result : (int?)null)
           .Where(x => x.HasValue)
           .Select(x => x.Value)
           .ToArray();
@@ -45,12 +43,10 @@ namespace Server.Commands
         }
         else if (obj is Mobile entity) entity.SayTo(e.Mobile, label);
         else if (obj is Item item) item.LabelTo(e.Mobile, label);
-        AddResponse($"Location: (x:{point.X}, y:{point.Y}, z:{point.Z})");
+        AddResponse($"Location: {label}");
       }
       else
-      {
         LogFailure("That is not locatable.");
-      }
     }
   }
 }


### PR DESCRIPTION
It was a bit annoying trying to get the XYZ location within the environment. This command will place a temporary graphic on any environment tile while also stating its XYZ position. It will also display a label on any item or mobile targeted displaying their position as well. Can be used with the `[multi` command.

Aliases: `[location`, `[loc`, `[pos`