### PR TITLE
Fixes messages and removes movement console logs

### DIFF
--- a/Projects/Server/Network/Packets/IncomingMovementPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingMovementPackets.cs
@@ -90,15 +90,6 @@ namespace Server.Network
             int seq = reader.ReadByte();
             var key = reader.ReadUInt32();
 
-            if (key != 0)
-            {
-                state.WriteConsole("OldMove w/ Key {0}", key);
-            }
-            else
-            {
-                state.WriteConsole("Old Movement!");
-            }
-
             if (state.Sequence == 0 && seq != 0 || !from.Move(dir))
             {
                 state.SendMovementRej(seq, from);

--- a/Projects/Server/Network/Packets/OutgoingMessagePackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingMessagePackets.cs
@@ -57,8 +57,8 @@ namespace Server.Network
             Serial serial, int graphic, MessageType type, int hue, int font, int number, string name = "", string args = ""
         )
         {
-            name = name?.Trim() ?? "";
-            args = args?.Trim() ?? "";
+            name ??= "";
+            args ??= "";
 
             if (hue == 0)
             {
@@ -111,9 +111,9 @@ namespace Server.Network
             AffixType affixType, string affix = "", string args = ""
         )
         {
-            name = name?.Trim() ?? "";
-            affix = affix?.Trim() ?? "";
-            args = args?.Trim() ?? "";
+            name ??= "";
+            affix ??= "";
+            args ??= "";
 
             if (hue == 0)
             {
@@ -183,9 +183,9 @@ namespace Server.Network
             string text
         )
         {
-            name = name?.Trim() ?? "";
-            text = text?.Trim() ?? "";
-            lang = lang?.Trim() ?? "ENU";
+            name ??= "";
+            text ??= "";
+            lang ??= "ENU";
 
             if (hue == 0)
             {


### PR DESCRIPTION
- [X] Fixes messages. Was trimming, and that removed the tab delimiters used in localized messages.
- [X] Removes a console log we didn't need.