### PR TITLE
Updates networking to make pipe writer awaitable

### DIFF
--- a/Projects/Server.Tests/Network/Packets/Old/Outgoing/AccountPacketTests.cs
+++ b/Projects/Server.Tests/Network/Packets/Old/Outgoing/AccountPacketTests.cs
@@ -19,13 +19,13 @@ namespace Server.Tests.Network
             secondMobile.RawName = null;
 
             var account = new MockAccount(new[] { firstMobile, null, secondMobile });
-            var oldPacket = new ChangeCharacter(account).Compile();
+            var expected = new ChangeCharacter(account).Compile();
 
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendChangeCharacter(ns, account);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), oldPacket);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -37,8 +37,8 @@ namespace Server.Tests.Network
 
             Packets.SendClientVersionRequest(ns);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -49,8 +49,8 @@ namespace Server.Tests.Network
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendCharacterDeleteResult(ns, DeleteResultType.BadRequest);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace Server.Tests.Network
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendPopupMessage(ns, PMMessage.LoginSyncError);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Theory]
@@ -83,8 +83,8 @@ namespace Server.Tests.Network
             var expected = new SupportedFeatures(ns).Compile();
             Packets.SendSupportedFeature(ns);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -104,8 +104,8 @@ namespace Server.Tests.Network
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendLoginConfirmation(ns, m);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -116,8 +116,8 @@ namespace Server.Tests.Network
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendLoginComplete(ns);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -134,8 +134,8 @@ namespace Server.Tests.Network
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendCharacterListUpdate(ns, acct);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -160,8 +160,8 @@ namespace Server.Tests.Network
 
             Packets.SendCharacterList(ns);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -185,8 +185,8 @@ namespace Server.Tests.Network
 
             Packets.SendCharacterList(ns);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -198,8 +198,8 @@ namespace Server.Tests.Network
             using var ns = PacketTestUtilities.CreateTestNetState();
             Packets.SendAccountLoginRejected(ns, reason);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -217,8 +217,8 @@ namespace Server.Tests.Network
 
             Packets.SendAccountLoginAck(ns);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
         [Fact]
@@ -233,8 +233,8 @@ namespace Server.Tests.Network
 
             Packets.SendPlayServerAck(ns, si, authId);
 
-            ns.SendPipe.Reader.TryRead(out var buffer);
-            AssertThat.Equal(buffer.GetSpan(0), expected);
+            var result = ns.SendPipe.Reader.TryRead();
+            AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
     }
 }

--- a/Projects/Server/Buffers/CircularBufferReader.cs
+++ b/Projects/Server/Buffers/CircularBufferReader.cs
@@ -35,7 +35,7 @@ namespace Server.Network
         {
         }
 
-        public CircularBufferReader(CircularBuffer<byte> buffer) : this(buffer.GetSpan(0), buffer.GetSpan(1))
+        public CircularBufferReader(ArraySegment<byte>[] buffer) : this(buffer[0], buffer[1])
         {
         }
 

--- a/Projects/Server/Buffers/CircularBufferWriter.cs
+++ b/Projects/Server/Buffers/CircularBufferWriter.cs
@@ -33,6 +33,10 @@ namespace System.Buffers
         {
         }
 
+        public CircularBufferWriter(ArraySegment<byte>[] buffer) : this(buffer[0], buffer[1])
+        {
+        }
+
         public CircularBufferWriter(Span<byte> first, Span<byte> second)
         {
             _first = first;

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -36,8 +36,8 @@ namespace Server.Network
 
     public partial class NetState : IComparable<NetState>, IDisposable
     {
-        private static int RecvPipeSize = 1024 * 64;
-        private static int SendPipeSize = 1024 * 256;
+        private static int RecvPipeSize = 1024 * 64 + 1;
+        private static int SendPipeSize = 1024 * 256 + 1;
         private static int GumpCap = 512;
         private static int HuePickerCap = 512;
         private static int MenuCap = 512;

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -369,9 +369,17 @@ namespace Server.Network
             NetworkState.Resume(ref m_NetworkState);
         }
 
+        public bool GetSendBuffer(out CircularBuffer<byte> cBuffer)
+        {
+            var result = SendPipe.Writer.TryGetMemory();
+            cBuffer = new CircularBuffer<byte>(result.Buffer);
+
+            return !(result.IsClosed || result.Length <= 0);
+        }
+
         public virtual void Send(ref CircularBuffer<byte> buffer, int length)
         {
-            if (Connection == null || BlockAllPackets || buffer.Length == 0 || length <= 0)
+            if (Connection == null || BlockAllPackets || length <= 0)
             {
                 return;
             }
@@ -407,15 +415,16 @@ namespace Server.Network
 
                 if (buffer.Length > 0 && length > 0)
                 {
-                    if (!SendPipe.Writer.GetAvailable(out var pipeBuffer))
+                    var result = writer.TryGetMemory();
+                    if (result.IsClosed)
                     {
                         p.OnSend();
                         return;
                     }
 
-                    if (pipeBuffer.Length >= length)
+                    if (result.Length >= length)
                     {
-                        pipeBuffer.CopyFrom(buffer.AsSpan(0, length));
+                        result.CopyFrom(buffer.AsSpan(0, length));
                         writer.Advance((uint)length);
 
                         // Flush at the end of the game loop
@@ -461,24 +470,23 @@ namespace Server.Network
         private async void SendTask(object state)
         {
             var reader = SendPipe.Reader;
-            var segments = new ArraySegment<byte>[2];
 
             try
             {
                 while (m_Running)
                 {
-                    var result = await reader.Read(segments);
-                    if (result.Closed)
+                    var result = await reader.Read();
+                    if (result.IsClosed)
                     {
                         break;
                     }
 
-                    if (segments[0].Count + segments[1].Count <= 0)
+                    if (result.Length <= 0)
                     {
                         continue;
                     }
 
-                    var bytesWritten = await Connection.SendAsync(segments, SocketFlags.None);
+                    var bytesWritten = await Connection.SendAsync(result.Buffer, SocketFlags.None);
 
                     if (bytesWritten > 0)
                     {
@@ -510,7 +518,6 @@ namespace Server.Network
         {
             var socket = Connection;
             var writer = RecvPipe.Writer;
-            var segments = new ArraySegment<byte>[2];
 
             try
             {
@@ -521,24 +528,25 @@ namespace Server.Network
                         continue;
                     }
 
-                    // TODO: Make awaitable
-                    if (!writer.GetAvailable(segments))
+                    var result = await writer.GetMemory();
+
+                    if (result.IsClosed)
                     {
                         break;
                     }
 
-                    if (segments[0].Count + segments[1].Count <= 0)
+                    if (result.Length <= 0)
                     {
                         continue;
                     }
 
-                    var bytesWritten = await socket.ReceiveAsync(segments, SocketFlags.None);
+                    var bytesWritten = await socket.ReceiveAsync(result.Buffer, SocketFlags.None);
                     if (bytesWritten <= 0)
                     {
                         break;
                     }
 
-                    DecodePacket(segments, ref bytesWritten);
+                    DecodePacket(result.Buffer, ref bytesWritten);
 
                     writer.Advance((uint)bytesWritten);
                     m_NextCheckActivity = Core.TickCount + 90000;
@@ -583,12 +591,14 @@ namespace Server.Network
                 // Process as many packets as we can synchronously
                 while (true)
                 {
-                    if (!reader.TryRead(out var buffer) || buffer.Length <= 0)
+                    var result = reader.TryRead();
+
+                    if (result.IsClosed || result.Length <= 0)
                     {
                         return;
                     }
 
-                    var bytesProcessed = PacketHandlers.ProcessPacket(this, ref buffer);
+                    var bytesProcessed = PacketHandlers.ProcessPacket(this, result.Buffer);
 
                     if (bytesProcessed <= 0)
                     {

--- a/Projects/Server/Network/PacketHandlers.cs
+++ b/Projects/Server/Network/PacketHandlers.cs
@@ -277,9 +277,9 @@ namespace Server.Network
             }
         }
 
-        public static int ProcessPacket(NetState ns, ref CircularBuffer<byte> buffer)
+        public static int ProcessPacket(NetState ns, ArraySegment<byte>[] buffer)
         {
-            var reader = new CircularBufferReader(ref buffer);
+            var reader = new CircularBufferReader(buffer);
 
             var packetId = reader.ReadByte();
 

--- a/Projects/Server/Network/Packets/AccountPackets.cs
+++ b/Projects/Server/Network/Packets/AccountPackets.cs
@@ -61,7 +61,7 @@ namespace Server.Network
          */
         public static void SendChangeCharacter(NetState ns, IAccount a)
         {
-            if (ns == null || a == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns == null || a == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }
@@ -109,7 +109,7 @@ namespace Server.Network
          */
         public static void SendClientVersionRequest(NetState ns)
         {
-            if (ns != null && ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns != null && ns.GetSendBuffer(out var buffer))
             {
                 buffer[0] = 0xBD; // Packet ID
                 buffer[1] = 0x00;
@@ -127,7 +127,7 @@ namespace Server.Network
          */
         public static void SendCharacterDeleteResult(NetState ns, DeleteResultType res)
         {
-            if (ns != null && ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns != null && ns.GetSendBuffer(out var buffer))
             {
                 buffer[0] = 0x85; // Packet ID
                 buffer[1] = (byte)res;
@@ -144,7 +144,7 @@ namespace Server.Network
          */
         public static void SendPopupMessage(NetState ns, PMMessage msg)
         {
-            if (ns != null && ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns != null && ns.GetSendBuffer(out var buffer))
             {
                 buffer[0] = 0x53; // Packet ID
                 buffer[1] = (byte)msg;
@@ -161,7 +161,7 @@ namespace Server.Network
          */
         public static void SendSupportedFeature(NetState ns)
         {
-            if (ns == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }
@@ -206,7 +206,7 @@ namespace Server.Network
          */
         public static void SendLoginConfirmation(NetState ns, Mobile m)
         {
-            if (ns == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }
@@ -247,7 +247,7 @@ namespace Server.Network
          */
         public static void SendLoginComplete(NetState ns)
         {
-            if (ns != null && ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns != null && ns.GetSendBuffer(out var buffer))
             {
                 buffer[0] = 0x55; // Packet ID
 
@@ -263,7 +263,7 @@ namespace Server.Network
          */
         public static void SendCharacterListUpdate(NetState ns, IAccount a)
         {
-            if (ns == null || a == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns == null || a == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }
@@ -316,7 +316,7 @@ namespace Server.Network
         {
             var acct = ns?.Account;
 
-            if (acct == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (acct == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }
@@ -415,7 +415,7 @@ namespace Server.Network
          */
         public static void SendAccountLoginRejected(NetState ns, ALRReason reason)
         {
-            if (ns != null && ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns != null && ns.GetSendBuffer(out var buffer))
             {
                 buffer[0] = 0x82; // Packet ID
                 buffer[1] = (byte)reason;
@@ -432,7 +432,7 @@ namespace Server.Network
          */
         public static void SendAccountLoginAck(NetState ns)
         {
-            if (ns == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }
@@ -469,7 +469,7 @@ namespace Server.Network
          */
         public static void SendPlayServerAck(NetState ns, ServerInfo si, int authId)
         {
-            if (ns == null || !ns.SendPipe.Writer.GetAvailable(out var buffer))
+            if (ns == null || !ns.GetSendBuffer(out var buffer))
             {
                 return;
             }


### PR DESCRIPTION
- [X] Updates result so it is preallocated
- [X] Updates PipeWriter so it is awaitable
- [X] Simplifies NetState code to match changes
- [X] Adds a byte for empty checking so incoming/outgoing can have full pipes.