### PR TITLE
fix(core): Fixes wrong offset for CircularBuffer

### DIFF
--- a/Projects/Server/Buffers/CircularBuffer.cs
+++ b/Projects/Server/Buffers/CircularBuffer.cs
@@ -42,7 +42,7 @@ namespace System.Buffers
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
-                return index < _first.Length ? _first[index] : _second[_first.Length - index];
+                return index < _first.Length ? _first[index] : _second[index - _first.Length];
             }
             set
             {
@@ -57,7 +57,7 @@ namespace System.Buffers
                 }
                 else
                 {
-                    _second[_first.Length - index] = value;
+                    _second[index - _first.Length] = value;
                 }
             }
         }


### PR DESCRIPTION
Fixes an issue where the circular buffer was out of bounds due to bad math.

Closes #343 