### PR TITLE
fix(net): Clean up for mobile packets

### DIFF
--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
@@ -63,7 +63,7 @@ namespace Server.Tests.Network
 
             var noto = 10;
 
-            var data = new MobileMoving(m, noto).Compile();
+            var data = new MobileMoving(m, noto, true).Compile();
 
             Span<byte> expectedData = stackalloc byte[17];
             var pos = 0;
@@ -74,7 +74,7 @@ namespace Server.Tests.Network
             expectedData.Write(ref pos, m.Location);
             expectedData.Write(ref pos, (byte)m.Direction);
             expectedData.Write(ref pos, (ushort)m.Hue);
-            expectedData.Write(ref pos, (byte)m.GetPacketFlags());
+            expectedData.Write(ref pos, (byte)m.GetPacketFlags(true));
             expectedData.Write(ref pos, (byte)noto);
 
             AssertThat.Equal(data, expectedData);
@@ -88,7 +88,7 @@ namespace Server.Tests.Network
 
             var noto = 10;
 
-            var data = new MobileMoving(m, noto).Compile();
+            var data = new MobileMoving(m, noto, false).Compile();
 
             Span<byte> expectedData = stackalloc byte[17];
             var pos = 0;
@@ -99,7 +99,7 @@ namespace Server.Tests.Network
             expectedData.Write(ref pos, m.Location);
             expectedData.Write(ref pos, (byte)m.Direction);
             expectedData.Write(ref pos, (ushort)m.Hue);
-            expectedData.Write(ref pos, (byte)m.GetOldPacketFlags());
+            expectedData.Write(ref pos, (byte)m.GetPacketFlags(false));
             expectedData.Write(ref pos, (byte)noto);
 
             AssertThat.Equal(data, expectedData);
@@ -389,7 +389,7 @@ namespace Server.Tests.Network
             var m = new Mobile(0x1);
             m.DefaultMobileInit();
 
-            var data = new MobileUpdate(m).Compile();
+            var data = new MobileUpdate(m, true).Compile();
 
             Span<byte> expectedData = stackalloc byte[19];
             var pos = 0;
@@ -405,7 +405,7 @@ namespace Server.Tests.Network
             pos++;
 #endif
             expectedData.Write(ref pos, (ushort)hue);
-            expectedData.Write(ref pos, (byte)m.GetPacketFlags());
+            expectedData.Write(ref pos, (byte)m.GetPacketFlags(true));
             expectedData.Write(ref pos, (ushort)m.X);
             expectedData.Write(ref pos, (ushort)m.Y);
 #if NO_LOCAL_INIT
@@ -425,7 +425,7 @@ namespace Server.Tests.Network
             var m = new Mobile(0x1);
             m.DefaultMobileInit();
 
-            var data = new MobileUpdateOld(m).Compile();
+            var data = new MobileUpdate(m, false).Compile();
 
             Span<byte> expectedData = stackalloc byte[19];
             var pos = 0;
@@ -441,7 +441,7 @@ namespace Server.Tests.Network
             pos++;
 #endif
             expectedData.Write(ref pos, (ushort)hue);
-            expectedData.Write(ref pos, (byte)m.GetOldPacketFlags());
+            expectedData.Write(ref pos, (byte)m.GetPacketFlags(false));
             expectedData.Write(ref pos, (ushort)m.X);
             expectedData.Write(ref pos, (ushort)m.Y);
 #if NO_LOCAL_INIT
@@ -526,7 +526,7 @@ namespace Server.Tests.Network
             expectedData.Write(ref pos, (byte)beheld.Z);
             expectedData.Write(ref pos, (byte)beheld.Direction);
             expectedData.Write(ref pos, (ushort)(isSolidHue ? beheld.SolidHueOverride : beheld.Hue));
-            expectedData.Write(ref pos, (byte)beheld.GetPacketFlags());
+            expectedData.Write(ref pos, (byte)beheld.GetPacketFlags(true));
             expectedData.Write(ref pos, (byte)Notoriety.Compute(beholder, beheld));
 
             byte layer;
@@ -627,10 +627,7 @@ namespace Server.Tests.Network
                 ProtocolChanges = protocolChanges
             };
 
-            var data = (ns.StygianAbyss
-                    ? (Packet)new MobileIncomingSA(beholder, beheld)
-                    : new MobileIncomingOld(beholder, beheld))
-                .Compile();
+            var data = new MobileIncomingOld(beholder, beheld, ns.StygianAbyss).Compile();
 
             Span<bool> layers = stackalloc bool[256];
 #if NO_LOCAL_INIT
@@ -667,7 +664,7 @@ namespace Server.Tests.Network
             expectedData.Write(ref pos, (byte)beheld.Z);
             expectedData.Write(ref pos, (byte)beheld.Direction);
             expectedData.Write(ref pos, (ushort)(isSolidHue ? beheld.SolidHueOverride : beheld.Hue));
-            expectedData.Write(ref pos, (byte)(ns.StygianAbyss ? beheld.GetOldPacketFlags() : beheld.GetPacketFlags()));
+            expectedData.Write(ref pos, (byte)beheld.GetPacketFlags(ns.StygianAbyss));
             expectedData.Write(ref pos, (byte)Notoriety.Compute(beholder, beheld));
 
             byte layer;

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
@@ -455,8 +455,13 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory, InlineData(0, 0, 0, 0), InlineData(10, 1024, 0, 0), InlineData(10, 1024, 11, 2048)]
-        public void TestMobileIncoming(int hairItemId, int hairHue, int facialHairItemId, int facialHairHue)
+        [Theory]
+        [InlineData(ProtocolChanges.Version70331, 0, 0, 0, 0)]
+        [InlineData(ProtocolChanges.Version70331, 10, 1024, 0, 0)]
+        [InlineData(ProtocolChanges.Version70331, 10, 1024, 11, 2048)]
+        public void TestMobileIncoming(
+            ProtocolChanges protocolChanges, int hairItemId, int hairHue, int facialHairItemId, int facialHairHue
+        )
         {
             var beholder = new Mobile(0x1)
             {
@@ -489,7 +494,12 @@ namespace Server.Tests.Network
             beheld.FacialHairItemID = facialHairItemId;
             beheld.FacialHairHue = facialHairHue;
 
-            var data = new MobileIncoming(beholder, beheld).Compile();
+            var ns = new NetState(null)
+            {
+                ProtocolChanges = protocolChanges
+            };
+
+            var data = new MobileIncoming(ns, beholder, beheld).Compile();
 
             Span<bool> layers = stackalloc bool[256];
 #if NO_LOCAL_INIT
@@ -582,11 +592,13 @@ namespace Server.Tests.Network
             AssertThat.Equal(data, expectedData);
         }
 
-        [Theory, InlineData(ProtocolChanges.Version6000, 0, 0, 0, 0),
-         InlineData(ProtocolChanges.Version6000, 10, 1024, 0, 0),
-         InlineData(ProtocolChanges.Version6000, 10, 1024, 11, 2048), InlineData(ProtocolChanges.Version7000, 0, 0, 0, 0),
-         InlineData(ProtocolChanges.Version7000, 10, 1024, 0, 0),
-         InlineData(ProtocolChanges.Version7000, 10, 1024, 11, 2048)]
+        [Theory]
+        [InlineData(ProtocolChanges.Version6000, 0, 0, 0, 0)]
+        [InlineData(ProtocolChanges.Version6000, 10, 1024, 0, 0)]
+        [InlineData(ProtocolChanges.Version6000, 10, 1024, 11, 2048)]
+        [InlineData(ProtocolChanges.Version7000, 0, 0, 0, 0)]
+        [InlineData(ProtocolChanges.Version7000, 10, 1024, 0, 0)]
+        [InlineData(ProtocolChanges.Version7000, 10, 1024, 11, 2048)]
         public void TestMobileIncomingOld(
             ProtocolChanges protocolChanges, int hairItemId, int hairHue, int facialHairItemId, int facialHairHue
         )
@@ -627,7 +639,7 @@ namespace Server.Tests.Network
                 ProtocolChanges = protocolChanges
             };
 
-            var data = new MobileIncomingOld(beholder, beheld, ns.StygianAbyss).Compile();
+            var data = new MobileIncoming(ns, beholder, beheld).Compile();
 
             Span<bool> layers = stackalloc bool[256];
 #if NO_LOCAL_INIT

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePacketTests.cs
@@ -610,7 +610,7 @@ namespace Server.Tests.Network
             if (itemId > 0 && !layers[layer])
             {
                 expectedData.Write(ref pos, FacialHairInfo.FakeSerial(beheld));
-                var hue = isSolidHue ? beheld.SolidHueOverride : beheld.HairHue;
+                var hue = isSolidHue ? beheld.SolidHueOverride : beheld.FacialHairHue;
                 itemId &= itemIdMask;
                 var writeHue = newPacket || hue != 0;
 

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2846,7 +2846,7 @@ namespace Server
                     Send(new ServerChange(m_Location, m_Map));
                 }
 
-                ns.Send(MobileIncoming.Create(ns, this, this));
+                ns.Send(new MobileIncoming(ns, this, this));
 
                 ns.Send(new MobileUpdate(this, ns.StygianAbyss));
                 CheckLightLevels(true);
@@ -2858,7 +2858,7 @@ namespace Server
 
             if (ns != null)
             {
-                ns.Send(MobileIncoming.Create(ns, this, this));
+                ns.Send(new MobileIncoming(ns, this, this));
                 ns.SendSupportedFeature();
                 ns.Send(new MobileUpdate(this, ns.StygianAbyss));
                 ns.Send(new MobileAttributes(this));
@@ -3074,7 +3074,7 @@ namespace Server
 
                 if (sendIncoming)
                 {
-                    ourState.Send(MobileIncoming.Create(ourState, m, m));
+                    ourState.Send(new MobileIncoming(ourState, m, m));
                 }
 
                 if (ourState.StygianAbyss)
@@ -3215,7 +3215,7 @@ namespace Server
 
                         if (sendIncoming)
                         {
-                            state.Send(MobileIncoming.Create(state, beholder, m));
+                            state.Send(new MobileIncoming(state, beholder, m));
 
                             if (m.IsDeadBondedPet)
                             {
@@ -3672,7 +3672,7 @@ namespace Server
 
                     if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
                     {
-                        m_NetState.Send(MobileIncoming.Create(m_NetState, this, attacker));
+                        m_NetState.Send(new MobileIncoming(m_NetState, this, attacker));
                     }
                 }
             }
@@ -3696,7 +3696,7 @@ namespace Server
 
                     if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
                     {
-                        m_NetState.Send(MobileIncoming.Create(m_NetState, this, defender));
+                        m_NetState.Send(new MobileIncoming(m_NetState, this, defender));
                     }
                 }
             }
@@ -4109,7 +4109,7 @@ namespace Server
 
                 if (CanSee(aggressor))
                 {
-                    m_NetState?.Send(MobileIncoming.Create(m_NetState, this, aggressor));
+                    m_NetState?.Send(new MobileIncoming(m_NetState, this, aggressor));
                 }
 
                 if (Combatant == null)
@@ -4132,7 +4132,7 @@ namespace Server
 
                 if (CanSee(aggressor))
                 {
-                    m_NetState?.Send(MobileIncoming.Create(m_NetState, this, aggressor));
+                    m_NetState?.Send(new MobileIncoming(m_NetState, this, aggressor));
                 }
 
                 if (Combatant == null)
@@ -4171,7 +4171,7 @@ namespace Server
 
                     if (m_NetState != null && CanSee(aggressed))
                     {
-                        m_NetState.Send(MobileIncoming.Create(m_NetState, this, aggressed));
+                        m_NetState.Send(new MobileIncoming(m_NetState, this, aggressed));
                     }
 
                     break;
@@ -4201,7 +4201,7 @@ namespace Server
 
                     if (m_NetState != null && CanSee(aggressor))
                     {
-                        m_NetState.Send(MobileIncoming.Create(m_NetState, this, aggressor));
+                        m_NetState.Send(new MobileIncoming(m_NetState, this, aggressor));
                     }
 
                     break;
@@ -7221,7 +7221,7 @@ namespace Server
                 {
                     if (CanSee(m) && Utility.InUpdateRange(m_Location, m.m_Location))
                     {
-                        ns.Send(MobileIncoming.Create(ns, this, m));
+                        ns.Send(new MobileIncoming(ns, this, m));
 
                         if (ns.StygianAbyss)
                         {
@@ -7365,7 +7365,7 @@ namespace Server
                 }
                 else
                 {
-                    state.Send(MobileIncoming.Create(state, state.Mobile, this));
+                    state.Send(new MobileIncoming(state, state.Mobile, this));
 
                     if (IsDeadBondedPet)
                     {
@@ -7631,7 +7631,7 @@ namespace Server
                             if (m.m_NetState != null &&
                                 (isTeleport && (!m.m_NetState.HighSeas || !NoMoveHS) || !inOldRange) && m.CanSee(this))
                             {
-                                m.m_NetState.Send(MobileIncoming.Create(m.m_NetState, m, this));
+                                m.m_NetState.Send(new MobileIncoming(m.m_NetState, m, this));
 
                                 if (m.m_NetState.StygianAbyss)
                                 {
@@ -7655,7 +7655,7 @@ namespace Server
                                 continue;
                             }
 
-                            ourState.Send(MobileIncoming.Create(ourState, this, m));
+                            ourState.Send(new MobileIncoming(ourState, this, m));
 
                             if (ourState.StygianAbyss)
                             {
@@ -7687,7 +7687,7 @@ namespace Server
                         if ((isTeleport && (!ns.HighSeas || !NoMoveHS) ||
                              !Utility.InUpdateRange(oldLocation, ns.Mobile.Location)) && ns.Mobile.CanSee(this))
                         {
-                            ns.Send(MobileIncoming.Create(ns, ns.Mobile, this));
+                            ns.Send(new MobileIncoming(ns, ns.Mobile, this));
 
                             if (ns.StygianAbyss)
                             {
@@ -7768,7 +7768,7 @@ namespace Server
             {
                 if (state.Mobile.CanSee(this))
                 {
-                    state.Send(MobileIncoming.Create(state, state.Mobile, this));
+                    state.Send(new MobileIncoming(state, state.Mobile, this));
 
                     if (state.StygianAbyss)
                     {

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2809,84 +2809,7 @@ namespace Server
                     }
 
                     m_Map = value;
-
-                    UpdateRegion();
-
-                    m_Map?.OnEnter(this);
-
-                    var ns = m_NetState;
-
-                    if (ns != null && m_Map != null)
-                    {
-                        ns.Sequence = 0;
-                        ns.SendMapChange(Map);
-
-                        if (!Core.SE && ns.ProtocolChanges < ProtocolChanges.Version6000)
-                        {
-                            ns.SendMapPatches();
-                        }
-
-                        ns.Send(SeasonChange.Instantiate(GetSeason(), true));
-
-                        if (ns.StygianAbyss)
-                        {
-                            ns.Send(new MobileUpdate(this));
-                        }
-                        else
-                        {
-                            ns.Send(new MobileUpdateOld(this));
-                        }
-                    }
-
-                    if (ns != null)
-                    {
-                        if (m_Map != null)
-                        {
-                            ns.Send(new ServerChange(m_Location, m_Map));
-                        }
-
-                        ns.Sequence = 0;
-
-                        ns.Send(MobileIncoming.Create(ns, this, this));
-
-                        if (ns.StygianAbyss)
-                        {
-                            ns.Send(new MobileUpdate(this));
-                            CheckLightLevels(true);
-                            ns.Send(new MobileUpdate(this));
-                        }
-                        else
-                        {
-                            ns.Send(new MobileUpdateOld(this));
-                            CheckLightLevels(true);
-                            ns.Send(new MobileUpdateOld(this));
-                        }
-                    }
-
-                    SendEverything();
-                    SendIncomingPacket();
-
-                    if (ns != null)
-                    {
-                        ns.Sequence = 0;
-
-                        ns.Send(MobileIncoming.Create(ns, this, this));
-
-                        if (ns.StygianAbyss)
-                        {
-                            ns.SendSupportedFeature();
-                            ns.Send(new MobileUpdate(this));
-                            ns.Send(new MobileAttributes(this));
-                        }
-                        else
-                        {
-                            ns.SendSupportedFeature();
-                            ns.Send(new MobileUpdateOld(this));
-                            ns.Send(new MobileAttributes(this));
-                        }
-                    }
-
-                    OnMapChange(oldMap);
+                    InternalMapChange(oldMap);
                 }
             }
         }
@@ -2896,6 +2819,52 @@ namespace Server
         {
             get => m_Location;
             set => SetLocation(value, true);
+        }
+
+        private void InternalMapChange(Map oldMap)
+        {
+            var ns = m_NetState;
+            m_Map?.OnEnter(this);
+            UpdateRegion();
+
+            if (ns != null)
+            {
+                ns.Sequence = 0;
+
+                if (m_Map != null)
+                {
+                    ns.SendMapChange(Map);
+
+                    if (!Core.SE && ns.ProtocolChanges < ProtocolChanges.Version6000)
+                    {
+                        ns.SendMapPatches();
+                    }
+
+                    ns.Send(SeasonChange.Instantiate(GetSeason(), true));
+
+                    ns.Send(new MobileUpdate(this, ns.StygianAbyss));
+                    Send(new ServerChange(m_Location, m_Map));
+                }
+
+                ns.Send(MobileIncoming.Create(ns, this, this));
+
+                ns.Send(new MobileUpdate(this, ns.StygianAbyss));
+                CheckLightLevels(true);
+                ns.Send(new MobileUpdate(this, ns.StygianAbyss));
+            }
+
+            SendEverything();
+            SendIncomingPacket();
+
+            if (ns != null)
+            {
+                ns.Send(MobileIncoming.Create(ns, this, this));
+                ns.SendSupportedFeature();
+                ns.Send(new MobileUpdate(this, ns.StygianAbyss));
+                ns.Send(new MobileAttributes(this));
+            }
+
+            OnMapChange(oldMap);
         }
 
         public virtual void MoveToWorld(Point3D newLocation, Map map)
@@ -2921,8 +2890,6 @@ namespace Server
             var oldLocation = m_Location;
             var oldMap = m_Map;
 
-            var oldRegion = m_Region;
-
             if (oldMap != null)
             {
                 oldMap.OnLeave(this);
@@ -2939,91 +2906,7 @@ namespace Server
             m_Map = map;
 
             m_Location = newLocation;
-
-            var ns = m_NetState;
-
-            if (m_Map != null)
-            {
-                m_Map.OnEnter(this);
-
-                UpdateRegion();
-
-                if (ns != null && m_Map != null)
-                {
-                    ns.Sequence = 0;
-                    ns.SendMapChange(Map);
-
-                    if (!Core.SE && ns.ProtocolChanges < ProtocolChanges.Version6000)
-                    {
-                        ns.SendMapPatches();
-                    }
-
-                    ns.Send(SeasonChange.Instantiate(GetSeason(), true));
-
-                    if (ns.StygianAbyss)
-                    {
-                        ns.Send(new MobileUpdate(this));
-                    }
-                    else
-                    {
-                        ns.Send(new MobileUpdateOld(this));
-                    }
-                }
-            }
-            else
-            {
-                UpdateRegion();
-            }
-
-            if (ns != null)
-            {
-                if (m_Map != null)
-                {
-                    Send(new ServerChange(m_Location, m_Map));
-                }
-
-                ns.Sequence = 0;
-
-                ns.Send(MobileIncoming.Create(ns, this, this));
-
-                if (ns.StygianAbyss)
-                {
-                    ns.Send(new MobileUpdate(this));
-                    CheckLightLevels(true);
-                    ns.Send(new MobileUpdate(this));
-                }
-                else
-                {
-                    ns.Send(new MobileUpdateOld(this));
-                    CheckLightLevels(true);
-                    ns.Send(new MobileUpdateOld(this));
-                }
-            }
-
-            SendEverything();
-            SendIncomingPacket();
-
-            if (ns != null)
-            {
-                ns.Sequence = 0;
-
-                ns.Send(MobileIncoming.Create(ns, this, this));
-
-                if (ns.StygianAbyss)
-                {
-                    ns.SendSupportedFeature();
-                    ns.Send(new MobileUpdate(this));
-                    ns.Send(new MobileAttributes(this));
-                }
-                else
-                {
-                    ns.SendSupportedFeature();
-                    ns.Send(new MobileUpdateOld(this));
-                    ns.Send(new MobileAttributes(this));
-                }
-            }
-
-            OnMapChange(oldMap);
+            InternalMapChange(oldMap);
             OnLocationChange(oldLocation);
 
             m_Region?.OnLocationChanged(this, oldLocation);
@@ -3186,15 +3069,7 @@ namespace Server
                 if (sendUpdate)
                 {
                     ourState.Sequence = 0;
-
-                    if (ourState.StygianAbyss)
-                    {
-                        ourState.Send(new MobileUpdate(m));
-                    }
-                    else
-                    {
-                        ourState.Send(new MobileUpdateOld(m));
-                    }
+                    ourState.Send(new MobileUpdate(m, ourState.StygianAbyss));
                 }
 
                 if (sendIncoming)
@@ -3207,7 +3082,7 @@ namespace Server
                     if (sendMoving)
                     {
                         var noto = Notoriety.Compute(m, m);
-                        ourState.Send(cache[0][noto] = Packet.Acquire(new MobileMoving(m, noto)));
+                        ourState.Send(cache[0][noto] = Packet.Acquire(new MobileMoving(m, noto, true)));
                     }
 
                     if (sendHealthbarPoison)
@@ -3225,7 +3100,7 @@ namespace Server
                     if (sendMoving || sendHealthbarPoison || sendHealthbarYellow)
                     {
                         var noto = Notoriety.Compute(m, m);
-                        ourState.Send(cache[1][noto] = Packet.Acquire(new MobileMovingOld(m, noto)));
+                        ourState.Send(cache[1][noto] = Packet.Acquire(new MobileMoving(m, noto, false)));
                     }
                 }
 
@@ -3358,7 +3233,7 @@ namespace Server
 
                                 if (p == null)
                                 {
-                                    cache[0][noto] = p = Packet.Acquire(new MobileMoving(m, noto));
+                                    cache[0][noto] = p = Packet.Acquire(new MobileMoving(m, noto, true));
                                 }
 
                                 state.Send(p);
@@ -3388,7 +3263,7 @@ namespace Server
 
                                 if (p == null)
                                 {
-                                    cache[1][noto] = p = Packet.Acquire(new MobileMovingOld(m, noto));
+                                    cache[1][noto] = p = Packet.Acquire(new MobileMoving(m, noto, false));
                                 }
 
                                 state.Send(p);
@@ -4729,7 +4604,7 @@ namespace Server
 
                             if (p == null)
                             {
-                                cache[0][noto] = p = Packet.Acquire(new MobileMoving(this, noto));
+                                cache[0][noto] = p = Packet.Acquire(new MobileMoving(this, noto, true));
                             }
 
                             ns.Send(p);
@@ -4741,7 +4616,7 @@ namespace Server
 
                             if (p == null)
                             {
-                                cache[1][noto] = p = Packet.Acquire(new MobileMovingOld(this, noto));
+                                cache[1][noto] = p = Packet.Acquire(new MobileMoving(this, noto, false));
                             }
 
                             ns.Send(p);
@@ -7085,12 +6960,6 @@ namespace Server
                 {
                     state.Mobile.ProcessDelta();
 
-                    // if (state.StygianAbyss) {
-                    // if (pNew == null)
-                    // pNew = Packet.Acquire(new NewMobileAnimation(this.Serial, action, frameCount, delay));
-
-                    // state.Send(pNew);
-                    // } else {
                     if (p == null)
                     {
                         if (Body.IsGargoyle)
@@ -7099,45 +6968,26 @@ namespace Server
 
                             if (Flying)
                             {
-                                if (action >= 9 && action <= 11)
+                                action = action switch
                                 {
-                                    action = 71;
-                                }
-                                else if (action >= 12 && action <= 14)
-                                {
-                                    action = 72;
-                                }
-                                else if (action == 20)
-                                {
-                                    action = 77;
-                                }
-                                else if (action == 31)
-                                {
-                                    action = 71;
-                                }
-                                else if (action == 34)
-                                {
-                                    action = 78;
-                                }
-                                else if (action >= 200 && action <= 259)
-                                {
-                                    action = 75;
-                                }
-                                else if (action >= 260 && action <= 270)
-                                {
-                                    action = 75;
-                                }
+                                    >= 9 and <= 11    => 71,
+                                    >= 12 and <= 14   => 72,
+                                    20                => 77,
+                                    31                => 71,
+                                    34                => 78,
+                                    >= 200 and <= 259 => 75,
+                                    >= 260 and <= 270 => 75,
+                                    _                 => action
+                                };
                             }
                             else
                             {
-                                if (action >= 200 && action <= 259)
+                                action = action switch
                                 {
-                                    action = 17;
-                                }
-                                else if (action >= 260 && action <= 270)
-                                {
-                                    action = 16;
-                                }
+                                    >= 200 and <= 259 => 17,
+                                    >= 260 and <= 270 => 16,
+                                    _                 => action
+                                };
                             }
                         }
 
@@ -7155,12 +7005,10 @@ namespace Server
                     }
 
                     state.Send(p);
-                    // }
                 }
             }
 
             Packet.Release(p);
-            // Packet.Release( pNew );
 
             eable.Free();
         }
@@ -7353,50 +7201,52 @@ namespace Server
         {
             var ns = m_NetState;
 
-            if (m_Map != null && ns != null)
+            if (m_Map == null || ns == null)
             {
-                var eable = m_Map.GetObjectsInRange(m_Location, Core.GlobalMaxUpdateRange);
+                return;
+            }
 
-                foreach (var o in eable)
+            var eable = m_Map.GetObjectsInRange(m_Location, Core.GlobalMaxUpdateRange);
+
+            foreach (var o in eable)
+            {
+                if (o is Item item)
                 {
-                    if (o is Item item)
+                    if (CanSee(item) && InRange(item.Location, item.GetUpdateRange(this)))
                     {
-                        if (CanSee(item) && InRange(item.Location, item.GetUpdateRange(this)))
-                        {
-                            item.SendInfoTo(ns);
-                        }
-                    }
-                    else if (o is Mobile m)
-                    {
-                        if (CanSee(m) && Utility.InUpdateRange(m_Location, m.m_Location))
-                        {
-                            ns.Send(MobileIncoming.Create(ns, this, m));
-
-                            if (ns.StygianAbyss)
-                            {
-                                if (m.Poisoned)
-                                {
-                                    ns.Send(new HealthbarPoison(m));
-                                }
-
-                                if (m.Blessed || m.YellowHealthbar)
-                                {
-                                    ns.Send(new HealthbarYellow(m));
-                                }
-                            }
-
-                            if (m.IsDeadBondedPet)
-                            {
-                                ns.SendBondedStatus(m.Serial, true);
-                            }
-
-                            m.SendOPLPacketTo(ns);
-                        }
+                        item.SendInfoTo(ns);
                     }
                 }
+                else if (o is Mobile m)
+                {
+                    if (CanSee(m) && Utility.InUpdateRange(m_Location, m.m_Location))
+                    {
+                        ns.Send(MobileIncoming.Create(ns, this, m));
 
-                eable.Free();
+                        if (ns.StygianAbyss)
+                        {
+                            if (m.Poisoned)
+                            {
+                                ns.Send(new HealthbarPoison(m));
+                            }
+
+                            if (m.Blessed || m.YellowHealthbar)
+                            {
+                                ns.Send(new HealthbarYellow(m));
+                            }
+                        }
+
+                        if (m.IsDeadBondedPet)
+                        {
+                            ns.SendBondedStatus(m.Serial, true);
+                        }
+
+                        m.SendOPLPacketTo(ns);
+                    }
+                }
             }
+
+            eable.Free();
         }
 
         public void UpdateRegion()
@@ -7431,7 +7281,7 @@ namespace Server
 
         public virtual int GetSeason() => m_Map?.Season ?? 1;
 
-        public virtual int GetPacketFlags()
+        public virtual int GetPacketFlags(bool stygianAbyss)
         {
             var flags = 0x0;
 
@@ -7445,47 +7295,19 @@ namespace Server
                 flags |= 0x02;
             }
 
-            if (m_Flying)
+            if (stygianAbyss)
             {
-                flags |= 0x04;
+                if (m_Flying)
+                {
+                    flags |= 0x04;
+                }
             }
-
-            if (m_Blessed || m_YellowHealthbar)
+            else
             {
-                flags |= 0x08;
-            }
-
-            if (m_Warmode)
-            {
-                flags |= 0x40;
-            }
-
-            if (m_Hidden)
-            {
-                flags |= 0x80;
-            }
-
-            return flags;
-        }
-
-        // Pre-7.0.0.0 Packet Flags
-        public virtual int GetOldPacketFlags()
-        {
-            var flags = 0x0;
-
-            if (m_Paralyzed || m_Frozen)
-            {
-                flags |= 0x01;
-            }
-
-            if (m_Female)
-            {
-                flags |= 0x02;
-            }
-
-            if (m_Poison != null)
-            {
-                flags |= 0x04;
+                if (m_Poison != null)
+                {
+                    flags |= 0x04;
+                }
             }
 
             if (m_Blessed || m_YellowHealthbar)
@@ -7751,15 +7573,7 @@ namespace Server
             if (isTeleport && m_NetState != null && (!m_NetState.HighSeas || !NoMoveHS))
             {
                 m_NetState.Sequence = 0;
-
-                if (m_NetState.StygianAbyss)
-                {
-                    m_NetState.Send(new MobileUpdate(this));
-                }
-                else
-                {
-                    m_NetState.Send(new MobileUpdateOld(this));
-                }
+                m_NetState.Send(new MobileUpdate(this, m_NetState.StygianAbyss));
             }
 
             var map = m_Map;

--- a/Projects/Server/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingAccountPackets.cs
@@ -316,75 +316,26 @@ namespace Server.Network
 
             state.Sequence = 0;
 
-            if (state.NewMobileIncoming)
-            {
-                state.Send(new MobileUpdate(m));
-                state.Send(new MobileUpdate(m));
+            state.Send(new MobileUpdate(m, state.StygianAbyss));
+            state.Send(new MobileUpdate(m, state.StygianAbyss));
 
-                m.CheckLightLevels(true);
+            m.CheckLightLevels(true);
 
-                state.Send(new MobileUpdate(m));
+            state.Send(new MobileUpdate(m, state.StygianAbyss));
 
-                state.Send(new MobileIncoming(m, m));
-                // state.Send( new MobileAttributes( m ) );
-                state.Send(new MobileStatus(m, m));
-                state.SendSetWarMode(m.Warmode);
+            state.Send(MobileIncoming.Create(state, m, m));
+            // state.Send( new MobileAttributes( m ) );
+            state.Send(new MobileStatus(m, m));
+            state.SendSetWarMode(m.Warmode);
 
-                m.SendEverything();
+            m.SendEverything();
 
-                state.SendSupportedFeature();
-                state.Send(new MobileUpdate(m));
-                // state.Send( new MobileAttributes( m ) );
-                state.Send(new MobileStatus(m, m));
-                state.SendSetWarMode(m.Warmode);
-                state.Send(new MobileIncoming(m, m));
-            }
-            else if (state.StygianAbyss)
-            {
-                state.Send(new MobileUpdate(m));
-                state.Send(new MobileUpdate(m));
-
-                m.CheckLightLevels(true);
-
-                state.Send(new MobileUpdate(m));
-
-                state.Send(new MobileIncomingSA(m, m));
-                // state.Send( new MobileAttributes( m ) );
-                state.Send(new MobileStatus(m, m));
-                state.SendSetWarMode(m.Warmode);
-
-                m.SendEverything();
-
-                state.SendSupportedFeature();
-                state.Send(new MobileUpdate(m));
-                // state.Send( new MobileAttributes( m ) );
-                state.Send(new MobileStatus(m, m));
-                state.SendSetWarMode(m.Warmode);
-                state.Send(new MobileIncomingSA(m, m));
-            }
-            else
-            {
-                state.Send(new MobileUpdateOld(m));
-                state.Send(new MobileUpdateOld(m));
-
-                m.CheckLightLevels(true);
-
-                state.Send(new MobileUpdateOld(m));
-
-                state.Send(new MobileIncomingOld(m, m));
-                // state.Send( new MobileAttributes( m ) );
-                state.Send(new MobileStatus(m, m));
-                state.SendSetWarMode(m.Warmode);
-
-                m.SendEverything();
-
-                state.SendSupportedFeature();
-                state.Send(new MobileUpdateOld(m));
-                // state.Send( new MobileAttributes( m ) );
-                state.Send(new MobileStatus(m, m));
-                state.SendSetWarMode(m.Warmode);
-                state.Send(new MobileIncomingOld(m, m));
-            }
+            state.SendSupportedFeature();
+            state.Send(new MobileUpdate(m, state.StygianAbyss));
+            // state.Send( new MobileAttributes( m ) );
+            state.Send(new MobileStatus(m, m));
+            state.SendSetWarMode(m.Warmode);
+            state.Send(MobileIncoming.Create(state, m, m));
 
             state.SendLoginComplete();
             state.Send(new CurrentTime());

--- a/Projects/Server/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingAccountPackets.cs
@@ -323,7 +323,7 @@ namespace Server.Network
 
             state.Send(new MobileUpdate(m, state.StygianAbyss));
 
-            state.Send(MobileIncoming.Create(state, m, m));
+            state.Send(new MobileIncoming(state, m, m));
             // state.Send( new MobileAttributes( m ) );
             state.Send(new MobileStatus(m, m));
             state.SendSetWarMode(m.Warmode);
@@ -335,7 +335,7 @@ namespace Server.Network
             // state.Send( new MobileAttributes( m ) );
             state.Send(new MobileStatus(m, m));
             state.SendSetWarMode(m.Warmode);
-            state.Send(MobileIncoming.Create(state, m, m));
+            state.Send(new MobileIncoming(state, m, m));
 
             state.SendLoginComplete();
             state.Send(new CurrentTime());

--- a/Projects/Server/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPlayerPackets.cs
@@ -475,14 +475,7 @@ namespace Server.Network
                 return;
             }
 
-            if (state.StygianAbyss)
-            {
-                state.Send(new MobileUpdate(from));
-            }
-            else
-            {
-                state.Send(new MobileUpdateOld(from));
-            }
+            state.Send(new MobileUpdate(from, state.StygianAbyss));
 
             state.Send(MobileIncoming.Create(state, from, from));
 

--- a/Projects/Server/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPlayerPackets.cs
@@ -477,7 +477,7 @@ namespace Server.Network
 
             state.Send(new MobileUpdate(from, state.StygianAbyss));
 
-            state.Send(MobileIncoming.Create(state, from, from));
+            state.Send(new MobileIncoming(state, from, from));
 
             from.SendEverything();
 

--- a/Projects/Server/Network/Packets/MobilePackets.cs
+++ b/Projects/Server/Network/Packets/MobilePackets.cs
@@ -494,8 +494,12 @@ namespace Server.Network
         private static readonly ThreadLocal<int[]> m_DupedLayersTL = new(() => new int[256]);
         private static readonly ThreadLocal<int> m_VersionTL = new();
 
-        public MobileIncoming(Mobile beholder, Mobile beheld) : base(0x78)
+        public MobileIncoming(NetState ns, Mobile beholder, Mobile beheld) : base(0x78)
         {
+            var sa = ns.StygianAbyss;
+            var newPacket = ns.NewMobileIncoming;
+            var itemIdMask = newPacket ? 0xFFFF : 0x7FFF;
+
             var m_Version = ++m_VersionTL.Value;
             var m_DupedLayers = m_DupedLayersTL.Value;
 
@@ -528,7 +532,7 @@ namespace Server.Network
             Stream.Write((sbyte)beheld.Z);
             Stream.Write((byte)beheld.Direction);
             Stream.Write((short)hue);
-            Stream.Write((byte)beheld.GetPacketFlags(true));
+            Stream.Write((byte)beheld.GetPacketFlags(sa));
             Stream.Write((byte)Notoriety.Compute(beholder, beheld));
 
             for (var i = 0; i < eq.Count; ++i)
@@ -548,132 +552,10 @@ namespace Server.Network
                         hue = beheld.SolidHueOverride;
                     }
 
-                    var itemID = item.ItemID & 0xFFFF;
+                    var itemID = item.ItemID & itemIdMask;
+                    var writeHue = newPacket || hue != 0;
 
-                    Stream.Write(item.Serial);
-                    Stream.Write((ushort)itemID);
-                    Stream.Write(layer);
-
-                    Stream.Write((short)hue);
-                }
-            }
-
-            if (beheld.HairItemID > 0)
-            {
-                if (m_DupedLayers[(int)Layer.Hair] != m_Version)
-                {
-                    m_DupedLayers[(int)Layer.Hair] = m_Version;
-                    hue = beheld.HairHue;
-
-                    if (beheld.SolidHueOverride >= 0)
-                    {
-                        hue = beheld.SolidHueOverride;
-                    }
-
-                    var itemID = beheld.HairItemID & 0xFFFF;
-
-                    Stream.Write(HairInfo.FakeSerial(beheld));
-                    Stream.Write((ushort)itemID);
-                    Stream.Write((byte)Layer.Hair);
-
-                    Stream.Write((short)hue);
-                }
-            }
-
-            if (beheld.FacialHairItemID > 0)
-            {
-                if (m_DupedLayers[(int)Layer.FacialHair] != m_Version)
-                {
-                    m_DupedLayers[(int)Layer.FacialHair] = m_Version;
-                    hue = beheld.FacialHairHue;
-
-                    if (beheld.SolidHueOverride >= 0)
-                    {
-                        hue = beheld.SolidHueOverride;
-                    }
-
-                    var itemID = beheld.FacialHairItemID & 0xFFFF;
-
-                    Stream.Write(FacialHairInfo.FakeSerial(beheld));
-                    Stream.Write((ushort)itemID);
-                    Stream.Write((byte)Layer.FacialHair);
-
-                    Stream.Write((short)hue);
-                }
-            }
-
-            Stream.Write(0); // terminate
-        }
-
-        public static Packet Create(NetState ns, Mobile beholder, Mobile beheld) =>
-            ns.NewMobileIncoming
-                ? (Packet)new MobileIncoming(beholder, beheld)
-                : new MobileIncomingOld(beholder, beheld, ns.StygianAbyss);
-    }
-
-    public sealed class MobileIncomingOld : Packet
-    {
-        private static readonly ThreadLocal<int[]> m_DupedLayersTL = new(() => new int[256]);
-        private static readonly ThreadLocal<int> m_VersionTL = new();
-
-        public MobileIncomingOld(Mobile beholder, Mobile beheld, bool stygianAbyss) : base(0x78)
-        {
-            var m_Version = ++m_VersionTL.Value;
-            var m_DupedLayers = m_DupedLayersTL.Value;
-
-            var eq = beheld.Items;
-            var count = eq.Count;
-
-            if (beheld.HairItemID > 0)
-            {
-                count++;
-            }
-
-            if (beheld.FacialHairItemID > 0)
-            {
-                count++;
-            }
-
-            EnsureCapacity(23 + count * 9);
-
-            var hue = beheld.Hue;
-
-            if (beheld.SolidHueOverride >= 0)
-            {
-                hue = beheld.SolidHueOverride;
-            }
-
-            Stream.Write(beheld.Serial);
-            Stream.Write((short)beheld.Body);
-            Stream.Write((short)beheld.X);
-            Stream.Write((short)beheld.Y);
-            Stream.Write((sbyte)beheld.Z);
-            Stream.Write((byte)beheld.Direction);
-            Stream.Write((short)hue);
-            Stream.Write((byte)beheld.GetPacketFlags(stygianAbyss));
-            Stream.Write((byte)Notoriety.Compute(beholder, beheld));
-
-            for (var i = 0; i < eq.Count; ++i)
-            {
-                var item = eq[i];
-
-                var layer = (byte)item.Layer;
-
-                if (!item.Deleted && beholder.CanSee(item) && m_DupedLayers[layer] != m_Version)
-                {
-                    m_DupedLayers[layer] = m_Version;
-
-                    hue = item.Hue;
-
-                    if (beheld.SolidHueOverride >= 0)
-                    {
-                        hue = beheld.SolidHueOverride;
-                    }
-
-                    var itemID = item.ItemID & 0x7FFF;
-                    var writeHue = hue != 0;
-
-                    if (writeHue)
+                    if (!newPacket)
                     {
                         itemID |= 0x8000;
                     }
@@ -701,11 +583,10 @@ namespace Server.Network
                         hue = beheld.SolidHueOverride;
                     }
 
-                    var itemID = beheld.HairItemID & 0x7FFF;
+                    var itemID = beheld.HairItemID & itemIdMask;
+                    var writeHue = newPacket || hue != 0;
 
-                    var writeHue = hue != 0;
-
-                    if (writeHue)
+                    if (!newPacket)
                     {
                         itemID |= 0x8000;
                     }
@@ -733,11 +614,10 @@ namespace Server.Network
                         hue = beheld.SolidHueOverride;
                     }
 
-                    var itemID = beheld.FacialHairItemID & 0x7FFF;
+                    var itemID = beheld.FacialHairItemID & itemIdMask;
+                    var writeHue = newPacket || hue != 0;
 
-                    var writeHue = hue != 0;
-
-                    if (writeHue)
+                    if (!newPacket)
                     {
                         itemID |= 0x8000;
                     }

--- a/Projects/UOContent/Commands/VisibilityList.cs
+++ b/Projects/UOContent/Commands/VisibilityList.cs
@@ -118,7 +118,7 @@ namespace Server.Commands
                             {
                                 if (targ.CanSee(pm))
                                 {
-                                    ns.Send(MobileIncoming.Create(ns, targ, pm));
+                                    ns.Send(new MobileIncoming(ns, targ, pm));
 
                                     pm.SendOPLPacketTo(ns);
 

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -983,21 +983,9 @@ namespace Server.Mobiles
             return true;
         }
 
-        public override int GetPacketFlags()
+        public override int GetPacketFlags(bool stygianAbyss)
         {
-            var flags = base.GetPacketFlags();
-
-            if (m_IgnoreMobiles)
-            {
-                flags |= 0x10;
-            }
-
-            return flags;
-        }
-
-        public override int GetOldPacketFlags()
-        {
-            var flags = base.GetOldPacketFlags();
+            var flags = base.GetPacketFlags(stygianAbyss);
 
             if (m_IgnoreMobiles)
             {
@@ -4287,17 +4275,7 @@ namespace Server.Mobiles
                 {
                     var ns = NetState;
 
-                    if (ns != null)
-                    {
-                        if (ns.StygianAbyss)
-                        {
-                            ns.Send(new MobileMoving(m, Notoriety.Compute(this, m)));
-                        }
-                        else
-                        {
-                            ns.Send(new MobileMovingOld(m, Notoriety.Compute(this, m)));
-                        }
-                    }
+                    ns?.Send(new MobileMoving(m, Notoriety.Compute(this, m), ns.StygianAbyss));
                 }
             }
         }

--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -2196,7 +2196,7 @@ namespace Server.Multis
 
                         Stream.Write((byte)m.Direction);
                         Stream.Write((short)m.Hue);
-                        Stream.Write((byte)m.GetPacketFlags());
+                        Stream.Write((byte)m.GetPacketFlags(true));
                     }
                     else if (ent is Item item)
                     {


### PR DESCRIPTION
### Breaking Change
- [X] `Mobile.GetOldPacketFlags()` no longer exists. Instead there is a flag for `Mobile.GetPacketFlags()`.

### Non-Breaking Changes
- [X] Consolidates move to world for mobiles
- [X] Consolidates mobile packets between stygian abyss and older

This PR supersedes changes in #337. That PR will need to be redone and broken out anyway.