### PR TITLE
Fix switch-expression related error message

### DIFF
--- a/Projects/UOContent/Engines/ConPVP/DuelContext.cs
+++ b/Projects/UOContent/Engines/ConPVP/DuelContext.cs
@@ -2070,16 +2070,12 @@ namespace Server.Engines.ConPVP
                     pack.DropItem(item);
 
                     // TODO: Use Layer instead of Type
-                    var number = item switch
+                    int number = item switch
                     {
                         BaseWeapon _ => 1062001, // You can no longer wield your ~1_WEAPON~
-                        BaseShield _ => 1062003  // You can no longer equip your ~1_SHIELD~
+                        _ when !(item is BaseShield) && (item is BaseArmor || item is BaseClothing) => 1062002, // You can no longer wear your ~1_ARMOR~
+                        _ => 1062003 // You can no longer equip your ~1_SHIELD~
                     };
-
-                    if (item is BaseArmor || item is BaseClothing)
-                    {
-                        number = 1062002; // You can no longer wear your ~1_ARMOR~
-                    }
 
                     mob.SendLocalizedMessage(number, item.Name ?? $"#{item.LabelNumber}");
                 }

--- a/Projects/UOContent/Engines/ConPVP/DuelContext.cs
+++ b/Projects/UOContent/Engines/ConPVP/DuelContext.cs
@@ -2070,12 +2070,16 @@ namespace Server.Engines.ConPVP
                     pack.DropItem(item);
 
                     // TODO: Use Layer instead of Type
-                    int number = item switch
+                    var number = item switch
                     {
                         BaseWeapon _ => 1062001, // You can no longer wield your ~1_WEAPON~
-                        BaseShield _ => 1062003, // You can no longer equip your ~1_SHIELD~
-                        _ when item is BaseArmor || item is BaseClothing => 1062002 // You can no longer wear your ~1_ARMOR~
+                        BaseShield _ => 1062003  // You can no longer equip your ~1_SHIELD~
                     };
+
+                    if (item is BaseArmor || item is BaseClothing)
+                    {
+                        number = 1062002; // You can no longer wear your ~1_ARMOR~
+                    }
 
                     mob.SendLocalizedMessage(number, item.Name ?? $"#{item.LabelNumber}");
                 }


### PR DESCRIPTION
This PR fixes this problem. Strangely the build pipeline doesnt seem to have a problem with that, neither does Rider.

But when you run ./publish locally you get this.

```
D:\Code\_Extern\ModernUO\Projects\UOContent\Engines\ConPVP\DuelContext.cs(2073,39):
error CS8846: The switch expression does not handle all possible values of its input type (it is not exhaustive).
For example, the pattern '_' is not covered. However, a pattern with a 'when' clause might successfully match this value.
[D:\Code\_Extern\ModernUO\Projects\UOContent\UOContent.csproj]
```
