### PR TITLE
Cleanup & Fixes for .NET 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,14 +9,14 @@
         <PlatformTarget>x64</PlatformTarget>
         <LangVersion>9</LangVersion>
         <PublicRelease>true</PublicRelease>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+<!--        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>-->
         <NoWarn>NU1603</NoWarn>
         <RuntimeIdentifiers>win-x64;debian.10-x64;debian.9-x64;ubuntu.16.04-x64;ubuntu.18.04-x64;ubuntu.20.04-x64;centos.7-x64;centos.8-x64;osx-x64</RuntimeIdentifiers>
         <Configurations>Debug;Release;Analyze</Configurations>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <UseNETCoreGenerator>true</UseNETCoreGenerator>
+<!--        <UseNETCoreGenerator>true</UseNETCoreGenerator>-->
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <WarningsAsErrors />
+<!--        <WarningsAsErrors />-->
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
         <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
@@ -46,16 +46,18 @@
         <Optimize>true</Optimize>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Configuration)'=='Analyze'">
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <CodeAnalysisRuleSet>..\..\Rules.ruleset</CodeAnalysisRuleSet>
+        <AnalysisLevel>latest</AnalysisLevel>
     </PropertyGroup>
     <ItemGroup Condition="'$(Configuration)'=='Analyze'">
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />
+<!--        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />-->
         <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-            <Version>3.0.0</Version>
+            <Version>3.3.1</Version>
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <AdditionalFiles Include=".\stylecop.json" />
+<!--        <AdditionalFiles Include=".\stylecop.json" />-->
         <AdditionalFiles Include=".\Rules.ruleset" />
     </ItemGroup>
 </Project>

--- a/Projects/Benchmarks/Packets/BenchmarkPacketConstruction.cs
+++ b/Projects/Benchmarks/Packets/BenchmarkPacketConstruction.cs
@@ -8,8 +8,7 @@ using Server.Network;
 
 namespace Benchmarks
 {
-    [MemoryDiagnoser]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.NetCoreApp31)]
     public class BenchmarkPacketConstruction
     {
         public List<BuyItemState> m_States;

--- a/Projects/Server.Tests/Buffers/CircularBufferReaderTests.cs
+++ b/Projects/Server.Tests/Buffers/CircularBufferReaderTests.cs
@@ -8,60 +8,59 @@ namespace Server.Tests.Network
 {
     public class CircularBufferReaderTests
     {
-        [Theory]
+        [Theory, InlineData("Test String", "us-ascii", false, -1, 1024, 1024, 0),
+         InlineData("Test String", "utf-u", false, -1, 1024, 1024, 0),
+         InlineData("Test String", "utf-16BE", false, -1, 1024, 1024, 0),
+         InlineData("Test String", "utf-16", false, -1, 1024, 1024, 0),
+         InlineData("Test String", "us-ascii", false, -1, 1024, 1024, 1030),
+         InlineData("Test String", "utf-u", false, -1, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16BE", false, -1, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16", false, -1, 1024, 1024, 1030),
+         InlineData("Test String", "us-ascii", false, -1, 1024, 1024, 1020),
+         InlineData("Test String", "utf-u", false, -1, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16BE", false, -1, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16", false, -1, 1024, 1024, 1020),
+         InlineData("Test String", "us-ascii", false, 8, 1024, 1024, 0),
+         InlineData("Test String", "utf-u", false, 8, 1024, 1024, 0),
+         InlineData("Test String", "utf-16BE", false, 8, 1024, 1024, 0),
+         InlineData("Test String", "utf-16", false, 8, 1024, 1024, 0),
+         InlineData("Test String", "us-ascii", false, 8, 1024, 1024, 1030),
+         InlineData("Test String", "utf-u", false, 8, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16BE", false, 8, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16", false, 8, 1024, 1024, 1030),
+         InlineData("Test String", "us-ascii", false, 8, 1024, 1024, 1020),
+         InlineData("Test String", "utf-u", false, 8, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16BE", false, 8, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16", false, 8, 1024, 1024, 1020),
+         InlineData("Test String", "us-ascii", false, 20, 1024, 1024, 0),
+         InlineData("Test String", "utf-u", false, 20, 1024, 1024, 0),
+         InlineData("Test String", "utf-16BE", false, 20, 1024, 1024, 0),
+         InlineData("Test String", "utf-16", false, 20, 1024, 1024, 0),
+         InlineData("Test String", "us-ascii", false, 20, 1024, 1024, 1030),
+         InlineData("Test String", "utf-u", false, 20, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16BE", false, 20, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16", false, 20, 1024, 1024, 1030),
+         InlineData("Test String", "us-ascii", false, 20, 1024, 1024, 1020),
+         InlineData("Test String", "utf-u", false, 20, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16BE", false, 20, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16", false, 20, 1024, 1024, 1020)]
         // First only, beginning
-        [InlineData("Test String", "us-ascii", false, -1, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-u", false, -1, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16BE", false, -1, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16", false, -1, 1024, 1024, 0)]
 
         // Second only
-        [InlineData("Test String", "us-ascii", false, -1, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-u", false, -1, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16BE", false, -1, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16", false, -1, 1024, 1024, 1030)]
 
         // Split
-        [InlineData("Test String", "us-ascii", false, -1, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-u", false, -1, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16BE", false, -1, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16", false, -1, 1024, 1024, 1020)]
 
         // First only, beginning, fixed length smaller
-        [InlineData("Test String", "us-ascii", false, 8, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-u", false, 8, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16BE", false, 8, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16", false, 8, 1024, 1024, 0)]
 
         // Second only, fixed length smaller
-        [InlineData("Test String", "us-ascii", false, 8, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-u", false, 8, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16BE", false, 8, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16", false, 8, 1024, 1024, 1030)]
 
         // Split, fixed length smaller
-        [InlineData("Test String", "us-ascii", false, 8, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-u", false, 8, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16BE", false, 8, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16", false, 8, 1024, 1024, 1020)]
 
         // First only, beginning, fixed length bigger
-        [InlineData("Test String", "us-ascii", false, 20, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-u", false, 20, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16BE", false, 20, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16", false, 20, 1024, 1024, 0)]
 
         // Second only, fixed length bigger
-        [InlineData("Test String", "us-ascii", false, 20, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-u", false, 20, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16BE", false, 20, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16", false, 20, 1024, 1024, 1030)]
 
         // Split, fixed length bigger
-        [InlineData("Test String", "us-ascii", false, 20, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-u", false, 20, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16BE", false, 20, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16", false, 20, 1024, 1024, 1020)]
         public void TestReadString(
             string value,
             string encodingStr,

--- a/Projects/Server.Tests/Buffers/CircularBufferWriterTests.cs
+++ b/Projects/Server.Tests/Buffers/CircularBufferWriterTests.cs
@@ -7,54 +7,47 @@ namespace Server.Tests.Buffers
 {
     public class CircularBufferWriterTests
     {
-        [Theory]
+        [Theory, InlineData("Test String", "us-ascii", -1, 1024, 1024, 0),
+         InlineData("Test String", "utf-8", -1, 1024, 1024, 0), InlineData("Test String", "utf-16BE", -1, 1024, 1024, 0),
+         InlineData("Test String", "utf-16", -1, 1024, 1024, 0), InlineData("Test String", "us-ascii", -1, 1024, 1024, 1030),
+         InlineData("Test String", "utf-8", -1, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16BE", -1, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16", -1, 1024, 1024, 1030),
+         InlineData("Test String", "us-ascii", -1, 1024, 1024, 1020),
+         InlineData("Test String", "utf-8", -1, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16BE", -1, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16", -1, 1024, 1024, 1020), InlineData("Test String", "us-ascii", 8, 1024, 1024, 0),
+         InlineData("Test String", "utf-16BE", 8, 1024, 1024, 0), InlineData("Test String", "utf-16", 8, 1024, 1024, 0),
+         InlineData("Test String", "us-ascii", 8, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16BE", 8, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16", 8, 1024, 1024, 1030),
+         InlineData("Test String", "us-ascii", 8, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16BE", 8, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16", 8, 1024, 1024, 1020), InlineData("Test String", "us-ascii", 20, 1024, 1024, 0),
+         InlineData("Test String", "utf-16BE", 20, 1024, 1024, 0), InlineData("Test String", "utf-16", 20, 1024, 1024, 0),
+         InlineData("Test String", "us-ascii", 20, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16BE", 20, 1024, 1024, 1030),
+         InlineData("Test String", "utf-16", 20, 1024, 1024, 1030),
+         InlineData("Test String", "us-ascii", 20, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16BE", 20, 1024, 1024, 1020),
+         InlineData("Test String", "utf-16", 20, 1024, 1024, 1020)]
         // First only, beginning
-        [InlineData("Test String", "us-ascii", -1, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-8", -1, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16BE", -1, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16", -1, 1024, 1024, 0)]
 
         // Second only
-        [InlineData("Test String", "us-ascii", -1, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-8", -1, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16BE", -1, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16", -1, 1024, 1024, 1030)]
 
         // Split
-        [InlineData("Test String", "us-ascii", -1, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-8", -1, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16BE", -1, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16", -1, 1024, 1024, 1020)]
 
         // First only, beginning, fixed length smaller
-        [InlineData("Test String", "us-ascii", 8, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16BE", 8, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16", 8, 1024, 1024, 0)]
 
         // Second only, fixed length smaller
-        [InlineData("Test String", "us-ascii", 8, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16BE", 8, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16", 8, 1024, 1024, 1030)]
 
         // Split, fixed length smaller
-        [InlineData("Test String", "us-ascii", 8, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16BE", 8, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16", 8, 1024, 1024, 1020)]
 
         // First only, beginning, fixed length bigger
-        [InlineData("Test String", "us-ascii", 20, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16BE", 20, 1024, 1024, 0)]
-        [InlineData("Test String", "utf-16", 20, 1024, 1024, 0)]
 
         // Second only, fixed length bigger
-        [InlineData("Test String", "us-ascii", 20, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16BE", 20, 1024, 1024, 1030)]
-        [InlineData("Test String", "utf-16", 20, 1024, 1024, 1030)]
 
         // Split, fixed length bigger
-        [InlineData("Test String", "us-ascii", 20, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16BE", 20, 1024, 1024, 1020)]
-        [InlineData("Test String", "utf-16", 20, 1024, 1024, 1020)]
         public void TestWriteString(
             string value,
             string encodingStr,

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/AccountPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/AccountPacketTests.cs
@@ -65,9 +65,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
-        [Theory]
-        [InlineData(ProtocolChanges.Version70610)]
-        [InlineData(ProtocolChanges.Version6000)]
+        [Theory, InlineData(ProtocolChanges.Version70610), InlineData(ProtocolChanges.Version6000)]
         public void TestSupportedFeatures(ProtocolChanges protocolChanges)
         {
             var firstMobile = new Mobile(0x1);

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/CombatPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/CombatPacketTests.cs
@@ -21,9 +21,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [Theory, InlineData(true), InlineData(false)]
         public void TestSetWarMode(bool warmode)
         {
             var expected = new SetWarMode(warmode).Compile();

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/DamagePacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/DamagePacketTests.cs
@@ -6,10 +6,7 @@ namespace Server.Tests.Network
 {
     public class DamagePacketTests : IClassFixture<ServerFixture>
     {
-        [Theory]
-        [InlineData(10)]
-        [InlineData(-5)]
-        [InlineData(1024)]
+        [Theory, InlineData(10), InlineData(-5), InlineData(1024)]
         public void TestDamagePacketOld(int inputAmount)
         {
             Serial serial = 0x1024;
@@ -23,11 +20,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
-        [Theory]
-        [InlineData(10)]
-        [InlineData(-5)]
-        [InlineData(1024)]
-        [InlineData(100000)]
+        [Theory, InlineData(10), InlineData(-5), InlineData(1024), InlineData(100000)]
         public void TestDamage(int inputAmount)
         {
             Serial serial = 0x1024;

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/EffectPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/EffectPacketTests.cs
@@ -6,8 +6,7 @@ namespace Server.Tests.Network
 {
     public class EffectPackets
     {
-        [Theory]
-        [InlineData(10, 1000, 10, 5)]
+        [Theory, InlineData(10, 1000, 10, 5)]
         public void TestSoundEffect(ushort soundID, int x, int y, int z)
         {
             var p = new Point3D(x, y, z);
@@ -91,9 +90,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(actual, expected);
         }
 
-        [Theory]
-        [InlineData(ScreenEffectType.DarkFlash)]
-        [InlineData(ScreenEffectType.FadeInOut)]
+        [Theory, InlineData(ScreenEffectType.DarkFlash), InlineData(ScreenEffectType.FadeInOut)]
         public void TestScreenEffect(ScreenEffectType screenType)
         {
             var expected = new ScreenEffect(screenType).Compile();

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
@@ -221,10 +221,8 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(ProtocolChanges.Version70610)]
-        [InlineData(ProtocolChanges.Version400a)]
-        [InlineData(ProtocolChanges.Version502b)]
+        [Theory, InlineData(ProtocolChanges.Version70610), InlineData(ProtocolChanges.Version400a),
+         InlineData(ProtocolChanges.Version502b)]
         public void TestMobileStatusExtended(ProtocolChanges changes)
         {
             var beholder = new Mobile(0x1)
@@ -340,10 +338,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData("None")]
-        [InlineData("Lesser")]
-        [InlineData("Lethal")]
+        [Theory, InlineData("None"), InlineData("Lesser"), InlineData("Lethal")]
         public void TestHealthbarPoison(string pName)
         {
             var p = Poison.GetPoison(pName);
@@ -366,11 +361,7 @@ namespace Server.Tests.Network
             Assert.Equal(p?.Level, m.Poison?.Level);
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
+        [Theory, InlineData(false, false), InlineData(true, false), InlineData(false, true), InlineData(true, true)]
         public void TestYellowBar(bool isBlessed, bool isYellowHealth)
         {
             var m = new Mobile(0x1);
@@ -464,10 +455,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(0, 0, 0, 0)]
-        [InlineData(10, 1024, 0, 0)]
-        [InlineData(10, 1024, 11, 2048)]
+        [Theory, InlineData(0, 0, 0, 0), InlineData(10, 1024, 0, 0), InlineData(10, 1024, 11, 2048)]
         public void TestMobileIncoming(int hairItemId, int hairHue, int facialHairItemId, int facialHairHue)
         {
             var beholder = new Mobile(0x1)
@@ -594,13 +582,11 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(ProtocolChanges.Version6000, 0, 0, 0, 0)]
-        [InlineData(ProtocolChanges.Version6000, 10, 1024, 0, 0)]
-        [InlineData(ProtocolChanges.Version6000, 10, 1024, 11, 2048)]
-        [InlineData(ProtocolChanges.Version7000, 0, 0, 0, 0)]
-        [InlineData(ProtocolChanges.Version7000, 10, 1024, 0, 0)]
-        [InlineData(ProtocolChanges.Version7000, 10, 1024, 11, 2048)]
+        [Theory, InlineData(ProtocolChanges.Version6000, 0, 0, 0, 0),
+         InlineData(ProtocolChanges.Version6000, 10, 1024, 0, 0),
+         InlineData(ProtocolChanges.Version6000, 10, 1024, 11, 2048), InlineData(ProtocolChanges.Version7000, 0, 0, 0, 0),
+         InlineData(ProtocolChanges.Version7000, 10, 1024, 0, 0),
+         InlineData(ProtocolChanges.Version7000, 10, 1024, 11, 2048)]
         public void TestMobileIncomingOld(
             ProtocolChanges protocolChanges, int hairItemId, int hairHue, int facialHairItemId, int facialHairHue
         )

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MovementPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MovementPacketTests.cs
@@ -7,10 +7,7 @@ namespace Server.Tests.Network
 {
     public class MovementPacketTests : IClassFixture<ServerFixture>
     {
-        [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
+        [Theory, InlineData(0), InlineData(1), InlineData(2)]
         public void TestSpeedControl(byte speedControl)
         {
             var data = new SpeedControl(speedControl).Compile();

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/PlayerPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/PlayerPacketTests.cs
@@ -43,9 +43,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [Theory, InlineData(false), InlineData(true)]
         public void TestDeathStatus(bool isDead)
         {
             var data = new DeathStatus(isDead).Compile();
@@ -61,11 +59,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(0, true)]
-        [InlineData(0, false)]
-        [InlineData(100, true)]
-        [InlineData(1000, false)]
+        [Theory, InlineData(0, true), InlineData(0, false), InlineData(100, true), InlineData(1000, false)]
         public void TestSpecialAbility(int abilityId, bool active)
         {
             var data = new ToggleSpecialAbility(abilityId, active).Compile();
@@ -82,9 +76,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData("This is a header", "This is a body", "This is a footer")]
-        [InlineData(null, null, null)]
+        [Theory, InlineData("This is a header", "This is a body", "This is a footer"), InlineData(null, null, null)]
         public void TestDisplayProfile(string header, string body, string footer)
         {
             Serial m = 0x1000;
@@ -110,9 +102,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(LRReason.CannotLift)]
-        [InlineData(LRReason.TryToSteal)]
+        [Theory, InlineData(LRReason.CannotLift), InlineData(LRReason.TryToSteal)]
         public void TestLiftRej(LRReason reason)
         {
             var data = new LiftRej(reason).Compile();
@@ -140,9 +130,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(1, 2, 3)]
-        [InlineData(4, 5, 6)]
+        [Theory, InlineData(1, 2, 3), InlineData(4, 5, 6)]
         public void TestWeather(int type, int density, int temp)
         {
             var data = new Weather(type, density, temp).Compile();
@@ -235,10 +223,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(10)]
-        [InlineData(255)]
+        [Theory, InlineData(0), InlineData(10), InlineData(255)]
         public void TestSequence(byte num)
         {
             var data = new Sequence(num).Compile();
@@ -252,10 +237,8 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(SkillName.Alchemy, 0, 1)]
-        [InlineData(SkillName.Archery, 10, 1000)]
-        [InlineData(SkillName.Begging, 100000, 1000)]
+        [Theory, InlineData(SkillName.Alchemy, 0, 1), InlineData(SkillName.Archery, 10, 1000),
+         InlineData(SkillName.Begging, 100000, 1000)]
         public void TestSkillChange(SkillName skillName, int baseFixedPoint, int capFixedPoint)
         {
             // TODO: Eliminate all of this and just create a Skill directly
@@ -287,10 +270,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("This is a URL, I promise")]
+        [Theory, InlineData(null), InlineData(""), InlineData("This is a URL, I promise")]
         public void TestLaunchBrowser(string url)
         {
             var data = new LaunchBrowser(url).Compile();
@@ -341,9 +321,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(1, false)]
-        [InlineData(2, true)]
+        [Theory, InlineData(1, false), InlineData(2, true)]
         public void TestSeasonChange(int season, bool playSound)
         {
             var data = new SeasonChange(season, playSound).Compile();
@@ -358,10 +336,8 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(0x1024, "Test Title", true, true)]
-        [InlineData(0x1024, "Test Title", false, true)]
-        [InlineData(0x1024, "Test Title", true, false)]
+        [Theory, InlineData(0x1024, "Test Title", true, true), InlineData(0x1024, "Test Title", false, true),
+         InlineData(0x1024, "Test Title", true, false)]
         public void TestDisplayPaperdoll(uint m, string title, bool warmode, bool canLift)
         {
             var data = new DisplayPaperdoll(m, title, warmode, canLift).Compile();
@@ -388,10 +364,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(MusicName.Approach)]
-        [InlineData(MusicName.Combat1)]
-        [InlineData(MusicName.ValoriaShips)]
+        [Theory, InlineData(MusicName.Approach), InlineData(MusicName.Combat1), InlineData(MusicName.ValoriaShips)]
         public void TestPlayMusic(MusicName music)
         {
             var data = new PlayMusic(music).Compile();
@@ -405,9 +378,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(10, 1, "Some text")]
-        [InlineData(100, 10, "Some more text")]
+        [Theory, InlineData(10, 1, "Some text"), InlineData(100, 10, "Some more text")]
         public void TestScrollMessage(int type, int tip, string text)
         {
             var data = new ScrollMessage(type, tip, text).Compile();
@@ -462,10 +433,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(10)]
-        [InlineData(100)]
+        [Theory, InlineData(0), InlineData(10), InlineData(100)]
         public void TestPingAck(byte ping)
         {
             var data = new PingAck(ping).Compile();

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/SecureTradePacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/SecureTradePacketTests.cs
@@ -8,9 +8,8 @@ namespace Server.Tests.Network
 {
     public class SecureTradePacketTests : IClassFixture<ServerFixture>
     {
-        [Theory]
-        [InlineData("short-name")]
-        [InlineData("this is a really long name that is more than 30 characters, probably")]
+        [Theory, InlineData("short-name"),
+         InlineData("this is a really long name that is more than 30 characters, probably")]
         public void TestDisplaySecureTrade(string name)
         {
             var m = new Mobile(0x1);
@@ -59,9 +58,9 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(true, false)] // Update first
-        [InlineData(false, true)] // Update second
+        [Theory, InlineData(true, false), InlineData(false, true)]
+        // Update first
+         // Update second
         public void TestUpdateSecureTrade(bool first, bool second)
         {
             var firstCont = new Container(World.NewItem);
@@ -83,9 +82,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory]
-        [InlineData(100000, 30, TradeFlag.UpdateGold)]
-        [InlineData(250000, 50000, TradeFlag.UpdateLedger)]
+        [Theory, InlineData(100000, 30, TradeFlag.UpdateGold), InlineData(250000, 50000, TradeFlag.UpdateLedger)]
         public void TestUpdateGoldSecureTrade(int gold, int plat, TradeFlag flag)
         {
             var cont = new Container(World.NewItem);

--- a/Projects/Server.Tests/Tests/Utility/HexStringConverterTest.cs
+++ b/Projects/Server.Tests/Tests/Utility/HexStringConverterTest.cs
@@ -5,8 +5,7 @@ namespace Server.Tests.Accounting
 {
     public class HexStringConverterTest
     {
-        [Theory]
-        [InlineData("ABCDEF1234", new byte[] { 0xAB, 0xCD, 0xEF, 0x12, 0x34 })]
+        [Theory, InlineData("ABCDEF1234", new byte[] { 0xAB, 0xCD, 0xEF, 0x12, 0x34 })]
         public void TestGetBytes(string input, byte[] bytes)
         {
             Span<byte> outputBytes = stackalloc byte[input.Length / 2];
@@ -16,8 +15,7 @@ namespace Server.Tests.Accounting
             Assert.Equal(input, bytes.ToHexString());
         }
 
-        [Theory]
-        [InlineData("[AB, CD, EF, 12, 34]", new byte[] { 0xAB, 0xCD, 0xEF, 0x12, 0x34 })]
+        [Theory, InlineData("[AB, CD, EF, 12, 34]", new byte[] { 0xAB, 0xCD, 0xEF, 0x12, 0x34 })]
         public void TestsGetStringDelimited(string expected, byte[] bytes)
         {
             Assert.Equal(expected, bytes.ToDelimitedHexString());

--- a/Projects/Server.Tests/Tests/Utility/StringHelperTests.cs
+++ b/Projects/Server.Tests/Tests/Utility/StringHelperTests.cs
@@ -4,10 +4,8 @@ namespace Server.Tests
 {
     public class TestStringHelpers
     {
-        [Theory]
-        [InlineData(null, "default value", "default value")]
-        [InlineData("", "default value", "default value")]
-        [InlineData("this is a valid string", "default value", "this is a valid string")]
+        [Theory, InlineData(null, "default value", "default value"), InlineData("", "default value", "default value"),
+         InlineData("this is a valid string", "default value", "this is a valid string")]
         public void TestIsNullOrDefault(string value, string defaultValue, string expected)
         {
             var actual = value.DefaultIfNullOrEmpty(defaultValue);

--- a/Projects/Server/Buffers/CircularBuffer.cs
+++ b/Projects/Server/Buffers/CircularBuffer.cs
@@ -100,7 +100,7 @@ namespace System.Buffers
         {
             if (bytes.Length < Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(bytes.Length));
+                throw new ArgumentOutOfRangeException(nameof(bytes));
             }
 
             if (_first.Length > 0)

--- a/Projects/Server/Buffers/SpanReader.cs
+++ b/Projects/Server/Buffers/SpanReader.cs
@@ -21,7 +21,7 @@ using Server;
 
 namespace System.Buffers
 {
-    ref struct SpanReader
+    public ref struct SpanReader
     {
         private readonly ReadOnlySpan<byte> _buffer;
 

--- a/Projects/Server/ClientVersion.cs
+++ b/Projects/Server/ClientVersion.cs
@@ -32,7 +32,7 @@ namespace Server
 
             try
             {
-                var br1 = fmt.IndexOf('.');
+                var br1 = fmt.IndexOf('.', StringComparison.Ordinal);
                 var br2 = fmt.IndexOf('.', br1 + 1);
 
                 var br3 = br2 + 1;
@@ -60,12 +60,15 @@ namespace Server
                     }
                 }
 
-                if (fmt.IndexOf("god", StringComparison.Ordinal) >= 0 || fmt.IndexOf("gq", StringComparison.Ordinal) >= 0)
+                if (fmt.Contains("god", StringComparison.Ordinal) || fmt.Contains("gq", StringComparison.Ordinal))
                 {
                     Type = ClientType.God;
                 }
-                else if (fmt.IndexOf("third dawn", StringComparison.Ordinal) >= 0 || fmt.IndexOf("uo:td", StringComparison.Ordinal) >= 0 || fmt.IndexOf("uotd", StringComparison.Ordinal) >= 0 ||
-                         fmt.IndexOf("uo3d", StringComparison.Ordinal) >= 0 || fmt.IndexOf("uo:3d", StringComparison.Ordinal) >= 0)
+                else if (fmt.Contains("third dawn", StringComparison.Ordinal) ||
+                         fmt.Contains("uo:td", StringComparison.Ordinal) ||
+                         fmt.Contains("uotd", StringComparison.Ordinal) ||
+                         fmt.Contains("uo3d", StringComparison.Ordinal) ||
+                         fmt.Contains("uo:3d", StringComparison.Ordinal))
                 {
                     Type = ClientType.UOTD;
                 }

--- a/Projects/Server/Commands.cs
+++ b/Projects/Server/Commands.cs
@@ -188,7 +188,7 @@ namespace Server
 
         public static bool Handle(Mobile from, string text, MessageType type = MessageType.Regular)
         {
-            if (!text.StartsWith(Prefix) && type != MessageType.Command)
+            if (!text.StartsWith(Prefix, StringComparison.Ordinal) && type != MessageType.Command)
             {
                 return false;
             }
@@ -198,7 +198,7 @@ namespace Server
                 text = text.Substring(Prefix.Length);
             }
 
-            var indexOf = text.IndexOf(' ');
+            var indexOf = text.IndexOf(' ', StringComparison.Ordinal);
 
             string command;
             string[] args;

--- a/Projects/Server/Configuration/ServerConfiguration.cs
+++ b/Projects/Server/Configuration/ServerConfiguration.cs
@@ -244,7 +244,7 @@ namespace Server
                     break;
                 }
 
-                if (ipStr.IndexOf(':') == -1)
+                if (!ipStr.Contains(':', StringComparison.Ordinal))
                 {
                     ipStr += ":2593";
                 }

--- a/Projects/Server/Geometry/Point2D.cs
+++ b/Projects/Server/Geometry/Point2D.cs
@@ -55,7 +55,7 @@ namespace Server
 
         public static Point2D Parse(string value)
         {
-            var start = value.IndexOf('(');
+            var start = value.IndexOf('(', StringComparison.Ordinal);
             var end = value.IndexOf(',', start + 1);
 
             Utility.ToInt32(value.Substring(start + 1, end - (start + 1)).Trim(), out var x);

--- a/Projects/Server/Geometry/Point3D.cs
+++ b/Projects/Server/Geometry/Point3D.cs
@@ -77,7 +77,7 @@ namespace Server
 
         public static Point3D Parse(string value)
         {
-            var start = value.IndexOf('(');
+            var start = value.IndexOf('(', StringComparison.Ordinal);
             var end = value.IndexOf(',', start + 1);
 
             Utility.ToInt32(value.Substring(start + 1, end - (start + 1)).Trim(), out var x);

--- a/Projects/Server/Geometry/Rectangle2D.cs
+++ b/Projects/Server/Geometry/Rectangle2D.cs
@@ -13,11 +13,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System;
+
 namespace Server
 {
-    [NoSort]
-    [Parsable]
-    [PropertyObject]
+    [NoSort, Parsable, PropertyObject]
     public struct Rectangle2D
     {
         private Point2D m_Start;
@@ -43,7 +43,7 @@ namespace Server
 
         public static Rectangle2D Parse(string value)
         {
-            var start = value.IndexOf('(');
+            var start = value.IndexOf('(', StringComparison.Ordinal);
             var end = value.IndexOf(',', start + 1);
 
             Utility.ToInt32(value.Substring(start + 1, end - (start + 1)).Trim(), out var x);

--- a/Projects/Server/Geometry/Rectangle3D.cs
+++ b/Projects/Server/Geometry/Rectangle3D.cs
@@ -15,8 +15,7 @@
 
 namespace Server
 {
-    [NoSort]
-    [PropertyObject]
+    [NoSort, PropertyObject]
     public struct Rectangle3D
     {
         private Point3D m_Start;

--- a/Projects/Server/Geometry/WorldLocation.cs
+++ b/Projects/Server/Geometry/WorldLocation.cs
@@ -142,7 +142,7 @@ namespace Server
 
         public static WorldLocation Parse(string value)
         {
-            var start = value.IndexOf('(');
+            var start = value.IndexOf('(', StringComparison.Ordinal);
             var end = value.IndexOf(',', start + 1);
 
             Utility.ToInt32(value.Substring(start + 1, end - (start + 1)).Trim(), out var x);

--- a/Projects/Server/Gumps/Gump.cs
+++ b/Projects/Server/Gumps/Gump.cs
@@ -55,7 +55,7 @@ namespace Server.Gumps
 
         public bool Closable { get; set; } = true;
 
-        public static int GetTypeID(Type type) => type?.FullName?.GetHashCode() ?? -1;
+        public static int GetTypeID(Type type) => type?.FullName?.GetHashCode(StringComparison.Ordinal) ?? -1;
 
         public void AddPage(int page)
         {

--- a/Projects/Server/IAccount.cs
+++ b/Projects/Server/IAccount.cs
@@ -11,7 +11,7 @@ namespace Server.Accounting
         ///     By default, when 1,000,000,000 Gold is accumulated, it will transform
         ///     into 1 Platinum.
         ///     !!! WARNING !!!
-        ///     The client is designed to perceive the currency threashold at 1,000,000,000
+        ///     The client is designed to perceive the currency threshold at 1,000,000,000
         ///     if you change this, it may cause unexpected results when using secure trading.
         /// </summary>
         public static int CurrencyThreshold = 1000000000;

--- a/Projects/Server/Insensitive.cs
+++ b/Projects/Server/Insensitive.cs
@@ -19,6 +19,6 @@ namespace Server
             a != null && b != null && a.Length >= b.Length && Comparer.Compare(a.Substring(a.Length - b.Length), b) == 0;
 
         public static bool Contains(string a, string b) =>
-            a != null && b != null && a.Length >= b.Length && a.IndexOf(b, StringComparison.OrdinalIgnoreCase) >= 0;
+            a != null && b != null && a.Length >= b.Length && a.Contains(b, StringComparison.Ordinal);
     }
 }

--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -1847,7 +1847,7 @@ namespace Server.Items
                 {
                     line = line.Trim();
 
-                    if (line.Length == 0 || line.StartsWith("#"))
+                    if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -524,8 +524,7 @@ namespace Server
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
         public int PileWeight => (int)Math.Ceiling(Weight * Amount);
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public virtual int Hue
         {
             get => m_Hue;

--- a/Projects/Server/Json/Converters/NullableStructSerializerFactory.cs
+++ b/Projects/Server/Json/Converters/NullableStructSerializerFactory.cs
@@ -25,7 +25,9 @@ namespace System.Text.Json.Serialization
             }
 
             var structType = typeToConvert.GenericTypeArguments[0];
-            return !structType.IsPrimitive && structType.Namespace?.StartsWith(nameof(System)) != true && !structType.IsEnum;
+            return !structType.IsPrimitive &&
+                   structType.Namespace?.StartsWith(nameof(System), StringComparison.Ordinal) != true &&
+                   !structType.IsEnum;
         }
 
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options) =>

--- a/Projects/Server/Main.cs
+++ b/Projects/Server/Main.cs
@@ -61,7 +61,9 @@ namespace Server
         public static bool IsRunningFromXUnit =>
             m_IsRunningFromXUnit ??= AppDomain.CurrentDomain.GetAssemblies()
                 .Any(
-                    a => a.FullName?.ToLowerInvariant().StartsWith("xunit") ?? false
+                    a => a.FullName?
+                        .ToUpperInvariant()
+                        .StartsWith("XUNIT", StringComparison.Ordinal) ?? false
                 );
 
         public static bool Profiling

--- a/Projects/Server/Mobiles/Body.cs
+++ b/Projects/Server/Mobiles/Body.cs
@@ -28,7 +28,7 @@ namespace Server
 
                 while ((line = ip.ReadLine()) != null)
                 {
-                    if (line.Length == 0 || line.StartsWith("#"))
+                    if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -9532,7 +9532,7 @@ namespace Server
             Effects.SendTargetEffect(this, itemID, speed, duration, hue, renderMode);
 
         public void FixedEffect(int itemID, int speed, int duration) =>
-            Effects.SendTargetEffect(this, itemID, speed, duration, 0, 0);
+            Effects.SendTargetEffect(this, itemID, speed, duration);
 
         public void FixedParticles(
             int itemID, int speed, int duration, int effect, int hue, int renderMode, EffectLayer layer, int unknown
@@ -9542,13 +9542,13 @@ namespace Server
         public void FixedParticles(
             int itemID, int speed, int duration, int effect, int hue, int renderMode, EffectLayer layer
         ) =>
-            Effects.SendTargetParticles(this, itemID, speed, duration, hue, renderMode, effect, layer, 0);
+            Effects.SendTargetParticles(this, itemID, speed, duration, hue, renderMode, effect, layer);
 
         public void FixedParticles(int itemID, int speed, int duration, int effect, EffectLayer layer, int unknown) =>
             Effects.SendTargetParticles(this, itemID, speed, duration, 0, 0, effect, layer, unknown);
 
         public void FixedParticles(int itemID, int speed, int duration, int effect, EffectLayer layer) =>
-            Effects.SendTargetParticles(this, itemID, speed, duration, 0, 0, effect, layer, 0);
+            Effects.SendTargetParticles(this, itemID, speed, duration, 0, 0, effect, layer);
 
         public void BoltEffect(int hue) => Effects.SendBoltEffect(this, true, hue);
 

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -293,8 +293,7 @@ namespace Server
         Locked
     }
 
-    [CustomEnum(new[] { "North", "Right", "East", "Down", "South", "Left", "West", "Up" })]
-    [Flags]
+    [CustomEnum(new[] { "North", "Right", "East", "Down", "South", "Left", "West", "Up" }), Flags]
     public enum Direction : byte
     {
         North = 0x0,
@@ -1340,8 +1339,7 @@ namespace Server
 
         public virtual int Luck => 0;
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public int HueMod
         {
             get => m_HueMod;
@@ -1356,8 +1354,7 @@ namespace Server
             }
         }
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public virtual int Hue
         {
             get
@@ -1778,8 +1775,7 @@ namespace Server
             }
         }
 
-        [Body]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Body, CommandProperty(AccessLevel.GameMaster)]
         public Body Body
         {
             get
@@ -1805,8 +1801,7 @@ namespace Server
             }
         }
 
-        [Body]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Body, CommandProperty(AccessLevel.GameMaster)]
         public int BodyValue
         {
             get => Body.BodyID;
@@ -2481,8 +2476,6 @@ namespace Server
             get => m_Poison;
             set
             {
-                /*if (m_Poison != value && (m_Poison == null || value == null || m_Poison.Level < value.Level))
-                {*/
                 m_Poison = value;
                 Delta(MobileDelta.HealthbarPoison);
 
@@ -2500,7 +2493,6 @@ namespace Server
                 }
 
                 CheckStatTimers();
-                /*}*/
             }
         }
 
@@ -9171,7 +9163,7 @@ namespace Server
             CheckStatTimers();
         }
 
-        private MobileDelta GetStatDelta(StatType type)
+        private static MobileDelta GetStatDelta(StatType type)
         {
             MobileDelta delta = 0;
 

--- a/Projects/Server/Mobiles/MovementRecord.cs
+++ b/Projects/Server/Mobiles/MovementRecord.cs
@@ -20,7 +20,7 @@ namespace Server.Mobiles
     public class MovementRecord
     {
         private static readonly Queue<MovementRecord> m_InstancePool = new Queue<MovementRecord>();
-        public long m_End;
+        private long m_End;
 
         private MovementRecord(long end) => m_End = end;
 

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -513,7 +513,7 @@ namespace Server.Network
                         continue;
                     }
 
-                    var bytesWritten = await Connection.SendAsync(result.Buffer, SocketFlags.None);
+                    var bytesWritten = await Connection.SendAsync(result.Buffer, SocketFlags.None).ConfigureAwait(false);
 
                     if (bytesWritten > 0)
                     {
@@ -567,7 +567,7 @@ namespace Server.Network
                         continue;
                     }
 
-                    var bytesWritten = await socket.ReceiveAsync(result.Buffer, SocketFlags.None);
+                    var bytesWritten = await socket.ReceiveAsync(result.Buffer, SocketFlags.None).ConfigureAwait(false);
                     if (bytesWritten <= 0)
                     {
                         break;

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -596,11 +596,9 @@ namespace Server.Network
 
         public static void HandleAllReceives()
         {
-            var clients = TcpServer.Instances;
-
-            for (int i = 0; i < clients.Count; ++i)
+            foreach (var ns in TcpServer.Instances)
             {
-                clients[i].HandleReceive();
+                ns.HandleReceive();
             }
         }
 
@@ -662,11 +660,9 @@ namespace Server.Network
 
         public static void FlushAll()
         {
-            var clients = TcpServer.Instances;
-
-            for (int i = 0; i < clients.Count; ++i)
+            foreach (var ns in TcpServer.Instances)
             {
-                clients[i].Flush();
+                ns.Flush();
             }
         }
 
@@ -685,11 +681,9 @@ namespace Server.Network
             {
                 long curTicks = Core.TickCount;
 
-                var clients = TcpServer.Instances;
-
-                for (int i = 0; i < clients.Count; ++i)
+                foreach (var ns in TcpServer.Instances)
                 {
-                    clients[i].CheckAlive(curTicks);
+                    ns.CheckAlive(curTicks);
                 }
             }
             catch (Exception ex)

--- a/Projects/Server/Network/Packet.cs
+++ b/Projects/Server/Network/Packet.cs
@@ -120,9 +120,11 @@ namespace Server.Network
             }
         }
 
+        private readonly object _object = new object();
+
         public byte[] Compile(bool compress, out int length)
         {
-            lock (this)
+            lock (_object)
             {
                 if (m_CompiledBuffer == null)
                 {

--- a/Projects/Server/Network/Packet.cs
+++ b/Projects/Server/Network/Packet.cs
@@ -10,7 +10,6 @@ namespace Server.Network
     {
         private const int CompressorBufferSize = 0x10000;
 
-        private const int BufferSize = 4096;
         private readonly int m_Length;
 
         private byte[] m_CompiledBuffer;

--- a/Projects/Server/Network/Packets/OutgoingAccountPackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingAccountPackets.cs
@@ -15,8 +15,8 @@
 
 using System;
 using System.IO;
-using Server.Accounting;
 using System.Buffers;
+using Server.Accounting;
 
 namespace Server.Network
 {

--- a/Projects/Server/Network/TcpServer.cs
+++ b/Projects/Server/Network/TcpServer.cs
@@ -180,7 +180,7 @@ namespace Server.Network
 
                 try
                 {
-                    socket = await listener.AcceptSocketAsync();
+                    socket = await listener.AcceptSocketAsync().ConfigureAwait(false);
                     if (Instances.Count >= MaxConnections)
                     {
                         socket.Send(socketRejected, SocketFlags.None);
@@ -205,8 +205,10 @@ namespace Server.Network
 
                     if (_nextMaximumSocketsReachedMessage <= ticks)
                     {
-                        var ipep = (IPEndPoint)socket!.RemoteEndPoint;
-                        Console.WriteLine("Listener {0}:{1}: Failed (Maximum connections reached)", ipep.Address, ipep.Port);
+                        if (socket?.RemoteEndPoint is IPEndPoint ipep)
+                        {
+                            Console.WriteLine("Listener {0}:{1}: Failed (Maximum connections reached)", ipep.Address, ipep.Port);
+                        }
                         _nextMaximumSocketsReachedMessage = ticks + _listenerErrorMessageDelay;
                     }
                 }

--- a/Projects/Server/Network/TcpServer.cs
+++ b/Projects/Server/Network/TcpServer.cs
@@ -39,7 +39,7 @@ namespace Server.Network
 
         public static IPEndPoint[] ListeningAddresses { get; private set; }
         public static TcpListener[] Listeners { get; private set; }
-        public static List<NetState> Instances { get; } = new List<NetState>(128);
+        public static HashSet<NetState> Instances { get; } = new HashSet<NetState>(128);
 
         public static ConcurrentQueue<NetState> m_ConnectedQueue = new ConcurrentQueue<NetState>();
 

--- a/Projects/Server/ObjectPropertyList.cs
+++ b/Projects/Server/ObjectPropertyList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text;
 using Server.Network;
@@ -99,7 +100,7 @@ namespace Server
             }
 
             AddHash(number);
-            AddHash(arguments.GetHashCode());
+            AddHash(arguments.GetHashCode(StringComparison.Ordinal));
 
             Stream.Write(number);
 

--- a/Projects/Server/Serialization/BinaryFileWriter.cs
+++ b/Projects/Server/Serialization/BinaryFileWriter.cs
@@ -31,25 +31,25 @@ namespace Server
             m_Position = m_File.Position;
         }
 
-        public override long Position => m_Position + m_Index;
+        public override long Position => m_Position + Index;
 
 
         protected override int BufferSize => 512;
 
         public override void Flush()
         {
-            if (m_Index > 0)
+            if (Index > 0)
             {
-                m_Position += m_Index;
+                m_Position += Index;
 
-                m_File.Write(m_Buffer, 0, (int)m_Index);
-                m_Index = 0;
+                m_File.Write(Buffer, 0, (int)Index);
+                Index = 0;
             }
         }
 
         public override void Close()
         {
-            if (m_Index > 0)
+            if (Index > 0)
             {
                 Flush();
             }

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -30,8 +30,7 @@ namespace Server
         private readonly Encoding m_Encoding;
         private readonly bool m_PrefixStrings;
 
-        protected byte[] m_Buffer;
-        protected long m_Index;
+        protected long Index { get; set; }
 
         private readonly char[] m_SingleCharBuffer = new char[1];
 
@@ -43,21 +42,21 @@ namespace Server
         {
             m_PrefixStrings = prefixStr;
             m_Encoding = Utility.UTF8;
-            m_Buffer = buffer;
+            Buffer = buffer;
         }
 
         public BufferWriter(bool prefixStr)
         {
             m_PrefixStrings = prefixStr;
             m_Encoding = Utility.UTF8;
-            m_Buffer = new byte[BufferSize];
+            Buffer = new byte[BufferSize];
         }
 
-        public virtual long Position => m_Index;
+        public virtual long Position => Index;
 
         protected virtual int BufferSize => 256;
 
-        public byte[] Data => m_Buffer;
+        public byte[] Buffer { get; protected set; }
 
         public virtual void Close()
         {
@@ -68,28 +67,28 @@ namespace Server
         public void Resize(int size)
         {
             var copy = new byte[size];
-            Buffer.BlockCopy(m_Buffer, 0, copy, 0, Math.Min(size, m_Buffer.Length));
-            m_Buffer = copy;
+            System.Buffer.BlockCopy(Buffer, 0, copy, 0, Math.Min(size, Buffer.Length));
+            Buffer = copy;
         }
 
         public virtual void Flush()
         {
-            Resize(m_Buffer.Length * 2);
+            Resize(Buffer.Length * 2);
         }
 
         public void Reset()
         {
-            m_Index = 0;
+            Index = 0;
         }
 
         public virtual long Seek(long offset, SeekOrigin origin)
         {
             return origin switch
             {
-                SeekOrigin.Begin   => m_Index = offset,
-                SeekOrigin.Current => m_Index += offset,
-                SeekOrigin.End     => m_Index = BufferSize - offset,
-                _                  => m_Index
+                SeekOrigin.Begin   => Index = offset,
+                SeekOrigin.Current => Index += offset,
+                SeekOrigin.End     => Index = BufferSize - offset,
+                _                  => Index
             };
         }
 
@@ -99,21 +98,21 @@ namespace Server
 
             while (v >= 0x80)
             {
-                if (m_Index + 1 > m_Buffer.Length)
+                if (Index + 1 > Buffer.Length)
                 {
                     Flush();
                 }
 
-                m_Buffer[m_Index++] = (byte)(v | 0x80);
+                Buffer[Index++] = (byte)(v | 0x80);
                 v >>= 7;
             }
 
-            if (m_Index + 1 > m_Buffer.Length)
+            if (Index + 1 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index++] = (byte)v;
+            Buffer[Index++] = (byte)v;
         }
 
         public void Write(string value)
@@ -122,21 +121,21 @@ namespace Server
             {
                 if (value == null)
                 {
-                    if (m_Index + 1 > m_Buffer.Length)
+                    if (Index + 1 > Buffer.Length)
                     {
                         Flush();
                     }
 
-                    m_Buffer[m_Index++] = 0;
+                    Buffer[Index++] = 0;
                 }
                 else
                 {
-                    if (m_Index + 1 > m_Buffer.Length)
+                    if (Index + 1 > Buffer.Length)
                     {
                         Flush();
                     }
 
-                    m_Buffer[m_Index++] = 1;
+                    Buffer[Index++] = 1;
 
                     InternalWriteString(value);
                 }
@@ -199,143 +198,143 @@ namespace Server
 
         public void Write(long value)
         {
-            if (m_Index + 8 > m_Buffer.Length)
+            if (Index + 8 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index] = (byte)value;
-            m_Buffer[m_Index + 1] = (byte)(value >> 8);
-            m_Buffer[m_Index + 2] = (byte)(value >> 16);
-            m_Buffer[m_Index + 3] = (byte)(value >> 24);
-            m_Buffer[m_Index + 4] = (byte)(value >> 32);
-            m_Buffer[m_Index + 5] = (byte)(value >> 40);
-            m_Buffer[m_Index + 6] = (byte)(value >> 48);
-            m_Buffer[m_Index + 7] = (byte)(value >> 56);
-            m_Index += 8;
+            Buffer[Index] = (byte)value;
+            Buffer[Index + 1] = (byte)(value >> 8);
+            Buffer[Index + 2] = (byte)(value >> 16);
+            Buffer[Index + 3] = (byte)(value >> 24);
+            Buffer[Index + 4] = (byte)(value >> 32);
+            Buffer[Index + 5] = (byte)(value >> 40);
+            Buffer[Index + 6] = (byte)(value >> 48);
+            Buffer[Index + 7] = (byte)(value >> 56);
+            Index += 8;
         }
 
         public void Write(ulong value)
         {
-            if (m_Index + 8 > m_Buffer.Length)
+            if (Index + 8 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index] = (byte)value;
-            m_Buffer[m_Index + 1] = (byte)(value >> 8);
-            m_Buffer[m_Index + 2] = (byte)(value >> 16);
-            m_Buffer[m_Index + 3] = (byte)(value >> 24);
-            m_Buffer[m_Index + 4] = (byte)(value >> 32);
-            m_Buffer[m_Index + 5] = (byte)(value >> 40);
-            m_Buffer[m_Index + 6] = (byte)(value >> 48);
-            m_Buffer[m_Index + 7] = (byte)(value >> 56);
-            m_Index += 8;
+            Buffer[Index] = (byte)value;
+            Buffer[Index + 1] = (byte)(value >> 8);
+            Buffer[Index + 2] = (byte)(value >> 16);
+            Buffer[Index + 3] = (byte)(value >> 24);
+            Buffer[Index + 4] = (byte)(value >> 32);
+            Buffer[Index + 5] = (byte)(value >> 40);
+            Buffer[Index + 6] = (byte)(value >> 48);
+            Buffer[Index + 7] = (byte)(value >> 56);
+            Index += 8;
         }
 
         public void Write(int value)
         {
-            if (m_Index + 4 > m_Buffer.Length)
+            if (Index + 4 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index] = (byte)value;
-            m_Buffer[m_Index + 1] = (byte)(value >> 8);
-            m_Buffer[m_Index + 2] = (byte)(value >> 16);
-            m_Buffer[m_Index + 3] = (byte)(value >> 24);
-            m_Index += 4;
+            Buffer[Index] = (byte)value;
+            Buffer[Index + 1] = (byte)(value >> 8);
+            Buffer[Index + 2] = (byte)(value >> 16);
+            Buffer[Index + 3] = (byte)(value >> 24);
+            Index += 4;
         }
 
         public void Write(uint value)
         {
-            if (m_Index + 4 > m_Buffer.Length)
+            if (Index + 4 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index] = (byte)value;
-            m_Buffer[m_Index + 1] = (byte)(value >> 8);
-            m_Buffer[m_Index + 2] = (byte)(value >> 16);
-            m_Buffer[m_Index + 3] = (byte)(value >> 24);
-            m_Index += 4;
+            Buffer[Index] = (byte)value;
+            Buffer[Index + 1] = (byte)(value >> 8);
+            Buffer[Index + 2] = (byte)(value >> 16);
+            Buffer[Index + 3] = (byte)(value >> 24);
+            Index += 4;
         }
 
         public void Write(short value)
         {
-            if (m_Index + 2 > m_Buffer.Length)
+            if (Index + 2 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index] = (byte)value;
-            m_Buffer[m_Index + 1] = (byte)(value >> 8);
-            m_Index += 2;
+            Buffer[Index] = (byte)value;
+            Buffer[Index + 1] = (byte)(value >> 8);
+            Index += 2;
         }
 
         public void Write(ushort value)
         {
-            if (m_Index + 2 > m_Buffer.Length)
+            if (Index + 2 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index] = (byte)value;
-            m_Buffer[m_Index + 1] = (byte)(value >> 8);
-            m_Index += 2;
+            Buffer[Index] = (byte)value;
+            Buffer[Index + 1] = (byte)(value >> 8);
+            Index += 2;
         }
 
         public unsafe void Write(double value)
         {
-            if (m_Index + 8 > m_Buffer.Length)
+            if (Index + 8 > Buffer.Length)
             {
                 Flush();
             }
 
-            fixed (byte* pBuffer = m_Buffer)
+            fixed (byte* pBuffer = Buffer)
             {
-                *(double*)(pBuffer + m_Index) = value;
+                *(double*)(pBuffer + Index) = value;
             }
 
-            m_Index += 8;
+            Index += 8;
         }
 
         public unsafe void Write(float value)
         {
-            if (m_Index + 4 > m_Buffer.Length)
+            if (Index + 4 > Buffer.Length)
             {
                 Flush();
             }
 
-            fixed (byte* pBuffer = m_Buffer)
+            fixed (byte* pBuffer = Buffer)
             {
-                *(float*)(pBuffer + m_Index) = value;
+                *(float*)(pBuffer + Index) = value;
             }
 
-            m_Index += 4;
+            Index += 4;
         }
 
         public void Write(char value)
         {
-            if (m_Index + 8 > m_Buffer.Length)
+            if (Index + 8 > Buffer.Length)
             {
                 Flush();
             }
 
             m_SingleCharBuffer[0] = value;
 
-            var byteCount = m_Encoding.GetBytes(m_SingleCharBuffer, 0, 1, m_Buffer, (int)m_Index);
-            m_Index += byteCount;
+            var byteCount = m_Encoding.GetBytes(m_SingleCharBuffer, 0, 1, Buffer, (int)Index);
+            Index += byteCount;
         }
 
         public void Write(byte value)
         {
-            if (m_Index + 1 > m_Buffer.Length)
+            if (Index + 1 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index++] = value;
+            Buffer[Index++] = value;
         }
 
         public void Write(byte[] value, int length)
@@ -345,15 +344,15 @@ namespace Server
 
             while (remaining > 0)
             {
-                int size = Math.Min(m_Buffer.Length - (int)m_Index, remaining);
-                Buffer.BlockCopy(value, idx, m_Buffer, (int)m_Index, size);
+                int size = Math.Min(Buffer.Length - (int)Index, remaining);
+                System.Buffer.BlockCopy(value, idx, Buffer, (int)Index, size);
                 // value.Slice(idx).CopyTo(m_Buffer.AsSpan(m_Index, size));
 
                 remaining -= size;
-                m_Index += size;
+                Index += size;
                 idx += size;
 
-                if (m_Index == m_Buffer.Length)
+                if (Index == Buffer.Length)
                 {
                     Flush();
                 }
@@ -362,22 +361,22 @@ namespace Server
 
         public void Write(sbyte value)
         {
-            if (m_Index + 1 > m_Buffer.Length)
+            if (Index + 1 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index++] = (byte)value;
+            Buffer[Index++] = (byte)value;
         }
 
         public void Write(bool value)
         {
-            if (m_Index + 1 > m_Buffer.Length)
+            if (Index + 1 > Buffer.Length)
             {
                 Flush();
             }
 
-            m_Buffer[m_Index++] = (byte)(value ? 1 : 0);
+            Buffer[Index++] = (byte)(value ? 1 : 0);
         }
 
         public void Write(Point3D value)
@@ -773,13 +772,13 @@ namespace Server
                     var charCount = charsLeft > m_MaxBufferChars ? m_MaxBufferChars : charsLeft;
                     var byteLength = m_Encoding.GetBytes(value, current, charCount, m_CharacterBuffer, 0);
 
-                    if (m_Index + byteLength > m_Buffer.Length)
+                    if (Index + byteLength > Buffer.Length)
                     {
                         Flush();
                     }
 
-                    Buffer.BlockCopy(m_CharacterBuffer, 0, m_Buffer, (int)m_Index, byteLength);
-                    m_Index += byteLength;
+                    System.Buffer.BlockCopy(m_CharacterBuffer, 0, Buffer, (int)Index, byteLength);
+                    Index += byteLength;
 
                     current += charCount;
                     charsLeft -= charCount;
@@ -789,13 +788,13 @@ namespace Server
             {
                 var byteLength = m_Encoding.GetBytes(value, 0, value.Length, m_CharacterBuffer, 0);
 
-                if (m_Index + byteLength > m_Buffer.Length)
+                if (Index + byteLength > Buffer.Length)
                 {
                     Flush();
                 }
 
-                Buffer.BlockCopy(m_CharacterBuffer, 0, m_Buffer, (int)m_Index, byteLength);
-                m_Index += byteLength;
+                System.Buffer.BlockCopy(m_CharacterBuffer, 0, Buffer, (int)Index, byteLength);
+                Index += byteLength;
             }
         }
     }

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -32,8 +32,8 @@
         </PackageReference>
         <PackageReference Include="Zlib.Bindings" Version="1.4.0" />
     </ItemGroup>
-    <ItemGroup Condition="'$(Configuration)'=='Analyze'">
-        <AdditionalFiles Include="..\..\stylecop.json" />
-        <AdditionalFiles Include="..\..\Rules.ruleset" />
-    </ItemGroup>
+<!--    <ItemGroup Condition="'$(Configuration)'=='Analyze'">-->
+<!--        <AdditionalFiles Include="..\..\stylecop.json" />-->
+<!--        <AdditionalFiles Include="..\..\Rules.ruleset" />-->
+<!--    </ItemGroup>-->
 </Project>

--- a/Projects/Server/TileMatrixPatch.cs
+++ b/Projects/Server/TileMatrixPatch.cs
@@ -5,9 +5,6 @@ namespace Server
 {
     public class TileMatrixPatch
     {
-        private readonly int m_LandBlocks;
-        private readonly int m_StaticBlocks;
-
         private StaticTile[] m_TileBuffer = new StaticTile[128];
 
         public TileMatrixPatch(TileMatrix matrix, int index)
@@ -22,7 +19,7 @@ namespace Server
 
             if (File.Exists(mapDataPath) && File.Exists(mapIndexPath))
             {
-                m_LandBlocks = PatchLand(matrix, mapDataPath, mapIndexPath);
+                LandBlocks = PatchLand(matrix, mapDataPath, mapIndexPath);
             }
 
             var staDataPath = Core.FindDataFile($"stadif{index}.mul", false);
@@ -31,33 +28,16 @@ namespace Server
 
             if (File.Exists(staDataPath) && File.Exists(staIndexPath) && File.Exists(staLookupPath))
             {
-                m_StaticBlocks = PatchStatics(matrix, staDataPath, staIndexPath, staLookupPath);
+                StaticBlocks = PatchStatics(matrix, staDataPath, staIndexPath, staLookupPath);
             }
         }
 
+        // TODO: Use configuration
         public static bool Enabled { get; set; } = true;
 
-        public int LandBlocks
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_LandBlocks;
-                }
-            }
-        }
+        public int LandBlocks { get; }
 
-        public int StaticBlocks
-        {
-            get
-            {
-                lock (this)
-                {
-                    return m_StaticBlocks;
-                }
-            }
-        }
+        public int StaticBlocks { get; }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
         private unsafe int PatchLand(TileMatrix matrix, string dataPath, string indexPath)

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -215,9 +215,9 @@ namespace Server
                 return "";
             }
 
-            var hasOpen = str.IndexOf('<') >= 0;
-            var hasClose = str.IndexOf('>') >= 0;
-            var hasPound = str.IndexOf('#') >= 0;
+            var hasOpen = str.Contains('<', StringComparison.Ordinal);
+            var hasClose = str.Contains('>', StringComparison.Ordinal);
+            var hasPound = str.Contains('#', StringComparison.Ordinal);
 
             if (!hasOpen && !hasClose && !hasPound)
             {
@@ -942,7 +942,7 @@ namespace Server
             int i;
 
 #pragma warning disable CA1806 // Do not ignore method results
-            if (value.StartsWith("0x"))
+            if (value.StartsWith("0x", StringComparison.Ordinal))
             {
                 int.TryParse(value.Substring(2), NumberStyles.HexNumber, null, out i);
             }
@@ -960,7 +960,7 @@ namespace Server
             uint i;
 
 #pragma warning disable CA1806 // Do not ignore method results
-            if (value.StartsWith("0x"))
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
             {
                 uint.TryParse(value.Substring(2), NumberStyles.HexNumber, null, out i);
             }
@@ -974,12 +974,12 @@ namespace Server
         }
 
         public static bool ToInt32(string value, out int i) =>
-            value.StartsWith("0x")
+            value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
                 ? int.TryParse(value.Substring(2), NumberStyles.HexNumber, null, out i)
                 : int.TryParse(value, out i);
 
         public static bool ToUInt32(string value, out uint i) =>
-            value.StartsWith("0x")
+            value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
                 ? uint.TryParse(value.Substring(2), NumberStyles.HexNumber, null, out i)
                 : uint.TryParse(value, out i);
 

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -891,23 +891,42 @@ namespace Server
             }
         }
 
-        public static List<TOutput> CastListContravariant<TInput, TOutput>(List<TInput> list) where TInput : TOutput =>
-            list.ConvertAll(value => (TOutput)value);
-
-        public static List<TOutput> CastListCovariant<TInput, TOutput>(List<TInput> list) where TOutput : TInput =>
-            list.ConvertAll(value => (TOutput)value);
-
-        public static List<TOutput> SafeConvertList<TInput, TOutput>(List<TInput> list) where TOutput : class
+        public static List<TOutput> CastListContravariant<TInput, TOutput>(this IReadOnlyCollection<TInput> coll)
+            where TInput : TOutput
         {
-            if ((list?.Capacity ?? 0) == 0)
+            var outputList = new List<TOutput>();
+            foreach (var entry in coll)
             {
-                return new List<TOutput>();
+                outputList.Add(entry);
             }
 
-            var output = new List<TOutput>(list.Capacity);
-            output.AddRange(list.OfType<TOutput>());
+            return outputList;
+        }
 
-            return output;
+        public static List<TOutput> CastListCovariant<TInput, TOutput>(this IReadOnlyCollection<TInput> coll)
+            where TOutput : TInput
+        {
+            var outputList = new List<TOutput>();
+            foreach (var entry in coll)
+            {
+                outputList.Add((TOutput)entry);
+            }
+
+            return outputList;
+        }
+
+        public static List<TOutput> SafeConvertList<TInput, TOutput>(this IReadOnlyCollection<TInput> coll) where TOutput : class
+        {
+            var outputList = new List<TOutput>();
+            foreach (var entry in coll)
+            {
+                if (entry is TOutput outEntry)
+                {
+                    outputList.Add(outEntry);
+                }
+            }
+
+            return outputList;
         }
 
         public static bool ToBoolean(string value)

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1034,7 +1034,7 @@ namespace Server
         public static string GetAttribute(XmlElement node, string attributeName, string defaultValue = null) =>
             node?.Attributes[attributeName]?.Value ?? defaultValue;
 
-        public static string GetText(XmlElement node, string defaultValue) => node == null ? defaultValue : node.InnerText;
+        public static string GetText(XmlElement node, string defaultValue) => node?.InnerText ?? defaultValue;
 
         public static int GetAddressValue(IPAddress address) => BitConverter.ToInt32(address.GetAddressBytes(), 0);
 

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -73,7 +73,8 @@ namespace Server
                     }
                 }
 
-                throw new Exception("No serials left to allocate for mobiles");
+                OutOfMemory("No serials left to allocate for mobiles");
+                return Serial.MinusOne;
             }
         }
 
@@ -98,7 +99,8 @@ namespace Server
                     }
                 }
 
-                throw new Exception("No serials left to allocate for items");
+                OutOfMemory("No serials left to allocate for items");
+                return Serial.MinusOne;
             }
         }
 
@@ -113,6 +115,8 @@ namespace Server
                 return _lastGuild;
             }
         }
+
+        private static void OutOfMemory(string message) => throw new OutOfMemoryException(message);
 
         internal static int _Saves;
         internal static List<Type> ItemTypes { get; } = new List<Type>();
@@ -338,7 +342,7 @@ namespace Server
                 reader.Seek(entry.Position, SeekOrigin.Begin);
 
                 t.SaveBuffer = new BufferWriter(new byte[entry.Length], true);
-                reader.Read(t.SaveBuffer.Data);
+                reader.Read(t.SaveBuffer.Buffer);
             }
 
             reader.Close();
@@ -737,7 +741,7 @@ namespace Server
         public static void SerializeTo(this ISerializable entity, IGenericWriter writer)
         {
             var saveBuffer = entity.SaveBuffer;
-            writer.Write(saveBuffer.Data, (int)saveBuffer.Position);
+            writer.Write(saveBuffer.Buffer, (int)saveBuffer.Position);
 
             // Resize to exact buffer size
             entity.SaveBuffer.Resize((int)entity.SaveBuffer.Position);

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -161,15 +161,13 @@ namespace Server
                 p = new UnicodeMessage(Serial.MinusOne, -1, MessageType.Regular, hue, 3, "ENU", "System", text);
             }
 
-            var list = TcpServer.Instances;
-
             p.Acquire();
 
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var ns in TcpServer.Instances)
             {
-                if (list[i].Mobile != null)
+                if (ns.Mobile != null)
                 {
-                    list[i].Send(p);
+                    ns.Send(p);
                 }
             }
 

--- a/Projects/UOContent.Tests/Accounting/Security/PasswordProtectionTest.cs
+++ b/Projects/UOContent.Tests/Accounting/Security/PasswordProtectionTest.cs
@@ -9,12 +9,9 @@ namespace Server.Tests.Accounting.Security
     {
         private const string plainPassword = "hello-good-sir";
 
-        [Theory]
-        [InlineData(typeof(Argon2PasswordProtection))]
-        [InlineData(typeof(PBKDF2PasswordProtection))]
-        [InlineData(typeof(SHA2PasswordProtection))]
-        [InlineData(typeof(SHA1PasswordProtection))]
-        [InlineData(typeof(MD5PasswordProtection))]
+        [Theory, InlineData(typeof(Argon2PasswordProtection)), InlineData(typeof(PBKDF2PasswordProtection)),
+         InlineData(typeof(SHA2PasswordProtection)), InlineData(typeof(SHA1PasswordProtection)),
+         InlineData(typeof(MD5PasswordProtection))]
         public void TestValidates(Type protectionType)
         {
             var passwordProtection = Activator.CreateInstance(protectionType) as IPasswordProtection;
@@ -28,12 +25,9 @@ namespace Server.Tests.Accounting.Security
             Assert.True(passwordProtection.ValidatePassword(encryptedPassword, plainPassword));
         }
 
-        [Theory]
-        [InlineData(typeof(Argon2PasswordProtection))]
-        [InlineData(typeof(PBKDF2PasswordProtection))]
-        [InlineData(typeof(SHA2PasswordProtection))]
-        [InlineData(typeof(SHA1PasswordProtection))]
-        [InlineData(typeof(MD5PasswordProtection))]
+        [Theory, InlineData(typeof(Argon2PasswordProtection)), InlineData(typeof(PBKDF2PasswordProtection)),
+         InlineData(typeof(SHA2PasswordProtection)), InlineData(typeof(SHA1PasswordProtection)),
+         InlineData(typeof(MD5PasswordProtection))]
         public void TestPasswordDoesNotValidate(Type protectionType)
         {
             var passwordProtection = Activator.CreateInstance(protectionType) as IPasswordProtection;

--- a/Projects/UOContent.Tests/Network/Packets/ArrowPacketTests.cs
+++ b/Projects/UOContent.Tests/Network/Packets/ArrowPacketTests.cs
@@ -18,10 +18,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(100, 10)]
-        [InlineData(100000, 100000)]
+        [Theory, InlineData(0, 0), InlineData(100, 10), InlineData(100000, 100000)]
         public void TestSetArrow(int x, int y)
         {
             var expected = new SetArrow(x, y).Compile();
@@ -33,10 +30,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(100, 10)]
-        [InlineData(100000, 100000)]
+        [Theory, InlineData(0, 0), InlineData(100, 10), InlineData(100000, 100000)]
         public void TestCancelArrowHS(int x, int y)
         {
             Serial serial = 0x1024;
@@ -51,10 +45,7 @@ namespace Server.Tests.Network
             AssertThat.Equal(result.Buffer[0].AsSpan(0), expected);
         }
 
-        [Theory]
-        [InlineData(0, 0)]
-        [InlineData(100, 10)]
-        [InlineData(100000, 100000)]
+        [Theory, InlineData(0, 0), InlineData(100, 10), InlineData(100000, 100000)]
         public void TestSetArrowHS(int x, int y)
         {
             Serial serial = 0x1024;

--- a/Projects/UOContent/Accounting/AccessRestrictions.cs
+++ b/Projects/UOContent/Accounting/AccessRestrictions.cs
@@ -16,7 +16,7 @@ namespace Server
         {
             try
             {
-                var ip = ((IPEndPoint)e.Connection.RemoteEndPoint).Address;
+                var ip = (e.Connection.RemoteEndPoint as IPEndPoint)?.Address;
 
                 if (Firewall.IsBlocked(ip))
                 {

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -775,7 +775,7 @@ namespace Server.Accounting
             }
 
             m_PasswordAlgorithm = algorithm;
-            Password = password?.Replace("-", string.Empty);
+            Password = password.Replace("-", string.Empty, StringComparison.Ordinal);
             return true;
         }
 

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -100,10 +100,9 @@ namespace Server.Misc
             }
         }
 
-        [Usage("Password <newPassword> <repeatPassword>")]
-        [Description(
-            "Changes the password of the commanding players account. Requires the same C-class IP address as the account's creator."
-        )]
+        [Usage("Password <newPassword> <repeatPassword>"), Description(
+             "Changes the password of the commanding players account. Requires the same C-class IP address as the account's creator."
+         )]
         public static void Password_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -177,7 +176,7 @@ namespace Server.Misc
 
                     if (entry != null)
                     {
-                        if (entry.Message.StartsWith("[Automated: Change Password]"))
+                        if (entry.Message.StartsWith("[Automated: Change Password]", StringComparison.Ordinal))
                         {
                             from.SendMessage("You already have a password change request in the help system queue.");
                         }
@@ -289,7 +288,9 @@ namespace Server.Misc
                 return null;
             }
 
-            var isSafe = !(un.StartsWith(" ") || un.EndsWith(" ") || un.EndsWith("."));
+            var isSafe = !(un.StartsWith(" ", StringComparison.Ordinal) ||
+                           un.EndsWith(" ", StringComparison.Ordinal) ||
+                           un.EndsWith(".", StringComparison.Ordinal));
 
             for (var i = 0; isSafe && i < un.Length; ++i)
             {

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -9,7 +9,7 @@ using Server.Regions;
 
 namespace Server.Misc
 {
-    public class AccountHandler
+    public static class AccountHandler
     {
         private static int MaxAccountsPerIP;
         private static bool AutoAccountCreation;

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -5,7 +5,7 @@ using System.Xml;
 
 namespace Server.Accounting
 {
-    public class Accounts
+    public static class Accounts
     {
         private static Dictionary<string, IAccount> m_Accounts = new Dictionary<string, IAccount>();
 
@@ -55,6 +55,11 @@ namespace Server.Accounting
             doc.Load(filePath);
 
             var root = doc["accounts"];
+
+            if (root == null)
+            {
+                throw new FileLoadException("Unable to load xml file");
+            }
 
             foreach (XmlElement account in root.GetElementsByTagName("account"))
             {

--- a/Projects/UOContent/Accounting/Firewall.cs
+++ b/Projects/UOContent/Accounting/Firewall.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -30,13 +31,13 @@ namespace Server
 
                     /*
                       object toAdd;
-          
+
                       IPAddress addr;
                       if (IPAddress.TryParse( line, out addr ))
                         toAdd = addr;
                       else
                         toAdd = line;
-          
+
                       m_Blocked.Add( toAdd.ToString() );
                        * */
                 }
@@ -73,9 +74,9 @@ namespace Server
             }
 
             // Try CIDR parse
-            var str = entry.Split('/');
+            var str = entry?.Split('/');
 
-            if (str.Length == 2)
+            if (str?.Length == 2)
             {
                 if (IPAddress.TryParse(str[0], out var cidrPrefix))
                 {
@@ -180,7 +181,7 @@ namespace Server
             return false;
             /*
             bool contains = false;
-      
+
             for ( int i = 0; !contains && i < m_Blocked.Count; ++i )
             {
               if (m_Blocked[i] is IPAddress)
@@ -188,14 +189,14 @@ namespace Server
                       else if (m_Blocked[i] is String)
                       {
                           string s = (string)m_Blocked[i];
-      
+
                           contains = Utility.IPMatchCIDR( s, ip );
-      
+
                           if (!contains)
                               contains = Utility.IPMatch( s, ip );
                       }
             }
-      
+
             return contains;
              * */
         }
@@ -312,10 +313,10 @@ namespace Server
                     return obj.Equals(m_Entry);
                 }
 
-                return obj is WildcardIPFirewallEntry entry && m_Entry.Equals(entry.m_Entry);
+                return obj is WildcardIPFirewallEntry entry && m_Entry == entry.m_Entry;
             }
 
-            public override int GetHashCode() => m_Entry.GetHashCode();
+            public override int GetHashCode() => m_Entry.GetHashCode(StringComparison.Ordinal);
         }
     }
 }

--- a/Projects/UOContent/Accounting/Firewall.cs
+++ b/Projects/UOContent/Accounting/Firewall.cs
@@ -5,7 +5,7 @@ using System.Net;
 
 namespace Server
 {
-    public class Firewall
+    public static class Firewall
     {
         static Firewall()
         {
@@ -48,22 +48,13 @@ namespace Server
 
         public static IFirewallEntry ToFirewallEntry(object entry)
         {
-            if (entry is IFirewallEntry firewallEntry)
+            return entry switch
             {
-                return firewallEntry;
-            }
-
-            if (entry is IPAddress address)
-            {
-                return new IPFirewallEntry(address);
-            }
-
-            if (entry is string s)
-            {
-                return ToFirewallEntry(s);
-            }
-
-            return null;
+                IFirewallEntry firewallEntry => firewallEntry,
+                IPAddress address            => new IPFirewallEntry(address),
+                string s                     => ToFirewallEntry(s),
+                _                            => null
+            };
         }
 
         public static IFirewallEntry ToFirewallEntry(string entry)

--- a/Projects/UOContent/Accounting/IPLimiter.cs
+++ b/Projects/UOContent/Accounting/IPLimiter.cs
@@ -4,11 +4,11 @@ using Server.Network;
 
 namespace Server.Misc
 {
-    public class IPLimiter
+    public static class IPLimiter
     {
-        public static IPAddress[] Exemptions =
+        public static readonly IPAddress[] Exemptions =
         {
-            // IPAddress.Parse( "127.0.0.1" ),
+            IPAddress.Parse( "127.0.0.1" )
         };
 
         public static bool Enabled { get; private set; }
@@ -31,15 +31,11 @@ namespace Server.Misc
                 return true;
             }
 
-            var netStates = TcpServer.Instances;
-
             var count = 0;
 
-            for (var i = 0; i < netStates.Count; ++i)
+            foreach (var ns in TcpServer.Instances)
             {
-                var compState = netStates[i];
-
-                if (ourAddress.Equals(compState.Address))
+                if (ourAddress.Equals(ns.Address))
                 {
                     ++count;
 

--- a/Projects/UOContent/Accounting/Security/MD5PasswordProtection.cs
+++ b/Projects/UOContent/Accounting/Security/MD5PasswordProtection.cs
@@ -22,7 +22,9 @@ namespace Server.Accounting.Security
     public class MD5PasswordProtection : IPasswordProtection
     {
         public static IPasswordProtection Instance = new MD5PasswordProtection();
+#pragma warning disable CA5351
         private readonly MD5CryptoServiceProvider m_MD5HashProvider = new MD5CryptoServiceProvider();
+#pragma warning restore CA5351
 
         public string EncryptPassword(string plainPassword)
         {

--- a/Projects/UOContent/Accounting/Security/PBKDF2PasswordProtection.cs
+++ b/Projects/UOContent/Accounting/Security/PBKDF2PasswordProtection.cs
@@ -26,8 +26,7 @@ namespace Server.Accounting.Security
         private const int m_SaltSize = 8;
         private const int m_HashSize = 32;
         private const int m_OutputSize = 2 + m_SaltSize + m_HashSize;
-        public static IPasswordProtection Instance = new PBKDF2PasswordProtection();
-        private static readonly HashAlgorithmName m_Algorithm = HashAlgorithmName.SHA256;
+        public static readonly IPasswordProtection Instance = new PBKDF2PasswordProtection();
 
         public string EncryptPassword(string plainPassword)
         {
@@ -35,7 +34,7 @@ namespace Server.Accounting.Security
             var iterations = Utility.RandomMinMax(m_MinIterations, m_MaxIterations);
             BinaryPrimitives.WriteUInt16LittleEndian(output.Slice(0, 2), (ushort)iterations);
 
-            var rfc2898 = new Rfc2898DeriveBytes(plainPassword, m_SaltSize, iterations, m_Algorithm);
+            var rfc2898 = new Rfc2898DeriveBytes(plainPassword, m_SaltSize, iterations, HashAlgorithmName.SHA256);
             rfc2898.Salt.CopyTo(output.Slice(2, m_SaltSize));
             rfc2898.GetBytes(m_HashSize).CopyTo(output.Slice(m_SaltSize + 2));
 
@@ -51,7 +50,7 @@ namespace Server.Accounting.Security
             var salt = encryptedBytes.Slice(2, m_SaltSize);
 
             ReadOnlySpan<byte> hash =
-                new Rfc2898DeriveBytes(plainPassword, salt.ToArray(), iterations, m_Algorithm).GetBytes(m_HashSize);
+                new Rfc2898DeriveBytes(plainPassword, salt.ToArray(), iterations, HashAlgorithmName.SHA256).GetBytes(m_HashSize);
 
             return hash.SequenceEqual(encryptedBytes.Slice(m_SaltSize + 2));
         }

--- a/Projects/UOContent/Accounting/Security/SHA1PasswordProtection.cs
+++ b/Projects/UOContent/Accounting/Security/SHA1PasswordProtection.cs
@@ -22,7 +22,9 @@ namespace Server.Accounting.Security
     public class SHA1PasswordProtection : IPasswordProtection
     {
         public static IPasswordProtection Instance = new SHA1PasswordProtection();
+#pragma warning disable CA5350
         private readonly SHA1CryptoServiceProvider m_SHA1HashProvider = new SHA1CryptoServiceProvider();
+#pragma warning restore CA5350
 
         public string EncryptPassword(string plainPassword)
         {

--- a/Projects/UOContent/Commands/Attributes.cs
+++ b/Projects/UOContent/Commands/Attributes.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace Server
 {
+    [AttributeUsage(AttributeTargets.Method)]
     public class UsageAttribute : Attribute
     {
         public UsageAttribute(string usage) => Usage = usage;
@@ -9,6 +10,7 @@ namespace Server
         public string Usage { get; }
     }
 
+    [AttributeUsage(AttributeTargets.Method)]
     public class DescriptionAttribute : Attribute
     {
         public DescriptionAttribute(string description) => Description = description;
@@ -16,6 +18,7 @@ namespace Server
         public string Description { get; }
     }
 
+    [AttributeUsage(AttributeTargets.Method)]
     public class AliasesAttribute : Attribute
     {
         public AliasesAttribute(params string[] aliases) => Aliases = aliases;

--- a/Projects/UOContent/Commands/Batch.cs
+++ b/Projects/UOContent/Commands/Batch.cs
@@ -187,8 +187,7 @@ namespace Server.Commands
             CommandSystem.Register("Batch", AccessLevel.Counselor, Batch_OnCommand);
         }
 
-        [Usage("Batch")]
-        [Description("Allows multiple commands to be run at the same time.")]
+        [Usage("Batch"), Description("Allows multiple commands to be run at the same time.")]
         public static void Batch_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendGump(new BatchGump(e.Mobile, new Batch()));
@@ -209,7 +208,7 @@ namespace Server.Commands
 
         public void GetDetails(out string command, out string argString, out string[] args)
         {
-            var indexOf = Command.IndexOf(' ');
+            var indexOf = Command.IndexOf(' ', StringComparison.Ordinal);
 
             if (indexOf >= 0)
             {

--- a/Projects/UOContent/Commands/Docs.cs
+++ b/Projects/UOContent/Commands/Docs.cs
@@ -109,8 +109,7 @@ namespace Server.Commands
             CommandSystem.Register("DocGen", AccessLevel.Administrator, DocGen_OnCommand);
         }
 
-        [Usage("DocGen")]
-        [Description("Generates RunUO documentation.")]
+        [Usage("DocGen"), Description("Generates RunUO documentation.")]
         private static void DocGen_OnCommand(CommandEventArgs e)
         {
             World.Broadcast(0x35, true, "Documentation is being generated, please wait.");
@@ -332,7 +331,7 @@ namespace Server.Commands
 
             if (type.IsGenericType)
             {
-                var index = type.Name.IndexOf('`');
+                var index = type.Name.IndexOf('`', StringComparison.Ordinal);
 
                 if (index > 0)
                 {
@@ -346,7 +345,7 @@ namespace Server.Commands
                         : new StringBuilder($"<a href=\"@directory@{rootType}-T-.html\">{rootType}</a>");
 
                     nameBuilder.Append("&lt;");
-                    fnamBuilder.Append("-");
+                    fnamBuilder.Append('-');
                     linkBuilder.Append("&lt;");
 
                     var typeArguments = type.GetGenericArguments();
@@ -364,7 +363,7 @@ namespace Server.Commands
                         var aliasedName = AliasForName(sanitizedName);
 
                         nameBuilder.Append(sanitizedName);
-                        fnamBuilder.Append("T");
+                        fnamBuilder.Append('T');
                         if (DontLink(typeArguments[i]))
                         {
                             linkBuilder.Append($"<font color=\"blue\">{aliasedName}</font>");
@@ -378,7 +377,7 @@ namespace Server.Commands
                     }
 
                     nameBuilder.Append("&gt;");
-                    fnamBuilder.Append("-");
+                    fnamBuilder.Append('-');
                     linkBuilder.Append("&gt;");
 
                     name = nameBuilder.ToString();
@@ -407,7 +406,7 @@ namespace Server.Commands
 
         public static string SanitizeType(string name)
         {
-            var anonymousType = name.Contains("<");
+            var anonymousType = name.Contains('<', StringComparison.Ordinal);
             var sb = new StringBuilder(name);
             for (var i = 0; i < ReplaceChars.Length; ++i)
             {
@@ -466,7 +465,7 @@ namespace Server.Commands
                 return true;
             }
 
-            if (type.Namespace.StartsWith("Server"))
+            if (type.Namespace.StartsWith("Server", StringComparison.Ordinal))
             {
                 return false;
             }
@@ -489,11 +488,12 @@ namespace Server.Commands
             }
 
             var index = 0;
-            var file = string.Concat(name, ext);
+            var file = $"{name}{ext}";
 
             while (File.Exists(Path.Combine(root, file)))
             {
-                file = string.Concat(name, ++index, ext);
+                index++;
+                file = $"{name}{index}{ext}";
             }
 
             return file;
@@ -604,7 +604,7 @@ namespace Server.Commands
                 if (realType?.IsGenericType == true)
                 {
                     FormatGeneric(realType, out _, out _, out var linkName);
-                    aliased = linkName.Replace("@directory@", null);
+                    aliased = linkName.Replace("@directory@", null, StringComparison.Ordinal);
                 }
                 else
                 {
@@ -621,7 +621,7 @@ namespace Server.Commands
                 aliased ??= realType?.Name ?? "";
             }
 
-            return string.Concat(prepend, aliased, append, name);
+            return $"{prepend}{aliased}{append}{name}";
         }
 
         private static bool Document()
@@ -1719,7 +1719,7 @@ namespace Server.Commands
                 {
                     line = line.Trim();
 
-                    if (line.Length == 0 || line.StartsWith("#"))
+                    if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                     {
                         continue;
                     }
@@ -2029,16 +2029,11 @@ namespace Server.Commands
 
                 var aliases = attrs.Length == 0 ? null : attrs[0] as AliasesAttribute;
 
-                var descString = desc.Description.Replace("<", "&lt;").Replace(">", "&gt;");
+                var descString = desc.Description
+                    .Replace("<", "&lt;", StringComparison.Ordinal)
+                    .Replace(">", "&gt;", StringComparison.Ordinal);
 
-                if (aliases == null)
-                {
-                    list.Add(new DocCommandEntry(e.AccessLevel, e.Command, null, usage.Usage, descString));
-                }
-                else
-                {
-                    list.Add(new DocCommandEntry(e.AccessLevel, e.Command, aliases.Aliases, usage.Usage, descString));
-                }
+                list.Add(new DocCommandEntry(e.AccessLevel, e.Command, aliases?.Aliases, usage.Usage, descString));
             }
 
             for (var i = 0; i < TargetCommands.AllCommands.Count; ++i)
@@ -2062,7 +2057,9 @@ namespace Server.Commands
                     aliases[j] = cmds[j + 1];
                 }
 
-                desc = desc.Replace("<", "&lt;").Replace(">", "&gt;");
+                desc = desc
+                    .Replace("<", "&lt;", StringComparison.Ordinal)
+                    .Replace(">", "&gt;", StringComparison.Ordinal);
 
                 if (command.Supports != CommandSupport.Single)
                 {
@@ -2138,7 +2135,9 @@ namespace Server.Commands
                     aliases[j] = cmds[j + 1];
                 }
 
-                desc = desc.Replace("<", "&lt;").Replace(">", "&gt;");
+                desc = desc
+                    .Replace("<", "&lt;", StringComparison.Ordinal)
+                    .Replace(">", "&gt;", StringComparison.Ordinal);
 
                 list.Add(new DocCommandEntry(command.AccessLevel, cmd, aliases, usage, desc));
             }
@@ -2237,7 +2236,9 @@ namespace Server.Commands
             {
                 html.Write(
                     "<td class=\"rentry\"><b>Usage: {0}</b><br>{1}</td>",
-                    usage.Replace("<", "&lt;").Replace(">", "&gt;"),
+                    usage
+                        .Replace("<", "&lt;", StringComparison.Ordinal)
+                        .Replace(">", "&gt;", StringComparison.Ordinal),
                     desc
                 );
             }
@@ -2245,7 +2246,9 @@ namespace Server.Commands
             {
                 html.Write(
                     "<td class=\"rentry\"><b>Usage: {0}</b><br>Alias{1}: ",
-                    usage.Replace("<", "&lt;").Replace(">", "&gt;"),
+                    usage
+                        .Replace("<", "&lt;", StringComparison.Ordinal)
+                        .Replace(">", "&gt;", StringComparison.Ordinal),
                     aliases.Length == 1 ? "" : "es"
                 );
 
@@ -2564,7 +2567,7 @@ namespace Server.Commands
                     if (ifaceInfo == null)
                     {
                         FormatGeneric(iface, out _, out _, out var linkName);
-                        typeHtml.Write($"<!-- DBG-2.1 -->{linkName.Replace("@directory@", null)}");
+                        typeHtml.Write($"<!-- DBG-2.1 -->{linkName.Replace("@directory@", null, StringComparison.Ordinal)}");
                     }
                     else
                     {
@@ -2910,7 +2913,7 @@ namespace Server.Commands
             public string FileName => m_FileName;
             public string TypeName => m_TypeName;
 
-            public string LinkName(string dirRoot) => m_LinkName.Replace("@directory@", dirRoot);
+            public string LinkName(string dirRoot) => m_LinkName.Replace("@directory@", dirRoot, StringComparison.Ordinal);
         }
 
         private class SpeechEntry
@@ -3009,7 +3012,7 @@ namespace Server.Commands
             return Body == e?.Body && BodyType == e.BodyType && Name == e.Name;
         }
 
-        public override int GetHashCode() => Body.BodyID ^ (int)BodyType ^ Name.GetHashCode();
+        public override int GetHashCode() => Body.BodyID ^ (int)BodyType ^ Name.GetHashCode(StringComparison.Ordinal);
     }
 
     public class BodyEntrySorter : IComparer<BodyEntry>

--- a/Projects/UOContent/Commands/Docs.cs
+++ b/Projects/UOContent/Commands/Docs.cs
@@ -11,7 +11,7 @@ using Server.Network;
 
 namespace Server.Commands
 {
-    public class Docs
+    public static class Docs
     {
         private const int Iron = 0xCCCCDD;
         private const int DullCopper = 0xAAAAAA;

--- a/Projects/UOContent/Commands/DragEffects.cs
+++ b/Projects/UOContent/Commands/DragEffects.cs
@@ -7,8 +7,7 @@ namespace Server.Commands
             CommandSystem.Register("DragEffects", AccessLevel.Developer, DragEffects_OnCommand);
         }
 
-        [Usage("DragEffects [enable=false]")]
-        [Description("Enables or disables the item drag and drop effects.")]
+        [Usage("DragEffects [enable=false]"), Description("Enables or disables the item drag and drop effects.")]
         public static void DragEffects_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 0)

--- a/Projects/UOContent/Commands/Dupe.cs
+++ b/Projects/UOContent/Commands/Dupe.cs
@@ -13,8 +13,7 @@ namespace Server.Commands
             CommandSystem.Register("DupeInBag", AccessLevel.GameMaster, DupeInBag_OnCommand);
         }
 
-        [Usage("Dupe [amount]")]
-        [Description("Dupes a targeted item.")]
+        [Usage("Dupe [amount]"), Description("Dupes a targeted item.")]
         private static void Dupe_OnCommand(CommandEventArgs e)
         {
             var amount = 1;
@@ -27,8 +26,7 @@ namespace Server.Commands
             e.Mobile.SendMessage("What do you wish to dupe?");
         }
 
-        [Usage("DupeInBag <count>")]
-        [Description("Dupes an item at it's current location (count) number of times.")]
+        [Usage("DupeInBag <count>"), Description("Dupes an item at it's current location (count) number of times.")]
         private static void DupeInBag_OnCommand(CommandEventArgs e)
         {
             var amount = 1;

--- a/Projects/UOContent/Commands/ExportWSC.cs
+++ b/Projects/UOContent/Commands/ExportWSC.cs
@@ -4,7 +4,7 @@ using Server.Items;
 
 namespace Server.Commands
 {
-    public class ExportCommand
+    public static class ExportCommand
     {
         private const string ExportFile = @"C:\Uo\WorldForge\items.wsc";
 

--- a/Projects/UOContent/Commands/Generic/Commands/Commands.cs
+++ b/Projects/UOContent/Commands/Generic/Commands/Commands.cs
@@ -12,7 +12,7 @@ using Server.Spells;
 
 namespace Server.Commands.Generic
 {
-    public class TargetCommands
+    public static class TargetCommands
     {
         public static List<BaseCommand> AllCommands { get; } = new List<BaseCommand>();
 

--- a/Projects/UOContent/Commands/Generic/Commands/Commands.cs
+++ b/Projects/UOContent/Commands/Generic/Commands/Commands.cs
@@ -788,7 +788,7 @@ namespace Server.Commands.Generic
                     var result = Properties.GetValue(e.Mobile, obj, e.GetString(i));
 
                     if (result == "Property not found." || result == "Property is write only." ||
-                        result.StartsWith("Getting this property"))
+                        result.StartsWith("Getting this property", StringComparison.Ordinal))
                     {
                         LogFailure(result);
                     }

--- a/Projects/UOContent/Commands/Generic/Implementors/BaseCommandImplementor.cs
+++ b/Projects/UOContent/Commands/Generic/Implementors/BaseCommandImplementor.cs
@@ -194,7 +194,7 @@ namespace Server.Commands.Generic
                     sb.Append(' ');
                 }
 
-                if (args[i].IndexOf(' ') >= 0)
+                if (args[i].Contains(' ', StringComparison.Ordinal))
                 {
                     sb.Append('"');
                     sb.Append(args[i]);

--- a/Projects/UOContent/Commands/Generic/Implementors/IPAddressCommandImplementor.cs
+++ b/Projects/UOContent/Commands/Generic/Implementors/IPAddressCommandImplementor.cs
@@ -38,11 +38,8 @@ namespace Server.Commands.Generic
                 var list = new List<object>();
                 var addresses = new List<IPAddress>();
 
-                var states = TcpServer.Instances;
-
-                for (var i = 0; i < states.Count; ++i)
+                foreach (var ns in TcpServer.Instances)
                 {
-                    var ns = states[i];
                     var mob = ns.Mobile;
 
                     if (mob != null && !addresses.Contains(ns.Address) && ext.IsValid(mob))

--- a/Projects/UOContent/Commands/Generic/Implementors/ObjectConditional.cs
+++ b/Projects/UOContent/Commands/Generic/Implementors/ObjectConditional.cs
@@ -103,21 +103,19 @@ namespace Server.Commands.Generic
                 return Empty;
             }
 
-            var index = 0;
-
-            var objectType = AssemblyHandler.FindFirstTypeForName(args[offset + index], true);
+            var objectType = AssemblyHandler.FindFirstTypeForName(args[offset], true);
 
             if (objectType == null)
             {
-                throw new Exception($"No type with that name ({args[offset + index]}) was found.");
+                throw new Exception($"No type with that name ({args[offset]}) was found.");
             }
-
-            ++index;
 
             var conditions = new List<ICondition[]>();
             var current = new List<ICondition>();
 
             current.Add(TypeCondition.Default);
+
+            var index = 1;
 
             while (index < size)
             {

--- a/Projects/UOContent/Commands/Generic/Implementors/OnlineCommandImplementor.cs
+++ b/Projects/UOContent/Commands/Generic/Implementors/OnlineCommandImplementor.cs
@@ -36,11 +36,8 @@ namespace Server.Commands.Generic
 
                 var list = new List<object>();
 
-                var states = TcpServer.Instances;
-
-                for (var i = 0; i < states.Count; ++i)
+                foreach (var ns in TcpServer.Instances)
                 {
-                    var ns = states[i];
                     var mob = ns.Mobile;
 
                     if (mob == null)

--- a/Projects/UOContent/Commands/Handlers.cs
+++ b/Projects/UOContent/Commands/Handlers.cs
@@ -17,7 +17,7 @@ using Server.Targets;
 
 namespace Server.Commands
 {
-    public class CommandHandlers
+    public static class CommandHandlers
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Commands/Handlers.cs
+++ b/Projects/UOContent/Commands/Handlers.cs
@@ -76,8 +76,7 @@ namespace Server.Commands
             CommandSystem.Register(command, access, handler);
         }
 
-        [Usage("SpeedBoost [true|false]")]
-        [Description("Enables a speed boost for the invoker.  Disable with parameters.")]
+        [Usage("SpeedBoost [true|false]"), Description("Enables a speed boost for the invoker.  Disable with parameters.")]
         private static void SpeedBoost_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -101,8 +100,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Where")]
-        [Description("Tells the commanding player his coordinates, region, and facet.")]
+        [Usage("Where"), Description("Tells the commanding player his coordinates, region, and facet.")]
         public static void Where_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -132,10 +130,9 @@ namespace Server.Commands
             }
         }
 
-        [Usage("DropHolding")]
-        [Description(
-            "Drops the item, if any, that a targeted player is holding. The item is placed into their backpack, or if that's full, at their feet."
-        )]
+        [Usage("DropHolding"), Description(
+             "Drops the item, if any, that a targeted player is holding. The item is placed into their backpack, or if that's full, at their feet."
+         )]
         public static void DropHolding_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, DropHolding_OnTarget);
@@ -221,8 +218,8 @@ namespace Server.Commands
             }
         }
 
-        [Usage("ClearFacet")]
-        [Description("Deletes all items and mobiles in your facet. Players and their inventory will not be deleted.")]
+        [Usage("ClearFacet"),
+         Description("Deletes all items and mobiles in your facet. Players and their inventory will not be deleted.")]
         public static void ClearFacet_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -282,8 +279,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("GetFollowers")]
-        [Description("Teleports all pets of a targeted player to your location.")]
+        [Usage("GetFollowers"), Description("Teleports all pets of a targeted player to your location.")]
         public static void GetFollowers_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, GetFollowers_OnTarget);
@@ -376,17 +372,16 @@ namespace Server.Commands
             }
         }
 
-        [Usage("ViewEquip")]
-        [Description("Lists equipment of a targeted mobile. From the list you can move, delete, or open props.")]
+        [Usage("ViewEquip"),
+         Description("Lists equipment of a targeted mobile. From the list you can move, delete, or open props.")]
         public static void ViewEquip_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new ViewEqTarget();
         }
 
-        [Usage("Sound <index> [toAll=true]")]
-        [Description(
-            "Plays a sound to players within 12 tiles of you. The (toAll) argument specifies to everyone, or just those who can see you."
-        )]
+        [Usage("Sound <index> [toAll=true]"), Description(
+             "Plays a sound to players within 12 tiles of you. The (toAll) argument specifies to everyone, or just those who can see you."
+         )]
         public static void Sound_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 1)
@@ -433,8 +428,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Echo <text>")]
-        [Description("Relays (text) as a system message.")]
+        [Usage("Echo <text>"), Description("Relays (text) as a system message.")]
         public static void Echo_OnCommand(CommandEventArgs e)
         {
             var toEcho = e.ArgString.Trim();
@@ -449,29 +443,25 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Bank")]
-        [Description("Opens the bank box of a given target.")]
+        [Usage("Bank"), Description("Opens the bank box of a given target.")]
         public static void Bank_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new BankTarget();
         }
 
-        [Usage("Client")]
-        [Description("Opens the client gump menu for a given player.")]
+        [Usage("Client"), Description("Opens the client gump menu for a given player.")]
         private static void Client_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new ClientTarget();
         }
 
-        [Usage("Move")]
-        [Description("Repositions a targeted item or mobile.")]
+        [Usage("Move"), Description("Repositions a targeted item or mobile.")]
         private static void Move_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new PickMoveTarget();
         }
 
-        [Usage("Save")]
-        [Description("Saves the world.")]
+        [Usage("Save"), Description("Saves the world.")]
         private static void Save_OnCommand(CommandEventArgs e)
         {
             AutoSave.Save();
@@ -494,10 +484,9 @@ namespace Server.Commands
             return validMap;
         }
 
-        [Usage("Go [name | serial | (x y [z]) | (deg min (N | S) deg min (E | W))]")]
-        [Description(
-            "With no arguments, this command brings up the go menu. With one argument, (name), you are moved to that regions \"go location.\" Or, if a numerical value is specified for one argument, (serial), you are moved to that object. Two or three arguments, (x y [z]), will move your character to that location. When six arguments are specified, (deg min (N | S) deg min (E | W)), your character will go to an approximate of those sextant coordinates."
-        )]
+        [Usage("Go [name | serial | (x y [z]) | (deg min (N | S) deg min (E | W))]"), Description(
+             "With no arguments, this command brings up the go menu. With one argument, (name), you are moved to that regions \"go location.\" Or, if a numerical value is specified for one argument, (serial), you are moved to that object. Two or three arguments, (x y [z]), will move your character to that location. When six arguments are specified, (deg min (N | S) deg min (E | W)), your character will go to an approximate of those sextant coordinates."
+         )]
         private static void Go_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -707,8 +696,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Help")]
-        [Description("Lists all available commands.")]
+        [Usage("Help"), Description("Lists all available commands.")]
         public static void Help_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;
@@ -755,17 +743,13 @@ namespace Server.Commands
             }
         }
 
-        [Usage("SMsg <text>")]
-        [Aliases("S", "SM")]
-        [Description("Broadcasts a message to all online staff.")]
+        [Usage("SMsg <text>"), Aliases("S", "SM"), Description("Broadcasts a message to all online staff.")]
         public static void StaffMessage_OnCommand(CommandEventArgs e)
         {
             BroadcastMessage(AccessLevel.Counselor, e.Mobile.SpeechHue, $"[{e.Mobile.Name}] {e.ArgString}");
         }
 
-        [Usage("BCast <text>")]
-        [Aliases("B", "BC")]
-        [Description("Broadcasts a message to everyone online.")]
+        [Usage("BCast <text>"), Aliases("B", "BC"), Description("Broadcasts a message to everyone online.")]
         public static void BroadcastMessage_OnCommand(CommandEventArgs e)
         {
             BroadcastMessage(AccessLevel.Player, 0x482, $"Staff message from {e.Mobile.Name}:");
@@ -785,9 +769,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("AutoPageNotify")]
-        [Aliases("APN")]
-        [Description("Toggles your auto-page-notify status.")]
+        [Usage("AutoPageNotify"), Aliases("APN"), Description("Toggles your auto-page-notify status.")]
         public static void APN_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;
@@ -797,8 +779,8 @@ namespace Server.Commands
             m.SendMessage("Your auto-page-notify has been turned {0}.", m.AutoPageNotify ? "on" : "off");
         }
 
-        [Usage("Animate <action> <frameCount> <repeatCount> <forward> <repeat> <delay>")]
-        [Description("Makes your character do a specified animation.")]
+        [Usage("Animate <action> <frameCount> <repeatCount> <forward> <repeat> <delay>"),
+         Description("Makes your character do a specified animation.")]
         public static void Animate_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 6)
@@ -818,8 +800,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Cast <name>")]
-        [Description("Casts a spell by name.")]
+        [Usage("Cast <name>"), Description("Casts a spell by name.")]
         public static void Cast_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 1)
@@ -846,22 +827,19 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Stuck")]
-        [Description("Opens a menu of towns, used for teleporting stuck mobiles.")]
+        [Usage("Stuck"), Description("Opens a menu of towns, used for teleporting stuck mobiles.")]
         public static void Stuck_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new StuckMenuTarget();
         }
 
-        [Usage("Light <level>")]
-        [Description("Set your local lightlevel.")]
+        [Usage("Light <level>"), Description("Set your local lightlevel.")]
         public static void Light_OnCommand(CommandEventArgs e)
         {
             e.Mobile.LightLevel = e.GetInt32(0);
         }
 
-        [Usage("Stats")]
-        [Description("View some stats about the server.")]
+        [Usage("Stats"), Description("View some stats about the server.")]
         public static void Stats_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendMessage("Open Connections: {0}", TcpServer.Instances.Count);

--- a/Projects/UOContent/Commands/HelpInfo.cs
+++ b/Projects/UOContent/Commands/HelpInfo.cs
@@ -9,7 +9,7 @@ using CommandInfoSorter = Server.Commands.Docs.CommandEntrySorter;
 
 namespace Server.Commands
 {
-    public class HelpInfo
+    public static class HelpInfo
     {
         public static Dictionary<string, CommandInfo> HelpInfos { get; } = new Dictionary<string, CommandInfo>();
 

--- a/Projects/UOContent/Commands/HelpInfo.cs
+++ b/Projects/UOContent/Commands/HelpInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Server.Commands.Generic;
@@ -22,10 +23,9 @@ namespace Server.Commands
             FillTable();
         }
 
-        [Usage("HelpInfo [<command>]")]
-        [Description(
-            "Gives information on a specified command, or when no argument specified, displays a gump containing all commands"
-        )]
+        [Usage("HelpInfo [<command>]"), Description(
+             "Gives information on a specified command, or when no argument specified, displays a gump containing all commands"
+         )]
         private static void HelpInfo_OnCommand(CommandEventArgs e)
         {
             if (e.Length > 0)
@@ -93,7 +93,9 @@ namespace Server.Commands
 
                 var aliases = attrs.Length == 0 ? null : attrs[0] as AliasesAttribute;
 
-                var descString = desc.Description.Replace("<", "(").Replace(">", ")");
+                var descString = desc.Description
+                    .Replace("<", "(", StringComparison.Ordinal)
+                    .Replace(">", ")", StringComparison.Ordinal);
 
                 if (aliases == null)
                 {
@@ -137,7 +139,9 @@ namespace Server.Commands
                     aliases[j] = cmds[j + 1];
                 }
 
-                desc = desc.Replace("<", "(").Replace(">", ")");
+                desc = desc
+                    .Replace("<", "(", StringComparison.Ordinal)
+                    .Replace(">", ")", StringComparison.Ordinal);
 
                 if (command.Supports != CommandSupport.Single)
                 {
@@ -224,7 +228,9 @@ namespace Server.Commands
                     aliases[j] = cmds[j + 1];
                 }
 
-                desc = desc.Replace("<", ")").Replace(">", ")");
+                desc = desc
+                    .Replace("<", ")", StringComparison.Ordinal)
+                    .Replace(">", ")", StringComparison.Ordinal);
 
                 list.Add(new CommandInfo(command.AccessLevel, cmd, aliases, usage, desc));
 
@@ -406,7 +412,10 @@ namespace Server.Commands
                 var sb = new StringBuilder();
 
                 sb.Append("Usage: ");
-                sb.Append(info.Usage.Replace("<", "(").Replace(">", ")"));
+                var usage = info.Usage
+                    .Replace("<", "(", StringComparison.Ordinal)
+                    .Replace(">", ")", StringComparison.Ordinal);
+                sb.Append(usage);
                 sb.Append("<BR>");
 
                 var aliases = info.Aliases;

--- a/Projects/UOContent/Commands/LocationCommand.cs
+++ b/Projects/UOContent/Commands/LocationCommand.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Server.Commands.Generic;
 using Server.Items;
 using Server.Targeting;

--- a/Projects/UOContent/Commands/LocationCommand.cs
+++ b/Projects/UOContent/Commands/LocationCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Server.Commands.Generic;
@@ -43,9 +44,7 @@ namespace Server.Commands
                     graphics = new List<int>();
                     foreach (var arg in e.Arguments)
                     {
-                        var numberStyles = arg.ToLower().StartsWith("0x") ? NumberStyles.HexNumber : NumberStyles.Integer;
-
-                        if (int.TryParse(arg, numberStyles, CultureInfo.InvariantCulture, out var result))
+                        if (Utility.ToInt32(arg, out var result))
                         {
                             graphics.Add(result);
                         }

--- a/Projects/UOContent/Commands/Logging.cs
+++ b/Projects/UOContent/Commands/Logging.cs
@@ -44,25 +44,13 @@ namespace Server.Commands
             }
         }
 
-        public static object Format(object o)
-        {
-            if (o is Mobile m)
+        public static object Format(object o) =>
+            o switch
             {
-                if (m.Account == null)
-                {
-                    return $"{m} (no account)";
-                }
-
-                return $"{m} ('{m.Account.Username}')";
-            }
-
-            if (o is Item item)
-            {
-                return $"0x{item.Serial.Value:X} ({item.GetType().Name})";
-            }
-
-            return o;
-        }
+                Mobile m  => m.Account == null ? $"{m} (no account)" : $"{m} ('{m.Account.Username}')",
+                Item item => $"0x{item.Serial.Value:X} ({item.GetType().Name})",
+                _         => o
+            };
 
         public static void WriteLine(Mobile from, string format, params object[] args)
         {
@@ -126,7 +114,7 @@ namespace Server.Commands
 
             for (var i = 0; isSafe && i < m_NotSafe.Length; ++i)
             {
-                isSafe = ip.IndexOf(m_NotSafe[i]) == -1;
+                isSafe = !ip.Contains(m_NotSafe[i], StringComparison.Ordinal);
             }
 
             if (isSafe)

--- a/Projects/UOContent/Commands/Logging.cs
+++ b/Projects/UOContent/Commands/Logging.cs
@@ -5,7 +5,7 @@ using Server.Accounting;
 
 namespace Server.Commands
 {
-    public class CommandLogging
+    public static class CommandLogging
     {
         private static readonly char[] m_NotSafe = { '\\', '/', ':', '*', '?', '"', '<', '>', '|' };
         public static bool Enabled { get; set; } = true;

--- a/Projects/UOContent/Commands/Object Creation/Add.cs
+++ b/Projects/UOContent/Commands/Object Creation/Add.cs
@@ -72,7 +72,7 @@ namespace Server.Commands
                 sb.AppendFormat("from {0} to {1} in {2}", start, end, from.Map);
             }
 
-            sb.Append(":");
+            sb.Append(':');
 
             for (var i = 0; i < args.Length; ++i)
             {
@@ -300,7 +300,7 @@ namespace Server.Commands
 
                 object obj = value;
 
-                if (value?.StartsWith("0x") == true)
+                if (value?.StartsWith("0x", StringComparison.Ordinal) == true)
                 {
                     if (IsSignedNumeric(type))
                     {
@@ -670,91 +670,81 @@ namespace Server.Commands
             }
         }
 
-        [Usage("Tile <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name into a targeted bounding box. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("Tile <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name into a targeted bounding box. Optional constructor parameters. Optional set property list."
+         )]
         public static void Tile_OnCommand(CommandEventArgs e)
         {
             Internal_OnCommand(e, false);
         }
 
-        [Usage("TileRXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name into a given bounding box, (x, y) parameters are relative to your characters position. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("TileRXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name into a given bounding box, (x, y) parameters are relative to your characters position. Optional constructor parameters. Optional set property list."
+         )]
         public static void TileRXYZ_OnCommand(CommandEventArgs e)
         {
             InternalRXYZ_OnCommand(e, false);
         }
 
-        [Usage("TileXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name into a given bounding box. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("TileXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name into a given bounding box. Optional constructor parameters. Optional set property list."
+         )]
         public static void TileXYZ_OnCommand(CommandEventArgs e)
         {
             InternalXYZ_OnCommand(e, false);
         }
 
-        [Usage("TileZ <z> <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name into a targeted bounding box at a fixed Z location. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("TileZ <z> <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name into a targeted bounding box at a fixed Z location. Optional constructor parameters. Optional set property list."
+         )]
         public static void TileZ_OnCommand(CommandEventArgs e)
         {
             InternalZ_OnCommand(e, false);
         }
 
-        [Usage("TileAvg <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name into a targeted bounding box on the map's average Z elevation. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("TileAvg <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name into a targeted bounding box on the map's average Z elevation. Optional constructor parameters. Optional set property list."
+         )]
         public static void TileAvg_OnCommand(CommandEventArgs e)
         {
             InternalAvg_OnCommand(e, false);
         }
 
-        [Usage("Outline <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name around a targeted bounding box. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("Outline <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name around a targeted bounding box. Optional constructor parameters. Optional set property list."
+         )]
         public static void Outline_OnCommand(CommandEventArgs e)
         {
             Internal_OnCommand(e, true);
         }
 
-        [Usage("OutlineRXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name around a given bounding box, (x, y) parameters are relative to your characters position. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("OutlineRXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name around a given bounding box, (x, y) parameters are relative to your characters position. Optional constructor parameters. Optional set property list."
+         )]
         public static void OutlineRXYZ_OnCommand(CommandEventArgs e)
         {
             InternalRXYZ_OnCommand(e, true);
         }
 
-        [Usage("OutlineXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name around a given bounding box. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("OutlineXYZ <x> <y> <w> <h> <z> <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name around a given bounding box. Optional constructor parameters. Optional set property list."
+         )]
         public static void OutlineXYZ_OnCommand(CommandEventArgs e)
         {
             InternalXYZ_OnCommand(e, true);
         }
 
-        [Usage("OutlineZ <z> <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name around a targeted bounding box at a fixed Z location. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("OutlineZ <z> <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name around a targeted bounding box at a fixed Z location. Optional constructor parameters. Optional set property list."
+         )]
         public static void OutlineZ_OnCommand(CommandEventArgs e)
         {
             InternalZ_OnCommand(e, true);
         }
 
-        [Usage("OutlineAvg <name> [params] [set {<propertyName> <value> ...}]")]
-        [Description(
-            "Tiles an item or npc by name around a targeted bounding box on the map's average Z elevation. Optional constructor parameters. Optional set property list."
-        )]
+        [Usage("OutlineAvg <name> [params] [set {<propertyName> <value> ...}]"), Description(
+             "Tiles an item or npc by name around a targeted bounding box on the map's average Z elevation. Optional constructor parameters. Optional set property list."
+         )]
         public static void OutlineAvg_OnCommand(CommandEventArgs e)
         {
             InternalAvg_OnCommand(e, true);

--- a/Projects/UOContent/Commands/Object Creation/Add.cs
+++ b/Projects/UOContent/Commands/Object Creation/Add.cs
@@ -8,7 +8,7 @@ using CPA = Server.CommandPropertyAttribute;
 
 namespace Server.Commands
 {
-    public class Add
+    public static class Add
     {
         private static readonly Type m_EntityType = typeof(IEntity);
 

--- a/Projects/UOContent/Commands/Object Creation/AddGump.cs
+++ b/Projects/UOContent/Commands/Object Creation/AddGump.cs
@@ -93,10 +93,9 @@ namespace Server.Gumps
             CommandSystem.Register("AddMenu", AccessLevel.GameMaster, AddMenu_OnCommand);
         }
 
-        [Usage("AddMenu [searchString]")]
-        [Description(
-            "Opens an add menu, with an optional initial search string. This menu allows you to search for Items or Mobiles and add them interactively."
-        )]
+        [Usage("AddMenu [searchString]"), Description(
+             "Opens an add menu, with an optional initial search string. This menu allows you to search for Items or Mobiles and add them interactively."
+         )]
         private static void AddMenu_OnCommand(CommandEventArgs e)
         {
             var val = e.ArgString.Trim();
@@ -135,7 +134,7 @@ namespace Server.Gumps
                 var t = types[i];
 
                 if ((typeofMobile.IsAssignableFrom(t) || typeofItem.IsAssignableFrom(t)) &&
-                    t.Name.ToLower().IndexOf(match, StringComparison.Ordinal) >= 0 && !results.Contains(t))
+                    t.Name.ToLower().Contains(match, StringComparison.Ordinal) && !results.Contains(t))
                 {
                     var ctors = t.GetConstructors();
 

--- a/Projects/UOContent/Commands/Object Creation/Categorization.cs
+++ b/Projects/UOContent/Commands/Object Creation/Categorization.cs
@@ -48,8 +48,7 @@ namespace Server.Commands
             CommandSystem.Register("RebuildCategorization", AccessLevel.Administrator, RebuildCategorization_OnCommand);
         }
 
-        [Usage("RebuildCategorization")]
-        [Description("Rebuilds the categorization data file used by the Add command.")]
+        [Usage("RebuildCategorization"), Description("Rebuilds the categorization data file used by the Add command.")]
         public static void RebuildCategorization_OnCommand(CommandEventArgs e)
         {
             var root = new CategoryEntry(null, "Add Menu", new[] { Items, Mobiles });
@@ -305,7 +304,7 @@ namespace Server.Commands
 
             var text = lines[index].Text;
 
-            var start = text.IndexOf('(');
+            var start = text.IndexOf('(', StringComparison.Ordinal);
 
             if (start < 0)
             {

--- a/Projects/UOContent/Commands/Object Creation/Decorate.cs
+++ b/Projects/UOContent/Commands/Object Creation/Decorate.cs
@@ -20,8 +20,7 @@ namespace Server.Commands
             CommandSystem.Register("Decorate", AccessLevel.Administrator, Decorate_OnCommand);
         }
 
-        [Usage("Decorate")]
-        [Description("Generates world decoration.")]
+        [Usage("Decorate"), Description("Generates world decoration.")]
         private static void Decorate_OnCommand(CommandEventArgs e)
         {
             m_Mobile = e.Mobile;
@@ -104,9 +103,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("LabelNumber"))
+                        if (m_Params[i].StartsWith("LabelNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -124,9 +123,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("LabelNumber"))
+                        if (m_Params[i].StartsWith("LabelNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -172,9 +171,9 @@ namespace Server.Commands
                         {
                             locked = true;
                         }
-                        else if (m_Params[i].StartsWith("TargetMap"))
+                        else if (m_Params[i].StartsWith("TargetMap", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -201,54 +200,54 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Range"))
+                        if (m_Params[i].StartsWith("Range", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 range = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningString"))
+                        else if (m_Params[i].StartsWith("WarningString", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageString = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningNumber"))
+                        else if (m_Params[i].StartsWith("WarningNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("HintString"))
+                        else if (m_Params[i].StartsWith("HintString", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 hintString = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("HintNumber"))
+                        else if (m_Params[i].StartsWith("HintNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 hintNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("ResetDelay"))
+                        else if (m_Params[i].StartsWith("ResetDelay", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -274,36 +273,36 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Range"))
+                        if (m_Params[i].StartsWith("Range", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 range = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningString"))
+                        else if (m_Params[i].StartsWith("WarningString", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageString = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningNumber"))
+                        else if (m_Params[i].StartsWith("WarningNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("ResetDelay"))
+                        else if (m_Params[i].StartsWith("ResetDelay", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -325,9 +324,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("CannonDirection"))
+                        if (m_Params[i].StartsWith("CannonDirection", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -349,27 +348,27 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Word"))
+                        if (m_Params[i].StartsWith("Word", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 word = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("DestStart"))
+                        else if (m_Params[i].StartsWith("DestStart", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 destination.Start = Point2D.Parse(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("DestEnd"))
+                        else if (m_Params[i].StartsWith("DestEnd", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -387,9 +386,9 @@ namespace Server.Commands
 
                     for (var i = 0; !fill && i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Content"))
+                        if (m_Params[i].StartsWith("Content", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -418,9 +417,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Facing"))
+                        if (m_Params[i].StartsWith("Facing", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -448,9 +447,9 @@ namespace Server.Commands
                 {
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("SpawnLocation"))
+                        if (m_Params[i].StartsWith("SpawnLocation", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -516,45 +515,45 @@ namespace Server.Commands
 
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Spawn"))
+                    if (m_Params[i].StartsWith("Spawn", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.AddEntry(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MinDelay"))
+                    else if (m_Params[i].StartsWith("MinDelay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.MinDelay = TimeSpan.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MaxDelay"))
+                    else if (m_Params[i].StartsWith("MaxDelay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.MaxDelay = TimeSpan.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("NextSpawn"))
+                    else if (m_Params[i].StartsWith("NextSpawn", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.NextSpawn = TimeSpan.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Count"))
+                    else if (m_Params[i].StartsWith("Count", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -565,36 +564,36 @@ namespace Server.Commands
                             }
                         }
                     }
-                    else if (m_Params[i].StartsWith("Team"))
+                    else if (m_Params[i].StartsWith("Team", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.Team = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("HomeRange"))
+                    else if (m_Params[i].StartsWith("HomeRange", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.HomeRange = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Running"))
+                    else if (m_Params[i].StartsWith("Running", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.Running = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Group"))
+                    else if (m_Params[i].StartsWith("Group", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -607,36 +606,36 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Description"))
+                    if (m_Params[i].StartsWith("Description", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             rune.Description = m_Params[i].Substring(++indexOf);
                         }
                     }
-                    else if (m_Params[i].StartsWith("Marked"))
+                    else if (m_Params[i].StartsWith("Marked", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             rune.Marked = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("TargetMap"))
+                    else if (m_Params[i].StartsWith("TargetMap", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             rune.TargetMap = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Target"))
+                    else if (m_Params[i].StartsWith("Target", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -649,108 +648,108 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Skill"))
+                    if (m_Params[i].StartsWith("Skill", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Skill = (SkillName)Enum.Parse(typeof(SkillName), m_Params[i].Substring(++indexOf), true);
                         }
                     }
-                    else if (m_Params[i].StartsWith("RequiredFixedPoint"))
+                    else if (m_Params[i].StartsWith("RequiredFixedPoint", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Required = Utility.ToInt32(m_Params[i].Substring(++indexOf)) * 0.1;
                         }
                     }
-                    else if (m_Params[i].StartsWith("Required"))
+                    else if (m_Params[i].StartsWith("Required", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Required = Utility.ToDouble(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MessageString"))
+                    else if (m_Params[i].StartsWith("MessageString", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.MessageString = m_Params[i].Substring(++indexOf);
                         }
                     }
-                    else if (m_Params[i].StartsWith("MessageNumber"))
+                    else if (m_Params[i].StartsWith("MessageNumber", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.MessageNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("PointDest"))
+                    else if (m_Params[i].StartsWith("PointDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.PointDest = Point3D.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MapDest"))
+                    else if (m_Params[i].StartsWith("MapDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.MapDest = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Creatures"))
+                    else if (m_Params[i].StartsWith("Creatures", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Creatures = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SourceEffect"))
+                    else if (m_Params[i].StartsWith("SourceEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.SourceEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("DestEffect"))
+                    else if (m_Params[i].StartsWith("DestEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.DestEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SoundID"))
+                    else if (m_Params[i].StartsWith("SoundID", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.SoundID = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Delay"))
+                    else if (m_Params[i].StartsWith("Delay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -768,90 +767,90 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Substring"))
+                    if (m_Params[i].StartsWith("Substring", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Substring = m_Params[i].Substring(++indexOf);
                         }
                     }
-                    else if (m_Params[i].StartsWith("Keyword"))
+                    else if (m_Params[i].StartsWith("Keyword", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Keyword = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Range"))
+                    else if (m_Params[i].StartsWith("Range", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Range = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("PointDest"))
+                    else if (m_Params[i].StartsWith("PointDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.PointDest = Point3D.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MapDest"))
+                    else if (m_Params[i].StartsWith("MapDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.MapDest = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Creatures"))
+                    else if (m_Params[i].StartsWith("Creatures", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Creatures = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SourceEffect"))
+                    else if (m_Params[i].StartsWith("SourceEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.SourceEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("DestEffect"))
+                    else if (m_Params[i].StartsWith("DestEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.DestEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SoundID"))
+                    else if (m_Params[i].StartsWith("SoundID", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.SoundID = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Delay"))
+                    else if (m_Params[i].StartsWith("Delay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -869,63 +868,63 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("PointDest"))
+                    if (m_Params[i].StartsWith("PointDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.PointDest = Point3D.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MapDest"))
+                    else if (m_Params[i].StartsWith("MapDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.MapDest = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Creatures"))
+                    else if (m_Params[i].StartsWith("Creatures", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.Creatures = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SourceEffect"))
+                    else if (m_Params[i].StartsWith("SourceEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.SourceEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("DestEffect"))
+                    else if (m_Params[i].StartsWith("DestEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.DestEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SoundID"))
+                    else if (m_Params[i].StartsWith("SoundID", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.SoundID = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Delay"))
+                    else if (m_Params[i].StartsWith("Delay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -943,9 +942,9 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("ContentType"))
+                    if (m_Params[i].StartsWith("ContentType", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -972,18 +971,18 @@ namespace Server.Commands
 
             for (var i = 0; i < m_Params.Length; ++i)
             {
-                if (m_Params[i].StartsWith("Light"))
+                if (m_Params[i].StartsWith("Light", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
                         item.Light = (LightType)Enum.Parse(typeof(LightType), m_Params[i].Substring(++indexOf), true);
                     }
                 }
-                else if (m_Params[i].StartsWith("Hue"))
+                else if (m_Params[i].StartsWith("Hue", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
@@ -999,18 +998,18 @@ namespace Server.Commands
                         }
                     }
                 }
-                else if (m_Params[i].StartsWith("Name"))
+                else if (m_Params[i].StartsWith("Name", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
                         item.Name = m_Params[i].Substring(++indexOf);
                     }
                 }
-                else if (m_Params[i].StartsWith("Amount"))
+                else if (m_Params[i].StartsWith("Amount", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
@@ -1249,7 +1248,7 @@ namespace Server.Commands
             {
                 line = line.Trim();
 
-                if (line.Length > 0 && !line.StartsWith("#"))
+                if (line.Length > 0 && !line.StartsWith("#", StringComparison.Ordinal))
                 {
                     break;
                 }
@@ -1262,7 +1261,7 @@ namespace Server.Commands
 
             var list = new DecorationList();
 
-            var indexOf = line.IndexOf(' ');
+            var indexOf = line.IndexOf(' ', StringComparison.Ordinal);
 
             list.m_Type = AssemblyHandler.FindFirstTypeForName(line.Substring(0, indexOf++), true);
 
@@ -1272,14 +1271,14 @@ namespace Server.Commands
             }
 
             line = line.Substring(indexOf);
-            indexOf = line.IndexOf('(');
+            indexOf = line.IndexOf('(', StringComparison.Ordinal);
             if (indexOf >= 0)
             {
                 list.m_ItemID = Utility.ToInt32(line.Substring(0, indexOf - 1));
 
                 var parms = line.Substring(++indexOf);
 
-                if (line.EndsWith(")"))
+                if (line.EndsWith(")", StringComparison.Ordinal))
                 {
                     parms = parms.Substring(0, parms.Length - 1);
                 }
@@ -1308,7 +1307,7 @@ namespace Server.Commands
                     break;
                 }
 
-                if (line.StartsWith("#"))
+                if (line.StartsWith("#", StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -1338,7 +1337,7 @@ namespace Server.Commands
 
         public static void Pop(out string v, ref string line)
         {
-            var space = line.IndexOf(' ');
+            var space = line.IndexOf(' ', StringComparison.Ordinal);
 
             if (space >= 0)
             {

--- a/Projects/UOContent/Commands/Object Creation/DecorateMag.cs
+++ b/Projects/UOContent/Commands/Object Creation/DecorateMag.cs
@@ -21,8 +21,7 @@ namespace Server.Commands
             CommandSystem.Register("DecorateMag", AccessLevel.Administrator, DecorateMag_OnCommand);
         }
 
-        [Usage("DecorateMag")]
-        [Description("Generates world decoration.")]
+        [Usage("DecorateMag"), Description("Generates world decoration.")]
         private static void DecorateMag_OnCommand(CommandEventArgs e)
         {
             m_Mobile = e.Mobile;
@@ -101,9 +100,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("LabelNumber"))
+                        if (m_Params[i].StartsWith("LabelNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -121,9 +120,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("LabelNumber"))
+                        if (m_Params[i].StartsWith("LabelNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -169,9 +168,9 @@ namespace Server.Commands
                         {
                             locked = true;
                         }
-                        else if (m_Params[i].StartsWith("TargetMap"))
+                        else if (m_Params[i].StartsWith("TargetMap", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -198,54 +197,54 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Range"))
+                        if (m_Params[i].StartsWith("Range", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 range = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningString"))
+                        else if (m_Params[i].StartsWith("WarningString", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageString = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningNumber"))
+                        else if (m_Params[i].StartsWith("WarningNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("HintString"))
+                        else if (m_Params[i].StartsWith("HintString", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 hintString = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("HintNumber"))
+                        else if (m_Params[i].StartsWith("HintNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 hintNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("ResetDelay"))
+                        else if (m_Params[i].StartsWith("ResetDelay", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -271,36 +270,36 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Range"))
+                        if (m_Params[i].StartsWith("Range", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 range = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningString"))
+                        else if (m_Params[i].StartsWith("WarningString", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageString = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("WarningNumber"))
+                        else if (m_Params[i].StartsWith("WarningNumber", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 messageNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("ResetDelay"))
+                        else if (m_Params[i].StartsWith("ResetDelay", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -322,9 +321,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("CannonDirection"))
+                        if (m_Params[i].StartsWith("CannonDirection", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -346,27 +345,27 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Word"))
+                        if (m_Params[i].StartsWith("Word", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 word = m_Params[i].Substring(++indexOf);
                             }
                         }
-                        else if (m_Params[i].StartsWith("DestStart"))
+                        else if (m_Params[i].StartsWith("DestStart", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
                                 destination.Start = Point2D.Parse(m_Params[i].Substring(++indexOf));
                             }
                         }
-                        else if (m_Params[i].StartsWith("DestEnd"))
+                        else if (m_Params[i].StartsWith("DestEnd", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -384,9 +383,9 @@ namespace Server.Commands
 
                     for (var i = 0; !fill && i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Content"))
+                        if (m_Params[i].StartsWith("Content", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -415,9 +414,9 @@ namespace Server.Commands
 
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("Facing"))
+                        if (m_Params[i].StartsWith("Facing", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -445,9 +444,9 @@ namespace Server.Commands
                 {
                     for (var i = 0; i < m_Params.Length; ++i)
                     {
-                        if (m_Params[i].StartsWith("SpawnLocation"))
+                        if (m_Params[i].StartsWith("SpawnLocation", StringComparison.Ordinal))
                         {
-                            var indexOf = m_Params[i].IndexOf('=');
+                            var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                             if (indexOf >= 0)
                             {
@@ -513,45 +512,45 @@ namespace Server.Commands
 
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Spawn"))
+                    if (m_Params[i].StartsWith("Spawn", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.AddEntry(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MinDelay"))
+                    else if (m_Params[i].StartsWith("MinDelay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.MinDelay = TimeSpan.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MaxDelay"))
+                    else if (m_Params[i].StartsWith("MaxDelay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.MaxDelay = TimeSpan.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("NextSpawn"))
+                    else if (m_Params[i].StartsWith("NextSpawn", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.NextSpawn = TimeSpan.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Count"))
+                    else if (m_Params[i].StartsWith("Count", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -562,36 +561,36 @@ namespace Server.Commands
                             }
                         }
                     }
-                    else if (m_Params[i].StartsWith("Team"))
+                    else if (m_Params[i].StartsWith("Team", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.Team = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("HomeRange"))
+                    else if (m_Params[i].StartsWith("HomeRange", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.HomeRange = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Running"))
+                    else if (m_Params[i].StartsWith("Running", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             sp.Running = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Group"))
+                    else if (m_Params[i].StartsWith("Group", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -604,36 +603,36 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Description"))
+                    if (m_Params[i].StartsWith("Description", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             rune.Description = m_Params[i].Substring(++indexOf);
                         }
                     }
-                    else if (m_Params[i].StartsWith("Marked"))
+                    else if (m_Params[i].StartsWith("Marked", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             rune.Marked = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("TargetMap"))
+                    else if (m_Params[i].StartsWith("TargetMap", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             rune.TargetMap = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Target"))
+                    else if (m_Params[i].StartsWith("Target", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -646,108 +645,108 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Skill"))
+                    if (m_Params[i].StartsWith("Skill", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Skill = (SkillName)Enum.Parse(typeof(SkillName), m_Params[i].Substring(++indexOf), true);
                         }
                     }
-                    else if (m_Params[i].StartsWith("RequiredFixedPoint"))
+                    else if (m_Params[i].StartsWith("RequiredFixedPoint", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Required = Utility.ToInt32(m_Params[i].Substring(++indexOf)) * 0.1;
                         }
                     }
-                    else if (m_Params[i].StartsWith("Required"))
+                    else if (m_Params[i].StartsWith("Required", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Required = Utility.ToDouble(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MessageString"))
+                    else if (m_Params[i].StartsWith("MessageString", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.MessageString = m_Params[i].Substring(++indexOf);
                         }
                     }
-                    else if (m_Params[i].StartsWith("MessageNumber"))
+                    else if (m_Params[i].StartsWith("MessageNumber", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.MessageNumber = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("PointDest"))
+                    else if (m_Params[i].StartsWith("PointDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.PointDest = Point3D.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MapDest"))
+                    else if (m_Params[i].StartsWith("MapDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.MapDest = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Creatures"))
+                    else if (m_Params[i].StartsWith("Creatures", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.Creatures = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SourceEffect"))
+                    else if (m_Params[i].StartsWith("SourceEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.SourceEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("DestEffect"))
+                    else if (m_Params[i].StartsWith("DestEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.DestEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SoundID"))
+                    else if (m_Params[i].StartsWith("SoundID", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             st.SoundID = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Delay"))
+                    else if (m_Params[i].StartsWith("Delay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -765,90 +764,90 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("Substring"))
+                    if (m_Params[i].StartsWith("Substring", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Substring = m_Params[i].Substring(++indexOf);
                         }
                     }
-                    else if (m_Params[i].StartsWith("Keyword"))
+                    else if (m_Params[i].StartsWith("Keyword", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Keyword = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Range"))
+                    else if (m_Params[i].StartsWith("Range", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Range = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("PointDest"))
+                    else if (m_Params[i].StartsWith("PointDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.PointDest = Point3D.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MapDest"))
+                    else if (m_Params[i].StartsWith("MapDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.MapDest = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Creatures"))
+                    else if (m_Params[i].StartsWith("Creatures", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.Creatures = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SourceEffect"))
+                    else if (m_Params[i].StartsWith("SourceEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.SourceEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("DestEffect"))
+                    else if (m_Params[i].StartsWith("DestEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.DestEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SoundID"))
+                    else if (m_Params[i].StartsWith("SoundID", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             kt.SoundID = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Delay"))
+                    else if (m_Params[i].StartsWith("Delay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -866,63 +865,63 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("PointDest"))
+                    if (m_Params[i].StartsWith("PointDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.PointDest = Point3D.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("MapDest"))
+                    else if (m_Params[i].StartsWith("MapDest", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.MapDest = Map.Parse(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Creatures"))
+                    else if (m_Params[i].StartsWith("Creatures", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.Creatures = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SourceEffect"))
+                    else if (m_Params[i].StartsWith("SourceEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.SourceEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("DestEffect"))
+                    else if (m_Params[i].StartsWith("DestEffect", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.DestEffect = Utility.ToBoolean(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("SoundID"))
+                    else if (m_Params[i].StartsWith("SoundID", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
                             tp.SoundID = Utility.ToInt32(m_Params[i].Substring(++indexOf));
                         }
                     }
-                    else if (m_Params[i].StartsWith("Delay"))
+                    else if (m_Params[i].StartsWith("Delay", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -940,9 +939,9 @@ namespace Server.Commands
             {
                 for (var i = 0; i < m_Params.Length; ++i)
                 {
-                    if (m_Params[i].StartsWith("ContentType"))
+                    if (m_Params[i].StartsWith("ContentType", StringComparison.Ordinal))
                     {
-                        var indexOf = m_Params[i].IndexOf('=');
+                        var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                         if (indexOf >= 0)
                         {
@@ -969,18 +968,18 @@ namespace Server.Commands
 
             for (var i = 0; i < m_Params.Length; ++i)
             {
-                if (m_Params[i].StartsWith("Light"))
+                if (m_Params[i].StartsWith("Light", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
                         item.Light = (LightType)Enum.Parse(typeof(LightType), m_Params[i].Substring(++indexOf), true);
                     }
                 }
-                else if (m_Params[i].StartsWith("Hue"))
+                else if (m_Params[i].StartsWith("Hue", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
@@ -996,18 +995,18 @@ namespace Server.Commands
                         }
                     }
                 }
-                else if (m_Params[i].StartsWith("Name"))
+                else if (m_Params[i].StartsWith("Name", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
                         item.Name = m_Params[i].Substring(++indexOf);
                     }
                 }
-                else if (m_Params[i].StartsWith("Amount"))
+                else if (m_Params[i].StartsWith("Amount", StringComparison.Ordinal))
                 {
-                    var indexOf = m_Params[i].IndexOf('=');
+                    var indexOf = m_Params[i].IndexOf('=', StringComparison.Ordinal);
 
                     if (indexOf >= 0)
                     {
@@ -1236,7 +1235,7 @@ namespace Server.Commands
             {
                 line = line.Trim();
 
-                if (line.Length > 0 && !line.StartsWith("#"))
+                if (line.Length > 0 && !line.StartsWith("#", StringComparison.Ordinal))
                 {
                     break;
                 }
@@ -1249,7 +1248,7 @@ namespace Server.Commands
 
             var list = new DecorationListMag();
 
-            var indexOf = line.IndexOf(' ');
+            var indexOf = line.IndexOf(' ', StringComparison.Ordinal);
 
             list.m_Type = AssemblyHandler.FindFirstTypeForName(line.Substring(0, indexOf++), true);
 
@@ -1259,14 +1258,14 @@ namespace Server.Commands
             }
 
             line = line.Substring(indexOf);
-            indexOf = line.IndexOf('(');
+            indexOf = line.IndexOf('(', StringComparison.Ordinal);
             if (indexOf >= 0)
             {
                 list.m_ItemID = Utility.ToInt32(line.Substring(0, indexOf - 1));
 
                 var parms = line.Substring(++indexOf);
 
-                if (line.EndsWith(")"))
+                if (line.EndsWith(")", StringComparison.Ordinal))
                 {
                     parms = parms.Substring(0, parms.Length - 1);
                 }
@@ -1295,7 +1294,7 @@ namespace Server.Commands
                     break;
                 }
 
-                if (line.StartsWith("#"))
+                if (line.StartsWith("#", StringComparison.Ordinal))
                 {
                     continue;
                 }
@@ -1325,7 +1324,7 @@ namespace Server.Commands
 
         public void Pop(out string v, ref string line)
         {
-            var space = line.IndexOf(' ');
+            var space = line.IndexOf(' ', StringComparison.Ordinal);
 
             if (space >= 0)
             {

--- a/Projects/UOContent/Commands/Object Creation/GenTeleporter.cs
+++ b/Projects/UOContent/Commands/Object Creation/GenTeleporter.cs
@@ -39,8 +39,7 @@ namespace Server.Commands
             CommandSystem.Register("TelGenDelete", AccessLevel.Administrator, TelGenDelete_OnCommand);
         }
 
-        [Usage("TelGenDelete")]
-        [Description("Destroys world/dungeon teleporters for all facets.")]
+        [Usage("TelGenDelete"), Description("Destroys world/dungeon teleporters for all facets.")]
         public static void TelGenDelete_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -70,8 +69,7 @@ namespace Server.Commands
             from.SendMessage(WarningHue, $"{count} Teleporters Removed.");
         }
 
-        [Usage("TelGen")]
-        [Description("Generates world/dungeon teleporters for all facets.")]
+        [Usage("TelGen"), Description("Generates world/dungeon teleporters for all facets.")]
         public static void GenTeleporter_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;

--- a/Projects/UOContent/Commands/Object Creation/GenTeleporter.cs
+++ b/Projects/UOContent/Commands/Object Creation/GenTeleporter.cs
@@ -19,13 +19,6 @@ namespace Server.Commands
         public bool Back { get; set; }
 
         public override string ToString() => $"{{{Source},{Destination},{Back}}}";
-
-        public bool Equals(TeleporterDefinition other) =>
-            Source.Equals(other.Source) && Destination.Equals(other.Destination) && Back == other.Back;
-
-        public override bool Equals(object obj) => obj is TeleporterDefinition other && Equals(other);
-
-        public override int GetHashCode() => HashCode.Combine(Source, Destination, Back);
     }
 
     public static class GenTeleporter

--- a/Projects/UOContent/Commands/Profiling.cs
+++ b/Projects/UOContent/Commands/Profiling.cs
@@ -19,8 +19,7 @@ namespace Server.Commands
             CommandSystem.Register("SetProfiles", AccessLevel.Administrator, SetProfiles_OnCommand);
         }
 
-        [Usage("WriteProfiles")]
-        [Description("Generates a log files containing performance diagnostic information.")]
+        [Usage("WriteProfiles"), Description("Generates a log files containing performance diagnostic information.")]
         public static void WriteProfiles_OnCommand(CommandEventArgs e)
         {
             try
@@ -55,8 +54,8 @@ namespace Server.Commands
             }
         }
 
-        [Usage("SetProfiles [true | false]")]
-        [Description("Enables, disables, or toggles the state of core packet and timer profiling.")]
+        [Usage("SetProfiles [true | false]"),
+         Description("Enables, disables, or toggles the state of core packet and timer profiling.")]
         public static void SetProfiles_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 1)
@@ -71,8 +70,8 @@ namespace Server.Commands
             e.Mobile.SendMessage("Profiling has been {0}.", Core.Profiling ? "enabled" : "disabled");
         }
 
-        [Usage("DumpTimers")]
-        [Description("Generates a log file of all currently executing timers. Used for tracing timer leaks.")]
+        [Usage("DumpTimers"),
+         Description("Generates a log file of all currently executing timers. Used for tracing timer leaks.")]
         public static void DumpTimers_OnCommand(CommandEventArgs e)
         {
             try
@@ -86,8 +85,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("CountObjects")]
-        [Description("Generates a log file detailing all item and mobile types in the world.")]
+        [Usage("CountObjects"), Description("Generates a log file detailing all item and mobile types in the world.")]
         public static void CountObjects_OnCommand(CommandEventArgs e)
         {
             using (var op = new StreamWriter("objects.log"))
@@ -141,8 +139,7 @@ namespace Server.Commands
             e.Mobile.SendMessage("Object table has been generated. See the file : <runuo root>/objects.log");
         }
 
-        [Usage("TraceExpanded")]
-        [Description("Generates a log file describing all items using expanded memory.")]
+        [Usage("TraceExpanded"), Description("Generates a log file describing all items using expanded memory.")]
         public static void TraceExpanded_OnCommand(CommandEventArgs e)
         {
             var typeTable = new Dictionary<Type, int[]>();
@@ -253,8 +250,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("TraceInternal")]
-        [Description("Generates a log file describing all items in the 'internal' map.")]
+        [Usage("TraceInternal"), Description("Generates a log file describing all items in the 'internal' map.")]
         public static void TraceInternal_OnCommand(CommandEventArgs e)
         {
             var totalCount = 0;
@@ -297,8 +293,8 @@ namespace Server.Commands
             }
         }
 
-        [Usage("ProfileWorld")]
-        [Description("Prints the amount of data serialized for every object type in your world file.")]
+        [Usage("ProfileWorld"),
+         Description("Prints the amount of data serialized for every object type in your world file.")]
         public static void ProfileWorld_OnCommand(CommandEventArgs e)
         {
             ProfileWorld("items", "worldprofile_items.log");

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -620,7 +620,7 @@ namespace Server.Commands
 
 namespace Server
 {
-    public abstract class PropertyException : ApplicationException
+    public abstract class PropertyException : Exception
     {
         protected Property m_Property;
 

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -49,8 +49,8 @@ namespace Server.Commands
             CommandSystem.Register("Props", AccessLevel.Counselor, Props_OnCommand);
         }
 
-        [Usage("Props [serial]")]
-        [Description("Opens a menu where you can view and edit all properties of a targeted (or specified) object.")]
+        [Usage("Props [serial]"),
+         Description("Opens a menu where you can view and edit all properties of a targeted (or specified) object.")]
         private static void Props_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 1)
@@ -254,7 +254,7 @@ namespace Server.Commands
                 {
                     var valueString = args[1 + i * 2];
 
-                    if (valueString.StartsWith("0x"))
+                    if (valueString.StartsWith("0x", StringComparison.Ordinal))
                     {
                         realValues[i] = Convert.ToInt32(valueString.Substring(2), 16);
                     }
@@ -483,7 +483,7 @@ namespace Server.Commands
             {
                 toSet = null;
             }
-            else if (value.StartsWith("0x") && IsNumeric(type))
+            else if (value.StartsWith("0x", StringComparison.Ordinal) && IsNumeric(type))
             {
                 try
                 {
@@ -739,13 +739,15 @@ namespace Server
 
         public PropertyAccess Access { get; private set; }
 
+        private void NotYetBound() => throw new NotYetBoundException(this);
+
         public PropertyInfo[] Chain
         {
             get
             {
                 if (!IsBound)
                 {
-                    throw new NotYetBoundException(this);
+                    NotYetBound();
                 }
 
                 return m_Chain;
@@ -758,7 +760,7 @@ namespace Server
             {
                 if (!IsBound)
                 {
-                    throw new NotYetBoundException(this);
+                    NotYetBound();
                 }
 
                 return m_Chain[^1].PropertyType;

--- a/Projects/UOContent/Commands/ShardTime.cs
+++ b/Projects/UOContent/Commands/ShardTime.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Server.Commands
 {
-    public class ShardTime
+    public static class ShardTime
     {
         public static void Initialize()
         {
@@ -12,7 +13,7 @@ namespace Server.Commands
         [Usage("Time"), Description("Returns the server's local time.")]
         private static void Time_OnCommand(CommandEventArgs e)
         {
-            e.Mobile.SendMessage(DateTime.UtcNow.ToString());
+            e.Mobile.SendMessage(DateTime.UtcNow.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/Projects/UOContent/Commands/ShardTime.cs
+++ b/Projects/UOContent/Commands/ShardTime.cs
@@ -9,8 +9,7 @@ namespace Server.Commands
             CommandSystem.Register("Time", AccessLevel.Player, Time_OnCommand);
         }
 
-        [Usage("Time")]
-        [Description("Returns the server's local time.")]
+        [Usage("Time"), Description("Returns the server's local time.")]
         private static void Time_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendMessage(DateTime.UtcNow.ToString());

--- a/Projects/UOContent/Commands/SignParser.cs
+++ b/Projects/UOContent/Commands/SignParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Server.Items;

--- a/Projects/UOContent/Commands/SignParser.cs
+++ b/Projects/UOContent/Commands/SignParser.cs
@@ -5,7 +5,7 @@ using Server.Items;
 
 namespace Server.Commands
 {
-    public class SignParser
+    public static class SignParser
     {
         private static readonly Queue<Item> m_ToDelete = new Queue<Item>();
 

--- a/Projects/UOContent/Commands/SignParser.cs
+++ b/Projects/UOContent/Commands/SignParser.cs
@@ -13,8 +13,7 @@ namespace Server.Commands
             CommandSystem.Register("SignGen", AccessLevel.Administrator, SignGen_OnCommand);
         }
 
-        [Usage("SignGen")]
-        [Description("Generates world/shop signs on all facets.")]
+        [Usage("SignGen"), Description("Generates world/shop signs on all facets.")]
         public static void SignGen_OnCommand(CommandEventArgs c)
         {
             Parse(c.Mobile);
@@ -108,14 +107,13 @@ namespace Server.Commands
 
             Item sign;
 
-            if (name.StartsWith("#"))
+            if (name.StartsWith("#", StringComparison.Ordinal))
             {
                 sign = new LocalizedSign(itemID, Utility.ToInt32(name.Substring(1)));
             }
             else
             {
-                sign = new Sign(itemID);
-                sign.Name = name;
+                sign = new Sign(itemID) { Name = name };
             }
 
             if (map == Map.Malas)

--- a/Projects/UOContent/Commands/Skills.cs
+++ b/Projects/UOContent/Commands/Skills.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Commands
 {
-    public class SkillsCommand
+    public static class SkillsCommand
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Commands/Skills.cs
+++ b/Projects/UOContent/Commands/Skills.cs
@@ -12,8 +12,7 @@ namespace Server.Commands
             CommandSystem.Register("SetAllSkills", AccessLevel.GameMaster, SetAllSkills_OnCommand);
         }
 
-        [Usage("SetSkill <name> <value>")]
-        [Description("Sets a skill value by name of a targeted mobile.")]
+        [Usage("SetSkill <name> <value>"), Description("Sets a skill value by name of a targeted mobile.")]
         public static void SetSkill_OnCommand(CommandEventArgs arg)
         {
             if (arg.Length != 2)
@@ -33,8 +32,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("SetAllSkills <name> <value>")]
-        [Description("Sets all skill values of a targeted mobile.")]
+        [Usage("SetAllSkills <name> <value>"), Description("Sets all skill values of a targeted mobile.")]
         public static void SetAllSkills_OnCommand(CommandEventArgs arg)
         {
             if (arg.Length != 1)
@@ -47,8 +45,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("GetSkill <name>")]
-        [Description("Gets a skill value by name of a targeted mobile.")]
+        [Usage("GetSkill <name>"), Description("Gets a skill value by name of a targeted mobile.")]
         public static void GetSkill_OnCommand(CommandEventArgs arg)
         {
             if (arg.Length != 1)

--- a/Projects/UOContent/Commands/SkillsMenu.cs
+++ b/Projects/UOContent/Commands/SkillsMenu.cs
@@ -15,8 +15,7 @@ namespace Server.Commands
             CommandSystem.Register("Skills", AccessLevel.Counselor, Skills_OnCommand);
         }
 
-        [Usage("Skills")]
-        [Description("Opens a menu where you can view or edit skills of a targeted mobile.")]
+        [Usage("Skills"), Description("Opens a menu where you can view or edit skills of a targeted mobile.")]
         private static void Skills_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new SkillsTarget();

--- a/Projects/UOContent/Commands/SkillsMenu.cs
+++ b/Projects/UOContent/Commands/SkillsMenu.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Commands
 {
-    public class Skills
+    public static class SkillsMenu
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Commands/Statics.cs
+++ b/Projects/UOContent/Commands/Statics.cs
@@ -6,7 +6,7 @@ using Server.Items;
 
 namespace Server
 {
-    public class Statics
+    public static class Statics
     {
         public delegate void FreezeCallback(Mobile from, bool okay, StateInfo si);
 

--- a/Projects/UOContent/Commands/Statics.cs
+++ b/Projects/UOContent/Commands/Statics.cs
@@ -47,16 +47,14 @@ namespace Server
             CommandSystem.Register("UnfreezeWorld", AccessLevel.Administrator, UnfreezeWorld_OnCommand);
         }
 
-        [Usage("Freeze")]
-        [Description("Makes a targeted area of dynamic items static.")]
+        [Usage("Freeze"), Description("Makes a targeted area of dynamic items static.")]
         public static void Freeze_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
             BoundingBoxPicker.Begin(from, (map, start, end) => FreezeBox_Callback(from, map, start, end));
         }
 
-        [Usage("FreezeMap")]
-        [Description("Makes every dynamic item in your map static.")]
+        [Usage("FreezeMap"), Description("Makes every dynamic item in your map static.")]
         public static void FreezeMap_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -76,8 +74,7 @@ namespace Server
             }
         }
 
-        [Usage("FreezeWorld")]
-        [Description("Makes every dynamic item on all maps static.")]
+        [Usage("FreezeWorld"), Description("Makes every dynamic item on all maps static.")]
         public static void FreezeWorld_OnCommand(CommandEventArgs e)
         {
             SendWarning(
@@ -406,16 +403,14 @@ namespace Server
             }
         }
 
-        [Usage("Unfreeze")]
-        [Description("Makes a targeted area of static items dynamic.")]
+        [Usage("Unfreeze"), Description("Makes a targeted area of static items dynamic.")]
         public static void Unfreeze_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
             BoundingBoxPicker.Begin(from, (map, start, end) => UnfreezeBox_Callback(from, map, start, end));
         }
 
-        [Usage("UnfreezeMap")]
-        [Description("Makes every static item in your map dynamic.")]
+        [Usage("UnfreezeMap"), Description("Makes every static item in your map dynamic.")]
         public static void UnfreezeMap_OnCommand(CommandEventArgs e)
         {
             var map = e.Mobile.Map;
@@ -434,8 +429,7 @@ namespace Server
             }
         }
 
-        [Usage("UnfreezeWorld")]
-        [Description("Makes every static item on all maps dynamic.")]
+        [Usage("UnfreezeWorld"), Description("Makes every static item on all maps dynamic.")]
         public static void UnfreezeWorld_OnCommand(CommandEventArgs e)
         {
             SendWarning(

--- a/Projects/UOContent/Commands/VisibilityList.cs
+++ b/Projects/UOContent/Commands/VisibilityList.cs
@@ -21,10 +21,9 @@ namespace Server.Commands
             (m as PlayerMobile)?.VisibilityList.Clear();
         }
 
-        [Usage("Vis")]
-        [Description(
-            "Adds or removes a targeted player from your visibility list.  Anyone on your visibility list will be able to see you at all times, even when you're hidden."
-        )]
+        [Usage("Vis"), Description(
+             "Adds or removes a targeted player from your visibility list.  Anyone on your visibility list will be able to see you at all times, even when you're hidden."
+         )]
         public static void Vis_OnCommand(CommandEventArgs e)
         {
             if (e.Mobile is PlayerMobile)
@@ -34,8 +33,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("VisList")]
-        [Description("Shows the names of everyone in your visibility list.")]
+        [Usage("VisList"), Description("Shows the names of everyone in your visibility list.")]
         public static void VisList_OnCommand(CommandEventArgs e)
         {
             if (e.Mobile is PlayerMobile pm)
@@ -58,8 +56,7 @@ namespace Server.Commands
             }
         }
 
-        [Usage("VisClear")]
-        [Description("Removes everyone from your visibility list.")]
+        [Usage("VisClear"), Description("Removes everyone from your visibility list.")]
         public static void VisClear_OnCommand(CommandEventArgs e)
         {
             if (e.Mobile is PlayerMobile pm)

--- a/Projects/UOContent/Commands/Wipe.cs
+++ b/Projects/UOContent/Commands/Wipe.cs
@@ -5,7 +5,7 @@ using Server.Multis;
 
 namespace Server.Commands
 {
-    public class Wipe
+    public static class Wipe
     {
         [Flags]
         public enum WipeType

--- a/Projects/UOContent/Commands/Wipe.cs
+++ b/Projects/UOContent/Commands/Wipe.cs
@@ -24,29 +24,25 @@ namespace Server.Commands
             CommandSystem.Register("WipeMultis", AccessLevel.GameMaster, WipeMultis_OnCommand);
         }
 
-        [Usage("Wipe")]
-        [Description("Wipes all items and npcs in a targeted bounding box.")]
+        [Usage("Wipe"), Description("Wipes all items and npcs in a targeted bounding box.")]
         private static void WipeAll_OnCommand(CommandEventArgs e)
         {
             BeginWipe(e.Mobile, WipeType.Items | WipeType.Mobiles);
         }
 
-        [Usage("WipeItems")]
-        [Description("Wipes all items in a targeted bounding box.")]
+        [Usage("WipeItems"), Description("Wipes all items in a targeted bounding box.")]
         private static void WipeItems_OnCommand(CommandEventArgs e)
         {
             BeginWipe(e.Mobile, WipeType.Items);
         }
 
-        [Usage("WipeNPCs")]
-        [Description("Wipes all npcs in a targeted bounding box.")]
+        [Usage("WipeNPCs"), Description("Wipes all npcs in a targeted bounding box.")]
         private static void WipeNPCs_OnCommand(CommandEventArgs e)
         {
             BeginWipe(e.Mobile, WipeType.Mobiles);
         }
 
-        [Usage("WipeMultis")]
-        [Description("Wipes all multis in a targeted bounding box.")]
+        [Usage("WipeMultis"), Description("Wipes all multis in a targeted bounding box.")]
         private static void WipeMultis_OnCommand(CommandEventArgs e)
         {
             BeginWipe(e.Mobile, WipeType.Multis);

--- a/Projects/UOContent/Context Menus/AddToSpellbookEntry.cs
+++ b/Projects/UOContent/Context Menus/AddToSpellbookEntry.cs
@@ -1,5 +1,4 @@
 using Server.Items;
-using Server.Network;
 using Server.Targeting;
 
 namespace Server.ContextMenus

--- a/Projects/UOContent/Engines/BulkOrders/BulkMaterialType.cs
+++ b/Projects/UOContent/Engines/BulkOrders/BulkMaterialType.cs
@@ -26,7 +26,7 @@ namespace Server.Engines.BulkOrders
         Leather
     }
 
-    public class BGTClassifier
+    public static class BGTClassifier
     {
         public static BulkGenericType Classify(BODType deedType, Type itemType)
         {

--- a/Projects/UOContent/Engines/BulkOrders/SmallBulkEntry.cs
+++ b/Projects/UOContent/Engines/BulkOrders/SmallBulkEntry.cs
@@ -65,7 +65,7 @@ namespace Server.Engines.BulkOrders
 
                 while ((line = ip.ReadLine()) != null)
                 {
-                    if (line.Length == 0 || line.StartsWith("#"))
+                    if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/Projects/UOContent/Engines/Chat/ChatActionHandlers.cs
+++ b/Projects/UOContent/Engines/Chat/ChatActionHandlers.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Engines.Chat
 {
-    public class ChatActionHandlers
+    public static class ChatActionHandlers
     {
         private static readonly ChatActionHandler[] m_Handlers;
 

--- a/Projects/UOContent/Engines/Chat/ChatActionHandlers.cs
+++ b/Projects/UOContent/Engines/Chat/ChatActionHandlers.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server.Engines.Chat
 {
     public class ChatActionHandlers
@@ -84,7 +86,7 @@ namespace Server.Engines.Chat
 
         public static void PrivateMessage(ChatUser from, Channel channel, string param)
         {
-            var indexOf = param.IndexOf(' ');
+            var indexOf = param.IndexOf(' ', StringComparison.Ordinal);
 
             var name = param.Substring(0, indexOf);
             var text = param.Substring(indexOf + 1);
@@ -171,7 +173,7 @@ namespace Server.Engines.Chat
             string name;
             string password = null;
 
-            var start = param.IndexOf('\"');
+            var start = param.IndexOf('\"', StringComparison.Ordinal);
 
             if (start >= 0)
             {
@@ -189,7 +191,7 @@ namespace Server.Engines.Chat
             }
             else
             {
-                var indexOf = param.IndexOf(' ');
+                var indexOf = param.IndexOf(' ', StringComparison.Ordinal);
 
                 if (indexOf >= 0)
                 {
@@ -226,7 +228,7 @@ namespace Server.Engines.Chat
             string name;
             string password = null;
 
-            var start = param.IndexOf('{');
+            var start = param.IndexOf('{', StringComparison.Ordinal);
 
             if (start >= 0)
             {

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -800,7 +800,7 @@ namespace Server.Engines.ConPVP
                 {
                     if (!m_Bomb.m_Flying && m_Bomb.Map != Map.Internal)
                     {
-                        Effects.SendLocationEffect(m_Bomb.GetWorldLocation(), m_Bomb.Map, 0x377A, 16, 10, m_Bomb.Hue, 0);
+                        Effects.SendLocationEffect(m_Bomb.GetWorldLocation(), m_Bomb.Map, 0x377A, 16, 10, m_Bomb.Hue);
                     }
 
                     if (m_Bomb.Location != m_Bomb.m_Game.Controller.BombHome)

--- a/Projects/UOContent/Engines/ConPVP/Games/TourneyMatch.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/TourneyMatch.cs
@@ -46,7 +46,7 @@ namespace Server.Engines.ConPVP
                     hasAppended = true;
                 }
 
-                sb.Append(".");
+                sb.Append('.');
 
                 part.AddLog(sb.ToString());
             }

--- a/Projects/UOContent/Engines/ConPVP/Gumps/TournamentBracketGump.cs
+++ b/Projects/UOContent/Engines/ConPVP/Gumps/TournamentBracketGump.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -25,7 +26,7 @@ namespace Server.Engines.ConPVP
         private const int BlackColor32 = 0x000008;
         private const int LabelColor32 = 0xFFFFFF;
         private readonly Mobile m_From;
-        private readonly List<object> m_List;
+        private List<object> m_List;
         private readonly object m_Object;
         private readonly int m_Page;
         private readonly Tournament m_Tournament;
@@ -279,9 +280,8 @@ namespace Server.Engines.ConPVP
                         AddPage(0);
                         AddBackground(0, 0, 300, 300, 9380);
 
-                        var pList = m_List != null
-                            ? Utility.CastListCovariant<object, TourneyParticipant>(m_List)
-                            : new List<TourneyParticipant>(tourney.Participants);
+                        var pList = m_List?.CastListCovariant<object, TourneyParticipant>()
+                                    ?? new List<TourneyParticipant>(tourney.Participants);
 
                         AddLeftArrow(25, 11, ToButtonID(0, 0));
                         AddHtml(25, 35, 250, 20, Center($"{pList.Count} Participant{(pList.Count == 1 ? "" : "s")}"));
@@ -440,7 +440,7 @@ namespace Server.Engines.ConPVP
                         }
 
                         var matchesList = m_List != null
-                            ? Utility.CastListCovariant<object, TourneyMatch>(m_List)
+                            ? m_List.CastListCovariant<object, TourneyMatch>()
                             : new List<TourneyMatch>(level.Matches);
 
                         AddRightArrow(

--- a/Projects/UOContent/Engines/ConPVP/Gumps/TournamentBracketGump.cs
+++ b/Projects/UOContent/Engines/ConPVP/Gumps/TournamentBracketGump.cs
@@ -522,31 +522,14 @@ namespace Server.Engines.ConPVP
                                     {
                                         if (m_Tournament.ParticipantsPerMatch == 4)
                                         {
-                                            var name = "(null)";
-
-                                            switch (j)
+                                            var name = j switch
                                             {
-                                                case 0:
-                                                    {
-                                                        name = "Minax";
-                                                        break;
-                                                    }
-                                                case 1:
-                                                    {
-                                                        name = "Council of Mages";
-                                                        break;
-                                                    }
-                                                case 2:
-                                                    {
-                                                        name = "True Britannians";
-                                                        break;
-                                                    }
-                                                case 3:
-                                                    {
-                                                        name = "Shadowlords";
-                                                        break;
-                                                    }
-                                            }
+                                                0 => "Minax",
+                                                1 => "Council of Mages",
+                                                2 => "True Britannians",
+                                                3 => "Shadowlords",
+                                                _ => "(null)"
+                                            };
 
                                             txt = $"{name} ({part.Players.Count})";
                                         }
@@ -658,31 +641,14 @@ namespace Server.Engines.ConPVP
                                 {
                                     if (m_Tournament.ParticipantsPerMatch == 4)
                                     {
-                                        var name = "(null)";
-
-                                        switch (i)
+                                        var name = i switch
                                         {
-                                            case 0:
-                                                {
-                                                    name = "Minax";
-                                                    break;
-                                                }
-                                            case 1:
-                                                {
-                                                    name = "Council of Mages";
-                                                    break;
-                                                }
-                                            case 2:
-                                                {
-                                                    name = "True Britannians";
-                                                    break;
-                                                }
-                                            case 3:
-                                                {
-                                                    name = "Shadowlords";
-                                                    break;
-                                                }
-                                        }
+                                            0 => "Minax",
+                                            1 => "Council of Mages",
+                                            2 => "True Britannians",
+                                            3 => "Shadowlords",
+                                            _ => "(null)"
+                                        };
 
                                         AddRightArrow(
                                             25,

--- a/Projects/UOContent/Engines/ConPVP/Tournament.cs
+++ b/Projects/UOContent/Engines/ConPVP/Tournament.cs
@@ -784,35 +784,14 @@ namespace Server.Engines.ConPVP
                         {
                             if (m_ParticipantsPerMatch == 4)
                             {
-                                var name = "(null)";
-
-                                switch (Pyramid.Levels[0]
-                                    .Matches[0]
-                                    .Participants.IndexOf(
-                                        winner
-                                    ))
+                                var name = Pyramid.Levels[0].Matches[0].Participants.IndexOf(winner) switch
                                 {
-                                    case 0:
-                                        {
-                                            name = "Minax";
-                                            break;
-                                        }
-                                    case 1:
-                                        {
-                                            name = "Council of Mages";
-                                            break;
-                                        }
-                                    case 2:
-                                        {
-                                            name = "True Britannians";
-                                            break;
-                                        }
-                                    case 3:
-                                        {
-                                            name = "Shadowlords";
-                                            break;
-                                        }
-                                }
+                                    0 => "Minax",
+                                    1 => "Council of Mages",
+                                    2 => "True Britannians",
+                                    3 => "Shadowlords",
+                                    _ => "(null)"
+                                };
 
                                 Alert("The tournament has completed!", $"The {name} team has won!");
                             }
@@ -940,33 +919,14 @@ namespace Server.Engines.ConPVP
                                     {
                                         if (m_ParticipantsPerMatch == 4)
                                         {
-                                            var name = "(null)";
-
-                                            switch (Pyramid.Levels[0]
-                                                .Matches[0]
-                                                .Participants.IndexOf(winner))
+                                            var name = Pyramid.Levels[0].Matches[0].Participants.IndexOf(winner) switch
                                             {
-                                                case 0:
-                                                    {
-                                                        name = "Minax";
-                                                        break;
-                                                    }
-                                                case 1:
-                                                    {
-                                                        name = "Council of Mages";
-                                                        break;
-                                                    }
-                                                case 2:
-                                                    {
-                                                        name = "True Britannians";
-                                                        break;
-                                                    }
-                                                case 3:
-                                                    {
-                                                        name = "Shadowlords";
-                                                        break;
-                                                    }
-                                            }
+                                                0 => "Minax",
+                                                1 => "Council of Mages",
+                                                2 => "True Britannians",
+                                                3 => "Shadowlords",
+                                                _ => "(null)"
+                                            };
 
                                             Alert("The tournament has completed!", $"The {name} team has won!");
                                         }

--- a/Projects/UOContent/Engines/ConPVP/Tournament.cs
+++ b/Projects/UOContent/Engines/ConPVP/Tournament.cs
@@ -478,7 +478,7 @@ namespace Server.Engines.ConPVP
                 hasAppended = true;
             }
 
-            sb.Append(".");
+            sb.Append('.');
 
             if (TourneyType == TourneyType.Standard)
             {

--- a/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
@@ -456,7 +456,7 @@ namespace Server.Engines.Craft
         {
             if (types.Length != amounts.Length)
             {
-                throw new ArgumentException();
+                throw new ArgumentOutOfRangeException(nameof(types));
             }
 
             var items = new Item[types.Length][];

--- a/Projects/UOContent/Engines/Craft/Core/Enhance.cs
+++ b/Projects/UOContent/Engines/Craft/Core/Enhance.cs
@@ -18,7 +18,7 @@ namespace Server.Engines.Craft
         NoSkill
     }
 
-    public class Enhance
+    public static class Enhance
     {
         public static EnhanceResult Invoke(
             Mobile from, CraftSystem craftSystem, BaseTool tool, Item item,

--- a/Projects/UOContent/Engines/Craft/Core/Recipes.cs
+++ b/Projects/UOContent/Engines/Craft/Core/Recipes.cs
@@ -43,8 +43,7 @@ namespace Server.Engines.Craft
             CommandSystem.Register("ForgetAllRecipes", AccessLevel.GameMaster, ForgetAllRecipes_OnCommand);
         }
 
-        [Usage("LearnAllRecipes")]
-        [Description("Teaches a player all available recipes.")]
+        [Usage("LearnAllRecipes"), Description("Teaches a player all available recipes.")]
         private static void LearnAllRecipes_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;
@@ -73,8 +72,7 @@ namespace Server.Engines.Craft
             );
         }
 
-        [Usage("ForgetAllRecipes")]
-        [Description("Makes a player forget all the recipes they've learned.")]
+        [Usage("ForgetAllRecipes"), Description("Makes a player forget all the recipes they've learned.")]
         private static void ForgetAllRecipes_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;

--- a/Projects/UOContent/Engines/Craft/Core/Repair.cs
+++ b/Projects/UOContent/Engines/Craft/Core/Repair.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server.Engines.Craft
 {
-    public class Repair
+    public static class Repair
     {
         public static void Do(Mobile from, CraftSystem craftSystem, BaseTool tool)
         {

--- a/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
+++ b/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
@@ -1351,10 +1351,12 @@ namespace Server.Engines.Craft
         }
     }
 
+    [AttributeUsage(AttributeTargets.Class)]
     public class ForgeAttribute : Attribute
     {
     }
 
+    [AttributeUsage(AttributeTargets.Class)]
     public class AnvilAttribute : Attribute
     {
     }

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
@@ -371,7 +371,7 @@ namespace Server.Engines.Doom
                         SendLocationEffect(lp_Center, 0x1153, 0, 60, 1);
                         PlaySounds(lp_Center, cs1);
 
-                        Effects.SendBoltEffect(player, true);
+                        Effects.SendBoltEffect(player);
                         player.MoveToWorld(lr_Enter, Map.Malas);
 
                         m_Timer = new LampRoomTimer(this);

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
@@ -189,8 +189,7 @@ namespace Server.Engines.Doom
             CommandSystem.Register("GenLeverPuzzle", AccessLevel.Administrator, GenLampPuzzle_OnCommand);
         }
 
-        [Usage("GenLeverPuzzle")]
-        [Description("Generates lamp room and lever puzzle in doom.")]
+        [Usage("GenLeverPuzzle"), Description("Generates lamp room and lever puzzle in doom.")]
         public static void GenLampPuzzle_OnCommand(CommandEventArgs e)
         {
             if (Map.Malas.GetItemsInRange(lp_Center, 0).OfType<LeverPuzzleController>().Any())

--- a/Projects/UOContent/Engines/Factions/Core/Generator.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Generator.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace Server.Factions
 {
-    public class Generator
+    public static class Generator
     {
         public static void Initialize()
         {
@@ -35,14 +35,14 @@ namespace Server.Factions
 
             var def = town.Definition;
 
-            if (!CheckExistance(def.Monolith, facet, typeof(TownMonolith)))
+            if (!CheckExistence(def.Monolith, facet, typeof(TownMonolith)))
             {
                 var mono = new TownMonolith(town);
                 mono.MoveToWorld(def.Monolith, facet);
                 mono.Sigil = new Sigil(town);
             }
 
-            if (!CheckExistance(def.TownStone, facet, typeof(TownStone)))
+            if (!CheckExistence(def.TownStone, facet, typeof(TownStone)))
             {
                 new TownStone(town).MoveToWorld(def.TownStone, facet);
             }
@@ -56,12 +56,12 @@ namespace Server.Factions
 
             var stronghold = faction.Definition.Stronghold;
 
-            if (!CheckExistance(stronghold.JoinStone, facet, typeof(JoinStone)))
+            if (!CheckExistence(stronghold.JoinStone, facet, typeof(JoinStone)))
             {
                 new JoinStone(faction).MoveToWorld(stronghold.JoinStone, facet);
             }
 
-            if (!CheckExistance(stronghold.FactionStone, facet, typeof(FactionStone)))
+            if (!CheckExistence(stronghold.FactionStone, facet, typeof(FactionStone)))
             {
                 new FactionStone(faction).MoveToWorld(stronghold.FactionStone, facet);
             }
@@ -70,14 +70,14 @@ namespace Server.Factions
             {
                 var monolith = stronghold.Monoliths[i];
 
-                if (!CheckExistance(monolith, facet, typeof(StrongholdMonolith)))
+                if (!CheckExistence(monolith, facet, typeof(StrongholdMonolith)))
                 {
                     new StrongholdMonolith(towns[i], faction).MoveToWorld(monolith, facet);
                 }
             }
         }
 
-        private static bool CheckExistance(Point3D loc, Map facet, Type type) =>
+        private static bool CheckExistence(Point3D loc, Map facet, Type type) =>
             facet.GetItemsInRange(loc, 0).Any(type.IsInstanceOfType);
     }
 }

--- a/Projects/UOContent/Engines/Factions/Core/MerchantTitles.cs
+++ b/Projects/UOContent/Engines/Factions/Core/MerchantTitles.cs
@@ -35,7 +35,7 @@ namespace Server.Factions
         public TextDefinition Assigned { get; }
     }
 
-    public class MerchantTitles
+    public static class MerchantTitles
     {
         public static MerchantTitleInfo[] Info { get; } =
         {

--- a/Projects/UOContent/Engines/Factions/Core/Reflector.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Reflector.cs
@@ -5,7 +5,7 @@ using Server.Utilities;
 
 namespace Server.Factions
 {
-    public class Reflector
+    public static class Reflector
     {
         private static List<Town> m_Towns;
 

--- a/Projects/UOContent/Engines/Factions/Core/Town.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Town.cs
@@ -286,7 +286,7 @@ namespace Server.Factions
 
         public void ConstructGuardLists()
         {
-            var defs = Owner?.Definition.Guards ?? new GuardDefinition[0];
+            var defs = Owner?.Definition.Guards ?? Array.Empty<GuardDefinition>();
 
             GuardLists = new List<GuardList>();
 

--- a/Projects/UOContent/Engines/Factions/Items/Traps/BaseFactionTrap.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Traps/BaseFactionTrap.cs
@@ -80,7 +80,7 @@ namespace Server.Factions
 
             var silverToAward = from.Alive ? 20 : 40;
 
-            if (silverToAward > 0 && Placer != null && Faction != null)
+            if (Placer != null && Faction != null)
             {
                 var victimState = PlayerState.Find(from);
 

--- a/Projects/UOContent/Engines/Factions/Items/Traps/FactionExplosionTrap.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Traps/FactionExplosionTrap.cs
@@ -24,7 +24,7 @@ namespace Server.Factions
 
         public override void DoVisibleEffect()
         {
-            Effects.SendLocationEffect(GetWorldLocation(), Map, 0x36BD, 15, 10);
+            Effects.SendLocationEffect(GetWorldLocation(), Map, 0x36BD, 15);
         }
 
         public override void DoAttackEffect(Mobile m)

--- a/Projects/UOContent/Engines/Factions/Items/Traps/FactionSawTrap.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Traps/FactionSawTrap.cs
@@ -20,7 +20,7 @@ namespace Server.Factions
 
         public override void DoVisibleEffect()
         {
-            Effects.SendLocationEffect(Location, Map, 0x11AD, 25, 10);
+            Effects.SendLocationEffect(Location, Map, 0x11AD, 25);
         }
 
         public override void DoAttackEffect(Mobile m)

--- a/Projects/UOContent/Engines/Help/PageQueue.cs
+++ b/Projects/UOContent/Engines/Help/PageQueue.cs
@@ -172,8 +172,7 @@ namespace Server.Engines.Help
             }
         }
 
-        [Usage("Pages")]
-        [Description("Opens the page queue menu.")]
+        [Usage("Pages"), Description("Opens the page queue menu.")]
         private static void Pages_OnCommand(CommandEventArgs e)
         {
             if (m_KeyedByHandler.TryGetValue(e.Mobile, out var entry))

--- a/Projects/UOContent/Engines/Help/PageQueue.cs
+++ b/Projects/UOContent/Engines/Help/PageQueue.cs
@@ -114,7 +114,7 @@ namespace Server.Engines.Help
         }
     }
 
-    public class PageQueue
+    public static class PageQueue
     {
         private static readonly Dictionary<Mobile, PageEntry> m_KeyedByHandler = new Dictionary<Mobile, PageEntry>();
         private static readonly Dictionary<Mobile, PageEntry> m_KeyedBySender = new Dictionary<Mobile, PageEntry>();

--- a/Projects/UOContent/Engines/Help/PageQueueGump.cs
+++ b/Projects/UOContent/Engines/Help/PageQueueGump.cs
@@ -188,7 +188,7 @@ namespace Server.Engines.Help
 
                 while ((line = ip.ReadLine()?.Trim()) != null)
                 {
-                    if (line.Length == 0 || line.StartsWith("#"))
+                    if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/Projects/UOContent/Engines/Help/SpeechLog.cs
+++ b/Projects/UOContent/Engines/Help/SpeechLog.cs
@@ -34,8 +34,7 @@ namespace Server.Engines.Help
             CommandSystem.Register("SpeechLog", AccessLevel.Counselor, SpeechLog_OnCommand);
         }
 
-        [Usage("SpeechLog")]
-        [Description("Opens the speech log of a given target.")]
+        [Usage("SpeechLog"), Description("Opens the speech log of a given target.")]
         private static void SpeechLog_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;

--- a/Projects/UOContent/Engines/Khaldun/KhaldunGen.cs
+++ b/Projects/UOContent/Engines/Khaldun/KhaldunGen.cs
@@ -4,7 +4,7 @@ using Server.Items;
 
 namespace Server.Commands
 {
-    public class GenKhaldun
+    public static class GenKhaldun
     {
         private static int m_Count;
 

--- a/Projects/UOContent/Engines/MLQuests/MLQuestSystem.cs
+++ b/Projects/UOContent/Engines/MLQuests/MLQuestSystem.cs
@@ -42,7 +42,9 @@ namespace Server.Engines.MLQuests
 
                 while ((line = sr.ReadLine()) != null)
                 {
-                    if (line.Length == 0 || line.StartsWith("#"))
+                    line = line.Trim();
+
+                    if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                     {
                         continue;
                     }
@@ -176,8 +178,8 @@ namespace Server.Engines.MLQuests
             EventSink.QuestGumpRequest += EventSink_QuestGumpRequest;
         }
 
-        [Usage("MLQuestsInfo")]
-        [Description("Displays general information about the ML quest system, or a quest by type name.")]
+        [Usage("MLQuestsInfo"),
+         Description("Displays general information about the ML quest system, or a quest by type name.")]
         public static void MLQuestsInfo_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;
@@ -202,8 +204,8 @@ namespace Server.Engines.MLQuests
             m.SendMessage("Number of active instances: {0}", quest.Instances.Count);
         }
 
-        [Usage("SaveQuest <type> [saveEnabled=true]")]
-        [Description("Allows serialization for a specific quest to be turned on or off.")]
+        [Usage("SaveQuest <type> [saveEnabled=true]"),
+         Description("Allows serialization for a specific quest to be turned on or off.")]
         public static void SaveQuest_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;
@@ -235,8 +237,8 @@ namespace Server.Engines.MLQuests
             }
         }
 
-        [Usage("SaveAllQuests [saveEnabled=true]")]
-        [Description("Allows serialization for all quests to be turned on or off.")]
+        [Usage("SaveAllQuests [saveEnabled=true]"),
+         Description("Allows serialization for all quests to be turned on or off.")]
         public static void SaveAllQuests_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;
@@ -264,8 +266,8 @@ namespace Server.Engines.MLQuests
             }
         }
 
-        [Usage("InvalidQuestItems")]
-        [Description("Provides an overview of all quest items not located in the top-level of a player's backpack.")]
+        [Usage("InvalidQuestItems"),
+         Description("Provides an overview of all quest items not located in the top-level of a player's backpack.")]
         public static void InvalidQuestItems_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;

--- a/Projects/UOContent/Engines/Pathing/FastAStarAlgorithm.cs
+++ b/Projects/UOContent/Engines/Pathing/FastAStarAlgorithm.cs
@@ -295,8 +295,7 @@ namespace Server.PathAlgorithms.FastAStar
                 int y;
                 switch (i)
                 {
-                    default:
-                    case 0:
+                    default: // 0
                         x = 0;
                         y = -1;
                         break;

--- a/Projects/UOContent/Engines/Pathing/SlowAStarAlgorithm.cs
+++ b/Projects/UOContent/Engines/Pathing/SlowAStarAlgorithm.cs
@@ -99,12 +99,12 @@ namespace Server.PathAlgorithms.SlowAStar
                     var yBacktrack = curNode.py;
                     var zBacktrack = curNode.pz;
 
+                    path[pathCount++] = (Direction)curNode.dir;
+
                     if (pathCount == MaxNodes)
                     {
                         break;
                     }
-
-                    path[pathCount++] = (Direction)curNode.dir;
 
                     while (xBacktrack != startNode.x || yBacktrack != startNode.y || zBacktrack != startNode.z)
                     {

--- a/Projects/UOContent/Engines/Quests/Dark Tides/Items/KronusScroll.cs
+++ b/Projects/UOContent/Engines/Quests/Dark Tides/Items/KronusScroll.cs
@@ -1,7 +1,6 @@
 using System;
 using Server.Items;
 using Server.Mobiles;
-using Server.Network;
 
 namespace Server.Engines.Quests.Necro
 {
@@ -32,21 +31,46 @@ namespace Server.Engines.Quests.Necro
                 return;
             }
 
-            if (from is PlayerMobile pm)
+            if (!(from is PlayerMobile pm))
             {
-                var qs = pm.Quest;
+                return;
+            }
 
-                if (qs is DarkTidesQuest)
+            var qs = pm.Quest;
+
+            if (qs is DarkTidesQuest)
+            {
+                if (qs.IsObjectiveInProgress(typeof(FindMardothAboutKronusObjective)))
                 {
-                    if (qs.IsObjectiveInProgress(typeof(FindMardothAboutKronusObjective)))
+                    pm.SendLocalizedMessage(
+                        1060151,
+                        "",
+                        0x41
+                    ); // You read the scroll, but decide against performing the calling until you are instructed to do so by Mardoth.
+                }
+                else if (qs.IsObjectiveInProgress(typeof(FindWellOfTearsObjective)))
+                {
+                    pm.SendLocalizedMessage(
+                        1060152,
+                        "",
+                        0x41
+                    ); // You must be at the Well of Tears in the city of Necromancers to use this scroll.
+                }
+                else if (qs.IsObjectiveInProgress(typeof(UseCallingScrollObjective)))
+                {
+                    if (pm.Map == m_WellOfTearsMap && m_WellOfTearsArea.Contains(pm))
                     {
-                        pm.SendLocalizedMessage(
-                            1060151,
-                            "",
-                            0x41
-                        ); // You read the scroll, but decide against performing the calling until you are instructed to do so by Mardoth.
+                        QuestObjective obj = qs.FindObjective<UseCallingScrollObjective>();
+
+                        if (obj?.Completed == false)
+                        {
+                            obj.Complete();
+                        }
+
+                        Delete();
+                        new CallingTimer(pm).Start();
                     }
-                    else if (qs.IsObjectiveInProgress(typeof(FindWellOfTearsObjective)))
+                    else
                     {
                         pm.SendLocalizedMessage(
                             1060152,
@@ -54,37 +78,14 @@ namespace Server.Engines.Quests.Necro
                             0x41
                         ); // You must be at the Well of Tears in the city of Necromancers to use this scroll.
                     }
-                    else if (qs.IsObjectiveInProgress(typeof(UseCallingScrollObjective)))
-                    {
-                        if (pm.Map == m_WellOfTearsMap && m_WellOfTearsArea.Contains(pm))
-                        {
-                            QuestObjective obj = qs.FindObjective<UseCallingScrollObjective>();
-
-                            if (obj?.Completed == false)
-                            {
-                                obj.Complete();
-                            }
-
-                            Delete();
-                            new CallingTimer(pm).Start();
-                        }
-                        else
-                        {
-                            pm.SendLocalizedMessage(
-                                1060152,
-                                "",
-                                0x41
-                            ); // You must be at the Well of Tears in the city of Necromancers to use this scroll.
-                        }
-                    }
-                    else
-                    {
-                        pm.SendLocalizedMessage(
-                            1060150,
-                            "",
-                            0x41
-                        ); // A strange terror grips your heart as you attempt to read the scroll.  You decide it would be a bad idea to read it out loud.
-                    }
+                }
+                else
+                {
+                    pm.SendLocalizedMessage(
+                        1060150,
+                        "",
+                        0x41
+                    ); // A strange terror grips your heart as you attempt to read the scroll.  You decide it would be a bad idea to read it out loud.
                 }
             }
         }

--- a/Projects/UOContent/Engines/Quests/Dark Tides/Items/MaabusCoffin.cs
+++ b/Projects/UOContent/Engines/Quests/Dark Tides/Items/MaabusCoffin.cs
@@ -78,9 +78,9 @@ namespace Server.Engines.Quests.Necro
             Maabus.Delete();
             Maabus = null;
 
-            foreach (MaabusCoffinComponent c in Components)
+            foreach (var c in Components)
             {
-                c.TurnToFull();
+                (c as MaabusCoffinComponent)?.TurnToFull();
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
@@ -49,7 +49,7 @@ namespace Server.Engines.Quests.Hag
             Corpse = new HagApprenticeCorpse();
             Corpse.MoveToWorld(m_CorpseLocation, map);
 
-            Effects.SendLocationEffect(m_CorpseLocation, map, 0x3728, 10, 10);
+            Effects.SendLocationEffect(m_CorpseLocation, map, 0x3728, 10);
             Effects.PlaySound(m_CorpseLocation, map, 0x1FE);
 
             Mobile imp = new Zeefzorpul();
@@ -65,7 +65,7 @@ namespace Server.Engines.Quests.Hag
         {
             if (m?.Deleted == false)
             {
-                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10, 10);
+                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10);
                 Effects.PlaySound(m.Location, m.Map, 0x1FE);
 
                 m.Delete();
@@ -213,7 +213,7 @@ namespace Server.Engines.Quests.Hag
             Mobile from = System.From;
             var map = from.Map;
 
-            Effects.SendLocationEffect(ImpLocation, map, 0x3728, 10, 10);
+            Effects.SendLocationEffect(ImpLocation, map, 0x3728, 10);
             Effects.PlaySound(ImpLocation, map, 0x1FE);
 
             Mobile imp = new Zeefzorpul();
@@ -228,7 +228,7 @@ namespace Server.Engines.Quests.Hag
         {
             if (imp is Mobile m && !m.Deleted)
             {
-                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10, 10);
+                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10);
                 Effects.PlaySound(m.Location, m.Map, 0x1FE);
 
                 m.Delete();

--- a/Projects/UOContent/Engines/Treasures of Tokuno/BasePigmentsOfTokuno.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/BasePigmentsOfTokuno.cs
@@ -228,12 +228,8 @@ namespace Server.Items
                 return true;
             }
 
-            if (i is ITokunoDyable)
-            {
-                return true;
-            }
-
-            return IsInTypeList(t, TreasuresOfTokuno.LesserArtifactsTotal)
+            return IsInTypeList(t, TreasuresOfTokuno.TokunoDyable)
+                   || IsInTypeList(t, TreasuresOfTokuno.LesserArtifactsTotal)
                    || IsInTypeList(t, TreasuresOfTokuno.GreaterArtifacts)
                    || IsInTypeList(t, DemonKnight.ArtifactRarity10)
                    || IsInTypeList(t, DemonKnight.ArtifactRarity11)
@@ -251,7 +247,7 @@ namespace Server.Items
         {
             for (var i = 0; i < list.Length; i++)
             {
-                if (list[i] == t)
+                if (list[i].IsAssignableFrom(t))
                 {
                     return true;
                 }

--- a/Projects/UOContent/Engines/Treasures of Tokuno/LesserArtifacts.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/LesserArtifacts.cs
@@ -783,8 +783,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2811, 0x2812)]
+    [Furniture, Flippable(0x2811, 0x2812)]
     public class ChestOfHeirlooms : LockableContainer
     {
         [Constructible]

--- a/Projects/UOContent/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
@@ -80,6 +80,12 @@ namespace Server.Misc
             typeof(ChestOfHeirlooms)
         };
 
+        public static Type[] TokunoDyable { get; } =
+        {
+            typeof(DupresShield), typeof(CrimsonCincture), typeof(OssianGrimoire), typeof(QuiverOfInfinity),
+            typeof(BaseFormTalisman), typeof(BaseWand), typeof(JesterHatofChuckles)
+        };
+
         public static TreasuresOfTokunoEra DropEra { get; set; } = TreasuresOfTokunoEra.None;
 
         public static TreasuresOfTokunoEra RewardEra { get; set; } = TreasuresOfTokunoEra.ToTOne;

--- a/Projects/UOContent/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
@@ -20,7 +20,7 @@ namespace Server.Misc
         ToTThree
     }
 
-    public class TreasuresOfTokuno
+    public static class TreasuresOfTokuno
     {
         public const int ItemsPerReward = 10;
 

--- a/Projects/UOContent/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/TreasuresOfTokuno.cs
@@ -344,7 +344,7 @@ namespace Server.Gumps
 
         public ToTTurnInGump(Mobile collector, List<ItemTileButtonInfo> buttons) : base(
             1071012,
-            Utility.CastListContravariant<ItemTileButtonInfo, ImageTileButtonInfo>(buttons)
+            buttons.ToList<ImageTileButtonInfo>()
         ) // Click a minor artifact to give it to Ihara Soko.
             =>
                 m_Collector = collector;

--- a/Projects/UOContent/Engines/VeteranRewards/RewardSystem.cs
+++ b/Projects/UOContent/Engines/VeteranRewards/RewardSystem.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 
 namespace Server.Engines.VeteranRewards
 {
-    public class RewardSystem
+    public static class RewardSystem
     {
         private static RewardCategory[] m_Categories;
         private static RewardList[] m_Lists;

--- a/Projects/UOContent/Engines/Virtues/Compassion.cs
+++ b/Projects/UOContent/Engines/Virtues/Compassion.cs
@@ -3,7 +3,7 @@ using Server.Mobiles;
 
 namespace Server
 {
-    public class CompassionVirtue
+    public static class CompassionVirtue
     {
         private const int LossAmount = 500;
         private static readonly TimeSpan LossDelay = TimeSpan.FromDays(7.0);

--- a/Projects/UOContent/Engines/Virtues/Honor.cs
+++ b/Projects/UOContent/Engines/Virtues/Honor.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server
 {
-    public class HonorVirtue
+    public static class HonorVirtue
     {
         private static readonly TimeSpan UseDelay = TimeSpan.FromMinutes(5.0);
 

--- a/Projects/UOContent/Engines/Virtues/Justice.cs
+++ b/Projects/UOContent/Engines/Virtues/Justice.cs
@@ -6,6 +6,7 @@ using Server.Targeting;
 
 namespace Server
 {
+#pragma warning disable CA1052
     public class JusticeVirtue
     {
         private const int LossAmount = 950;
@@ -285,4 +286,5 @@ namespace Server
             }
         }
     }
+#pragma warning restore CA1052
 }

--- a/Projects/UOContent/Engines/Virtues/Sacrifice.cs
+++ b/Projects/UOContent/Engines/Virtues/Sacrifice.cs
@@ -6,7 +6,7 @@ using Server.Targeting;
 
 namespace Server
 {
-    public class SacrificeVirtue
+    public static class SacrificeVirtue
     {
         private const int LossAmount = 500;
         private static readonly TimeSpan GainDelay = TimeSpan.FromDays(1.0);

--- a/Projects/UOContent/Engines/Virtues/Valor.cs
+++ b/Projects/UOContent/Engines/Virtues/Valor.cs
@@ -5,7 +5,7 @@ using Server.Targeting;
 
 namespace Server
 {
-    public class ValorVirtue
+    public static class ValorVirtue
     {
         private const int LossAmount = 250;
         private static readonly TimeSpan LossDelay = TimeSpan.FromDays(7.0);

--- a/Projects/UOContent/Engines/Virtues/VirtueHelper.cs
+++ b/Projects/UOContent/Engines/Virtues/VirtueHelper.cs
@@ -23,7 +23,7 @@ namespace Server
         Honesty
     }
 
-    public class VirtueHelper
+    public static class VirtueHelper
     {
         public static bool HasAny(Mobile from, VirtueName virtue) => from.Virtues.GetValue((int)virtue) > 0;
 

--- a/Projects/UOContent/Gumps/AddDoorGump.cs
+++ b/Projects/UOContent/Gumps/AddDoorGump.cs
@@ -102,8 +102,7 @@ namespace Server.Gumps
             CommandSystem.Register("AddDoor", AccessLevel.GameMaster, AddDoor_OnCommand);
         }
 
-        [Usage("AddDoor")]
-        [Description("Displays a menu from which you can interactively add doors.")]
+        [Usage("AddDoor"), Description("Displays a menu from which you can interactively add doors.")]
         public static void AddDoor_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendGump(new AddDoorGump());

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -612,14 +612,11 @@ namespace Server.Gumps
                         if (m_List == null)
                         {
                             sharedAccounts = GetAllSharedAccounts();
-                            m_List = Utility.CastListContravariant<KeyValuePair<IPAddress, List<Account>>, object>(
-                                sharedAccounts
-                            );
+                            m_List = sharedAccounts.CastListContravariant<KeyValuePair<IPAddress, List<Account>>, object>();
                         }
                         else
                         {
-                            sharedAccounts =
-                                Utility.CastListCovariant<object, KeyValuePair<IPAddress, List<Account>>>(m_List);
+                            sharedAccounts = m_List.CastListCovariant<object, KeyValuePair<IPAddress, List<Account>>>();
                         }
 
                         AddLabelCropped(12, 120, 60, 20, LabelHue, "Count");
@@ -1007,11 +1004,11 @@ namespace Server.Gumps
                         if (m_List == null)
                         {
                             ipAddresses = a.LoginIPs.ToList();
-                            m_List = Utility.CastListContravariant<IPAddress, object>(ipAddresses);
+                            m_List = ipAddresses.CastListContravariant<IPAddress, object>();
                         }
                         else
                         {
-                            ipAddresses = Utility.CastListCovariant<object, IPAddress>(m_List);
+                            ipAddresses = m_List.CastListCovariant<object, IPAddress>();
                         }
 
                         AddHtml(10, 195, 400, 20, Color(Center("Client Addresses"), LabelColor32));
@@ -1079,11 +1076,11 @@ namespace Server.Gumps
                         if (m_List == null)
                         {
                             ipRestrictions = a.IPRestrictions.ToList();
-                            m_List = Utility.CastListContravariant<string, object>(ipRestrictions);
+                            m_List = ipRestrictions.CastListContravariant<string, object>();
                         }
                         else
                         {
-                            ipRestrictions = Utility.CastListCovariant<object, string>(m_List);
+                            ipRestrictions = m_List.CastListCovariant<object, string>();
                         }
 
                         AddHtml(10, 195, 400, 20, Color(Center("Address Restrictions"), LabelColor32));
@@ -1268,11 +1265,11 @@ namespace Server.Gumps
                         if (m_List == null)
                         {
                             firewallEntries = Firewall.List;
-                            m_List = Utility.CastListContravariant<Firewall.IFirewallEntry, object>(firewallEntries);
+                            m_List = firewallEntries.CastListContravariant<Firewall.IFirewallEntry, object>();
                         }
                         else
                         {
-                            firewallEntries = Utility.CastListCovariant<object, Firewall.IFirewallEntry>(m_List);
+                            firewallEntries = m_List.CastListCovariant<object, Firewall.IFirewallEntry>();
                         }
 
                         AddLabelCropped(12, 120, 358, 20, LabelHue, "IP Address");
@@ -1354,11 +1351,11 @@ namespace Server.Gumps
                             }
 
                             blockedAccts.Sort(AccountComparer.Instance);
-                            m_List = Utility.CastListContravariant<Account, object>(blockedAccts);
+                            m_List = blockedAccts.CastListContravariant<Account, object>();
                         }
                         else
                         {
-                            blockedAccts = Utility.CastListCovariant<object, Account>(m_List);
+                            blockedAccts = m_List.CastListCovariant<object, Account>();
                         }
 
                         if (listPage > 0)
@@ -1971,7 +1968,7 @@ namespace Server.Gumps
 
             if (m_PageType == AdminGumpPage.Accounts)
             {
-                var list = Utility.CastListCovariant<object, Account>(m_List);
+                var list = m_List.CastListCovariant<object, Account>();
 
                 if (list != null && m_State is List<Account> rads)
                 {
@@ -2511,7 +2508,7 @@ namespace Server.Gumps
                                                     from,
                                                     AdminGumpPage.Clients,
                                                     0,
-                                                    Utility.CastListContravariant<NetState, object>(results),
+                                                    results.CastListContravariant<NetState, object>(),
                                                     "One match found."
                                                 )
                                             );
@@ -2524,7 +2521,7 @@ namespace Server.Gumps
                                                 from,
                                                 AdminGumpPage.Clients,
                                                 0,
-                                                Utility.CastListContravariant<NetState, object>(results),
+                                                results.CastListContravariant<NetState, object>(),
                                                 notice ?? (results.Count == 0 ? "Nothing matched your search terms." : null)
                                             )
                                         );
@@ -2744,7 +2741,7 @@ namespace Server.Gumps
                                                 from,
                                                 AdminGumpPage.Accounts,
                                                 0,
-                                                Utility.CastListContravariant<IAccount, object>(results),
+                                                results.CastListContravariant<IAccount, object>(),
                                                 results.Count == 0 ? "Nothing matched your search terms." : null,
                                                 new List<object>()
                                             )
@@ -2872,7 +2869,7 @@ namespace Server.Gumps
                                                 from,
                                                 AdminGumpPage.Accounts,
                                                 0,
-                                                Utility.CastListContravariant<Account, object>(list),
+                                                list.CastListContravariant<Account, object>(),
                                                 null,
                                                 new List<object>()
                                             )
@@ -3495,7 +3492,7 @@ namespace Server.Gumps
                                                         from,
                                                         AdminGumpPage.Accounts,
                                                         0,
-                                                        Utility.CastListContravariant<Account, object>(kvp.Value),
+                                                        kvp.Value.CastListContravariant<Account, object>(),
                                                         null,
                                                         new List<object>()
                                                     )
@@ -3961,7 +3958,7 @@ namespace Server.Gumps
                                             from,
                                             AdminGumpPage.Accounts,
                                             0,
-                                            Utility.CastListContravariant<Account, object>(list),
+                                            list.CastListContravariant<Account, object>(),
                                             null,
                                             new List<object>()
                                         )

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -446,7 +446,7 @@ namespace Server.Gumps
                     {
                         if (m_List == null)
                         {
-                            var states = TcpServer.Instances;
+                            var states = TcpServer.Instances.ToList();
                             states.Sort(NetStateComparer.Instance);
 
                             m_List = states.ToList<object>();
@@ -2349,12 +2349,10 @@ namespace Server.Gumps
 
                                     if (level > AccessLevel.Player)
                                     {
-                                        var clients = TcpServer.Instances;
                                         var count = 0;
 
-                                        for (var i = 0; i < clients.Count; ++i)
+                                        foreach (var ns in TcpServer.Instances)
                                         {
-                                            var ns = clients[i];
                                             var a = ns.Account;
 
                                             if (a == null)
@@ -2449,12 +2447,8 @@ namespace Server.Gumps
                                     }
                                     else
                                     {
-                                        var instances = TcpServer.Instances;
-
-                                        for (var i = 0; i < instances.Count; ++i)
+                                        foreach (var ns in TcpServer.Instances)
                                         {
-                                            var ns = instances[i];
-
                                             bool isMatch;
 
                                             if (forName)
@@ -3690,7 +3684,7 @@ namespace Server.Gumps
                                 {
                                     index -= 4;
 
-                                    if (m_List != null && index >= 0 && index < m_List.Count)
+                                    if (m_List != null && index < m_List.Count)
                                     {
                                         from.SendGump(
                                             new AdminGump(from, AdminGumpPage.FirewallInfo, 0, null, null, m_List[index])
@@ -3898,7 +3892,7 @@ namespace Server.Gumps
                     }
                 case 8:
                     {
-                        if (m_List != null && index >= 0 && index < m_List.Count)
+                        if (m_List != null && index < m_List.Count)
                         {
                             if (!(m_State is Account a))
                             {
@@ -3942,7 +3936,7 @@ namespace Server.Gumps
                     }
                 case 9:
                     {
-                        if (m_List != null && index >= 0 && index < m_List.Count)
+                        if (m_List != null && index < m_List.Count)
                         {
                             if (m_PageType == AdminGumpPage.AccountDetails_Access_ClientIPs)
                             {
@@ -3993,7 +3987,7 @@ namespace Server.Gumps
                     }
                 case 10:
                     {
-                        if (m_List != null && index >= 0 && index < m_List.Count)
+                        if (m_List != null && index < m_List.Count)
                         {
                             if (m_PageType == AdminGumpPage.AccountDetails_Access_ClientIPs)
                             {

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -196,8 +196,8 @@ namespace Server.Gumps
                         AddLabel(20, 350, LabelHue, "Operating System: ");
                         var os = Environment.OSVersion.ToString();
 
-                        os = os.Replace("Microsoft", "MSFT");
-                        os = os.Replace("Service Pack", "SP");
+                        os = os.Replace("Microsoft", "MSFT", StringComparison.Ordinal);
+                        os = os.Replace("Service Pack", "SP", StringComparison.Ordinal);
 
                         AddLabel(150, 350, LabelHue, os);
 
@@ -243,7 +243,7 @@ namespace Server.Gumps
                         sb.Append(curIOCP);
                         sb.Append("<br>Usage: ");
                         sb.Append((maxIOCP - curIOCP) * 100 / maxIOCP);
-                        sb.Append("%");
+                        sb.Append('%');
 
                         AddLabel(20, 200, LabelHue, "Pooling:");
                         AddHtml(20, 220, 380, 150, sb.ToString(), true, true);
@@ -1485,10 +1485,9 @@ namespace Server.Gumps
             CommandSystem.Register("Admin", AccessLevel.Administrator, Admin_OnCommand);
         }
 
-        [Usage("Admin")]
-        [Description(
-            "Opens an interface providing server information and administration features including client, account, and firewall management."
-        )]
+        [Usage("Admin"), Description(
+             "Opens an interface providing server information and administration features including client, account, and firewall management."
+         )]
         public static void Admin_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendGump(new AdminGump(e.Mobile, AdminGumpPage.Clients));
@@ -2463,12 +2462,12 @@ namespace Server.Gumps
                                                 var m = ns.Mobile;
                                                 var a = ns.Account;
 
-                                                isMatch = m?.Name.ToLower().IndexOf(match, StringComparison.Ordinal) >= 0
-                                                          || a?.Username.ToLower().IndexOf(match, StringComparison.Ordinal) >= 0;
+                                                isMatch = m?.Name.ToLower().Contains(match, StringComparison.Ordinal) == true
+                                                          || a?.Username.ToLower().Contains(match, StringComparison.Ordinal) == true;
                                             }
                                             else
                                             {
-                                                isMatch = ns.ToString().IndexOf(match, StringComparison.Ordinal) >= 0;
+                                                isMatch = ns.ToString().Contains(match, StringComparison.Ordinal);
                                             }
 
                                             if (isMatch)
@@ -2726,7 +2725,7 @@ namespace Server.Gumps
                                     {
                                         results = Accounts.GetAccounts()
                                             .Where(acct =>
-                                                acct.Username.ToLower().IndexOf(match, StringComparison.Ordinal) >= 0)
+                                                acct.Username.ToLower().Contains(match, StringComparison.Ordinal))
                                             .ToList();
                                         results.Sort(AccountComparer.Instance);
                                     }
@@ -3539,7 +3538,7 @@ namespace Server.Gumps
                                         {
                                             var check = Firewall.List[i].ToString();
 
-                                            if (check?.IndexOf(match) >= 0)
+                                            if (check?.Contains(match, StringComparison.Ordinal) == true)
                                             {
                                                 results.Add(Firewall.List[i]);
                                             }

--- a/Projects/UOContent/Gumps/CommentsGump.cs
+++ b/Projects/UOContent/Gumps/CommentsGump.cs
@@ -62,8 +62,7 @@ namespace Server.Gumps
             CommandSystem.Register("Comments", AccessLevel.Counselor, Comments_OnCommand);
         }
 
-        [Usage("Comments")]
-        [Description("View/Modify/Add account comments.")]
+        [Usage("Comments"), Description("View/Modify/Add account comments.")]
         private static void Comments_OnCommand(CommandEventArgs args)
         {
             args.Mobile.SendMessage("Select the player to view account comments.");

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclareWarPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclareWarPrompt.cs
@@ -36,7 +36,7 @@ namespace Server.Gumps
 
             if (text.Length >= 3)
             {
-                var guilds = Utility.CastListCovariant<BaseGuild, Guild>(BaseGuild.Search(text));
+                var guilds = BaseGuild.Search(text).CastListCovariant<BaseGuild, Guild>();
 
                 GuildGump.EnsureClosed(m_Mobile);
 

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/DiplomacyGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/DiplomacyGump.cs
@@ -26,7 +26,7 @@ namespace Server.Guilds
                 "",
                 0,
                 GuildDisplayType.All,
-                Utility.CastListCovariant<BaseGuild, Guild>(new List<BaseGuild>(World.Guilds.Values)),
+                World.Guilds.Values.CastListCovariant<BaseGuild, Guild>(),
                 1063136 + (int)GuildDisplayType.All
             )
         {
@@ -44,7 +44,7 @@ namespace Server.Guilds
                 filter,
                 startNumber,
                 display,
-                Utility.CastListCovariant<BaseGuild, Guild>(new List<BaseGuild>(World.Guilds.Values)),
+                World.Guilds.Values.CastListCovariant<BaseGuild, Guild>(),
                 1063136 + (int)display
             )
         {

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/GuildRosterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/GuildRosterGump.cs
@@ -28,7 +28,7 @@ namespace Server.Guilds
             : base(
                 pm,
                 g,
-                Utility.SafeConvertList<Mobile, PlayerMobile>(g.Members),
+                g.Members.SafeConvertList<Mobile, PlayerMobile>(),
                 currentComparer,
                 ascending,
                 filter,

--- a/Projects/UOContent/Gumps/Props/PropsConfig.cs
+++ b/Projects/UOContent/Gumps/Props/PropsConfig.cs
@@ -1,6 +1,6 @@
 namespace Server.Gumps
 {
-    public class PropsConfig
+    public static class PropsConfig
     {
         public static readonly bool OldStyle = false;
 
@@ -13,7 +13,7 @@ namespace Server.Gumps
         public static readonly int OffsetGumpID = 0x0A40; // Pure black
 
         public static readonly int
-            HeaderGumpID = OldStyle ? 0x0BBC : 0x0E14; // Light offwhite, textured : Dark navy blue, textured
+            HeaderGumpID = OldStyle ? 0x0BBC : 0x0E14; // Light off-white, textured : Dark navy blue, textured
 
         public static readonly int EntryGumpID = 0x0BBC;                   // Light offwhite, textured
         public static readonly int BackGumpID = 0x13BE;                    // Gray slate/stoney

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -757,7 +757,7 @@ namespace Server.Gumps
             if (t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort) || t == typeof(int) ||
                 t == typeof(uint) || t == typeof(long) || t == typeof(ulong))
             {
-                if (s.StartsWith("0x"))
+                if (s.StartsWith("0x", StringComparison.Ordinal))
                 {
                     if (t == typeof(ulong) || t == typeof(uint) || t == typeof(ushort) || t == typeof(byte))
                     {

--- a/Projects/UOContent/Gumps/Props/SetBodyGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetBodyGump.cs
@@ -310,7 +310,7 @@ namespace Server.Gumps
 
                 for (var i = 0; i < m_GroupNames.Length; ++i)
                 {
-                    if (DisplayName.StartsWith(m_GroupNames[i]))
+                    if (DisplayName.StartsWith(m_GroupNames[i], StringComparison.Ordinal))
                     {
                         DisplayName = DisplayName.Substring(m_GroupNames[i].Length);
                         break;

--- a/Projects/UOContent/Gumps/ToTAdminGump.cs
+++ b/Projects/UOContent/Gumps/ToTAdminGump.cs
@@ -120,8 +120,7 @@ namespace Server.Gumps
             CommandSystem.Register("ToTAdmin", AccessLevel.Administrator, ToTAdmin_OnCommand);
         }
 
-        [Usage("ToTAdmin")]
-        [Description("Displays a menu to configure Treasures of Tokuno.")]
+        [Usage("ToTAdmin"), Description("Displays a menu to configure Treasures of Tokuno.")]
         public static void ToTAdmin_OnCommand(CommandEventArgs e)
         {
             ToTAdminGump tg;

--- a/Projects/UOContent/Gumps/ViewHousesGump.cs
+++ b/Projects/UOContent/Gumps/ViewHousesGump.cs
@@ -160,10 +160,9 @@ namespace Server.Gumps
             CommandSystem.Register("ViewHouses", AccessLevel.GameMaster, ViewHouses_OnCommand);
         }
 
-        [Usage("ViewHouses")]
-        [Description(
-            "Displays a menu listing all houses of a targeted player. The menu also contains specific house details, and options to: go to house, open house menu, and demolish house."
-        )]
+        [Usage("ViewHouses"), Description(
+             "Displays a menu listing all houses of a targeted player. The menu also contains specific house details, and options to: go to house, open house menu, and demolish house."
+         )]
         public static void ViewHouses_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, ViewHouses_OnTarget);

--- a/Projects/UOContent/Gumps/WhoGump.cs
+++ b/Projects/UOContent/Gumps/WhoGump.cs
@@ -316,9 +316,14 @@ namespace Server.Gumps
 
             public int Compare(Mobile x, Mobile y)
             {
-                if (x == null || y == null)
+                if (x == null)
                 {
-                    throw new ArgumentException();
+                    throw new ArgumentNullException(nameof(x));
+                }
+
+                if (y == null)
+                {
+                    throw new ArgumentNullException(nameof(y));
                 }
 
                 if (x.AccessLevel > y.AccessLevel)
@@ -326,12 +331,7 @@ namespace Server.Gumps
                     return -1;
                 }
 
-                if (x.AccessLevel < y.AccessLevel)
-                {
-                    return 1;
-                }
-
-                return Insensitive.Compare(x.Name, y.Name);
+                return x.AccessLevel < y.AccessLevel ? 1 : Insensitive.Compare(x.Name, y.Name);
             }
         }
     }

--- a/Projects/UOContent/Gumps/WhoGump.cs
+++ b/Projects/UOContent/Gumps/WhoGump.cs
@@ -83,9 +83,8 @@ namespace Server.Gumps
             CommandSystem.Register("WhoList", AccessLevel.Counselor, WhoList_OnCommand);
         }
 
-        [Usage("WhoList [filter]")]
-        [Aliases("Who")]
-        [Description("Lists all connected clients. Optionally filters results by name.")]
+        [Usage("WhoList [filter]"), Aliases("Who"),
+         Description("Lists all connected clients. Optionally filters results by name.")]
         private static void WhoList_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendGump(new WhoGump(e.Mobile, e.ArgString));
@@ -105,7 +104,7 @@ namespace Server.Gumps
                 if (m != null && (m == owner || !m.Hidden || owner.AccessLevel >= m.AccessLevel ||
                                   m is PlayerMobile mobile && mobile.VisibilityList.Contains(owner)))
                 {
-                    if (filter != null && !(m.Name?.ToLower().IndexOf(filter, StringComparison.Ordinal) >= 0))
+                    if (filter != null && m.Name?.ToLower().Contains(filter, StringComparison.Ordinal) != true)
                     {
                         continue;
                     }

--- a/Projects/UOContent/Gumps/WhoGump.cs
+++ b/Projects/UOContent/Gumps/WhoGump.cs
@@ -95,11 +95,10 @@ namespace Server.Gumps
             var filter = rawFilter.Trim().ToLower().DefaultIfNullOrEmpty(null);
 
             var list = new List<Mobile>();
-            var states = TcpServer.Instances;
 
-            for (var i = 0; i < states.Count; ++i)
+            foreach (var ns in TcpServer.Instances)
             {
-                var m = states[i].Mobile;
+                var m = ns.Mobile;
 
                 if (m != null && (m == owner || !m.Hidden || owner.AccessLevel >= m.AccessLevel ||
                                   m is PlayerMobile mobile && mobile.VisibilityList.Contains(owner)))

--- a/Projects/UOContent/Holiday Stuff/Christmas/2010/Items/AngelDecoration.cs
+++ b/Projects/UOContent/Holiday Stuff/Christmas/2010/Items/AngelDecoration.cs
@@ -1,7 +1,6 @@
 ﻿namespace Server.Items.Holiday
 {
-    [TypeAlias("Server.Items.AngelDecoration")]
-    [Flippable(0x46FA, 0x46FB)]
+    [TypeAlias("Server.Items.AngelDecoration"), Flippable(0x46FA, 0x46FB)]
     public class AngelDecoration : Item
     {
         public AngelDecoration() : base(0x46FA)

--- a/Projects/UOContent/Holiday Stuff/Christmas/2010/Items/RockingHorse.cs
+++ b/Projects/UOContent/Holiday Stuff/Christmas/2010/Items/RockingHorse.cs
@@ -1,7 +1,6 @@
 ﻿namespace Server.Items.Holiday
 {
-    [TypeAlias("Server.Items.RockingHorse")]
-    [Flippable(0x4214, 0x4215)]
+    [TypeAlias("Server.Items.RockingHorse"), Flippable(0x4214, 0x4215)]
     public class RockingHorse : Item
     {
         public RockingHorse() : base(0x4214)

--- a/Projects/UOContent/Holiday Stuff/Halloween/2009/Engines/PumpkinPatch.cs
+++ b/Projects/UOContent/Holiday Stuff/Halloween/2009/Engines/PumpkinPatch.cs
@@ -5,7 +5,7 @@ using Server.Items;
 
 namespace Server.Engines.Events
 {
-    public class PumpkinPatchSpawner
+    public static class PumpkinPatchSpawner
     {
         private static Timer m_Timer;
 
@@ -31,7 +31,7 @@ namespace Server.Engines.Events
             }
         }
 
-        protected static void PumpkinPatchSpawnerCallback()
+        private static void PumpkinPatchSpawnerCallback()
         {
             AddPumpkin(Map.Felucca);
             AddPumpkin(Map.Trammel);

--- a/Projects/UOContent/Holiday Stuff/Halloween/2012/Engines/PlayerZombies.cs
+++ b/Projects/UOContent/Holiday Stuff/Halloween/2012/Engines/PlayerZombies.cs
@@ -6,7 +6,7 @@ using Server.Mobiles;
 
 namespace Server.Engines.Events
 {
-    public class HalloweenHauntings
+    public static class HalloweenHauntings
     {
         private static Timer m_Timer;
         private static Timer m_ClearTimer;

--- a/Projects/UOContent/Items/Addons/AddonComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonComponent.cs
@@ -181,8 +181,7 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public Point3D Offset { get; set; }
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;

--- a/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
@@ -26,8 +26,7 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public Point3D Offset { get; set; }
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;

--- a/Projects/UOContent/Items/Addons/ArcheryButteAddon.cs
+++ b/Projects/UOContent/Items/Addons/ArcheryButteAddon.cs
@@ -78,10 +78,7 @@ namespace Server.Items
 
         private ScoreEntry GetEntryFor(Mobile from)
         {
-            if (m_Entries == null)
-            {
-                m_Entries = new Dictionary<Mobile, ScoreEntry>();
-            }
+            m_Entries ??= new Dictionary<Mobile, ScoreEntry>();
 
             if (!m_Entries.TryGetValue(from, out var e))
             {

--- a/Projects/UOContent/Items/Addons/BaseAddon.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddon.cs
@@ -44,8 +44,7 @@ namespace Server.Items
 
         public virtual bool ShareHue => true;
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;

--- a/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
@@ -20,8 +20,7 @@ namespace Server.Items
 
         public override bool DisplayWeight => false;
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;
@@ -33,8 +32,6 @@ namespace Server.Items
 
                     if (!Deleted && ShareHue && Components != null)
                     {
-                        Hue = value;
-
                         foreach (var c in Components)
                         {
                             c.Hue = value;

--- a/Projects/UOContent/Items/Addons/FlourMillEastAddon.cs
+++ b/Projects/UOContent/Items/Addons/FlourMillEastAddon.cs
@@ -140,14 +140,9 @@ namespace Server.Items
         {
             var components = Components;
 
-            var stageTable = m_StageTable;
-
             for (var i = 0; i < components.Count; ++i)
             {
-                if (!(components[i] is AddonComponent component))
-                {
-                    continue;
-                }
+                var component = components[i];
 
                 var itemTable = FindItemTable(component.ItemID);
 

--- a/Projects/UOContent/Items/Addons/FlourMillSouthAddon.cs
+++ b/Projects/UOContent/Items/Addons/FlourMillSouthAddon.cs
@@ -129,14 +129,9 @@ namespace Server.Items
         {
             var components = Components;
 
-            var stageTable = m_StageTable;
-
             for (var i = 0; i < components.Count; ++i)
             {
-                if (!(components[i] is AddonComponent component))
-                {
-                    continue;
-                }
+                var component = components[i];
 
                 var itemTable = FindItemTable(component.ItemID);
 

--- a/Projects/UOContent/Items/Addons/SHTeleporter.cs
+++ b/Projects/UOContent/Items/Addons/SHTeleporter.cs
@@ -187,8 +187,7 @@ namespace Server.Items
             CommandSystem.Register("SHTelGen", AccessLevel.Administrator, SHTelGen_OnCommand);
         }
 
-        [Usage("SHTelGen")]
-        [Description("Generates solen hives teleporters.")]
+        [Usage("SHTelGen"), Description("Generates solen hives teleporters.")]
         public static void SHTelGen_OnCommand(CommandEventArgs e)
         {
             World.Broadcast(0x35, true, "Solen hives teleporters are being generated, please wait.");

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -471,8 +471,7 @@ namespace Server.Items
 
         public virtual Race RequiredRace => null;
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;

--- a/Projects/UOContent/Items/Body Parts/Head.cs
+++ b/Projects/UOContent/Items/Body Parts/Head.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server.Items
 {
     public enum HeadType
@@ -79,17 +81,17 @@ namespace Server.Items
 
                     if (format != null)
                     {
-                        if (format.StartsWith("the head of "))
+                        if (format.StartsWith("the head of ", StringComparison.Ordinal))
                         {
-                            format = format.Substring("the head of ".Length);
+                            format = format.Substring(14); // "the head of|..."
                         }
 
-                        if (format.EndsWith(", taken in a duel"))
+                        if (format.EndsWith(", taken in a duel", StringComparison.Ordinal))
                         {
                             format = format.Substring(0, format.Length - ", taken in a duel".Length);
                             HeadType = HeadType.Duel;
                         }
-                        else if (format.EndsWith(", taken in a tournament"))
+                        else if (format.EndsWith(", taken in a tournament", StringComparison.Ordinal))
                         {
                             format = format.Substring(0, format.Length - ", taken in a tournament".Length);
                             HeadType = HeadType.Tournament;

--- a/Projects/UOContent/Items/Clothing/Artifacts/CrimsonCincture.cs
+++ b/Projects/UOContent/Items/Clothing/Artifacts/CrimsonCincture.cs
@@ -1,6 +1,6 @@
 namespace Server.Items
 {
-    public class CrimsonCincture : HalfApron, ITokunoDyable
+    public class CrimsonCincture : HalfApron
     {
         [Constructible]
         public CrimsonCincture()

--- a/Projects/UOContent/Items/Construction/Ankhs.cs
+++ b/Projects/UOContent/Items/Construction/Ankhs.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 
 namespace Server.Items
 {
-    public class Ankhs
+    public static class Ankhs
     {
         public const int ResurrectRange = 2;
         public const int TitheRange = 2;

--- a/Projects/UOContent/Items/Construction/Ankhs.cs
+++ b/Projects/UOContent/Items/Construction/Ankhs.cs
@@ -130,8 +130,7 @@ namespace Server.Items
 
         public override bool HandlesOnMovement => true; // Tell the core that we implement OnMovement
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;
@@ -222,8 +221,7 @@ namespace Server.Items
 
             public override bool HandlesOnMovement => true; // Tell the core that we implement OnMovement
 
-            [Hue]
-            [CommandProperty(AccessLevel.GameMaster)]
+            [Hue, CommandProperty(AccessLevel.GameMaster)]
             public override int Hue
             {
                 get => base.Hue;
@@ -319,8 +317,7 @@ namespace Server.Items
 
         public override bool HandlesOnMovement => true; // Tell the core that we implement OnMovement
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;
@@ -413,8 +410,7 @@ namespace Server.Items
 
             public override bool HandlesOnMovement => true; // Tell the core that we implement OnMovement
 
-            [Hue]
-            [CommandProperty(AccessLevel.GameMaster)]
+            [Hue, CommandProperty(AccessLevel.GameMaster)]
             public override int Hue
             {
                 get => base.Hue;

--- a/Projects/UOContent/Items/Construction/Chairs/Benchs.cs
+++ b/Projects/UOContent/Items/Construction/Chairs/Benchs.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0xB2D, 0xB2C)]
+    [Furniture, Flippable(0xB2D, 0xB2C)]
     public class WoodenBench : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Chairs/Chairs.cs
+++ b/Projects/UOContent/Items/Construction/Chairs/Chairs.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0xB4F, 0xB4E, 0xB50, 0xB51)]
+    [Furniture, Flippable(0xB4F, 0xB4E, 0xB50, 0xB51)]
     public class FancyWoodenChairCushion : Item
     {
         [Constructible]
@@ -31,8 +30,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB53, 0xB52, 0xB54, 0xB55)]
+    [Furniture, Flippable(0xB53, 0xB52, 0xB54, 0xB55)]
     public class WoodenChairCushion : Item
     {
         [Constructible]
@@ -62,8 +60,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB57, 0xB56, 0xB59, 0xB58)]
+    [Furniture, Flippable(0xB57, 0xB56, 0xB59, 0xB58)]
     public class WoodenChair : Item
     {
         [Constructible]
@@ -93,8 +90,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB5B, 0xB5A, 0xB5C, 0xB5D)]
+    [Furniture, Flippable(0xB5B, 0xB5A, 0xB5C, 0xB5D)]
     public class BambooChair : Item
     {
         [Constructible]
@@ -124,8 +120,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0x1218, 0x1219, 0x121A, 0x121B)]
+    [DynamicFliping, Flippable(0x1218, 0x1219, 0x121A, 0x121B)]
     public class StoneChair : Item
     {
         [Constructible]
@@ -150,8 +145,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0x2DE3, 0x2DE4, 0x2DE5, 0x2DE6)]
+    [DynamicFliping, Flippable(0x2DE3, 0x2DE4, 0x2DE5, 0x2DE6)]
     public class OrnateElvenChair : Item
     {
         [Constructible]
@@ -176,8 +170,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0x2DEB, 0x2DEC, 0x2DED, 0x2DEE)]
+    [DynamicFliping, Flippable(0x2DEB, 0x2DEC, 0x2DED, 0x2DEE)]
     public class BigElvenChair : Item
     {
         [Constructible]
@@ -204,8 +197,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0x2DF5, 0x2DF6)]
+    [DynamicFliping, Flippable(0x2DF5, 0x2DF6)]
     public class ElvenReadingChair : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Chairs/Thrones.cs
+++ b/Projects/UOContent/Items/Construction/Chairs/Thrones.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0xB32, 0xB33)]
+    [Furniture, Flippable(0xB32, 0xB33)]
     public class Throne : Item
     {
         [Constructible]
@@ -31,8 +30,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB2E, 0xB2F, 0xB31, 0xB30)]
+    [Furniture, Flippable(0xB2E, 0xB2F, 0xB31, 0xB30)]
     public class WoodenThrone : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
+++ b/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
@@ -135,8 +135,7 @@ namespace Server.Items
             CommandSystem.Register("ChainLink", AccessLevel.GameMaster, ChainLink_OnCommand);
         }
 
-        [Usage("Link")]
-        [Description("Links two targeted doors together.")]
+        [Usage("Link"), Description("Links two targeted doors together.")]
         private static void Link_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, Link_OnFirstTarget);
@@ -172,8 +171,7 @@ namespace Server.Items
             }
         }
 
-        [Usage("ChainLink")]
-        [Description("Chain-links two or more targeted doors together.")]
+        [Usage("ChainLink"), Description("Chain-links two or more targeted doors together.")]
         private static void ChainLink_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, ChainLink_OnTarget, new List<BaseDoor>());

--- a/Projects/UOContent/Items/Construction/Misc/Easel.cs
+++ b/Projects/UOContent/Items/Construction/Misc/Easel.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0xF65, 0xF67, 0xF69)]
+    [Furniture, Flippable(0xF65, 0xF67, 0xF69)]
     public class Easel : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Misc/MusicStand.cs
+++ b/Projects/UOContent/Items/Construction/Misc/MusicStand.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0xEBB, 0xEBC)]
+    [Furniture, Flippable(0xEBB, 0xEBC)]
     public class TallMusicStand : Item
     {
         [Constructible]
@@ -31,8 +30,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xEB6, 0xEB8)]
+    [Furniture, Flippable(0xEB6, 0xEB8)]
     public class ShortMusicStand : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Misc/Screens.cs
+++ b/Projects/UOContent/Items/Construction/Misc/Screens.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0x24D0, 0x24D1, 0x24D2, 0x24D3, 0x24D4)]
+    [Furniture, Flippable(0x24D0, 0x24D1, 0x24D2, 0x24D3, 0x24D4)]
     public class BambooScreen : Item
     {
         [Constructible]
@@ -26,8 +25,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x24CB, 0x24CC, 0x24CD, 0x24CE, 0x24CF)]
+    [Furniture, Flippable(0x24CB, 0x24CC, 0x24CD, 0x24CE, 0x24CF)]
     public class ShojiScreen : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Tables/Tables.cs
+++ b/Projects/UOContent/Items/Construction/Tables/Tables.cs
@@ -50,8 +50,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB90, 0xB7D)]
+    [Furniture, Flippable(0xB90, 0xB7D)]
     public class LargeTable : Item
     {
         [Constructible]
@@ -81,8 +80,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB35, 0xB34)]
+    [Furniture, Flippable(0xB35, 0xB34)]
     public class Nightstand : Item
     {
         [Constructible]
@@ -112,8 +110,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xB8F, 0xB7C)]
+    [Furniture, Flippable(0xB8F, 0xB7C)]
     public class YewWoodTable : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Construction/Tables/WritingTable.cs
+++ b/Projects/UOContent/Items/Construction/Tables/WritingTable.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0xB4A, 0xB49, 0xB4B, 0xB4C)]
+    [Furniture, Flippable(0xB4A, 0xB49, 0xB4B, 0xB4C)]
     public class WritingTable : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Containers/Container.cs
+++ b/Projects/UOContent/Items/Containers/Container.cs
@@ -597,8 +597,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x9AA, 0xE7D)]
+    [Furniture, Flippable(0x9AA, 0xE7D)]
     public class WoodenBox : LockableContainer
     {
         [Constructible]
@@ -623,8 +622,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x9A9, 0xE7E)]
+    [Furniture, Flippable(0x9A9, 0xE7E)]
     public class SmallCrate : LockableContainer
     {
         [Constructible]
@@ -654,8 +652,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xE3F, 0xE3E)]
+    [Furniture, Flippable(0xE3F, 0xE3E)]
     public class MediumCrate : LockableContainer
     {
         [Constructible]
@@ -685,8 +682,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xE3D, 0xE3C)]
+    [Furniture, Flippable(0xE3D, 0xE3C)]
     public class LargeCrate : LockableContainer
     {
         [Constructible]
@@ -716,8 +712,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0x9A8, 0xE80)]
+    [DynamicFliping, Flippable(0x9A8, 0xE80)]
     public class MetalBox : LockableContainer
     {
         [Constructible]
@@ -749,8 +744,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0x9AB, 0xE7C)]
+    [DynamicFliping, Flippable(0x9AB, 0xE7C)]
     public class MetalChest : LockableContainer
     {
         [Constructible]
@@ -782,8 +776,7 @@ namespace Server.Items
         }
     }
 
-    [DynamicFliping]
-    [Flippable(0xE41, 0xE40)]
+    [DynamicFliping, Flippable(0xE41, 0xE40)]
     public class MetalGoldenChest : LockableContainer
     {
         [Constructible]
@@ -815,8 +808,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xe43, 0xe42)]
+    [Furniture, Flippable(0xe43, 0xe42)]
     public class WoodenChest : LockableContainer
     {
         [Constructible]
@@ -846,8 +838,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x280B, 0x280C)]
+    [Furniture, Flippable(0x280B, 0x280C)]
     public class PlainWoodenChest : LockableContainer
     {
         [Constructible]
@@ -879,8 +870,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x280D, 0x280E)]
+    [Furniture, Flippable(0x280D, 0x280E)]
     public class OrnateWoodenChest : LockableContainer
     {
         [Constructible]
@@ -912,8 +902,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x280F, 0x2810)]
+    [Furniture, Flippable(0x280F, 0x2810)]
     public class GildedWoodenChest : LockableContainer
     {
         [Constructible]
@@ -945,8 +934,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2811, 0x2812)]
+    [Furniture, Flippable(0x2811, 0x2812)]
     public class WoodenFootLocker : LockableContainer
     {
         [Constructible]
@@ -981,8 +969,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2813, 0x2814)]
+    [Furniture, Flippable(0x2813, 0x2814)]
     public class FinishedWoodenChest : LockableContainer
     {
         [Constructible]

--- a/Projects/UOContent/Items/Containers/FillableContainers.cs
+++ b/Projects/UOContent/Items/Containers/FillableContainers.cs
@@ -792,9 +792,7 @@ namespace Server.Items
 
         public static FillableContent ArtisanGuild = new FillableContent(
             1,
-            new Type[]
-            {
-            },
+            Array.Empty<Type>(),
             new[]
             {
                 new FillableEntry(1, typeof(PaintsAndBrush)),
@@ -1047,9 +1045,7 @@ namespace Server.Items
 
         public static FillableContent Guard = new FillableContent(
             3,
-            new Type[]
-            {
-            },
+            Array.Empty<Type>(),
             new[]
             {
                 new FillableEntry(12, Loot.ArmorTypes),
@@ -1095,9 +1091,7 @@ namespace Server.Items
 
         public static FillableContent Inn = new FillableContent(
             1,
-            new Type[]
-            {
-            },
+            Array.Empty<Type>(),
             new[]
             {
                 new FillableEntry(1, typeof(Candle)),
@@ -1223,9 +1217,7 @@ namespace Server.Items
 
         public static FillableContent Mill = new FillableContent(
             1,
-            new Type[]
-            {
-            },
+            Array.Empty<Type>(),
             new[]
             {
                 new FillableEntry(1, typeof(SackFlour))
@@ -1250,9 +1242,7 @@ namespace Server.Items
 
         public static FillableContent Observatory = new FillableContent(
             1,
-            new Type[]
-            {
-            },
+            Array.Empty<Type>(),
             new[]
             {
                 new FillableEntry(2, typeof(Sextant)),
@@ -1263,9 +1253,7 @@ namespace Server.Items
 
         public static FillableContent Painter = new FillableContent(
             1,
-            new Type[]
-            {
-            },
+            Array.Empty<Type>(),
             new[]
             {
                 new FillableEntry(1, typeof(PaintsAndBrush)),

--- a/Projects/UOContent/Items/Containers/FurnitureContainer.cs
+++ b/Projects/UOContent/Items/Containers/FurnitureContainer.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0x2815, 0x2816)]
+    [Furniture, Flippable(0x2815, 0x2816)]
     public class TallCabinet : BaseContainer
     {
         [Constructible]
@@ -27,8 +26,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2817, 0x2818)]
+    [Furniture, Flippable(0x2817, 0x2818)]
     public class ShortCabinet : BaseContainer
     {
         [Constructible]
@@ -51,8 +49,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2857, 0x2858)]
+    [Furniture, Flippable(0x2857, 0x2858)]
     public class RedArmoire : BaseContainer
     {
         [Constructible]
@@ -75,8 +72,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x285D, 0x285E)]
+    [Furniture, Flippable(0x285D, 0x285E)]
     public class CherryArmoire : BaseContainer
     {
         [Constructible]
@@ -99,8 +95,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x285B, 0x285C)]
+    [Furniture, Flippable(0x285B, 0x285C)]
     public class MapleArmoire : BaseContainer
     {
         [Constructible]
@@ -123,8 +118,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2859, 0x285A)]
+    [Furniture, Flippable(0x2859, 0x285A)]
     public class ElegantArmoire : BaseContainer
     {
         [Constructible]
@@ -147,8 +141,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xa97, 0xa99, 0xa98, 0xa9a, 0xa9b, 0xa9c)]
+    [Furniture, Flippable(0xa97, 0xa99, 0xa98, 0xa9a, 0xa9b, 0xa9c)]
     public class FullBookcase : BaseContainer
     {
         [Constructible]
@@ -171,8 +164,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xa9d, 0xa9e)]
+    [Furniture, Flippable(0xa9d, 0xa9e)]
     public class EmptyBookcase : BaseContainer
     {
         [Constructible]
@@ -203,8 +195,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xa2c, 0xa34)]
+    [Furniture, Flippable(0xa2c, 0xa34)]
     public class Drawer : BaseContainer
     {
         [Constructible]
@@ -227,8 +218,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xa30, 0xa38)]
+    [Furniture, Flippable(0xa30, 0xa38)]
     public class FancyDrawer : BaseContainer
     {
         [Constructible]
@@ -251,8 +241,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xa4f, 0xa53)]
+    [Furniture, Flippable(0xa4f, 0xa53)]
     public class Armoire : BaseContainer
     {
         [Constructible]
@@ -285,8 +274,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0xa4d, 0xa51)]
+    [Furniture, Flippable(0xa4d, 0xa51)]
     public class FancyArmoire : BaseContainer
     {
         [Constructible]
@@ -319,7 +307,7 @@ namespace Server.Items
         }
     }
 
-    public class DynamicFurniture
+    public static class DynamicFurniture
     {
         private static readonly Dictionary<Container, Timer> m_Table = new Dictionary<Container, Timer>();
 

--- a/Projects/UOContent/Items/Containers/MarkContainer.cs
+++ b/Projects/UOContent/Items/Containers/MarkContainer.cs
@@ -97,8 +97,7 @@ namespace Server.Items
             CommandSystem.Register("SecretLocGen", AccessLevel.Administrator, SecretLocGen_OnCommand);
         }
 
-        [Usage("SecretLocGen")]
-        [Description("Generates mark containers to Malas secret locations.")]
+        [Usage("SecretLocGen"), Description("Generates mark containers to Malas secret locations.")]
         public static void SecretLocGen_OnCommand(CommandEventArgs e)
         {
             CreateMalasPassage(951, 546, -70, 1006, 994, -70, false, false);

--- a/Projects/UOContent/Items/Containers/TrappableContainer.cs
+++ b/Projects/UOContent/Items/Containers/TrappableContainer.cs
@@ -102,7 +102,7 @@ namespace Server.Items
                                 from.LocalOverheadMessage(MessageType.Regular, 0x2A, 503000);
                             }
 
-                            Effects.SendLocationEffect(loc, facet, 0x36BD, 15, 10);
+                            Effects.SendLocationEffect(loc, facet, 0x36BD, 15);
                             Effects.PlaySound(loc, facet, 0x307);
 
                             break;

--- a/Projects/UOContent/Items/Decoration Artifacts/StealableArtifactsSpawner.cs
+++ b/Projects/UOContent/Items/Decoration Artifacts/StealableArtifactsSpawner.cs
@@ -175,8 +175,7 @@ namespace Server.Items
             CommandSystem.Register("RemoveStealArties", AccessLevel.Administrator, RemoveStealArties_OnCommand);
         }
 
-        [Usage("GenStealArties")]
-        [Description("Generates the stealable artifacts spawner.")]
+        [Usage("GenStealArties"), Description("Generates the stealable artifacts spawner.")]
         private static void GenStealArties_OnCommand(CommandEventArgs args)
         {
             var from = args.Mobile;
@@ -191,8 +190,8 @@ namespace Server.Items
             }
         }
 
-        [Usage("RemoveStealArties")]
-        [Description("Removes the stealable artifacts spawner and every not yet stolen stealable artifacts.")]
+        [Usage("RemoveStealArties"),
+         Description("Removes the stealable artifacts spawner and every not yet stolen stealable artifacts.")]
         private static void RemoveStealArties_OnCommand(CommandEventArgs args)
         {
             var from = args.Mobile;

--- a/Projects/UOContent/Items/Food/Cooking.cs
+++ b/Projects/UOContent/Items/Food/Cooking.cs
@@ -3,21 +3,6 @@ using Server.Targeting;
 
 namespace Server.Items
 {
-    public class UtilityItem
-    {
-        public static int RandomChoice(int itemID1, int itemID2)
-        {
-            var iRet = Utility.Random(2) switch
-            {
-                0 => itemID1,
-                1 => itemID2,
-                _ => itemID1
-            };
-
-            return iRet;
-        }
-    }
-
     // ********** Dough **********
     public class Dough : Item
     {
@@ -230,7 +215,7 @@ namespace Server.Items
         {
           if (!Movable)
             return;
-    
+
           from.Target = new InternalTarget( this );
         }*/
 
@@ -324,51 +309,51 @@ namespace Server.Items
       {
         Weight = 1.0;
       }
-  
+
       public PitcherWater( Serial serial ) : base( serial )
       {
       }
-  
+
       public override void Serialize( GenericWriter writer )
       {
         base.Serialize( writer );
-  
+
         writer.Write( (int) 0 ); // version
       }
-  
+
       public override void Deserialize( GenericReader reader )
       {
         base.Deserialize( reader );
-  
+
         int version = reader.ReadInt();
       }
-  
+
       public override void OnDoubleClick( Mobile from )
       {
         if (!Movable)
           return;
-  
+
         from.Target = new InternalTarget( this );
       }
-  
+
       private class InternalTarget : Target
       {
         private PitcherWater m_Item;
-  
+
         public InternalTarget( PitcherWater item ) : base( 1, false, TargetFlags.None )
         {
           m_Item = item;
         }
-  
+
         protected override void OnTarget( Mobile from, object targeted )
         {
           if (m_Item.Deleted ) return;
-  
+
           if (targeted is BowlFlour)
           {
             m_Item.Delete();
             ((BowlFlour)targeted).Delete();
-  
+
             from.AddToBackpack( new Dough() );
             from.AddToBackpack( new WoodenBowl() );
           }

--- a/Projects/UOContent/Items/Misc/FlippableAddonAttribute.cs
+++ b/Projects/UOContent/Items/Misc/FlippableAddonAttribute.cs
@@ -76,7 +76,7 @@ namespace Server.Items
 
                             ClearComponents(addon);
 
-                            flipMethod.Invoke(addon, new object[2] { from, Directions[index] });
+                            flipMethod.Invoke(addon, new object[] { from, Directions[index] });
 
                             if (result == AddonFitResult.Blocked)
                             {

--- a/Projects/UOContent/Items/Misc/FlippableAttribute.cs
+++ b/Projects/UOContent/Items/Misc/FlippableAttribute.cs
@@ -10,8 +10,7 @@ namespace Server.Items
             CommandSystem.Register("Flip", AccessLevel.GameMaster, Flip_OnCommand);
         }
 
-        [Usage("Flip")]
-        [Description("Turns an item.")]
+        [Usage("Flip"), Description("Turns an item.")]
         public static void Flip_OnCommand(CommandEventArgs e)
         {
             e.Mobile.Target = new FlipTarget();

--- a/Projects/UOContent/Items/Misc/FlippableAttribute.cs
+++ b/Projects/UOContent/Items/Misc/FlippableAttribute.cs
@@ -3,7 +3,7 @@ using Server.Targeting;
 
 namespace Server.Items
 {
-    public class FlipCommandHandlers
+    public static class FlipCommandHandlers
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Items/Misc/PublicMoongate.cs
+++ b/Projects/UOContent/Items/Misc/PublicMoongate.cs
@@ -114,8 +114,7 @@ namespace Server.Items
             CommandSystem.Register("MoonGen", AccessLevel.Administrator, MoonGen_OnCommand);
         }
 
-        [Usage("MoonGen")]
-        [Description("Generates public moongates. Removes all old moongates.")]
+        [Usage("MoonGen"), Description("Generates public moongates. Removes all old moongates.")]
         public static void MoonGen_OnCommand(CommandEventArgs e)
         {
             DeleteAll();

--- a/Projects/UOContent/Items/Misc/Teleporter.cs
+++ b/Projects/UOContent/Items/Misc/Teleporter.cs
@@ -260,14 +260,14 @@ namespace Server.Items
 
             if (m_SourceEffect && sendEffect)
             {
-                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10, 10);
+                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10);
             }
 
             m.MoveToWorld(p, map);
 
             if (m_DestEffect && sendEffect)
             {
-                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10, 10);
+                Effects.SendLocationEffect(m.Location, m.Map, 0x3728, 10);
             }
 
             if (m_SoundID > 0 && sendEffect)

--- a/Projects/UOContent/Items/Misc/Teleporter.cs
+++ b/Projects/UOContent/Items/Misc/Teleporter.cs
@@ -598,7 +598,7 @@ namespace Server.Items
                 {
                     isMatch = true;
                 }
-                else if (m_Substring != null && e.Speech.ToLower().IndexOf(m_Substring.ToLower(), StringComparison.Ordinal) >= 0)
+                else if (m_Substring != null && e.Speech.ToLower().Contains(m_Substring.ToLower(), StringComparison.Ordinal))
                 {
                     isMatch = true;
                 }

--- a/Projects/UOContent/Items/Misc/UnholyBone.cs
+++ b/Projects/UOContent/Items/Misc/UnholyBone.cs
@@ -26,7 +26,7 @@ namespace Server.Items
         public void Carve(Mobile from, Item item)
         {
             Effects.PlaySound(GetWorldLocation(), Map, 0x48F);
-            Effects.SendLocationEffect(GetWorldLocation(), Map, 0x3728, 10, 10, 0, 0);
+            Effects.SendLocationEffect(GetWorldLocation(), Map, 0x3728, 10);
 
             if (Utility.RandomDouble() < 0.3)
             {

--- a/Projects/UOContent/Items/Skill Items/Blacksmith Items/Misc/AnvilForge.cs
+++ b/Projects/UOContent/Items/Skill Items/Blacksmith Items/Misc/AnvilForge.cs
@@ -2,8 +2,7 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    [Flippable(0xFAF, 0xFB0)]
-    [Anvil]
+    [Flippable(0xFAF, 0xFB0), Anvil]
     public class Anvil : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Skill Items/Fishing/Misc/SpecialFishingNet.cs
+++ b/Projects/UOContent/Items/Skill Items/Fishing/Misc/SpecialFishingNet.cs
@@ -226,8 +226,7 @@ namespace Server.Items
 
                         switch (Utility.Random(8))
                         {
-                            default:
-                            case 0:
+                            default: // 0
                                 x = -1;
                                 y = -1;
                                 break;

--- a/Projects/UOContent/Items/Skill Items/Magical/Potions/Explosion Potions/BaseExplosionPotion.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Potions/Explosion Potions/BaseExplosionPotion.cs
@@ -208,7 +208,7 @@ namespace Server.Items
 
             Effects.PlaySound(loc, map, 0x307);
 
-            Effects.SendLocationEffect(loc, map, 0x36B0, 9, 10, 0, 0);
+            Effects.SendLocationEffect(loc, map, 0x36B0, 9);
             var alchemyBonus = 0;
 
             if (direct)

--- a/Projects/UOContent/Items/Skill Items/Magical/Runebook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Runebook.cs
@@ -5,7 +5,6 @@ using Server.Engines.Craft;
 using Server.Gumps;
 using Server.Mobiles;
 using Server.Multis;
-using Server.Network;
 
 namespace Server.Items
 {

--- a/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
@@ -259,8 +259,7 @@ namespace Server.Items
             CommandSystem.Register("AllSpells", AccessLevel.GameMaster, AllSpells_OnCommand);
         }
 
-        [Usage("AllSpells")]
-        [Description("Completely fills a targeted spellbook with scrolls.")]
+        [Usage("AllSpells"), Description("Completely fills a targeted spellbook with scrolls.")]
         private static void AllSpells_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, AllSpells_OnTarget);

--- a/Projects/UOContent/Items/Skill Items/Ninjitsu/LeatherNinjaBelt.cs
+++ b/Projects/UOContent/Items/Skill Items/Ninjitsu/LeatherNinjaBelt.cs
@@ -6,7 +6,7 @@ using Server.Mobiles;
 namespace Server.Items
 {
     [Flippable(0x2790, 0x27DB)]
-    public class LeatherNinjaBelt : BaseWaist, IDyable, INinjaWeapon
+    public class LeatherNinjaBelt : BaseWaist, INinjaWeapon
     {
         private Poison m_Poison;
         private int m_PoisonCharges;

--- a/Projects/UOContent/Items/Skill Items/Ninjitsu/NinjaWeapons.cs
+++ b/Projects/UOContent/Items/Skill Items/Ninjitsu/NinjaWeapons.cs
@@ -39,7 +39,7 @@ namespace Server.Items
         void AttackAnimation(Mobile from, Mobile to);
     }
 
-    public class NinjaWeapon
+    public static class NinjaWeapon
     {
         private const int MaxUses = 10;
 

--- a/Projects/UOContent/Items/Skill Items/Thief/DisguiseKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Thief/DisguiseKit.cs
@@ -283,7 +283,7 @@ namespace Server.Items
         }
     }
 
-    public class DisguiseTimers
+    public static class DisguiseTimers
     {
         public static Dictionary<Mobile, Timer> Timers { get; } = new Dictionary<Mobile, Timer>();
 

--- a/Projects/UOContent/Items/Skill Items/Tools/BaseRunicTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/BaseRunicTool.cs
@@ -132,14 +132,7 @@ namespace Server.Items
                 percent = v;
             }
 
-            var scaledBy = Math.Abs(high - low) + 1;
-
-            if (scaledBy != 0)
-            {
-                scaledBy = 10000 / scaledBy;
-            }
-
-            percent *= 10000 + scaledBy;
+            percent *= 10000 + 10000 / Math.Abs(high - low) + 1;
 
             return low + (high - low) * percent / 1000001;
         }
@@ -497,7 +490,7 @@ namespace Server.Items
               totalDamage = AssignElementalDamage( weapon, AosElementAttribute.Energy, totalDamage );
               totalDamage = AssignElementalDamage( weapon, AosElementAttribute.Fire, totalDamage );
               totalDamage = AssignElementalDamage( weapon, AosElementAttribute.Poison, totalDamage );
-      
+
               weapon.AosElementDamages[AosElementAttribute.Physical] = 100 - totalDamage;
              * */
 

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/DupresShield.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/DupresShield.cs
@@ -1,6 +1,6 @@
 namespace Server.Items
 {
-    public class DupresShield : BaseShield, ITokunoDyable
+    public class DupresShield : BaseShield
     {
         [Constructible]
         public DupresShield() : base(0x2B01)

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/OssianGrimoire.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/OssianGrimoire.cs
@@ -1,6 +1,6 @@
 ﻿namespace Server.Items
 {
-    public class OssianGrimoire : NecromancerSpellbook, ITokunoDyable
+    public class OssianGrimoire : NecromancerSpellbook
     {
         [Constructible]
         public OssianGrimoire()

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/QuiverOfInfinity.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/QuiverOfInfinity.cs
@@ -1,6 +1,6 @@
 ﻿namespace Server.Items
 {
-    public class QuiverOfInfinity : BaseQuiver, ITokunoDyable
+    public class QuiverOfInfinity : BaseQuiver
     {
         [Constructible]
         public QuiverOfInfinity() : base(0x2B02)

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/Talismans.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/Talismans.cs
@@ -12,7 +12,7 @@ namespace Server.Items
         Reptalon = 1075202
     }
 
-    public class BaseFormTalisman : Item, ITokunoDyable
+    public class BaseFormTalisman : Item
     {
         public BaseFormTalisman() : base(0x2F59)
         {

--- a/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/ColoredAnvil.cs
+++ b/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/ColoredAnvil.cs
@@ -2,8 +2,7 @@ using Server.Engines.Craft;
 
 namespace Server.Items
 {
-    [Anvil]
-    [Flippable(0xFAF, 0xFB0)]
+    [Anvil, Flippable(0xFAF, 0xFB0)]
     public class ColoredAnvil : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Special/Community Collection/JesterHatofChuckles.cs
+++ b/Projects/UOContent/Items/Special/Community Collection/JesterHatofChuckles.cs
@@ -1,6 +1,6 @@
 ﻿namespace Server.Items
 {
-    public class JesterHatofChuckles : BaseHat, ITokunoDyable
+    public class JesterHatofChuckles : BaseHat
     {
         [Constructible]
         public JesterHatofChuckles() : this(Utility.RandomList(0x13e, 0x03, 0x172, 0x3f))

--- a/Projects/UOContent/Items/Special/Evil Home Decor Collection/SacrificialAltar.cs
+++ b/Projects/UOContent/Items/Special/Evil Home Decor Collection/SacrificialAltar.cs
@@ -114,7 +114,7 @@ namespace Server.Items
                 var location = Location;
                 location.Z += 10;
 
-                Effects.SendLocationEffect(location, Map, 0x3709, 10, 10, 0x356, 0);
+                Effects.SendLocationEffect(location, Map, 0x3709, 10, 10, 0x356);
                 Effects.PlaySound(location, Map, 0x32E);
 
                 if (Items.Count > 0)

--- a/Projects/UOContent/Items/Special/HeritageToken.cs
+++ b/Projects/UOContent/Items/Special/HeritageToken.cs
@@ -2,10 +2,6 @@
 
 namespace Server.Items
 {
-    public interface ITokunoDyable
-    {
-    }
-
     public class HeritageToken : Item
     {
         [Constructible]

--- a/Projects/UOContent/Items/Special/Holiday/GiftBox.cs
+++ b/Projects/UOContent/Items/Special/Holiday/GiftBox.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0x232A, 0x232B)]
+    [Furniture, Flippable(0x232A, 0x232B)]
     public class GiftBox : BaseContainer
     {
         [Constructible]

--- a/Projects/UOContent/Items/Special/Holiday/HolidayGiftBoxes.cs
+++ b/Projects/UOContent/Items/Special/Holiday/HolidayGiftBoxes.cs
@@ -1,6 +1,6 @@
 ﻿namespace Server.Items
 {
-    public class GiftBoxHues
+    public static class GiftBoxHues
     {
         /* there's possibly a couple more, but this is what we could verify on OSI */
 

--- a/Projects/UOContent/Items/Special/Holiday/Stockings.cs
+++ b/Projects/UOContent/Items/Special/Holiday/Stockings.cs
@@ -1,7 +1,6 @@
 namespace Server.Items
 {
-    [Furniture]
-    [Flippable(0x2bd9, 0x2bda)]
+    [Furniture, Flippable(0x2bd9, 0x2bda)]
     public class GreenStocking : BaseContainer
     {
         [Constructible]
@@ -29,8 +28,7 @@ namespace Server.Items
         }
     }
 
-    [Furniture]
-    [Flippable(0x2bdb, 0x2bdc)]
+    [Furniture, Flippable(0x2bdb, 0x2bdc)]
     public class RedStocking : BaseContainer
     {
         [Constructible]

--- a/Projects/UOContent/Items/Special/MonsterStatuette.cs
+++ b/Projects/UOContent/Items/Special/MonsterStatuette.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Engines.VeteranRewards;
 using Server.Gumps;
 using Server.Multis;
@@ -82,7 +83,7 @@ namespace Server.Items
             /* Efreet */ new MonsterStatuetteInfo(1080521, 0x2590, 0x300),
             /* Slime */ new MonsterStatuetteInfo(1015246, 0x20E8, 456),
             /* PlagueBeast */ new MonsterStatuetteInfo(1029747, 0x2613, 0x1BF),
-            /* RedDeath */ new MonsterStatuetteInfo(1094932, 0x2617, new int[] { }),
+            /* RedDeath */ new MonsterStatuetteInfo(1094932, 0x2617, Array.Empty<int>()),
             /* Spider */ new MonsterStatuetteInfo(1029668, 0x25C4, 1170),
             /* OphidianArchMage */ new MonsterStatuetteInfo(1029641, 0x25A9, 639),
             /* OphidianWarrior */ new MonsterStatuetteInfo(1029645, 0x25AD, 634),

--- a/Projects/UOContent/Items/Special/Solen Items/MessageHelper.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/MessageHelper.cs
@@ -2,7 +2,7 @@ using Server.Network;
 
 namespace Server
 {
-    public class MessageHelper
+    public static class MessageHelper
     {
         public static void SendLocalizedMessageTo(Item from, Mobile to, int number, int hue)
         {

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -331,8 +331,7 @@ namespace Server.Items
             CommandSystem.Register("RandomTalisman", AccessLevel.GameMaster, RandomTalisman_OnCommand);
         }
 
-        [Usage("RandomTalisman <count>")]
-        [Description("Generates random talismans in your backpack.")]
+        [Usage("RandomTalisman <count>"), Description("Generates random talismans in your backpack.")]
         public static void RandomTalisman_OnCommand(CommandEventArgs e)
         {
             var m = e.Mobile;

--- a/Projects/UOContent/Items/Talismans/TalismanAttribute.cs
+++ b/Projects/UOContent/Items/Talismans/TalismanAttribute.cs
@@ -61,7 +61,7 @@ namespace Server.Items
         public bool IsEmpty => Type == null;
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public bool IsItem => Type?.Namespace.Equals("Server.Items") == true;
+        public bool IsItem => Type?.Namespace == "Server.Items";
 
         public override string ToString() => Type?.Name ?? "None";
 
@@ -89,7 +89,7 @@ namespace Server.Items
 
             if (GetSaveFlag(flags, SaveFlag.Type))
             {
-                writer.Write(Type.FullName);
+                writer.Write(Type!.FullName);
             }
 
             if (GetSaveFlag(flags, SaveFlag.Name))

--- a/Projects/UOContent/Items/Traps/GasTrap.cs
+++ b/Projects/UOContent/Items/Traps/GasTrap.cs
@@ -71,7 +71,7 @@ namespace Server.Items
                 return;
             }
 
-            Effects.SendLocationEffect(Location, Map, GetBaseID(Type) - 2, 16, 3, GetEffectHue(), 0);
+            Effects.SendLocationEffect(Location, Map, GetBaseID(Type) - 2, 16, 3, GetEffectHue());
             Effects.PlaySound(Location, Map, 0x231);
 
             from.ApplyPoison(from, Poison);

--- a/Projects/UOContent/Items/Traps/GiantSpikeTrap.cs
+++ b/Projects/UOContent/Items/Traps/GiantSpikeTrap.cs
@@ -26,7 +26,7 @@ namespace Server.Items
                 return;
             }
 
-            Effects.SendLocationEffect(Location, Map, 0x1D99, 48, 2, GetEffectHue(), 0);
+            Effects.SendLocationEffect(Location, Map, 0x1D99, 48, 2, GetEffectHue());
 
             if (from.Alive && CheckRange(from.Location, 0))
             {

--- a/Projects/UOContent/Items/Traps/SawTrap.cs
+++ b/Projects/UOContent/Items/Traps/SawTrap.cs
@@ -64,7 +64,7 @@ namespace Server.Items
                 return;
             }
 
-            Effects.SendLocationEffect(Location, Map, GetBaseID(Type) + 1, 6, 3, GetEffectHue(), 0);
+            Effects.SendLocationEffect(Location, Map, GetBaseID(Type) + 1, 6, 3, GetEffectHue());
             Effects.PlaySound(Location, Map, 0x21C);
 
             SpellHelper.Damage(TimeSpan.FromTicks(1), from, from, Utility.RandomMinMax(5, 15));

--- a/Projects/UOContent/Items/Traps/SpikeTrap.cs
+++ b/Projects/UOContent/Items/Traps/SpikeTrap.cs
@@ -107,7 +107,7 @@ namespace Server.Items
                 return;
             }
 
-            Effects.SendLocationEffect(Location, Map, GetBaseID(Type) + 1, 18, 3, GetEffectHue(), 0);
+            Effects.SendLocationEffect(Location, Map, GetBaseID(Type) + 1, 18, 3, GetEffectHue());
             Effects.PlaySound(Location, Map, 0x22C);
 
             foreach (var mob in GetMobilesInRange(0))
@@ -132,7 +132,7 @@ namespace Server.Items
         public virtual void OnSpikeRetracted()
         {
             Extended = false;
-            Effects.SendLocationEffect(Location, Map, GetExtendedID(Type) - 1, 6, 3, GetEffectHue(), 0);
+            Effects.SendLocationEffect(Location, Map, GetExtendedID(Type) - 1, 6, 3, GetEffectHue());
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Items/Wands/BaseWand.cs
+++ b/Projects/UOContent/Items/Wands/BaseWand.cs
@@ -21,7 +21,7 @@ namespace Server.Items
         ManaDraining
     }
 
-    public abstract class BaseWand : BaseBashing, ITokunoDyable
+    public abstract class BaseWand : BaseBashing
     {
         private int m_Charges;
 

--- a/Projects/UOContent/Items/Wands/RandomWand.cs
+++ b/Projects/UOContent/Items/Wands/RandomWand.cs
@@ -1,9 +1,0 @@
-namespace Server.Items
-{
-    public class RandomWand
-    {
-        public static BaseWand CreateWand() => CreateRandomWand();
-
-        public static BaseWand CreateRandomWand() => Loot.RandomWand();
-    }
-}

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -123,8 +123,7 @@ namespace Server.Items
 
         public virtual int VirtualDamageBonus => 0;
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -1918,7 +1918,7 @@ namespace Server.Items
                 {
                     pois = 100;
                 }
-                else if (type == 4)
+                else
                 {
                     nrgy = 100;
                 }
@@ -4144,14 +4144,12 @@ namespace Server.Items
                             m_MaxRange = 1; // default
                         }
 
-                        if (version < 5)
-                        {
-                            m_Resource = CraftResource.Iron;
-                            Attributes = new AosAttributes(this);
-                            WeaponAttributes = new AosWeaponAttributes(this);
-                            AosElementDamages = new AosElementAttributes(this);
-                            SkillBonuses = new AosSkillBonuses(this);
-                        }
+                        // version < 5
+                        m_Resource = CraftResource.Iron;
+                        Attributes = new AosAttributes(this);
+                        WeaponAttributes = new AosWeaponAttributes(this);
+                        AosElementDamages = new AosElementAttributes(this);
+                        SkillBonuses = new AosSkillBonuses(this);
 
                         m_MinDamage = reader.ReadInt();
                         m_MaxDamage = reader.ReadInt();

--- a/Projects/UOContent/Items/Weapons/HitLower.cs
+++ b/Projects/UOContent/Items/Weapons/HitLower.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Server.Items
 {
-    public class HitLower
+    public static class HitLower
     {
         public static readonly TimeSpan AttackEffectDuration = TimeSpan.FromSeconds(10.0);
         public static readonly TimeSpan DefenseEffectDuration = TimeSpan.FromSeconds(8.0);

--- a/Projects/UOContent/Items/Weapons/Maces/FireworksWand.cs
+++ b/Projects/UOContent/Items/Weapons/Maces/FireworksWand.cs
@@ -80,9 +80,7 @@ namespace Server.Items
                 new Entity(Serial.Zero, endLoc, map),
                 0x36E4,
                 5,
-                0,
-                false,
-                false
+                0
             );
 
             Timer.DelayCall(TimeSpan.FromSeconds(1.0), FinishLaunch, endLoc, map);

--- a/Projects/UOContent/Misc/AOS.cs
+++ b/Projects/UOContent/Misc/AOS.cs
@@ -9,7 +9,7 @@ using Server.Spells.Seventh;
 
 namespace Server
 {
-    public class AOS
+    public static class AOS
     {
         public static void DisableStatInfluences()
         {

--- a/Projects/UOContent/Misc/AccountPrompt.cs
+++ b/Projects/UOContent/Misc/AccountPrompt.cs
@@ -3,7 +3,7 @@ using Server.Accounting;
 
 namespace Server.Misc
 {
-    public class AccountPrompt
+    public static class AccountPrompt
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Misc/AttackMessage.cs
+++ b/Projects/UOContent/Misc/AttackMessage.cs
@@ -3,7 +3,7 @@ using Server.Network;
 
 namespace Server.Misc
 {
-    public class AttackMessage
+    public static class AttackMessage
     {
         private const string AggressorFormat = "You are attacking {0}!";
         private const string AggressedFormat = "{0} is attacking you!";

--- a/Projects/UOContent/Misc/AutoSave.cs
+++ b/Projects/UOContent/Misc/AutoSave.cs
@@ -26,8 +26,7 @@ namespace Server.Misc
             CommandSystem.Register("SetSaves", AccessLevel.Administrator, SetSaves_OnCommand);
         }
 
-        [Usage("SetSaves <true | false>")]
-        [Description("Enables or disables automatic shard saving.")]
+        [Usage("SetSaves <true | false>"), Description("Enables or disables automatic shard saving.")]
         public static void SetSaves_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 1)
@@ -169,7 +168,7 @@ namespace Server.Misc
             {
                 var info = new DirectoryInfo(paths[i]);
 
-                if (info.Name.StartsWith(match))
+                if (info.Name.StartsWith(match, StringComparison.Ordinal))
                 {
                     return info;
                 }
@@ -183,7 +182,7 @@ namespace Server.Misc
 
         private static string FindTimeStamp(string input)
         {
-            var start = input.IndexOf('(');
+            var start = input.IndexOf('(', StringComparison.Ordinal);
 
             if (start >= 0)
             {

--- a/Projects/UOContent/Misc/Cleanup.cs
+++ b/Projects/UOContent/Misc/Cleanup.cs
@@ -5,7 +5,7 @@ using Server.Multis;
 
 namespace Server.Misc
 {
-    public class Cleanup
+    public static class Cleanup
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Misc/CrashGuard.cs
+++ b/Projects/UOContent/Misc/CrashGuard.cs
@@ -185,18 +185,16 @@ namespace Server.Misc
 
                         op.WriteLine("- Count: {0}", states.Count);
 
-                        for (var i = 0; i < states.Count; ++i)
+                        foreach (var ns in TcpServer.Instances)
                         {
-                            var state = states[i];
+                            op.Write("+ {0}:", ns);
 
-                            op.Write("+ {0}:", state);
-
-                            if (state.Account is Account a)
+                            if (ns.Account is Account a)
                             {
                                 op.Write(" (account = {0})", a.Username);
                             }
 
-                            var m = state.Mobile;
+                            var m = ns.Mobile;
 
                             if (m != null)
                             {

--- a/Projects/UOContent/Misc/DoorGenerator.cs
+++ b/Projects/UOContent/Misc/DoorGenerator.cs
@@ -3,7 +3,7 @@ using Server.Network;
 
 namespace Server
 {
-    public class DoorGenerator
+    public static class DoorGenerator
     {
         private static readonly Rectangle2D[] m_BritRegions =
         {

--- a/Projects/UOContent/Misc/DoorGenerator.cs
+++ b/Projects/UOContent/Misc/DoorGenerator.cs
@@ -337,8 +337,7 @@ namespace Server
             CommandSystem.Register("DoorGen", AccessLevel.Administrator, DoorGen_OnCommand);
         }
 
-        [Usage("DoorGen")]
-        [Description("Generates doors by analyzing the map. Slow.")]
+        [Usage("DoorGen"), Description("Generates doors by analyzing the map. Slow.")]
         public static void DoorGen_OnCommand(CommandEventArgs e)
         {
             Generate();

--- a/Projects/UOContent/Misc/Email.cs
+++ b/Projects/UOContent/Misc/Email.cs
@@ -119,13 +119,13 @@ namespace Server.Misc
                 try
                 {
                     using var client = new SmtpClient();
-                    await client.ConnectAsync(EmailConfiguration.EmailServer, EmailConfiguration.EmailPort, true);
+                    await client.ConnectAsync(EmailConfiguration.EmailServer, EmailConfiguration.EmailPort, true).ConfigureAwait(false);
                     await client.AuthenticateAsync(
                         EmailConfiguration.EmailServerUsername,
                         EmailConfiguration.EmailServerPassword
-                    );
-                    await client.SendAsync(message);
-                    await client.DisconnectAsync(true);
+                    ).ConfigureAwait(false);
+                    await client.SendAsync(message).ConfigureAwait(false);
+                    await client.DisconnectAsync(true).ConfigureAwait(false);
                     return;
                 }
                 catch (Exception ex)
@@ -138,7 +138,7 @@ namespace Server.Misc
 
                     delay *= delay;
 
-                    await Task.Delay(delay * 1000);
+                    await Task.Delay(delay * 1000).ConfigureAwait(false);
                 }
             }
         }

--- a/Projects/UOContent/Misc/Guild.cs
+++ b/Projects/UOContent/Misc/Guild.cs
@@ -928,10 +928,9 @@ namespace Server.Guilds
             Alliance = null;
         }
 
-        [Usage("GuildProps")]
-        [Description(
-            "Opens a menu where you can view and edit guild properties of a targeted player or guild stone.  If the new Guild system is active, also brings up the guild gump."
-        )]
+        [Usage("GuildProps"), Description(
+             "Opens a menu where you can view and edit guild properties of a targeted player or guild stone.  If the new Guild system is active, also brings up the guild gump."
+         )]
         private static void GuildProps_OnCommand(CommandEventArgs e)
         {
             var arg = e.ArgString.Trim();

--- a/Projects/UOContent/Misc/HardwareInfo.cs
+++ b/Projects/UOContent/Misc/HardwareInfo.cs
@@ -94,8 +94,7 @@ namespace Server
             CommandSystem.Register("HWInfo", AccessLevel.GameMaster, HWInfo_OnCommand);
         }
 
-        [Usage("HWInfo")]
-        [Description("Displays information about a targeted player's hardware.")]
+        [Usage("HWInfo"), Description("Displays information about a targeted player's hardware.")]
         public static void HWInfo_OnCommand(CommandEventArgs e)
         {
             e.Mobile.BeginTarget(-1, false, TargetFlags.None, HWInfo_OnTarget);

--- a/Projects/UOContent/Misc/LanguageStatistics.cs
+++ b/Projects/UOContent/Misc/LanguageStatistics.cs
@@ -188,8 +188,7 @@ namespace Server.Misc
             CommandSystem.Register("LanguageStatistics", AccessLevel.Administrator, LanguageStatistics_OnCommand);
         }
 
-        [Usage("LanguageStatistics")]
-        [Description("Generate a file containing the list of languages for each PlayerMobile.")]
+        [Usage("LanguageStatistics"), Description("Generate a file containing the list of languages for each PlayerMobile.")]
         public static void LanguageStatistics_OnCommand(CommandEventArgs e)
         {
             var ht = new Dictionary<string, InternationalCodeCounter>();

--- a/Projects/UOContent/Misc/LanguageStatistics.cs
+++ b/Projects/UOContent/Misc/LanguageStatistics.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Server.Accounting;

--- a/Projects/UOContent/Misc/LightCycle.cs
+++ b/Projects/UOContent/Misc/LightCycle.cs
@@ -38,8 +38,7 @@ namespace Server
             CommandSystem.Register("GlobalLight", AccessLevel.GameMaster, Light_OnCommand);
         }
 
-        [Usage("GlobalLight <value>")]
-        [Description("Sets the current global light level.")]
+        [Usage("GlobalLight <value>"), Description("Sets the current global light level.")]
         private static void Light_OnCommand(CommandEventArgs e)
         {
             if (e.Length >= 1)

--- a/Projects/UOContent/Misc/LightCycle.cs
+++ b/Projects/UOContent/Misc/LightCycle.cs
@@ -4,6 +4,7 @@ using Server.Network;
 
 namespace Server
 {
+#pragma warning disable CA1052
     public class LightCycle
     {
         public const int DayLevel = 0;
@@ -20,9 +21,8 @@ namespace Server
             {
                 m_LevelOverride = value;
 
-                for (var i = 0; i < TcpServer.Instances.Count; ++i)
+                foreach (var ns in TcpServer.Instances)
                 {
-                    var ns = TcpServer.Instances[i];
                     var m = ns.Mobile;
 
                     m?.CheckLightLevels(false);
@@ -110,12 +110,9 @@ namespace Server
 
             protected override void OnTick()
             {
-                for (var i = 0; i < TcpServer.Instances.Count; ++i)
+                foreach (var ns in TcpServer.Instances)
                 {
-                    var ns = TcpServer.Instances[i];
-                    var m = ns.Mobile;
-
-                    m?.CheckLightLevels(false);
+                    ns.Mobile?.CheckLightLevels(false);
                 }
             }
         }
@@ -138,4 +135,5 @@ namespace Server
             }
         }
     }
+#pragma warning restore CA1052
 }

--- a/Projects/UOContent/Misc/LoginStats.cs
+++ b/Projects/UOContent/Misc/LoginStats.cs
@@ -2,7 +2,7 @@ using Server.Network;
 
 namespace Server.Misc
 {
-    public class LoginStats
+    public static class LoginStats
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Misc/Loot.cs
+++ b/Projects/UOContent/Misc/Loot.cs
@@ -4,7 +4,7 @@ using Server.Utilities;
 
 namespace Server
 {
-    public class Loot
+    public static class Loot
     {
         public static Type[] MLWeaponTypes { get; } =
         {

--- a/Projects/UOContent/Misc/NameVerification.cs
+++ b/Projects/UOContent/Misc/NameVerification.cs
@@ -105,8 +105,7 @@ namespace Server.Misc
             CommandSystem.Register("ValidateName", AccessLevel.Administrator, ValidateName_OnCommand);
         }
 
-        [Usage("ValidateName")]
-        [Description("Checks the result of NameValidation on the specified name.")]
+        [Usage("ValidateName"), Description("Checks the result of NameValidation on the specified name.")]
         public static void ValidateName_OnCommand(CommandEventArgs e)
         {
             if (Validate(e.ArgString, 2, 16, true, false, true, 1, SpaceDashPeriodQuote))
@@ -236,7 +235,7 @@ namespace Server.Misc
 
             for (var i = 0; i < startDisallowed.Length; ++i)
             {
-                if (name.StartsWith(startDisallowed[i]))
+                if (name.StartsWith(startDisallowed[i], StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/Projects/UOContent/Misc/NameVerification.cs
+++ b/Projects/UOContent/Misc/NameVerification.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Misc
 {
-    public class NameVerification
+    public static class NameVerification
     {
         public static readonly char[] SpaceDashPeriodQuote =
         {

--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -12,7 +12,7 @@ using Server.Spells.Seventh;
 
 namespace Server.Misc
 {
-    public class NotorietyHandlers
+    public static class NotorietyHandlers
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Misc/ProfanityProtection.cs
+++ b/Projects/UOContent/Misc/ProfanityProtection.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Server.Misc
 {
     public enum ProfanityAction
@@ -24,7 +26,7 @@ namespace Server.Misc
             '{', '}', '?', '|', '(', ')', '%', '$', '&', '#', '@'
         };
 
-        public static string[] StartDisallowed { get; } = { };
+        public static string[] StartDisallowed { get; } = Array.Empty<string>();
 
         public static string[] Disallowed { get; } =
         {

--- a/Projects/UOContent/Misc/RaceDefinitions.cs
+++ b/Projects/UOContent/Misc/RaceDefinitions.cs
@@ -1,6 +1,6 @@
 namespace Server.Misc
 {
-    public class RaceDefinitions
+    public static class RaceDefinitions
     {
         public static void Configure()
         {

--- a/Projects/UOContent/Misc/RegenRates.cs
+++ b/Projects/UOContent/Misc/RegenRates.cs
@@ -7,7 +7,7 @@ using Server.Spells.Ninjitsu;
 
 namespace Server.Misc
 {
-    public class RegenRates
+    public static class RegenRates
     {
         [CallPriority(10)]
         public static void Configure()

--- a/Projects/UOContent/Misc/RenameRequests.cs
+++ b/Projects/UOContent/Misc/RenameRequests.cs
@@ -25,7 +25,7 @@ namespace Server.Misc
                     0,
                     NameVerification.Empty,
                     NameVerification.StartDisallowed,
-                    Core.ML ? NameVerification.Disallowed : new string[] { }
+                    Core.ML ? NameVerification.Disallowed : Array.Empty<string>()
                 ))
                 {
                     if (Core.ML)

--- a/Projects/UOContent/Misc/ResourceInfo.cs
+++ b/Projects/UOContent/Misc/ResourceInfo.cs
@@ -870,22 +870,22 @@ namespace Server.Items
         /// </summary>
         public static CraftResource GetFromOreInfo(OreInfo info)
         {
-            if (info.Name.IndexOf("Spined", StringComparison.Ordinal) >= 0)
+            if (info.Name.Contains("Spined", StringComparison.Ordinal))
             {
                 return CraftResource.SpinedLeather;
             }
 
-            if (info.Name.IndexOf("Horned", StringComparison.Ordinal) >= 0)
+            if (info.Name.Contains("Horned", StringComparison.Ordinal))
             {
                 return CraftResource.HornedLeather;
             }
 
-            if (info.Name.IndexOf("Barbed", StringComparison.Ordinal) >= 0)
+            if (info.Name.Contains("Barbed", StringComparison.Ordinal))
             {
                 return CraftResource.BarbedLeather;
             }
 
-            if (info.Name.IndexOf("Leather", StringComparison.Ordinal) >= 0)
+            if (info.Name.Contains("Leather", StringComparison.Ordinal))
             {
                 return CraftResource.RegularLeather;
             }

--- a/Projects/UOContent/Misc/ShrinkTable.cs
+++ b/Projects/UOContent/Misc/ShrinkTable.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Server
 {
-    public class ShrinkTable
+    public static class ShrinkTable
     {
         public const int DefaultItemID = 0x1870; // Yellow virtue stone
 

--- a/Projects/UOContent/Misc/ShrinkTable.cs
+++ b/Projects/UOContent/Misc/ShrinkTable.cs
@@ -56,7 +56,7 @@ namespace Server
             {
                 line = line.Trim();
 
-                if (line.Length == 0 || line.StartsWith("#"))
+                if (line.Length == 0 || line.StartsWith("#", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/Projects/UOContent/Misc/SkillCheck.cs
+++ b/Projects/UOContent/Misc/SkillCheck.cs
@@ -5,7 +5,7 @@ using Server.Regions;
 
 namespace Server.Misc
 {
-    public class SkillCheck
+    public static class SkillCheck
     {
         public enum Stat
         {

--- a/Projects/UOContent/Misc/TextDefinition.cs
+++ b/Projects/UOContent/Misc/TextDefinition.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using Server.Gumps;
 using Server.Network;
@@ -200,14 +201,7 @@ namespace Server
                 return null;
             }
 
-            int i;
-            bool isInteger;
-
-            isInteger = value.StartsWith("0x")
-                ? int.TryParse(value.Substring(2), NumberStyles.HexNumber, null, out i)
-                : int.TryParse(value, out i);
-
-            return isInteger ? new TextDefinition(i) : new TextDefinition(value);
+            return Utility.ToInt32(value, out var i) ? new TextDefinition(i) : new TextDefinition(value);
         }
 
         public static bool IsNullOrEmpty(TextDefinition def) => def?.IsEmpty != false;

--- a/Projects/UOContent/Misc/TextDefinition.cs
+++ b/Projects/UOContent/Misc/TextDefinition.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Globalization;
 using Server.Gumps;
 using Server.Network;
 

--- a/Projects/UOContent/Misc/Titles.cs
+++ b/Projects/UOContent/Misc/Titles.cs
@@ -5,7 +5,7 @@ using Server.Mobiles;
 
 namespace Server.Misc
 {
-    public class Titles
+    public static class Titles
     {
         public const int MinFame = 0;
         public const int MaxFame = 15000;
@@ -395,7 +395,7 @@ namespace Server.Misc
                 var skillLevel = GetSkillLevel(highest);
                 var skillTitle = highest.Info.Title;
 
-                if (mob.Female && skillTitle.EndsWith("man"))
+                if (mob.Female && skillTitle.EndsWith("man", StringComparison.Ordinal))
                 {
                     skillTitle = $"{skillTitle.Substring(0, skillTitle.Length - 3)}woman";
                 }

--- a/Projects/UOContent/Misc/VendorGenerator.cs
+++ b/Projects/UOContent/Misc/VendorGenerator.cs
@@ -40,8 +40,8 @@ namespace Server
             CommandSystem.Register("VendorGen", AccessLevel.Administrator, VendorGen_OnCommand);
         }
 
-        [Usage("VendorGen")]
-        [Description("Generates vendors based on display cases and floor plans. Analyzes the map files, slow.")]
+        [Usage("VendorGen"),
+         Description("Generates vendors based on display cases and floor plans. Analyzes the map files, slow.")]
         private static void VendorGen_OnCommand(CommandEventArgs e)
         {
             Process(Map.Trammel, m_BritRegions);

--- a/Projects/UOContent/Misc/Weather.cs
+++ b/Projects/UOContent/Misc/Weather.cs
@@ -354,13 +354,10 @@ namespace Server.Misc
                     type = 2;
                 }
 
-                var states = TcpServer.Instances;
-
                 Packet weatherPacket = null;
 
-                for (var i = 0; i < states.Count; ++i)
+                foreach (var ns in TcpServer.Instances)
                 {
-                    var ns = states[i];
                     var mob = ns.Mobile;
 
                     if (mob == null || mob.Map != Facet)

--- a/Projects/UOContent/Misc/WeightOverloading.cs
+++ b/Projects/UOContent/Misc/WeightOverloading.cs
@@ -23,21 +23,12 @@ namespace Server.Misc
 
         public static void FatigueOnDamage(Mobile m, int damage)
         {
-            var fatigue = 0.0;
-
-            switch (DFA)
+            var fatigue = DFA switch
             {
-                case DFAlgorithm.Standard:
-                    {
-                        fatigue = damage * (100.0 / m.Hits) * ((double)m.Stam / 100) - 5.0;
-                        break;
-                    }
-                case DFAlgorithm.PainSpike:
-                    {
-                        fatigue = damage * (100.0 / m.Hits + (50.0 + m.Stam) / 100 - 1.0) - 5.0;
-                        break;
-                    }
-            }
+                DFAlgorithm.Standard  => damage * (100.0 / m.Hits) * ((double)m.Stam / 100) - 5.0,
+                DFAlgorithm.PainSpike => damage * (100.0 / m.Hits + (50.0 + m.Stam) / 100 - 1.0) - 5.0,
+                _                     => 0.0
+            };
 
             if (fatigue > 0)
             {

--- a/Projects/UOContent/Mobiles/Animals/Misc/PackHorse.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/PackHorse.cs
@@ -92,15 +92,7 @@ namespace Server.Mobiles
 
         public override DeathMoveResult GetInventoryMoveResultFor(Item item) => DeathMoveResult.MoveToCorpse;
 
-        public override bool IsSnoop(Mobile from)
-        {
-            if (PackAnimal.CheckAccess(this, from))
-            {
-                return false;
-            }
-
-            return base.IsSnoop(from);
-        }
+        public override bool IsSnoop(Mobile from) => !PackAnimal.CheckAccess(this, from) && base.IsSnoop(from);
 
         public override bool OnDragDrop(Mobile from, Item item)
         {
@@ -157,7 +149,7 @@ namespace Server.Mobiles
         }
     }
 
-    public class PackAnimal
+    public static class PackAnimal
     {
         public static void GetContextMenuEntries(BaseCreature animal, Mobile from, List<ContextMenuEntry> list)
         {
@@ -167,21 +159,10 @@ namespace Server.Mobiles
             }
         }
 
-        public static bool CheckAccess(BaseCreature animal, Mobile from)
-        {
-            if (from == animal || from.AccessLevel >= AccessLevel.GameMaster)
-            {
-                return true;
-            }
-
-            if (from.Alive && animal.Controlled && !animal.IsDeadPet &&
-                (from == animal.ControlMaster || from == animal.SummonMaster || animal.IsPetFriend(from)))
-            {
-                return true;
-            }
-
-            return false;
-        }
+        public static bool CheckAccess(BaseCreature animal, Mobile from) =>
+            from == animal || from.AccessLevel >= AccessLevel.GameMaster || from.Alive && animal.Controlled &&
+            !animal.IsDeadPet &&
+            (from == animal.ControlMaster || from == animal.SummonMaster || animal.IsPetFriend(from));
 
         public static void CombineBackpacks(BaseCreature animal)
         {

--- a/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
@@ -43,8 +43,7 @@ namespace Server.Mobiles
         public virtual bool AllowMaleRider => true;
         public virtual bool AllowFemaleRider => true;
 
-        [Hue]
-        [CommandProperty(AccessLevel.GameMaster)]
+        [Hue, CommandProperty(AccessLevel.GameMaster)]
         public override int Hue
         {
             get => base.Hue;

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
@@ -141,7 +141,7 @@ namespace Server.Mobiles
 
             if (Core.ML && IsRewardItem)
             {
-                list.Add(RewardSystem.GetRewardYearLabel(this, new object[] { })); // X Year Veteran Reward
+                list.Add(RewardSystem.GetRewardYearLabel(this, Array.Empty<object>())); // X Year Veteran Reward
             }
         }
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -1361,7 +1361,7 @@ namespace Server.Mobiles
                 from.Damage(amount, from);
             }
 
-            base.Damage(amount, from);
+            base.Damage(amount, from, informMount);
 
             if (SubdueBeforeTame && !Controlled && oldHits > HitsMax / 10 && Hits <= HitsMax / 10)
             {

--- a/Projects/UOContent/Mobiles/Monsters/Ants/SolenHelper.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/SolenHelper.cs
@@ -3,7 +3,7 @@ using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class SolenHelper
+    public static class SolenHelper
     {
         public static void PackPicnicBasket(BaseCreature solen)
         {

--- a/Projects/UOContent/Mobiles/Monsters/Humanoid/Melee/KhaldunZealot.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Humanoid/Melee/KhaldunZealot.cs
@@ -113,7 +113,7 @@ namespace Server.Mobiles
             }
 
             Effects.PlaySound(this, GetDeathSound());
-            Effects.SendLocationEffect(Location, Map, 0x3709, 30, 10, 0x835, 0);
+            Effects.SendLocationEffect(Location, Map, 0x3709, 30, 10, 0x835);
             rm.MoveToWorld(Location, Map);
 
             Delete();

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
@@ -67,7 +67,7 @@ namespace Server.Mobiles
         public override string CorpseName => "a corpse of Ilhenir";
         public override ChampionSkullType SkullType => ChampionSkullType.Pain;
 
-        public override Type[] UniqueList => new Type[] { };
+        public override Type[] UniqueList => Array.Empty<Type>();
 
         public override Type[] SharedList => new[]
         {

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Meraktus.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Meraktus.cs
@@ -62,7 +62,7 @@ namespace Server.Mobiles
         public override ChampionSkullType SkullType => ChampionSkullType.Pain;
 
         public override Type[] UniqueList => new[] { typeof(Subdue) };
-        public override Type[] SharedList => new Type[] { };
+        public override Type[] SharedList => Array.Empty<Shared>();
 
         public override Type[] DecorativeList => new[]
         {

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Meraktus.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Meraktus.cs
@@ -62,7 +62,7 @@ namespace Server.Mobiles
         public override ChampionSkullType SkullType => ChampionSkullType.Pain;
 
         public override Type[] UniqueList => new[] { typeof(Subdue) };
-        public override Type[] SharedList => Array.Empty<Shared>();
+        public override Type[] SharedList => Array.Empty<Type>();
 
         public override Type[] DecorativeList => new[]
         {

--- a/Projects/UOContent/Mobiles/Monsters/SE/FanDancer.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/FanDancer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using Server.Engines.Plants;
 using Server.Items;
-using Server.Network;
 
 namespace Server.Mobiles
 {
@@ -96,9 +95,7 @@ namespace Server.Mobiles
                 Location,
                 to.Location,
                 10,
-                0,
-                false,
-                false
+                0
             );
 
             AOS.Damage(to, this, Utility.RandomMinMax(50, 65), 100, 0, 0, 0, 0);

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -1749,9 +1749,7 @@ namespace Server.Mobiles
 
             if (item is BaseArmor || item is BaseWeapon)
             {
-                Hits = Hits;
-                Stam = Stam;
-                Mana = Mana;
+                CheckStatTimers();
             }
 
             if (NetState != null)
@@ -1766,9 +1764,7 @@ namespace Server.Mobiles
 
             if (item is BaseArmor || item is BaseWeapon)
             {
-                Hits = Hits;
-                Stam = Stam;
-                Mana = Mana;
+                CheckStatTimers();
             }
 
             if (NetState != null)
@@ -1876,12 +1872,7 @@ namespace Server.Mobiles
                 }
             }
 
-            if (DuelContext?.AllowSkillUse(this, skill) == false)
-            {
-                return false;
-            }
-
-            return DesignContext.Check(this);
+            return DuelContext?.AllowSkillUse(this, skill) != false && DesignContext.Check(this);
         }
 
         public virtual void RecheckTownProtection()

--- a/Projects/UOContent/Mobiles/Special/LordOaks.cs
+++ b/Projects/UOContent/Mobiles/Special/LordOaks.cs
@@ -71,7 +71,7 @@ namespace Server.Mobiles
             typeof(DirtPatch)
         };
 
-        public override MonsterStatuetteType[] StatueTypes => new MonsterStatuetteType[] { };
+        public override MonsterStatuetteType[] StatueTypes => Array.Empty<MonsterStatuetteType>();
 
         public override string DefaultName => "Lord Oaks";
 

--- a/Projects/UOContent/Mobiles/Special/Neira.cs
+++ b/Projects/UOContent/Mobiles/Special/Neira.cs
@@ -82,7 +82,7 @@ namespace Server.Mobiles
 
         public override Type[] DecorativeList => new[] { typeof(WallBlood), typeof(TatteredAncientMummyWrapping) };
 
-        public override MonsterStatuetteType[] StatueTypes => new MonsterStatuetteType[] { };
+        public override MonsterStatuetteType[] StatueTypes => Array.Empty<MonsterStatuetteType>();
 
         public override string DefaultName => "Neira";
 

--- a/Projects/UOContent/Mobiles/Special/Paragon.cs
+++ b/Projects/UOContent/Mobiles/Special/Paragon.cs
@@ -4,7 +4,7 @@ using Server.Utilities;
 
 namespace Server.Mobiles
 {
-    public class Paragon
+    public static class Paragon
     {
         public static double ChestChance = .10;               // Chance that a paragon will carry a paragon chest
         public static double ChocolateIngredientChance = .20; // Chance that a paragon will drop a chocolatiering ingredient

--- a/Projects/UOContent/Mobiles/Special/Semidar.cs
+++ b/Projects/UOContent/Mobiles/Special/Semidar.cs
@@ -56,7 +56,7 @@ namespace Server.Mobiles
 
         public override Type[] DecorativeList => new[] { typeof(LavaTile), typeof(DemonSkull) };
 
-        public override MonsterStatuetteType[] StatueTypes => new MonsterStatuetteType[] { };
+        public override MonsterStatuetteType[] StatueTypes => Array.Empty<MonsterStatuetteType>();
 
         public override string DefaultName => "Semidar";
 

--- a/Projects/UOContent/Mobiles/Special/Serado.cs
+++ b/Projects/UOContent/Mobiles/Special/Serado.cs
@@ -63,7 +63,7 @@ namespace Server.Mobiles
 
         public override Type[] DecorativeList => new[] { typeof(Futon), typeof(SwampTile) };
 
-        public override MonsterStatuetteType[] StatueTypes => new MonsterStatuetteType[] { };
+        public override MonsterStatuetteType[] StatueTypes => Array.Empty<MonsterStatuetteType>();
 
         public override string DefaultName => "Serado";
 

--- a/Projects/UOContent/Mobiles/Townfolk/TownCrier.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/TownCrier.cs
@@ -89,8 +89,7 @@ namespace Server.Mobiles
             CommandSystem.Register("TownCriers", AccessLevel.GameMaster, TownCriers_OnCommand);
         }
 
-        [Usage("TownCriers")]
-        [Description("Manages the global town crier list.")]
+        [Usage("TownCriers"), Description("Manages the global town crier list.")]
         public static void TownCriers_OnCommand(CommandEventArgs e)
         {
             e.Mobile.SendGump(new TownCrierGump(e.Mobile, Instance));

--- a/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
+++ b/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Server.ContextMenus;
 using Server.Gumps;
@@ -386,7 +387,7 @@ namespace Server.Mobiles
 
                 CloseClaimList(e.Mobile);
 
-                var index = e.Speech.IndexOf(' ');
+                var index = e.Speech.IndexOf(' ', StringComparison.Ordinal);
 
                 if (index != -1)
                 {

--- a/Projects/UOContent/Multis/BaseHouse.cs
+++ b/Projects/UOContent/Multis/BaseHouse.cs
@@ -1688,8 +1688,7 @@ namespace Server.Multis
                     4 => new GenericHouseDoor(facing, 0x6B5, 0xEA, 0xF1),
                     5 => new GenericHouseDoor(facing, 0x6C5, 0xEC, 0xF3),
                     6 => new GenericHouseDoor(facing, 0x6D5, 0xEA, 0xF1),
-                    7 => new GenericHouseDoor(facing, 0x6E5, 0xEA, 0xF1),
-                    _ => null
+                    _ => new GenericHouseDoor(facing, 0x6E5, 0xEA, 0xF1) // 7
                 };
             }
             else if (itemID >= 0x314 && itemID < 0x364)
@@ -1792,8 +1791,7 @@ namespace Server.Multis
                 door = type switch
                 {
                     0 => new GenericHouseDoor(facing, 0x367B, 0xED, 0xF4),
-                    1 => new GenericHouseDoor(facing, 0x368B, 0xEC, 0x3E7),
-                    _ => null
+                    _ => new GenericHouseDoor(facing, 0x368B, 0xEC, 0x3E7) // 1
                 };
             }
             else if (itemID >= 0x409B && itemID < 0x40A3)

--- a/Projects/UOContent/Multis/Boats/Strandedness.cs
+++ b/Projects/UOContent/Multis/Boats/Strandedness.cs
@@ -1,6 +1,6 @@
 namespace Server.Misc
 {
-    public class Strandedness
+    public static class Strandedness
     {
         private static readonly Point2D[] m_Felucca =
         {

--- a/Projects/UOContent/Multis/DynamicDecay.cs
+++ b/Projects/UOContent/Multis/DynamicDecay.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Server.Multis
 {
-    public class DynamicDecay
+    public static class DynamicDecay
     {
         private static readonly Dictionary<DecayLevel, DecayStageInfo> m_Stages;
 

--- a/Projects/UOContent/Multis/HousePlacement.cs
+++ b/Projects/UOContent/Multis/HousePlacement.cs
@@ -18,7 +18,7 @@ namespace Server.Multis
         BadRegionRaffle
     }
 
-    public class HousePlacement
+    public static class HousePlacement
     {
         private const int YardSize = 5;
 

--- a/Projects/UOContent/Regions/GuardedRegion.cs
+++ b/Projects/UOContent/Regions/GuardedRegion.cs
@@ -71,8 +71,7 @@ namespace Server.Regions
             CommandSystem.Register("ToggleGuarded", AccessLevel.Administrator, ToggleGuarded_OnCommand);
         }
 
-        [Usage("CheckGuarded")]
-        [Description("Returns a value indicating if the current region is guarded or not.")]
+        [Usage("CheckGuarded"), Description("Returns a value indicating if the current region is guarded or not.")]
         private static void CheckGuarded_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -92,8 +91,7 @@ namespace Server.Regions
             }
         }
 
-        [Usage("SetGuarded <true|false>")]
-        [Description("Enables or disables guards for the current region.")]
+        [Usage("SetGuarded <true|false>"), Description("Enables or disables guards for the current region.")]
         private static void SetGuarded_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;
@@ -123,8 +121,7 @@ namespace Server.Regions
             }
         }
 
-        [Usage("ToggleGuarded")]
-        [Description("Toggles the state of guards for the current region.")]
+        [Usage("ToggleGuarded"), Description("Toggles the state of guards for the current region.")]
         private static void ToggleGuarded_OnCommand(CommandEventArgs e)
         {
             var from = e.Mobile;

--- a/Projects/UOContent/SpecialSystems/Engines/GiftGiving.cs
+++ b/Projects/UOContent/SpecialSystems/Engines/GiftGiving.cs
@@ -10,7 +10,7 @@ namespace Server.Misc
         BankBox
     }
 
-    public class GiftGiving
+    public static class GiftGiving
     {
         private static readonly List<GiftGiver> m_Givers = new List<GiftGiver>();
 

--- a/Projects/UOContent/SpecialSystems/Engines/TestCenter.cs
+++ b/Projects/UOContent/SpecialSystems/Engines/TestCenter.cs
@@ -267,7 +267,7 @@ namespace Server.Misc
                     case 3: // Command list
                         {
                             sender.Mobile.SendAsciiMessage(0x482, "The command prefix is \"{0}\"", CommandSystem.Prefix);
-                            CommandHandlers.Help_OnCommand(new CommandEventArgs(sender.Mobile, "help", "", new string[0]));
+                            CommandHandlers.Help_OnCommand(new CommandEventArgs(sender.Mobile, "help", "", Array.Empty<string>()));
 
                             break;
                         }

--- a/Projects/UOContent/SpecialSystems/Engines/TestCenter.cs
+++ b/Projects/UOContent/SpecialSystems/Engines/TestCenter.cs
@@ -6,7 +6,7 @@ using Server.Network;
 
 namespace Server.Misc
 {
-    public class TestCenter
+    public static class TestCenter
     {
         public static bool Enabled { get; private set; }
 

--- a/Projects/UOContent/Spells/Base/SpellHelper.cs
+++ b/Projects/UOContent/Spells/Base/SpellHelper.cs
@@ -61,7 +61,7 @@ namespace Server.Spells
         TeleportTo
     }
 
-    public class SpellHelper
+    public static class SpellHelper
     {
         private static readonly TimeSpan AosDamageDelay = TimeSpan.FromSeconds(1.0);
         private static readonly TimeSpan OldDamageDelay = TimeSpan.FromSeconds(0.5);
@@ -1221,7 +1221,7 @@ namespace Server.Spells
         }
     }
 
-    public class TransformationSpellHelper
+    public static class TransformationSpellHelper
     {
         private static readonly Dictionary<Mobile, TransformContext> m_Table = new Dictionary<Mobile, TransformContext>();
 

--- a/Projects/UOContent/Spells/Base/SpellHelper.cs
+++ b/Projects/UOContent/Spells/Base/SpellHelper.cs
@@ -18,6 +18,7 @@ using Server.Targeting;
 
 namespace Server
 {
+#pragma warning disable CA1052
     public class DefensiveSpell
     {
         public static void Nullify(Mobile from)
@@ -46,6 +47,7 @@ namespace Server
             }
         }
     }
+#pragma warning restore CA1052
 }
 
 namespace Server.Spells
@@ -197,7 +199,7 @@ namespace Server.Spells
                     from.Direction = from.GetDirectionTo(item.GetWorldLocation());
                 }
             }
-            else if (from != target)
+            else if (from.Equals(target))
             {
                 from.Direction = from.GetDirectionTo(target);
             }

--- a/Projects/UOContent/Spells/Base/SpellRegistry.cs
+++ b/Projects/UOContent/Spells/Base/SpellRegistry.cs
@@ -152,7 +152,7 @@ namespace Server.Spells
 
         public static Spell NewSpell(string name, Mobile caster, Item scroll)
         {
-            name = name.Replace(" ", "");
+            name = name.Replace(" ", "", StringComparison.Ordinal);
 
             for (var i = 0; i < m_CircleNames.Length; ++i)
             {

--- a/Projects/UOContent/Spells/Base/SpellRegistry.cs
+++ b/Projects/UOContent/Spells/Base/SpellRegistry.cs
@@ -4,7 +4,7 @@ using Server.Utilities;
 
 namespace Server.Spells
 {
-    public class SpellRegistry
+    public static class SpellRegistry
     {
         private static readonly Type[] m_Types = new Type[700];
         private static int m_Count;

--- a/Projects/UOContent/Spells/Initializer.cs
+++ b/Projects/UOContent/Spells/Initializer.cs
@@ -16,7 +16,7 @@ using Server.Spells.Third;
 
 namespace Server.Spells
 {
-    public class Initializer
+    public static class Initializer
     {
         public static void Initialize()
         {

--- a/Projects/UOContent/Spells/Ninjitsu/AnimalForm.cs
+++ b/Projects/UOContent/Spells/Ninjitsu/AnimalForm.cs
@@ -617,7 +617,7 @@ namespace Server.Spells.Ninjitsu
             {
                 m_Mobile.RevealingAction();
                 m_Mobile.PlaySound(0x227);
-                Effects.SendMovingEffect(m_Mobile, target, 0x36D4, 5, 0, false, false);
+                Effects.SendMovingEffect(m_Mobile, target, 0x36D4, 5, 0);
 
                 DelayCall(TimeSpan.FromSeconds(1), BreathDamage_Callback, target);
             }

--- a/Rules.ruleset
+++ b/Rules.ruleset
@@ -373,8 +373,10 @@
         <Rule Id="CA1031" Action="None" />
         <Rule Id="CA1034" Action="None" />
         <Rule Id="CA1036" Action="None" />
+        <Rule Id="CA1051" Action="None" /> <!-- Visible fields that shouldn't be -->
         <Rule Id="CA1054" Action="None" />
         <Rule Id="CA1055" Action="None" />
+        <Rule Id="CA1056" Action="None" />
         <Rule Id="CA1062" Action="None" />
         <Rule Id="CA1063" Action="None" />
         <Rule Id="CA1069" Action="None" />
@@ -397,6 +399,7 @@
         <Rule Id="CA1819" Action="None" />
         <Rule Id="CA1822" Action="None" />
         <Rule Id="CA1823" Action="None" />
+        <Rule Id="CA2119" Action="None" /> <!-- Lots of properties and methods are not used but provided for consumption -->
         <Rule Id="CA2211" Action="None" />
         <Rule Id="CA2214" Action="None" />
         <Rule Id="CA2225" Action="None" />

--- a/Rules.ruleset
+++ b/Rules.ruleset
@@ -373,6 +373,7 @@
         <Rule Id="CA1031" Action="None" />
         <Rule Id="CA1034" Action="None" />
         <Rule Id="CA1036" Action="None" />
+        <Rule Id="CA1043" Action="None" /> <!-- Non integral/string indexers -->
         <Rule Id="CA1051" Action="None" /> <!-- Visible fields that shouldn't be -->
         <Rule Id="CA1054" Action="None" />
         <Rule Id="CA1055" Action="None" />

--- a/Rules.ruleset
+++ b/Rules.ruleset
@@ -369,15 +369,19 @@
     <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
         <Rule Id="CA1010" Action="None" />
         <Rule Id="CA1028" Action="None" />
+        <Rule Id="CA1030" Action="None" />
         <Rule Id="CA1031" Action="None" />
         <Rule Id="CA1034" Action="None" />
         <Rule Id="CA1036" Action="None" />
         <Rule Id="CA1054" Action="None" />
+        <Rule Id="CA1055" Action="None" />
         <Rule Id="CA1062" Action="None" />
         <Rule Id="CA1063" Action="None" />
+        <Rule Id="CA1069" Action="None" />
         <Rule Id="CA1707" Action="None" />
         <Rule Id="CA1710" Action="None" />
         <Rule Id="CA1714" Action="None" />
+        <Rule Id="CA1715" Action="None" />
         <Rule Id="CA1716" Action="None" />
         <Rule Id="CA1717" Action="None" />
         <Rule Id="CA1720" Action="None" />
@@ -385,6 +389,8 @@
         <Rule Id="CA1724" Action="None" />
         <Rule Id="CA1801" Action="None" />
         <Rule Id="CA1802" Action="None" />
+        <Rule Id="CA1805" Action="None" />
+        <Rule Id="CA1806" Action="None" /> <!-- Enable to find leaked objects -->
         <Rule Id="CA1812" Action="None" />
         <Rule Id="CA1814" Action="None" />
         <Rule Id="CA1815" Action="None" />
@@ -397,6 +403,7 @@
         <Rule Id="CA2227" Action="None" />
     </Rules>
     <Rules AnalyzerId="Microsoft.CodeQuality.CSharp.Analyzers" RuleNamespace="Microsoft.CodeQuality.CSharp.Analyzers">
+        <Rule Id="CA1000" Action="None" /> <!-- No generics in static classes -->
         <Rule Id="CA1001" Action="None" />
         <Rule Id="CA1032" Action="None" />
         <Rule Id="CA2234" Action="None" />
@@ -405,7 +412,9 @@
         <Rule Id="CA1303" Action="None" />
         <Rule Id="CA1304" Action="None" />
         <Rule Id="CA1305" Action="None" />
-        <Rule Id="CA1307" Action="None" />
+        <Rule Id="CA1307" Action="Warning" />
+        <Rule Id="CA1309" Action="Warning" />
+        <Rule Id="CA1310" Action="Warning" />
         <Rule Id="CA1816" Action="None" />
         <Rule Id="CA2000" Action="None" />
         <Rule Id="CA2213" Action="None" />


### PR DESCRIPTION
Notes:
- [CA1051] - Turned off visible fields
- [CA1806] - Turned off objects created and not referenced (self registering objects, might be memory leak)
- [CA2119] - Turned off unused methods (we have this on purpose because we are a platform/framework for consumption/overriding)
- [CA1307] - Enabled for .NET 5 changes
- [CA1309] - Enabled for .NET 5 changes
- [CA1310] - Enabled for .NET 5 changes
- [CA5350], [CA5351] - Disabled in code for backwards compatibility
- [CA1052] - Fixed most of them. Disabled in code for classes that use it's type for BeginAction/EndAction

Fixes several bugs too.