### PR TITLE
Removes int XOR in GetHashCode

### DIFF
--- a/Projects/Scripts/Commands/Docs.cs
+++ b/Projects/Scripts/Commands/Docs.cs
@@ -2639,7 +2639,7 @@ namespace Server.Commands
       return Body == e?.Body && BodyType == e.BodyType && Name == e.Name;
     }
 
-    public override int GetHashCode() => Utility.HashArray(Body.BodyID, (int)BodyType, Name);
+    public override int GetHashCode() => Body.BodyID ^ (int)BodyType ^ Name.GetHashCode();
   }
 
   public class BodyEntrySorter : IComparer<BodyEntry>

--- a/Projects/Scripts/Commands/Docs.cs
+++ b/Projects/Scripts/Commands/Docs.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using Server.Commands.Generic;
@@ -2638,7 +2639,7 @@ namespace Server.Commands
       return Body == e?.Body && BodyType == e.BodyType && Name == e.Name;
     }
 
-    public override int GetHashCode() => Body.BodyID ^ (int)BodyType ^ Name.GetHashCode();
+    public override int GetHashCode() => Utility.HashArray(Body.BodyID, (int)BodyType, Name);
   }
 
   public class BodyEntrySorter : IComparer<BodyEntry>

--- a/Projects/Server/ClientVersion.cs
+++ b/Projects/Server/ClientVersion.cs
@@ -143,7 +143,16 @@ namespace Server
 
     public static bool operator <(ClientVersion l, ClientVersion r) => Compare(l, r) < 0;
 
-    public override int GetHashCode() => Utility.HashArray(Major, Minor, Revision, Patch, (int)Type);
+    public override int GetHashCode()
+    {
+      int[] values = {Major, Minor, Revision, Patch, (int) Type};
+
+      int result = 1;
+
+      foreach (int element in values) result = 31 * result + element;
+
+      return result;
+    }
 
     int IComparer<ClientVersion>.Compare(ClientVersion x, ClientVersion y) => Compare(x, y);
 

--- a/Projects/Server/ClientVersion.cs
+++ b/Projects/Server/ClientVersion.cs
@@ -143,7 +143,7 @@ namespace Server
 
     public static bool operator <(ClientVersion l, ClientVersion r) => Compare(l, r) < 0;
 
-    public override int GetHashCode() => Major ^ Minor ^ Revision ^ Patch ^ (int)Type;
+    public override int GetHashCode() => Utility.HashArray(Major, Minor, Revision, Patch, (int)Type);
 
     int IComparer<ClientVersion>.Compare(ClientVersion x, ClientVersion y) => Compare(x, y);
 

--- a/Projects/Server/Geometry.cs
+++ b/Projects/Server/Geometry.cs
@@ -83,7 +83,16 @@ namespace Server
 
     public override bool Equals(object o) => o is IPoint2D p && m_X == p.X && m_Y == p.Y;
 
-    public override int GetHashCode() => Utility.HashArray(m_X, m_Y);
+    public override int GetHashCode()
+    {
+      int[] values = {m_X, m_Y};
+
+      int result = 1;
+
+      foreach (int element in values) result = 31 * result + element;
+
+      return result;
+    }
 
     public static bool operator ==(Point2D l, Point2D r) => l.m_X == r.m_X && l.m_Y == r.m_Y;
 
@@ -169,7 +178,16 @@ namespace Server
 
     public override bool Equals(object o) => o is IPoint3D p && m_X == p.X && m_Y == p.Y && m_Z == p.Z;
 
-    public override int GetHashCode() => Utility.HashArray(m_X, m_Y, m_Z);
+    public override int GetHashCode()
+    {
+      int[] values = {m_X, m_Y, m_Z};
+
+      int result = 1;
+
+      foreach (int element in values) result = 31 * result + element;
+
+      return result;
+    }
 
     public static Point3D Parse(string value)
     {

--- a/Projects/Server/Geometry.cs
+++ b/Projects/Server/Geometry.cs
@@ -83,7 +83,7 @@ namespace Server
 
     public override bool Equals(object o) => o is IPoint2D p && m_X == p.X && m_Y == p.Y;
 
-    public override int GetHashCode() => m_X ^ m_Y;
+    public override int GetHashCode() => Utility.HashArray(m_X, m_Y);
 
     public static bool operator ==(Point2D l, Point2D r) => l.m_X == r.m_X && l.m_Y == r.m_Y;
 
@@ -169,7 +169,7 @@ namespace Server
 
     public override bool Equals(object o) => o is IPoint3D p && m_X == p.X && m_Y == p.Y && m_Z == p.Z;
 
-    public override int GetHashCode() => m_X ^ m_Y ^ m_Z;
+    public override int GetHashCode() => Utility.HashArray(m_X, m_Y, m_Z);
 
     public static Point3D Parse(string value)
     {

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1105,5 +1105,18 @@ namespace Server
         RandomList(0x03, 0x0D, 0x13, 0x1C, 0x21, 0x30, 0x37, 0x3A, 0x44, 0x59);
 
     #endregion
+
+    #region Hash of Array
+    public static int HashArray(params object[] values)
+    {
+      if (values == null) return 0;
+
+      int result = 1;
+
+      foreach (object element in values) result = 31 * result + (element?.GetHashCode() ?? 0);
+
+      return result;
+    }
+    #endregion
   }
 }

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1106,17 +1106,5 @@ namespace Server
 
     #endregion
 
-    #region Hash of Array
-    public static int HashArray(params object[] values)
-    {
-      if (values == null) return 0;
-
-      int result = 1;
-
-      foreach (object element in values) result = 31 * result + (element?.GetHashCode() ?? 0);
-
-      return result;
-    }
-    #endregion
   }
 }


### PR DESCRIPTION
Fixes #24

Introduces new Utility method (sorry 😔) `HashArray`, which hashes an array of values.
Replaced xor of ints with this method.