### PR TITLE
expand buffer until large enough for input bytes

### DIFF
--- a/Projects/Server/Serialization/BufferedFileWriter.cs
+++ b/Projects/Server/Serialization/BufferedFileWriter.cs
@@ -274,7 +274,7 @@ namespace Server
 
         public void Write(byte[] value, int length)
         {
-            if (m_Index + length > Data.Length)
+            while (m_Index + length > Data.Length)
                 Expand();
 
             Buffer.BlockCopy(value, 0, Data, m_Index, length);


### PR DESCRIPTION
Fixes an `ArgumentOutOfRange` exception when the `byte[]` value is bigger than the default buffer expansion size. This will increase buffer until the value fits.