### PR TITLE
fix(core): Fixes several serialization issues

### DIFF
--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Server.Guilds
@@ -40,7 +41,7 @@ namespace Server.Guilds
         public void Serialize()
         {
             SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Reset();
+            SaveBuffer.Seek(0, SeekOrigin.Current);
             Serialize(SaveBuffer);
         }
 

--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -41,7 +41,7 @@ namespace Server.Guilds
         public void Serialize()
         {
             SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Seek(0, SeekOrigin.Current);
+            SaveBuffer.Seek(0, SeekOrigin.Begin);
             Serialize(SaveBuffer);
         }
 

--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -33,19 +33,12 @@ namespace Server.Guilds
 
         public bool Deleted => Disbanded;
 
-        public BufferWriter SaveBuffer { get; set; }
-
         [CommandProperty(AccessLevel.Counselor)]
         public Serial Serial { get; }
 
-        public int TypeRef => 0;
+        BufferWriter ISerializable.SaveBuffer { get; set; }
 
-        public void Serialize()
-        {
-            SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Seek(0, SeekOrigin.Begin);
-            Serialize(SaveBuffer);
-        }
+        public int TypeRef => 0;
 
         public abstract void Serialize(IGenericWriter writer);
         public abstract void Deserialize(IGenericReader reader);

--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -31,6 +31,8 @@ namespace Server.Guilds
         public abstract bool Disbanded { get; }
         public abstract void Delete();
 
+        public bool Deleted => Disbanded;
+
         public BufferWriter SaveBuffer { get; set; }
 
         [CommandProperty(AccessLevel.Counselor)]

--- a/Projects/Server/IEntity.cs
+++ b/Projects/Server/IEntity.cs
@@ -45,8 +45,10 @@ namespace Server
             Deleted = false;
         }
 
-        public BufferWriter SaveBuffer { get; set; }
+        BufferWriter ISerializable.SaveBuffer { get; set; }
+
         public int TypeRef { get; } = -1;
+
         public Serial Serial { get; }
 
         public Point3D Location { get; private set; }
@@ -96,10 +98,6 @@ namespace Server
             && p.X <= Location.m_X + range
             && p.Y >= Location.m_Y - range
             && p.Y <= Location.m_Y + range;
-
-        public void Serialize()
-        {
-        }
 
         public void Deserialize(IGenericReader reader)
         {

--- a/Projects/Server/Items/Containers.cs
+++ b/Projects/Server/Items/Containers.cs
@@ -65,7 +65,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        Owner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<Mobile>();
                         Opened = reader.ReadBool();
 
                         if (Owner == null)

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -795,19 +795,12 @@ namespace Server
             AddNameProperties(list);
         }
 
-        public BufferWriter SaveBuffer { get; set; }
+        BufferWriter ISerializable.SaveBuffer { get; set; }
 
         [CommandProperty(AccessLevel.Counselor)]
         public Serial Serial { get; }
 
         public int TypeRef { get; }
-
-        public void Serialize()
-        {
-            SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Seek(0, SeekOrigin.Begin);
-            Serialize(SaveBuffer);
-        }
 
         public virtual void Serialize(IGenericWriter writer)
         {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1039,19 +1039,12 @@ namespace Server
 
             if (GetSaveFlag(flags, SaveFlag.Parent))
             {
-                if (m_Parent?.Deleted == false)
-                {
-                    writer.Write(m_Parent.Serial);
-                }
-                else
-                {
-                    writer.Write(Serial.MinusOne);
-                }
+                writer.Write(m_Parent);
             }
 
             if (GetSaveFlag(flags, SaveFlag.Items))
             {
-                writer.Write(items, false);
+                writer.Write(items);
             }
 
             if (GetSaveFlag(flags, SaveFlag.IntWeight))
@@ -2710,7 +2703,7 @@ namespace Server
 
                         if (GetSaveFlag(flags, SaveFlag.Items))
                         {
-                            var items = reader.ReadStrongItemList();
+                            var items = reader.ReadEntityList<Item>();
 
                             if (this is Container)
                             {
@@ -2768,17 +2761,17 @@ namespace Server
                         if (GetSaveFlag(flags, SaveFlag.InsuredFor))
                             /*m_InsuredFor = */
                         {
-                            reader.ReadMobile();
+                            reader.ReadEntity<Mobile>();
                         }
 
                         if (GetSaveFlag(flags, SaveFlag.BlessedFor))
                         {
-                            AcquireCompactInfo().m_BlessedFor = reader.ReadMobile();
+                            AcquireCompactInfo().m_BlessedFor = reader.ReadEntity<Mobile>();
                         }
 
                         if (GetSaveFlag(flags, SaveFlag.HeldBy))
                         {
-                            AcquireCompactInfo().m_HeldBy = reader.ReadMobile();
+                            AcquireCompactInfo().m_HeldBy = reader.ReadEntity<Mobile>();
                         }
 
                         if (GetSaveFlag(flags, SaveFlag.SavedFlags))
@@ -2871,7 +2864,7 @@ namespace Server
 
                         if (GetSaveFlag(flags, SaveFlag.Items))
                         {
-                            var items = reader.ReadStrongItemList();
+                            var items = reader.ReadEntityList<Item>();
 
                             if (this is Container cont)
                             {
@@ -2994,7 +2987,7 @@ namespace Server
 
                             for (var i = 0; i < count; ++i)
                             {
-                                var item = reader.ReadItem();
+                                var item = reader.ReadEntity<Item>();
 
                                 if (item != null)
                                 {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -805,7 +805,7 @@ namespace Server
         public void Serialize()
         {
             SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Reset();
+            SaveBuffer.Seek(0, SeekOrigin.Current);
             Serialize(SaveBuffer);
         }
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -805,7 +805,7 @@ namespace Server
         public void Serialize()
         {
             SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Seek(0, SeekOrigin.Current);
+            SaveBuffer.Seek(0, SeekOrigin.Begin);
             Serialize(SaveBuffer);
         }
 

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2567,19 +2567,12 @@ namespace Server
             AddNameProperties(list);
         }
 
-        public BufferWriter SaveBuffer { get; set; }
+        BufferWriter ISerializable.SaveBuffer { get; set; }
 
         [CommandProperty(AccessLevel.Counselor)]
         public Serial Serial { get; }
 
         public int TypeRef { get; }
-
-        public void Serialize()
-        {
-            SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Seek(0, SeekOrigin.Begin);
-            Serialize(SaveBuffer);
-        }
 
         public virtual void Serialize(IGenericWriter writer)
         {
@@ -6468,7 +6461,7 @@ namespace Server
                     }
                 case 12:
                     {
-                        m_Guild = reader.ReadEntity<Guild>();
+                        m_Guild = reader.ReadEntity<BaseGuild>();
 
                         goto case 11;
                     }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2628,7 +2628,8 @@ namespace Server
 
             writer.Write(CreationTime);
 
-            writer.Write(Stabled, true);
+            Stabled.Tidy();
+            writer.Write(Stabled);
 
             writer.Write(CantWalk);
 
@@ -6393,7 +6394,7 @@ namespace Server
                 case 25:
                 case 24:
                     {
-                        Corpse = reader.ReadItem() as Container;
+                        Corpse = reader.ReadEntity<Container>();
 
                         goto case 23;
                     }
@@ -6406,7 +6407,7 @@ namespace Server
                 case 22: // Just removed followers
                 case 21:
                     {
-                        Stabled = reader.ReadStrongMobileList();
+                        Stabled = reader.ReadEntityList<Mobile>();
 
                         goto case 20;
                     }
@@ -6461,13 +6462,13 @@ namespace Server
                     }
                 case 13:
                     {
-                        GuildFealty = reader.ReadMobile();
+                        GuildFealty = reader.ReadEntity<Mobile>();
 
                         goto case 12;
                     }
                 case 12:
                     {
-                        m_Guild = reader.ReadGuild();
+                        m_Guild = reader.ReadEntity<Guild>();
 
                         goto case 11;
                     }
@@ -6491,7 +6492,7 @@ namespace Server
                     }
                 case 8:
                     {
-                        m_Holding = reader.ReadItem();
+                        m_Holding = reader.ReadEntity<Item>();
 
                         goto case 7;
                     }
@@ -6599,7 +6600,7 @@ namespace Server
 
                         Skills = new Skills(this, reader);
 
-                        Items = reader.ReadStrongItemList();
+                        Items = reader.ReadEntityList<Item>();
 
                         m_Player = reader.ReadBool();
                         m_Title = reader.ReadString();

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2577,7 +2577,7 @@ namespace Server
         public void Serialize()
         {
             SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Seek(0, SeekOrigin.Current);
+            SaveBuffer.Seek(0, SeekOrigin.Begin);
             Serialize(SaveBuffer);
         }
 

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2577,7 +2577,7 @@ namespace Server
         public void Serialize()
         {
             SaveBuffer ??= new BufferWriter(true);
-            SaveBuffer.Reset();
+            SaveBuffer.Seek(0, SeekOrigin.Current);
             Serialize(SaveBuffer);
         }
 

--- a/Projects/Server/Serialization/BufferReader.cs
+++ b/Projects/Server/Serialization/BufferReader.cs
@@ -225,9 +225,9 @@ namespace Server
         {
             return origin switch
             {
-                SeekOrigin.Begin   => Position = offset,
                 SeekOrigin.Current => Position += offset,
-                SeekOrigin.End     => Position = _buffer.Length - offset
+                SeekOrigin.End     => Position = _buffer.Length - offset,
+                _                  => Position = offset // Begin
             };
         }
     }

--- a/Projects/Server/Serialization/BufferReader.cs
+++ b/Projects/Server/Serialization/BufferReader.cs
@@ -157,27 +157,20 @@ namespace Server
 
         public Map ReadMap() => Map.Maps[ReadByte()];
 
-        public IEntity ReadEntity()
+        public T ReadEntity<T>() where T : class, ISerializable
         {
             Serial serial = ReadUInt();
-            return World.FindEntity(serial) ?? new Entity(serial, new Point3D(0, 0, 0), Map.Internal);
+
+            // Special case for now:
+            if (typeof(T).IsAssignableTo(typeof(BaseGuild)))
+            {
+                return World.FindGuild(serial) as T;
+            }
+
+            return World.FindEntity(serial) as T;
         }
 
-        public Item ReadItem() => World.FindItem(ReadUInt());
-
-        public Mobile ReadMobile() => World.FindMobile(ReadUInt());
-
-        public BaseGuild ReadGuild() => World.FindGuild(ReadUInt());
-
-        public T ReadItem<T>() where T : Item => ReadItem() as T;
-
-        public T ReadMobile<T>() where T : Mobile => ReadMobile() as T;
-
-        public T ReadGuild<T>() where T : BaseGuild => ReadGuild() as T;
-
-        public List<Item> ReadStrongItemList() => ReadStrongItemList<Item>();
-
-        public List<T> ReadStrongItemList<T>() where T : Item
+        public List<T> ReadEntityList<T>() where T : class, ISerializable
         {
             var count = ReadInt();
 
@@ -185,108 +178,28 @@ namespace Server
 
             for (var i = 0; i < count; ++i)
             {
-                if (ReadItem() is T item)
+                var entity = ReadEntity<T>();
+                if (entity != null)
                 {
-                    list.Add(item);
+                    list.Add(entity);
                 }
             }
 
             return list;
         }
 
-        public HashSet<Item> ReadItemSet() => ReadItemSet<Item>();
-
-        public HashSet<T> ReadItemSet<T>() where T : Item
+        public HashSet<T> ReadEntitySet<T>() where T : class, ISerializable
         {
             var count = ReadInt();
 
-            var set = new HashSet<T>();
+            var set = new HashSet<T>(count);
 
             for (var i = 0; i < count; ++i)
             {
-                if (ReadItem() is T item)
+                var entity = ReadEntity<T>();
+                if (entity != null)
                 {
-                    set.Add(item);
-                }
-            }
-
-            return set;
-        }
-
-        public List<Mobile> ReadStrongMobileList() => ReadStrongMobileList<Mobile>();
-
-        public List<T> ReadStrongMobileList<T>() where T : Mobile
-        {
-            var count = ReadInt();
-
-            var list = new List<T>(count);
-
-            for (var i = 0; i < count; ++i)
-            {
-                if (ReadMobile() is T m)
-                {
-                    list.Add(m);
-                }
-            }
-
-            return list;
-        }
-
-        public HashSet<Mobile> ReadMobileSet() => ReadMobileSet<Mobile>();
-
-        public HashSet<T> ReadMobileSet<T>() where T : Mobile
-        {
-            var count = ReadInt();
-            var set = new HashSet<T>();
-
-            for (var i = 0; i < count; ++i)
-            {
-                if (ReadMobile() is T item)
-                {
-                    set.Add(item);
-                }
-            }
-
-            return set;
-        }
-
-        public List<BaseGuild> ReadStrongGuildList() => ReadStrongGuildList<BaseGuild>();
-
-        public List<T> ReadStrongGuildList<T>() where T : BaseGuild
-        {
-            var count = ReadInt();
-            var list = new List<T>(count);
-
-            if (count > 0)
-            {
-                for (var i = 0; i < count; ++i)
-                {
-                    if (ReadGuild() is T g)
-                    {
-                        list.Add(g);
-                    }
-                }
-            }
-
-            return list;
-        }
-
-        public HashSet<BaseGuild> ReadGuildSet() => ReadGuildSet<BaseGuild>();
-
-        public HashSet<T> ReadGuildSet<T>() where T : BaseGuild
-        {
-            var count = ReadInt();
-
-            var set = new HashSet<T>();
-
-            if (count > 0)
-            {
-                for (var i = 0; i < count; ++i)
-                {
-                    if (ReadGuild() is T item)
-                    {
-                        set.Add(item);
-                    }
+                    set.Add(entity);
                 }
             }
 
@@ -314,8 +227,7 @@ namespace Server
             {
                 SeekOrigin.Begin   => Position = offset,
                 SeekOrigin.Current => Position += offset,
-                SeekOrigin.End     => Position = _buffer.Length - offset,
-                _                  => Position
+                SeekOrigin.End     => Position = _buffer.Length - offset
             };
         }
     }

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -117,7 +117,7 @@ namespace Server
             {
                 SeekOrigin.Current => Index += offset,
                 SeekOrigin.End     => Index = _buffer.Length - offset,
-                SeekOrigin.Begin   => Index = offset // Begin
+                _   => Index = offset // Begin
             };
         }
 

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -95,9 +95,7 @@ namespace Server
             while (remaining > 0)
             {
                 // In case the length of the bytes is too long, and we loop in case doubling is not enough
-                while (FlushIfNeeded(remaining))
-                {
-                }
+                FlushIfNeeded(remaining);
 
                 var count = Math.Min((int)(_buffer.Length - Index), remaining);
                 bytes.Slice(idx, count).CopyTo(_buffer.AsSpan((int)Index, count));

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -210,13 +210,13 @@ namespace Server
             FlushIfNeeded(8);
 
             _buffer[Index++] = (byte)value;
-            _buffer[Index] = (byte)(value >> 8);
-            _buffer[Index] = (byte)(value >> 16);
-            _buffer[Index] = (byte)(value >> 24);
-            _buffer[Index] = (byte)(value >> 32);
-            _buffer[Index] = (byte)(value >> 40);
-            _buffer[Index] = (byte)(value >> 48);
-            _buffer[Index] = (byte)(value >> 56);
+            _buffer[Index++] = (byte)(value >> 8);
+            _buffer[Index++] = (byte)(value >> 16);
+            _buffer[Index++] = (byte)(value >> 24);
+            _buffer[Index++] = (byte)(value >> 32);
+            _buffer[Index++] = (byte)(value >> 40);
+            _buffer[Index++] = (byte)(value >> 48);
+            _buffer[Index++] = (byte)(value >> 56);
         }
 
         public void Write(ulong value)

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -94,7 +94,6 @@ namespace Server
 
             while (remaining > 0)
             {
-                // In case the length of the bytes is too long, and we loop in case doubling is not enough
                 FlushIfNeeded(remaining);
 
                 var count = Math.Min((int)(_buffer.Length - Index), remaining);

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -151,32 +151,27 @@ namespace Server
 
         public void Write(DateTime value)
         {
-            Write(value.Ticks);
-        }
+            var ticks = (value.Kind switch
+            {
+                DateTimeKind.Local       => value.ToUniversalTime(),
+                DateTimeKind.Unspecified => value.ToLocalTime().ToUniversalTime(),
+                _                        => value
+            }).Ticks;
 
-        public void Write(DateTimeOffset value)
-        {
-            Write(value.Ticks);
-            Write(value.Offset.Ticks);
+            Write(ticks);
         }
 
         public void WriteDeltaTime(DateTime value)
         {
-            var ticks = value.Ticks;
-            var now = DateTime.UtcNow.Ticks;
-
-            TimeSpan d;
-
-            try
+            var ticks = (value.Kind switch
             {
-                d = new TimeSpan(ticks - now);
-            }
-            catch
-            {
-                d = TimeSpan.MaxValue;
-            }
+                DateTimeKind.Local       => value.ToUniversalTime(),
+                DateTimeKind.Unspecified => value.ToLocalTime().ToUniversalTime(),
+                _                        => value
+            }).Ticks;
 
-            Write(d);
+            // Technically supports negative deltas for times in the past
+            Write(ticks - DateTime.UtcNow.Ticks);
         }
 
         public void Write(IPAddress value)

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -44,6 +44,13 @@ namespace Server
             _buffer = GC.AllocateUninitializedArray<byte>(BufferSize);
         }
 
+        public BufferWriter(int count, bool prefixStr)
+        {
+            m_PrefixStrings = prefixStr;
+            m_Encoding = Utility.UTF8;
+            _buffer = GC.AllocateUninitializedArray<byte>(count);
+        }
+
         public virtual long Position => Index;
 
         protected virtual int BufferSize => 256;

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -47,7 +47,7 @@ namespace Server
 
         public virtual long Position => Index;
 
-        protected virtual int BufferSize => 256;
+        protected virtual int BufferSize => 128;
 
         public byte[] Buffer => _buffer;
 
@@ -69,7 +69,10 @@ namespace Server
 
         public virtual void Flush()
         {
-            Resize(_buffer.Length * 2);
+            // Need to avoid buffer.Length = 2, buffer * 2 is 4, but we need 8 or 16bytes, causing an exception.
+            // The least we need is 16bytes + Index, but we use BufferSize since it should always be big enough for a single
+            // non-dynamic field.
+            Resize(Math.Max(BufferSize, _buffer.Length * 2));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -79,11 +82,6 @@ namespace Server
             {
                 Flush();
             }
-        }
-
-        public void Reset()
-        {
-            Index = 0;
         }
 
         public void Write(ReadOnlySpan<byte> bytes)

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -135,11 +135,11 @@ namespace Server
             {
                 if (value == null)
                 {
-                    Write((byte)0);
+                    Write(false);
                 }
                 else
                 {
-                    Write((byte)1);
+                    Write(true);
                     InternalWriteString(value);
                 }
             }
@@ -292,16 +292,18 @@ namespace Server
             _buffer[Index++] = value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(sbyte value)
         {
             FlushIfNeeded(1);
             _buffer[Index++] = (byte)value;
         }
 
-        public void Write(bool value)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe void Write(bool value)
         {
             FlushIfNeeded(1);
-            _buffer[Index++] = value ? 1 : 0;
+            _buffer[Index++] = *(byte*)&value; // up to 30% faster to dereference the raw value on the stack
         }
 
         public void Write(Point3D value)

--- a/Projects/Server/Serialization/IGenericReader.cs
+++ b/Projects/Server/Serialization/IGenericReader.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using Server.Guilds;
 
 namespace Server
 {
@@ -45,25 +44,9 @@ namespace Server
         Rectangle2D ReadRect2D();
         Rectangle3D ReadRect3D();
         Map ReadMap();
-        IEntity ReadEntity();
-        Item ReadItem();
-        Mobile ReadMobile();
-        BaseGuild ReadGuild();
-        T ReadItem<T>() where T : Item;
-        T ReadMobile<T>() where T : Mobile;
-        T ReadGuild<T>() where T : BaseGuild;
-        List<Item> ReadStrongItemList();
-        List<T> ReadStrongItemList<T>() where T : Item;
-        List<Mobile> ReadStrongMobileList();
-        List<T> ReadStrongMobileList<T>() where T : Mobile;
-        List<BaseGuild> ReadStrongGuildList();
-        List<T> ReadStrongGuildList<T>() where T : BaseGuild;
-        HashSet<Item> ReadItemSet();
-        HashSet<T> ReadItemSet<T>() where T : Item;
-        HashSet<Mobile> ReadMobileSet();
-        HashSet<T> ReadMobileSet<T>() where T : Mobile;
-        HashSet<BaseGuild> ReadGuildSet();
-        HashSet<T> ReadGuildSet<T>() where T : BaseGuild;
+        T ReadEntity<T>() where T : class, ISerializable;
+        List<T> ReadEntityList<T>() where T : class, ISerializable;
+        HashSet<T> ReadEntitySet<T>() where T : class, ISerializable;
         Race ReadRace();
         int Read(Span<byte> buffer);
     }

--- a/Projects/Server/Serialization/IGenericReader.cs
+++ b/Projects/Server/Serialization/IGenericReader.cs
@@ -24,7 +24,6 @@ namespace Server
     {
         string ReadString();
         DateTime ReadDateTime();
-        DateTimeOffset ReadDateTimeOffset();
         TimeSpan ReadTimeSpan();
         DateTime ReadDeltaTime();
         decimal ReadDecimal();

--- a/Projects/Server/Serialization/IGenericWriter.cs
+++ b/Projects/Server/Serialization/IGenericWriter.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using Server.Guilds;
 
 namespace Server
 {
@@ -48,38 +47,9 @@ namespace Server
         void Write(Rectangle2D value);
         void Write(Rectangle3D value);
         void Write(Map value);
-        void WriteEntity(IEntity value);
-        void Write(Item value);
-        void Write(Mobile value);
-        void Write(BaseGuild value);
-        void WriteItem<T>(T value) where T : Item;
-        void WriteMobile<T>(T value) where T : Mobile;
-        void WriteGuild<T>(T value) where T : BaseGuild;
+        void Write(ISerializable value);
         void Write(Race value);
-        void Write(List<Item> list);
-        void Write(List<Item> list, bool tidy);
-        void WriteItemList<T>(List<T> list) where T : Item;
-        void WriteItemList<T>(List<T> list, bool tidy) where T : Item;
-        void Write(HashSet<Item> list);
-        void Write(HashSet<Item> list, bool tidy);
-        void WriteItemSet<T>(HashSet<T> set) where T : Item;
-        void WriteItemSet<T>(HashSet<T> set, bool tidy) where T : Item;
-        void Write(List<Mobile> list);
-        void Write(List<Mobile> list, bool tidy);
-        void WriteMobileList<T>(List<T> list) where T : Mobile;
-        void WriteMobileList<T>(List<T> list, bool tidy) where T : Mobile;
-        void Write(HashSet<Mobile> list);
-        void Write(HashSet<Mobile> list, bool tidy);
-        void WriteMobileSet<T>(HashSet<T> set) where T : Mobile;
-        void WriteMobileSet<T>(HashSet<T> set, bool tidy) where T : Mobile;
-        void Write(List<BaseGuild> list);
-        void Write(List<BaseGuild> list, bool tidy);
-        void WriteGuildList<T>(List<T> list) where T : BaseGuild;
-        void WriteGuildList<T>(List<T> list, bool tidy) where T : BaseGuild;
-        void Write(HashSet<BaseGuild> list);
-        void Write(HashSet<BaseGuild> list, bool tidy);
-        void WriteGuildSet<T>(HashSet<T> set) where T : BaseGuild;
-        void WriteGuildSet<T>(HashSet<T> set, bool tidy) where T : BaseGuild;
+        void Write<T>(ICollection<T> list) where T : class, ISerializable;
         void Write(ReadOnlySpan<byte> bytes);
 
         long Seek(long offset, SeekOrigin origin);

--- a/Projects/Server/Serialization/IGenericWriter.cs
+++ b/Projects/Server/Serialization/IGenericWriter.cs
@@ -27,7 +27,6 @@ namespace Server
         void Close();
         void Write(string value);
         void Write(DateTime value);
-        void Write(DateTimeOffset value);
         void Write(TimeSpan value);
         void Write(decimal value);
         void Write(long value);

--- a/Projects/Server/Serialization/ISerializable.cs
+++ b/Projects/Server/Serialization/ISerializable.cs
@@ -13,17 +13,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System.IO;
+
 namespace Server
 {
     public interface ISerializable
     {
-        BufferWriter SaveBuffer { get; set; }
+        BufferWriter SaveBuffer { get; protected internal set; }
         int TypeRef { get; }
         Serial Serial { get; }
-        void Serialize();
         void Deserialize(IGenericReader reader);
         void Serialize(IGenericWriter writer);
         void Delete();
         bool Deleted { get; }
+
+        public void InitializeSaveBuffer(byte[] buffer)
+        {
+            SaveBuffer = new BufferWriter(buffer, true);
+        }
+
+        public void Serialize()
+        {
+            SaveBuffer ??= new BufferWriter(true);
+            SaveBuffer.Seek(0, SeekOrigin.Begin);
+            Serialize(SaveBuffer);
+        }
     }
 }

--- a/Projects/Server/Serialization/ISerializable.cs
+++ b/Projects/Server/Serialization/ISerializable.cs
@@ -24,5 +24,6 @@ namespace Server
         void Deserialize(IGenericReader reader);
         void Serialize(IGenericWriter writer);
         void Delete();
+        bool Deleted { get; }
     }
 }

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1437,5 +1437,24 @@ namespace Server
 
             return string.Join(lineSeparator, parts);
         }
+
+        public static void Tidy<T>(this List<T> list) where T : ISerializable
+        {
+            for (int i = list.Count - 1; i >= 0; i--)
+            {
+                var entry = list[i];
+                if (entry?.Deleted != false)
+                {
+                    list.RemoveAt(i);
+                }
+            }
+
+            list.TrimExcess();
+        }
+
+        public static void Tidy<T>(this HashSet<T> set) where T : ISerializable
+        {
+            set.RemoveWhere(entry => entry?.Deleted != false);
+        }
     }
 }

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -290,7 +290,7 @@ namespace Server
             return map;
         }
 
-        private static void SaveBuffers<I, T>(IIndexInfo<I> indexInfo, List<EntityIndex<T>> entities) where T : ISerializable
+        private static void SaveBuffers<I, T>(IIndexInfo<I> indexInfo, List<EntityIndex<T>> entities) where T : class, ISerializable
         {
             var indexType = indexInfo.TypeName;
 
@@ -306,20 +306,20 @@ namespace Server
 
             foreach (var entry in entities)
             {
-                T t = entry.Entity;
+                T e = entry.Entity;
 
-                if (t == null || t is IEntity entity && entity.Deleted)
+                if (e == null || e is IEntity entity && entity.Deleted)
                 {
                     continue;
                 }
 
                 byte[] saveBuffer = GC.AllocateUninitializedArray<byte>(entry.Length);
                 reader.Read(saveBuffer, 0, entry.Length);
-                t.SaveBuffer = new BufferWriter(saveBuffer, true);
+                e.InitializeSaveBuffer(saveBuffer);
             }
         }
 
-        private static void LoadData<I, T>(IIndexInfo<I> indexInfo, List<EntityIndex<T>> entities) where T : ISerializable
+        private static void LoadData<I, T>(IIndexInfo<I> indexInfo, List<EntityIndex<T>> entities) where T : class, ISerializable
         {
             var indexType = indexInfo.TypeName;
 
@@ -772,7 +772,7 @@ namespace Server
 
         public static void RemoveGuild(BaseGuild guild) => Guilds.Remove(guild.Serial);
 
-        public static void SerializeTo(this ISerializable entity, IGenericWriter writer)
+        private static void SerializeTo(this ISerializable entity, IGenericWriter writer)
         {
             var saveBuffer = entity.SaveBuffer;
             writer.Write(saveBuffer.Buffer.AsSpan(0, (int)saveBuffer.Position));

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -126,7 +126,7 @@ namespace Server
 
         public static WorldState WorldState { get; private set; }
         public static bool Saving => WorldState == WorldState.Saving;
-        public static bool Running => WorldState == WorldState.Running;
+        public static bool Running => WorldState != WorldState.Loading && WorldState != WorldState.Initial;
         public static bool Loading => WorldState == WorldState.Loading;
 
         public static Dictionary<Serial, Mobile> Mobiles { get; private set; }

--- a/Projects/UOContent/Engines/CannedEvil/ChampionAltar.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionAltar.cs
@@ -38,7 +38,7 @@ namespace Server.Engines.CannedEvil
             {
                 case 0:
                     {
-                        m_Spawn = reader.ReadItem() as ChampionSpawn;
+                        m_Spawn = reader.ReadEntity<ChampionSpawn>();
 
                         if (m_Spawn == null)
                         {

--- a/Projects/UOContent/Engines/CannedEvil/ChampionPlatform.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionPlatform.cs
@@ -80,7 +80,7 @@ namespace Server.Engines.CannedEvil
             {
                 case 0:
                     {
-                        m_Spawn = reader.ReadItem() as ChampionSpawn;
+                        m_Spawn = reader.ReadEntity<ChampionSpawn>();
 
                         if (m_Spawn == null)
                         {

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSkullBrazier.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSkullBrazier.cs
@@ -157,8 +157,8 @@ namespace Server.Engines.CannedEvil
                 case 0:
                     {
                         m_Type = (ChampionSkullType)reader.ReadInt();
-                        Platform = reader.ReadItem() as ChampionSkullPlatform;
-                        m_Skull = reader.ReadItem();
+                        Platform = reader.ReadEntity<ChampionSkullPlatform>();
+                        m_Skull = reader.ReadEntity<Item>();
 
                         if (Platform == null)
                         {

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSkullPlatform.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSkullPlatform.cs
@@ -112,12 +112,12 @@ namespace Server.Engines.CannedEvil
             {
                 case 0:
                     {
-                        m_Power = reader.ReadItem() as ChampionSkullBrazier;
-                        m_Enlightenment = reader.ReadItem() as ChampionSkullBrazier;
-                        m_Venom = reader.ReadItem() as ChampionSkullBrazier;
-                        m_Pain = reader.ReadItem() as ChampionSkullBrazier;
-                        m_Greed = reader.ReadItem() as ChampionSkullBrazier;
-                        m_Death = reader.ReadItem() as ChampionSkullBrazier;
+                        m_Power = reader.ReadEntity<ChampionSkullBrazier>();
+                        m_Enlightenment = reader.ReadEntity<ChampionSkullBrazier>();
+                        m_Venom = reader.ReadEntity<ChampionSkullBrazier>();
+                        m_Pain = reader.ReadEntity<ChampionSkullBrazier>();
+                        m_Greed = reader.ReadEntity<ChampionSkullBrazier>();
+                        m_Death = reader.ReadEntity<ChampionSkullBrazier>();
 
                         break;
                     }

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
@@ -1169,7 +1169,7 @@ namespace Server.Engines.CannedEvil
             }
 
             writer.Write(ConfinedRoaming);
-            writer.WriteItem(m_Idol);
+            writer.Write(m_Idol);
             writer.Write(HasBeenAdvanced);
             writer.Write(m_SpawnArea);
 
@@ -1180,11 +1180,14 @@ namespace Server.Engines.CannedEvil
 
             writer.Write(m_Active);
             writer.Write((int)m_Type);
-            writer.Write(m_Creatures, true);
-            writer.Write(m_RedSkulls, true);
-            writer.Write(m_WhiteSkulls, true);
-            writer.WriteItem(m_Platform);
-            writer.WriteItem(m_Altar);
+            m_Creatures.Tidy();
+            writer.Write(m_Creatures);
+            m_RedSkulls.Tidy();
+            writer.Write(m_RedSkulls);
+            m_WhiteSkulls.Tidy();
+            writer.Write(m_WhiteSkulls);
+            writer.Write(m_Platform);
+            writer.Write(m_Altar);
             writer.Write(ExpireDelay);
             writer.WriteDeltaTime(ExpireTime);
             writer.Write(Champion);
@@ -1218,7 +1221,7 @@ namespace Server.Engines.CannedEvil
                         var entries = reader.ReadInt();
                         for (var i = 0; i < entries; ++i)
                         {
-                            var m = reader.ReadMobile();
+                            var m = reader.ReadEntity<Mobile>();
                             var damage = reader.ReadInt();
 
                             if (m == null)
@@ -1234,7 +1237,7 @@ namespace Server.Engines.CannedEvil
                 case 4:
                     {
                         ConfinedRoaming = reader.ReadBool();
-                        m_Idol = reader.ReadItem<IdolOfTheChampion>();
+                        m_Idol = reader.ReadEntity<IdolOfTheChampion>();
                         HasBeenAdvanced = reader.ReadBool();
 
                         goto case 3;
@@ -1277,14 +1280,14 @@ namespace Server.Engines.CannedEvil
 
                         var active = reader.ReadBool();
                         m_Type = (ChampionSpawnType)reader.ReadInt();
-                        m_Creatures = reader.ReadStrongMobileList();
-                        m_RedSkulls = reader.ReadStrongItemList();
-                        m_WhiteSkulls = reader.ReadStrongItemList();
-                        m_Platform = reader.ReadItem<ChampionPlatform>();
-                        m_Altar = reader.ReadItem<ChampionAltar>();
+                        m_Creatures = reader.ReadEntityList<Mobile>();
+                        m_RedSkulls = reader.ReadEntityList<Item>();
+                        m_WhiteSkulls = reader.ReadEntityList<Item>();
+                        m_Platform = reader.ReadEntity<ChampionPlatform>();
+                        m_Altar = reader.ReadEntity<ChampionAltar>();
                         ExpireDelay = reader.ReadTimeSpan();
                         ExpireTime = reader.ReadDeltaTime();
-                        Champion = reader.ReadMobile();
+                        Champion = reader.ReadEntity<Mobile>();
                         RestartDelay = reader.ReadTimeSpan();
 
                         if (reader.ReadBool())
@@ -1384,7 +1387,7 @@ namespace Server.Engines.CannedEvil
             {
                 case 0:
                     {
-                        Spawn = reader.ReadItem() as ChampionSpawn;
+                        Spawn = reader.ReadEntity<ChampionSpawn>();
 
                         if (Spawn == null)
                         {

--- a/Projects/UOContent/Engines/CannedEvil/HarrowerGate.cs
+++ b/Projects/UOContent/Engines/CannedEvil/HarrowerGate.cs
@@ -40,7 +40,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        m_Harrower = reader.ReadMobile();
+                        m_Harrower = reader.ReadEntity<Mobile>();
 
                         if (m_Harrower == null)
                         {

--- a/Projects/UOContent/Engines/ConPVP/Arena.cs
+++ b/Projects/UOContent/Engines/ConPVP/Arena.cs
@@ -263,14 +263,14 @@ namespace Server.Engines.ConPVP
                     }
                 case 6:
                     {
-                        Ladder = reader.ReadItem() as LadderController;
+                        Ladder = reader.ReadEntity<LadderController>();
 
                         goto case 5;
                     }
                 case 5:
                     {
-                        m_Tournament = reader.ReadItem() as TournamentController;
-                        Announcer = reader.ReadMobile();
+                        m_Tournament = reader.ReadEntity<TournamentController>();
+                        Announcer = reader.ReadEntity<Mobile>();
 
                         goto case 4;
                     }
@@ -290,13 +290,13 @@ namespace Server.Engines.ConPVP
                     {
                         GateIn = reader.ReadPoint3D();
                         m_GateOut = reader.ReadPoint3D();
-                        Teleporter = reader.ReadItem();
+                        Teleporter = reader.ReadEntity<Item>();
 
                         goto case 1;
                     }
                 case 1:
                     {
-                        Players = reader.ReadStrongMobileList();
+                        Players = reader.ReadEntityList<Mobile>();
 
                         goto case 0;
                     }

--- a/Projects/UOContent/Engines/ConPVP/DuelContext.cs
+++ b/Projects/UOContent/Engines/ConPVP/DuelContext.cs
@@ -2747,7 +2747,7 @@ namespace Server.Engines.ConPVP
 
                             for (var i = 0; i < count; ++i)
                             {
-                                var mob = reader.ReadMobile();
+                                var mob = reader.ReadEntity<Mobile>();
                                 var loc = reader.ReadPoint3D();
                                 var map = reader.ReadMap();
 

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -1380,10 +1380,10 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        Board = ip.ReadItem() as BRBoard;
+                        Board = ip.ReadEntity<BRBoard>();
                         TeamName = ip.ReadString();
                         Color = ip.ReadEncodedInt();
-                        m_Goal = ip.ReadItem() as BRGoal;
+                        m_Goal = ip.ReadEntity<BRGoal>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ConPVP/Games/CTF.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/CTF.cs
@@ -665,7 +665,7 @@ namespace Server.Engines.ConPVP
             {
                 case 2:
                     {
-                        Board = ip.ReadItem() as CTFBoard;
+                        Board = ip.ReadEntity<CTFBoard>();
 
                         goto case 1;
                     }
@@ -679,7 +679,7 @@ namespace Server.Engines.ConPVP
                     {
                         Color = ip.ReadEncodedInt();
 
-                        Flag = ip.ReadItem() as CTFFlag;
+                        Flag = ip.ReadEntity<CTFFlag>();
                         Origin = ip.ReadPoint3D();
                         break;
                     }

--- a/Projects/UOContent/Engines/ConPVP/Games/DoubleDom.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/DoubleDom.cs
@@ -311,7 +311,7 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        Board = ip.ReadItem() as DDBoard;
+                        Board = ip.ReadEntity<DDBoard>();
                         TeamName = ip.ReadString();
                         Color = ip.ReadEncodedInt();
                         Origin = ip.ReadPoint3D();
@@ -481,8 +481,8 @@ namespace Server.Engines.ConPVP
                             TeamInfo[i] = new DDTeamInfo(i, reader);
                         }
 
-                        PointA = reader.ReadItem() as DDWayPoint;
-                        PointB = reader.ReadItem() as DDWayPoint;
+                        PointA = reader.ReadEntity<DDWayPoint>();
+                        PointB = reader.ReadEntity<DDWayPoint>();
 
                         break;
                     }

--- a/Projects/UOContent/Engines/ConPVP/Games/KingOfTheHill.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/KingOfTheHill.cs
@@ -354,7 +354,7 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        m_Controller = reader.ReadItem() as KHController;
+                        m_Controller = reader.ReadEntity<KHController>();
                         break;
                     }
             }
@@ -814,7 +814,8 @@ namespace Server.Engines.ConPVP
             writer.WriteEncodedInt(m_ScoreInterval);
             writer.Write(Duration);
 
-            writer.WriteItemList(Boards, true);
+            Boards.Tidy();
+            writer.Write(Boards);
 
             writer.WriteEncodedInt(Hills.Length);
             for (var i = 0; i < Hills.Length; ++i)
@@ -843,12 +844,12 @@ namespace Server.Engines.ConPVP
 
                         Duration = reader.ReadTimeSpan();
 
-                        Boards = reader.ReadStrongItemList<KHBoard>();
+                        Boards = reader.ReadEntityList<KHBoard>();
 
                         Hills = new HillOfTheKing[reader.ReadEncodedInt()];
                         for (var i = 0; i < Hills.Length; ++i)
                         {
-                            Hills[i] = reader.ReadItem() as HillOfTheKing;
+                            Hills[i] = reader.ReadEntity<HillOfTheKing>();
                         }
 
                         TeamInfo = new KHTeamInfo[reader.ReadEncodedInt()];

--- a/Projects/UOContent/Engines/ConPVP/Gumps/LadderGump.cs
+++ b/Projects/UOContent/Engines/ConPVP/Gumps/LadderGump.cs
@@ -38,7 +38,7 @@ namespace Server.Engines.ConPVP
             {
                 case 1:
                     {
-                        Ladder = reader.ReadItem<LadderController>();
+                        Ladder = reader.ReadEntity<LadderController>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ConPVP/Ladder.cs
+++ b/Projects/UOContent/Engines/ConPVP/Ladder.cs
@@ -337,7 +337,7 @@ namespace Server.Engines.ConPVP
                 case 1:
                 case 0:
                     {
-                        Mobile = reader.ReadMobile();
+                        Mobile = reader.ReadEntity<Mobile>();
                         m_Experience = reader.ReadEncodedInt();
                         Wins = reader.ReadEncodedInt();
                         Losses = reader.ReadEncodedInt();

--- a/Projects/UOContent/Engines/ConPVP/Preferences.cs
+++ b/Projects/UOContent/Engines/ConPVP/Preferences.cs
@@ -149,7 +149,7 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        Mobile = reader.ReadMobile();
+                        Mobile = reader.ReadEntity<Mobile>();
 
                         var count = reader.ReadEncodedInt();
 

--- a/Projects/UOContent/Engines/ConPVP/Tournament.cs
+++ b/Projects/UOContent/Engines/ConPVP/Tournament.cs
@@ -61,7 +61,7 @@ namespace Server.Engines.ConPVP
                     }
                 case 4:
                     {
-                        EventController = reader.ReadItem() as EventController;
+                        EventController = reader.ReadEntity<EventController>();
 
                         goto case 3;
                     }

--- a/Projects/UOContent/Engines/ConPVP/TournamentBracketItem.cs
+++ b/Projects/UOContent/Engines/ConPVP/TournamentBracketItem.cs
@@ -53,7 +53,7 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        Tournament = reader.ReadItem() as TournamentController;
+                        Tournament = reader.ReadEntity<TournamentController>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ConPVP/TournamentRegistrar.cs
+++ b/Projects/UOContent/Engines/ConPVP/TournamentRegistrar.cs
@@ -98,7 +98,7 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        Tournament = reader.ReadItem() as TournamentController;
+                        Tournament = reader.ReadEntity<TournamentController>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ConPVP/TournamentSignupItem.cs
+++ b/Projects/UOContent/Engines/ConPVP/TournamentSignupItem.cs
@@ -187,8 +187,8 @@ namespace Server.Engines.ConPVP
             {
                 case 0:
                     {
-                        Tournament = reader.ReadItem() as TournamentController;
-                        Registrar = reader.ReadMobile();
+                        Tournament = reader.ReadEntity<TournamentController>();
+                        Registrar = reader.ReadEntity<Mobile>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ConPVP/Trophy.cs
+++ b/Projects/UOContent/Engines/ConPVP/Trophy.cs
@@ -70,7 +70,7 @@ namespace Server.Items
 
             Title = reader.ReadString();
             m_Rank = (TrophyRank)reader.ReadInt();
-            Owner = reader.ReadMobile();
+            Owner = reader.ReadEntity<Mobile>();
             Date = reader.ReadDateTime();
 
             if (version == 0)

--- a/Projects/UOContent/Engines/Doom/GauntletSpawner.cs
+++ b/Projects/UOContent/Engines/Doom/GauntletSpawner.cs
@@ -405,14 +405,14 @@ namespace Server.Engines.Doom
 
             writer.Write(RegionBounds);
 
-            writer.WriteItemList(Traps, false);
+            writer.Write(Traps);
 
-            writer.Write(Creatures, false);
+            writer.Write(Creatures);
 
             writer.Write(TypeName);
-            writer.WriteItem(Door);
-            writer.WriteItem(Addon);
-            writer.WriteItem(Sequence);
+            writer.Write(Door);
+            writer.Write(Addon);
+            writer.Write(Sequence);
 
             writer.Write((int)m_State);
         }
@@ -428,7 +428,7 @@ namespace Server.Engines.Doom
                 case 1:
                     {
                         RegionBounds = reader.ReadRect2D();
-                        Traps = reader.ReadStrongItemList<BaseTrap>();
+                        Traps = reader.ReadEntityList<BaseTrap>();
 
                         goto case 0;
                     }
@@ -440,12 +440,12 @@ namespace Server.Engines.Doom
                             RegionBounds = new Rectangle2D(X - 40, Y - 40, 80, 80);
                         }
 
-                        Creatures = reader.ReadStrongMobileList();
+                        Creatures = reader.ReadEntityList<Mobile>();
 
                         TypeName = reader.ReadString();
-                        Door = reader.ReadItem<BaseDoor>();
-                        Addon = reader.ReadItem<BaseAddon>();
-                        Sequence = reader.ReadItem<GauntletSpawner>();
+                        Door = reader.ReadEntity<BaseDoor>();
+                        Addon = reader.ReadEntity<BaseAddon>();
+                        Sequence = reader.ReadEntity<GauntletSpawner>();
 
                         State = (GauntletSpawnerState)reader.ReadInt();
 

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
@@ -534,9 +534,16 @@ namespace Server.Engines.Doom
         {
             base.Serialize(writer);
             writer.Write(0); // version
-            writer.WriteItemList(m_Levers, true);
-            writer.WriteItemList(m_Statues, true);
-            writer.WriteItemList(m_Teles, true);
+
+            m_Levers.Tidy();
+            writer.Write(m_Levers);
+
+            m_Statues.Tidy();
+            writer.Write(m_Statues);
+
+            m_Teles.Tidy();
+            writer.Write(m_Teles);
+
             writer.Write(m_Box);
         }
 
@@ -546,11 +553,11 @@ namespace Server.Engines.Doom
 
             var version = reader.ReadInt();
 
-            m_Levers = reader.ReadStrongItemList();
-            m_Statues = reader.ReadStrongItemList();
-            m_Teles = reader.ReadStrongItemList();
+            m_Levers = reader.ReadEntityList<Item>();
+            m_Statues = reader.ReadEntityList<Item>();
+            m_Teles = reader.ReadEntityList<Item>();
 
-            m_Box = reader.ReadItem() as LampRoomBox;
+            m_Box = reader.ReadEntity<LampRoomBox>();
 
             m_Tiles = new List<LeverPuzzleRegion>();
             for (var i = 4; i < 9; i++)

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleItems.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleItems.cs
@@ -66,7 +66,7 @@ namespace Server.Engines.Doom
         {
             base.Deserialize(reader);
             var version = reader.ReadInt();
-            m_Controller = reader.ReadItem() as LeverPuzzleController;
+            m_Controller = reader.ReadEntity<LeverPuzzleController>();
         }
     }
 
@@ -104,7 +104,7 @@ namespace Server.Engines.Doom
         {
             base.Deserialize(reader);
             var version = reader.ReadInt();
-            m_Controller = reader.ReadItem() as LeverPuzzleController;
+            m_Controller = reader.ReadEntity<LeverPuzzleController>();
         }
     }
 
@@ -162,7 +162,7 @@ namespace Server.Engines.Doom
             base.Deserialize(reader);
             var version = reader.ReadInt();
             Code = reader.ReadUShort();
-            m_Controller = reader.ReadItem() as LeverPuzzleController;
+            m_Controller = reader.ReadEntity<LeverPuzzleController>();
         }
     }
 

--- a/Projects/UOContent/Engines/Ethics/Core/Player.cs
+++ b/Projects/UOContent/Engines/Ethics/Core/Player.cs
@@ -32,13 +32,13 @@ namespace Server.Ethics
             {
                 case 0:
                     {
-                        Mobile = reader.ReadMobile();
+                        Mobile = reader.ReadEntity<Mobile>();
 
                         Power = reader.ReadEncodedInt();
                         History = reader.ReadEncodedInt();
 
-                        Steed = reader.ReadMobile();
-                        Familiar = reader.ReadMobile();
+                        Steed = reader.ReadEntity<Mobile>();
+                        Familiar = reader.ReadEntity<Mobile>();
 
                         m_Shield = reader.ReadDeltaTime();
 

--- a/Projects/UOContent/Engines/Factions/Core/Election.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Election.cs
@@ -426,7 +426,7 @@ namespace Server.Factions
             {
                 case 0:
                     {
-                        From = reader.ReadMobile();
+                        From = reader.ReadEntity<Mobile>();
                         Address = Utility.Intern(reader.ReadIPAddress());
                         Time = reader.ReadDateTime();
 
@@ -498,7 +498,7 @@ namespace Server.Factions
             {
                 case 1:
                     {
-                        Mobile = reader.ReadMobile();
+                        Mobile = reader.ReadEntity<Mobile>();
 
                         var count = reader.ReadEncodedInt();
                         Voters = new List<Voter>(count);
@@ -517,9 +517,9 @@ namespace Server.Factions
                     }
                 case 0:
                     {
-                        Mobile = reader.ReadMobile();
+                        Mobile = reader.ReadEntity<Mobile>();
 
-                        var mobs = reader.ReadStrongMobileList();
+                        var mobs = reader.ReadEntityList<Mobile>();
                         Voters = new List<Voter>(mobs.Count);
 
                         for (var i = 0; i < mobs.Count; ++i)

--- a/Projects/UOContent/Engines/Factions/Core/FactionItem.cs
+++ b/Projects/UOContent/Engines/Factions/Core/FactionItem.cs
@@ -25,7 +25,7 @@ namespace Server.Factions
             {
                 case 0:
                     {
-                        Item = reader.ReadItem();
+                        Item = reader.ReadEntity<Item>();
                         Expiration = reader.ReadDateTime();
                         break;
                     }

--- a/Projects/UOContent/Engines/Factions/Core/FactionState.cs
+++ b/Projects/UOContent/Engines/Factions/Core/FactionState.cs
@@ -61,7 +61,7 @@ namespace Server.Factions
                     {
                         m_Faction = Faction.ReadReference(reader);
 
-                        m_Commander = reader.ReadMobile();
+                        m_Commander = reader.ReadEntity<Mobile>();
 
                         if (version < 5)
                         {
@@ -136,7 +136,7 @@ namespace Server.Factions
 
                             for (var i = 0; i < factionTrapCount; ++i)
                             {
-                                if (reader.ReadItem() is BaseFactionTrap trap && !trap.CheckDecay())
+                                if (reader.ReadEntity<Item>() is BaseFactionTrap trap && !trap.CheckDecay())
                                 {
                                     Traps.Add(trap);
                                 }

--- a/Projects/UOContent/Engines/Factions/Core/PlayerState.cs
+++ b/Projects/UOContent/Engines/Factions/Core/PlayerState.cs
@@ -43,7 +43,7 @@ namespace Server.Factions
                     }
                 case 0:
                     {
-                        Mobile = reader.ReadMobile();
+                        Mobile = reader.ReadEntity<Mobile>();
 
                         m_KillPoints = reader.ReadEncodedInt();
                         m_MerchantTitle = (MerchantTitle)reader.ReadEncodedInt();

--- a/Projects/UOContent/Engines/Factions/Core/TownState.cs
+++ b/Projects/UOContent/Engines/Factions/Core/TownState.cs
@@ -39,8 +39,8 @@ namespace Server.Factions
                         Town = Town.ReadReference(reader);
                         Owner = Faction.ReadReference(reader);
 
-                        m_Sheriff = reader.ReadMobile();
-                        m_Finance = reader.ReadMobile();
+                        m_Sheriff = reader.ReadEntity<Mobile>();
+                        m_Finance = reader.ReadEntity<Mobile>();
 
                         Town.State = this;
 

--- a/Projects/UOContent/Engines/Factions/Items/BaseMonolith.cs
+++ b/Projects/UOContent/Engines/Factions/Items/BaseMonolith.cs
@@ -128,7 +128,7 @@ namespace Server.Factions
                     {
                         Town = Town.ReadReference(reader);
                         Faction = Faction.ReadReference(reader);
-                        m_Sigil = reader.ReadItem() as Sigil;
+                        m_Sigil = reader.ReadEntity<Sigil>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/Factions/Items/Sigil.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Sigil.cs
@@ -429,7 +429,7 @@ namespace Server.Factions
                         m_Corrupted = Faction.ReadReference(reader);
                         m_Corrupting = Faction.ReadReference(reader);
 
-                        LastMonolith = reader.ReadItem() as BaseMonolith;
+                        LastMonolith = reader.ReadEntity<BaseMonolith>();
 
                         LastStolen = reader.ReadDateTime();
                         GraceStart = reader.ReadDateTime();

--- a/Projects/UOContent/Engines/Factions/Items/Traps/BaseFactionTrap.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Traps/BaseFactionTrap.cs
@@ -255,7 +255,7 @@ namespace Server.Factions
             var version = reader.ReadInt();
 
             Faction = Faction.ReadReference(reader);
-            Placer = reader.ReadMobile();
+            Placer = reader.ReadEntity<Mobile>();
             TimeOfPlacement = reader.ReadDateTime();
 
             if (Visible)

--- a/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
@@ -522,7 +522,7 @@ namespace Server.Factions
 
             var version = reader.ReadInt();
 
-            Rider = reader.ReadMobile();
+            Rider = reader.ReadEntity<Mobile>();
 
             if (Rider == null)
             {

--- a/Projects/UOContent/Engines/Factions/Mobiles/Guards/Orders.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/Guards/Orders.cs
@@ -74,7 +74,7 @@ namespace Server.Factions.AI
             {
                 case 1:
                     {
-                        Follow = reader.ReadMobile();
+                        Follow = reader.ReadEntity<Mobile>();
                         goto case 0;
                     }
                 case 0:

--- a/Projects/UOContent/Engines/Khaldun/PuzzleChest.cs
+++ b/Projects/UOContent/Engines/Khaldun/PuzzleChest.cs
@@ -589,7 +589,7 @@ namespace Server.Items
             var guesses = reader.ReadEncodedInt();
             for (var i = 0; i < guesses; i++)
             {
-                var m = reader.ReadMobile();
+                var m = reader.ReadEntity<Mobile>();
                 var sol = new PuzzleChestSolutionAndTime(reader);
 
                 m_Guesses[m] = sol;

--- a/Projects/UOContent/Engines/Khaldun/RaiseSwitch.cs
+++ b/Projects/UOContent/Engines/Khaldun/RaiseSwitch.cs
@@ -119,7 +119,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            RaisableItem = (RaisableItem)reader.ReadItem();
+            RaisableItem = (RaisableItem)reader.ReadEntity<Item>();
 
             Reset();
         }

--- a/Projects/UOContent/Engines/MLQuests/MLQuestContext.cs
+++ b/Projects/UOContent/Engines/MLQuests/MLQuestContext.cs
@@ -31,7 +31,7 @@ namespace Server.Engines.MLQuests
 
         public MLQuestContext(IGenericReader reader, int version)
         {
-            Owner = reader.ReadMobile<PlayerMobile>();
+            Owner = reader.ReadEntity<PlayerMobile>();
             QuestInstances = new List<MLQuestInstance>();
             m_DoneQuests = new List<MLDoneQuestInfo>();
             ChainOffers = new List<MLQuest>();
@@ -234,7 +234,7 @@ namespace Server.Engines.MLQuests
         {
             // Version info is written in MLQuestPersistence.Serialize
 
-            writer.WriteMobile(Owner);
+            writer.Write(Owner);
             writer.Write(QuestInstances.Count);
 
             foreach (var instance in QuestInstances)

--- a/Projects/UOContent/Engines/Quests/Dark Tides/Items/MaabusCoffin.cs
+++ b/Projects/UOContent/Engines/Quests/Dark Tides/Items/MaabusCoffin.cs
@@ -100,7 +100,7 @@ namespace Server.Engines.Quests.Necro
 
             var version = reader.ReadInt();
 
-            Maabus = reader.ReadMobile() as Maabus;
+            Maabus = reader.ReadEntity<Maabus>();
             SpawnLocation = reader.ReadPoint3D();
 
             Sleep();

--- a/Projects/UOContent/Engines/Quests/Dark Tides/Mobiles/SummonedPaladin.cs
+++ b/Projects/UOContent/Engines/Quests/Dark Tides/Mobiles/SummonedPaladin.cs
@@ -150,7 +150,7 @@ namespace Server.Engines.Quests.Necro
 
             var version = reader.ReadInt();
 
-            m_Necromancer = reader.ReadMobile() as PlayerMobile;
+            m_Necromancer = reader.ReadEntity<PlayerMobile>();
             m_ToDelete = reader.ReadBool();
 
             if (m_ToDelete)

--- a/Projects/UOContent/Engines/Quests/Study of the Solen Hive/StudyOfSolenQuest.cs
+++ b/Projects/UOContent/Engines/Quests/Study of the Solen Hive/StudyOfSolenQuest.cs
@@ -41,7 +41,7 @@ namespace Server.Engines.Quests.Naturalist
         {
             var version = reader.ReadEncodedInt();
 
-            Naturalist = (Naturalist)reader.ReadMobile();
+            Naturalist = (Naturalist)reader.ReadEntity<Mobile>();
         }
 
         public override void ChildSerialize(IGenericWriter writer)

--- a/Projects/UOContent/Engines/Quests/The Summoning/Items/BellOfTheDead.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Items/BellOfTheDead.cs
@@ -126,8 +126,8 @@ namespace Server.Engines.Quests.Doom
 
             var version = reader.ReadInt();
 
-            Chyloth = reader.ReadMobile() as Chyloth;
-            Dragon = reader.ReadMobile() as SkeletalDragon;
+            Chyloth = reader.ReadEntity<Chyloth>();
+            Dragon = reader.ReadEntity<SkeletalDragon>();
 
             Chyloth?.Delete();
         }

--- a/Projects/UOContent/Engines/Quests/The Summoning/Items/SummoningAltar.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Items/SummoningAltar.cs
@@ -54,7 +54,7 @@ namespace Server.Engines.Quests.Doom
 
             var version = reader.ReadInt();
 
-            m_Daemon = reader.ReadMobile() as BoneDemon;
+            m_Daemon = reader.ReadEntity<BoneDemon>();
 
             CheckDaemon();
         }

--- a/Projects/UOContent/Engines/Quests/The Summoning/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Objectives.cs
@@ -173,8 +173,8 @@ namespace Server.Engines.Quests.Doom
         {
             var version = reader.ReadEncodedInt();
 
-            m_Daemon = reader.ReadMobile() as BoneDemon;
-            CorpseWithSkull = reader.ReadItem() as Corpse;
+            m_Daemon = reader.ReadEntity<BoneDemon>();
+            CorpseWithSkull = reader.ReadEntity<Corpse>();
         }
 
         public override void ChildSerialize(IGenericWriter writer)

--- a/Projects/UOContent/Engines/Quests/The Summoning/TheSummoningQuest.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/TheSummoningQuest.cs
@@ -105,7 +105,7 @@ namespace Server.Engines.Quests.Doom
         {
             var version = reader.ReadEncodedInt();
 
-            Victoria = reader.ReadMobile() as Victoria;
+            Victoria = reader.ReadEntity<Victoria>();
             WaitForSummon = reader.ReadBool();
         }
 

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Items/Cannon.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Items/Cannon.cs
@@ -133,7 +133,7 @@ namespace Server.Engines.Quests.Haven
             var version = reader.ReadInt();
 
             CannonDirection = (CannonDirection)reader.ReadEncodedInt();
-            Canoneer = (MilitiaCanoneer)reader.ReadMobile();
+            Canoneer = (MilitiaCanoneer)reader.ReadEntity<Mobile>();
         }
     }
 

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Items/SchmendrickApprenticeCorpse.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Items/SchmendrickApprenticeCorpse.cs
@@ -205,7 +205,7 @@ namespace Server.Engines.Quests.Haven
 
             var version = reader.ReadInt();
 
-            m_Lantern = (Lantern)reader.ReadItem();
+            m_Lantern = (Lantern)reader.ReadEntity<Item>();
         }
     }
 }

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Objectives.cs
@@ -429,7 +429,7 @@ namespace Server.Engines.Quests.Haven
         {
             var version = reader.ReadEncodedInt();
 
-            CorpseWithBone = (Container)reader.ReadItem();
+            CorpseWithBone = (Container)reader.ReadEntity<Item>();
         }
 
         public override void ChildSerialize(IGenericWriter writer)

--- a/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
@@ -90,7 +90,7 @@ namespace Server.Engines.Quests.Hag
                     }
                 case 0:
                     {
-                        Corpse = (Corpse)reader.ReadItem();
+                        Corpse = (Corpse)reader.ReadEntity<Item>();
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
@@ -981,7 +981,7 @@ namespace Server.Engines.Spawners
                 case 3:
                 case 2:
                     {
-                        WayPoint = reader.ReadItem() as WayPoint;
+                        WayPoint = reader.ReadEntity<WayPoint>();
 
                         goto case 1;
                     }
@@ -1040,23 +1040,27 @@ namespace Server.Engines.Spawners
 
                             for (var i = 0; i < count; ++i)
                             {
-                                if (reader.ReadEntity() is ISpawnable e)
+                                var e = reader.ReadEntity<ISpawnable>();
+
+                                if (e == null)
                                 {
-                                    if (e is BaseCreature creature)
-                                    {
-                                        creature.RemoveIfUntamed = true;
-                                    }
+                                    continue;
+                                }
 
-                                    e.Spawner = this;
+                                if (e is BaseCreature creature)
+                                {
+                                    creature.RemoveIfUntamed = true;
+                                }
 
-                                    for (var j = 0; j < Entries.Count; j++)
+                                e.Spawner = this;
+
+                                for (var j = 0; j < Entries.Count; j++)
+                                {
+                                    if (AssemblyHandler.FindFirstTypeForName(Entries[j].SpawnedName) == e.GetType())
                                     {
-                                        if (AssemblyHandler.FindFirstTypeForName(Entries[j].SpawnedName) == e.GetType())
-                                        {
-                                            Entries[j].Spawned.Add(e);
-                                            Spawned.Add(e, Entries[j]);
-                                            break;
-                                        }
+                                        Entries[j].Spawned.Add(e);
+                                        Spawned.Add(e, Entries[j]);
+                                        break;
                                     }
                                 }
                             }

--- a/Projects/UOContent/Engines/Spawners/SpawnerEntry.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnerEntry.cs
@@ -32,7 +32,9 @@ namespace Server.Engines.Spawners
 
             for (var i = 0; i < count; ++i)
             {
-                if (reader.ReadEntity() is ISpawnable e)
+                var e = reader.ReadEntity<ISpawnable>();
+
+                if (e != null)
                 {
                     e.Spawner = parent;
 

--- a/Projects/UOContent/Engines/VeteranRewards/Character Statue Maker/CharacterStatue.cs
+++ b/Projects/UOContent/Engines/VeteranRewards/Character Statue Maker/CharacterStatue.cs
@@ -233,10 +233,10 @@ namespace Server.Mobiles
             m_Pose = (StatuePose)reader.ReadInt();
             m_Material = (StatueMaterial)reader.ReadInt();
 
-            m_SculptedBy = reader.ReadMobile();
+            m_SculptedBy = reader.ReadEntity<Mobile>();
             SculptedOn = reader.ReadDateTime();
 
-            Plinth = reader.ReadItem() as CharacterStatuePlinth;
+            Plinth = reader.ReadEntity<CharacterStatuePlinth>();
             IsRewardItem = reader.ReadBool();
 
             InvalidatePose();
@@ -581,7 +581,7 @@ namespace Server.Mobiles
                 m_Type = (StatueType)reader.ReadInt();
             }
 
-            Statue = reader.ReadMobile() as CharacterStatue;
+            Statue = reader.ReadEntity<CharacterStatue>();
             m_IsRewardItem = reader.ReadBool();
         }
     }

--- a/Projects/UOContent/Engines/VeteranRewards/Character Statue Maker/CharacterStatuePlinth.cs
+++ b/Projects/UOContent/Engines/VeteranRewards/Character Statue Maker/CharacterStatuePlinth.cs
@@ -97,7 +97,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            m_Statue = reader.ReadMobile() as CharacterStatue;
+            m_Statue = reader.ReadEntity<CharacterStatue>();
 
             if (m_Statue?.SculptedBy == null || Map == Map.Internal)
             {

--- a/Projects/UOContent/Holiday Stuff/Halloween/2012/Engines/PlayerZombies.cs
+++ b/Projects/UOContent/Holiday Stuff/Halloween/2012/Engines/PlayerZombies.cs
@@ -262,7 +262,7 @@ namespace Server.Engines.Events
             base.Serialize(writer);
             writer.Write(0);
 
-            writer.WriteMobile(m_DeadPlayer);
+            writer.Write(m_DeadPlayer);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -270,7 +270,7 @@ namespace Server.Engines.Events
             base.Deserialize(reader);
             var version = reader.ReadInt();
 
-            m_DeadPlayer = reader.ReadMobile<PlayerMobile>();
+            m_DeadPlayer = reader.ReadEntity<PlayerMobile>();
         }
     }
 }

--- a/Projects/UOContent/Items/Addons/AddonComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonComponent.cs
@@ -260,7 +260,7 @@ namespace Server.Items
                 case 1:
                 case 0:
                     {
-                        Addon = reader.ReadItem() as BaseAddon;
+                        Addon = reader.ReadEntity<BaseAddon>();
                         Offset = reader.ReadPoint3D();
 
                         Addon?.OnComponentLoaded(this);

--- a/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
@@ -112,7 +112,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            Addon = reader.ReadItem() as BaseAddonContainer;
+            Addon = reader.ReadEntity<BaseAddonContainer>();
             Offset = reader.ReadPoint3D();
 
             Addon?.OnComponentLoaded(this);

--- a/Projects/UOContent/Items/Addons/BallotBox.cs
+++ b/Projects/UOContent/Items/Addons/BallotBox.cs
@@ -105,8 +105,11 @@ namespace Server.Items
                 writer.Write(Topic[i]);
             }
 
-            writer.Write(Yes, true);
-            writer.Write(No, true);
+            Yes.Tidy();
+            writer.Write(Yes);
+
+            No.Tidy();
+            writer.Write(No);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -122,8 +125,8 @@ namespace Server.Items
                 Topic[i] = reader.ReadString();
             }
 
-            Yes = reader.ReadStrongMobileList();
-            No = reader.ReadStrongMobileList();
+            Yes = reader.ReadEntityList<Mobile>();
+            No = reader.ReadEntityList<Mobile>();
         }
 
         private class InternalGump : Gump

--- a/Projects/UOContent/Items/Addons/BaseAddon.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddon.cs
@@ -283,7 +283,7 @@ namespace Server.Items
 
             writer.Write(1); // version
 
-            writer.WriteItemList(Components);
+            writer.Write(Components);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -297,7 +297,7 @@ namespace Server.Items
                 case 1:
                 case 0:
                     {
-                        Components = reader.ReadStrongItemList<AddonComponent>();
+                        Components = reader.ReadEntityList<AddonComponent>();
                         break;
                     }
             }

--- a/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
@@ -192,7 +192,7 @@ namespace Server.Items
 
             writer.Write(0); // version
 
-            writer.WriteItemList(Components);
+            writer.Write(Components);
             writer.Write((int)m_Resource);
         }
 
@@ -202,7 +202,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            Components = reader.ReadStrongItemList<AddonContainerComponent>();
+            Components = reader.ReadEntityList<AddonContainerComponent>();
             m_Resource = (CraftResource)reader.ReadInt();
 
             AddonComponent.ApplyLightTo(this);

--- a/Projects/UOContent/Items/Addons/SHTeleporter.cs
+++ b/Projects/UOContent/Items/Addons/SHTeleporter.cs
@@ -115,7 +115,7 @@ namespace Server.Items
             var version = reader.ReadInt();
 
             m_Active = reader.ReadBool();
-            m_TeleDest = reader.ReadItem() as SHTeleComponent;
+            m_TeleDest = reader.ReadEntity<SHTeleComponent>();
             TeleOffset = reader.ReadPoint3D();
         }
     }
@@ -302,10 +302,10 @@ namespace Server.Items
 
             External = reader.ReadBool();
 
-            UpTele = (SHTeleComponent)reader.ReadItem();
-            RightTele = (SHTeleComponent)reader.ReadItem();
-            DownTele = (SHTeleComponent)reader.ReadItem();
-            LeftTele = (SHTeleComponent)reader.ReadItem();
+            UpTele = (SHTeleComponent)reader.ReadEntity<Item>();
+            RightTele = (SHTeleComponent)reader.ReadEntity<Item>();
+            DownTele = (SHTeleComponent)reader.ReadEntity<Item>();
+            LeftTele = (SHTeleComponent)reader.ReadEntity<Item>();
         }
 
         public class SHTeleporterCreator

--- a/Projects/UOContent/Items/Addons/SolenAntHole.cs
+++ b/Projects/UOContent/Items/Addons/SolenAntHole.cs
@@ -179,7 +179,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 
-            writer.WriteMobileList(m_Spawned);
+            writer.Write(m_Spawned);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -188,7 +188,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            m_Spawned = reader.ReadStrongMobileList<Mobile>();
+            m_Spawned = reader.ReadEntityList<Mobile>();
         }
     }
 }

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -1233,7 +1233,7 @@ namespace Server.Items
 
                         if (GetSaveFlag(flags, SaveFlag.Crafter))
                         {
-                            m_Crafter = reader.ReadMobile();
+                            m_Crafter = reader.ReadEntity<Mobile>();
                         }
 
                         if (GetSaveFlag(flags, SaveFlag.Quality))
@@ -1394,7 +1394,7 @@ namespace Server.Items
                         m_ArmorBase = reader.ReadInt();
                         m_MaxHitPoints = reader.ReadInt();
                         m_HitPoints = reader.ReadInt();
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
                         m_Quality = (ArmorQuality)reader.ReadInt();
                         m_Durability = (ArmorDurabilityLevel)reader.ReadInt();
                         m_Protection = (ArmorProtectionLevel)reader.ReadInt();

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -1087,7 +1087,7 @@ namespace Server.Items
 
                         if (GetSaveFlag(flags, SaveFlag.Crafter))
                         {
-                            m_Crafter = reader.ReadMobile();
+                            m_Crafter = reader.ReadEntity<Mobile>();
                         }
 
                         if (GetSaveFlag(flags, SaveFlag.Quality))
@@ -1137,7 +1137,7 @@ namespace Server.Items
                     }
                 case 1:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
                         m_Quality = (ClothingQuality)reader.ReadInt();
                         break;
                     }

--- a/Projects/UOContent/Items/Construction/Ankhs.cs
+++ b/Projects/UOContent/Items/Construction/Ankhs.cs
@@ -201,7 +201,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -292,7 +292,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as AnkhWest;
+                m_Item = reader.ReadEntity<AnkhWest>();
             }
         }
     }
@@ -388,7 +388,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         [TypeAlias("Server.Items.AnkhEast+InternalItem")]
@@ -481,7 +481,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as AnkhNorth;
+                m_Item = reader.ReadEntity<AnkhNorth>();
             }
         }
     }

--- a/Projects/UOContent/Items/Construction/Decorative/DecorativeWeapon.cs
+++ b/Projects/UOContent/Items/Construction/Decorative/DecorativeWeapon.cs
@@ -154,7 +154,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -210,7 +210,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as DecorativeSwordNorth;
+                m_Item = reader.ReadEntity<DecorativeSwordNorth>();
             }
         }
     }
@@ -269,7 +269,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -325,7 +325,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as DecorativeSwordWest;
+                m_Item = reader.ReadEntity<DecorativeSwordWest>();
             }
         }
     }
@@ -384,7 +384,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -440,7 +440,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as DecorativeDAxeNorth;
+                m_Item = reader.ReadEntity<DecorativeDAxeNorth>();
             }
         }
     }
@@ -499,7 +499,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -555,7 +555,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as DecorativeDAxeWest;
+                m_Item = reader.ReadEntity<DecorativeDAxeWest>();
             }
         }
     }

--- a/Projects/UOContent/Items/Construction/Decorative/Tapestry.cs
+++ b/Projects/UOContent/Items/Construction/Decorative/Tapestry.cs
@@ -54,7 +54,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -110,7 +110,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry1N;
+                m_Item = reader.ReadEntity<Tapestry1N>();
             }
         }
     }
@@ -169,7 +169,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -225,7 +225,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry2N;
+                m_Item = reader.ReadEntity<Tapestry2N>();
             }
         }
     }
@@ -284,7 +284,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -340,7 +340,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry2W;
+                m_Item = reader.ReadEntity<Tapestry2W>();
             }
         }
     }
@@ -399,7 +399,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -455,7 +455,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry3N;
+                m_Item = reader.ReadEntity<Tapestry3N>();
             }
         }
     }
@@ -514,7 +514,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -570,7 +570,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry3W;
+                m_Item = reader.ReadEntity<Tapestry3W>();
             }
         }
     }
@@ -629,7 +629,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -685,7 +685,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry4N;
+                m_Item = reader.ReadEntity<Tapestry4N>();
             }
         }
     }
@@ -744,7 +744,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -800,7 +800,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry4W;
+                m_Item = reader.ReadEntity<Tapestry4W>();
             }
         }
     }
@@ -859,7 +859,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -915,7 +915,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry5N;
+                m_Item = reader.ReadEntity<Tapestry5N>();
             }
         }
     }
@@ -974,7 +974,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -1030,7 +1030,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry5W;
+                m_Item = reader.ReadEntity<Tapestry5W>();
             }
         }
     }
@@ -1089,7 +1089,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -1145,7 +1145,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry6N;
+                m_Item = reader.ReadEntity<Tapestry6N>();
             }
         }
     }
@@ -1204,7 +1204,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
+            m_Item = reader.ReadEntity<InternalItem>();
         }
 
         private class InternalItem : Item
@@ -1260,7 +1260,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as Tapestry6W;
+                m_Item = reader.ReadEntity<Tapestry6W>();
             }
         }
     }

--- a/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
+++ b/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
@@ -543,7 +543,7 @@ namespace Server.Items
                         OpenedSound = reader.ReadInt();
                         ClosedSound = reader.ReadInt();
                         Offset = reader.ReadPoint3D();
-                        m_Link = reader.ReadItem() as BaseDoor;
+                        m_Link = reader.ReadEntity<BaseDoor>();
 
                         m_Timer = new InternalTimer(this);
 

--- a/Projects/UOContent/Items/Containers/Strongbox.cs
+++ b/Projects/UOContent/Items/Containers/Strongbox.cs
@@ -70,8 +70,8 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        m_Owner = reader.ReadMobile();
-                        m_House = reader.ReadItem() as BaseHouse;
+                        m_Owner = reader.ReadEntity<Mobile>();
+                        m_House = reader.ReadEntity<BaseHouse>();
 
                         break;
                     }

--- a/Projects/UOContent/Items/Containers/TreasureMapChest.cs
+++ b/Projects/UOContent/Items/Containers/TreasureMapChest.cs
@@ -414,14 +414,16 @@ namespace Server.Items
 
             writer.Write(2); // version
 
-            writer.Write(Guardians, true);
+            Guardians.Tidy();
+            writer.Write(Guardians);
             writer.Write(Temporary);
 
             writer.Write(Owner);
 
             writer.Write(Level);
             writer.WriteDeltaTime(DeleteTime);
-            writer.Write(m_Lifted, true);
+            m_Lifted.Tidy();
+            writer.Write(m_Lifted);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -434,14 +436,14 @@ namespace Server.Items
             {
                 case 2:
                     {
-                        Guardians = reader.ReadStrongMobileList();
+                        Guardians = reader.ReadEntityList<Mobile>();
                         Temporary = reader.ReadBool();
 
                         goto case 1;
                     }
                 case 1:
                     {
-                        Owner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<Mobile>();
 
                         goto case 0;
                     }
@@ -449,7 +451,7 @@ namespace Server.Items
                     {
                         Level = reader.ReadInt();
                         DeleteTime = reader.ReadDeltaTime();
-                        m_Lifted = reader.ReadStrongItemList();
+                        m_Lifted = reader.ReadEntityList<Item>();
 
                         if (version < 2)
                         {

--- a/Projects/UOContent/Items/Decoration Artifacts/StealableArtifactsSpawner.cs
+++ b/Projects/UOContent/Items/Decoration Artifacts/StealableArtifactsSpawner.cs
@@ -296,7 +296,7 @@ namespace Server.Items
 
             for (var i = 0; i < length; i++)
             {
-                var item = reader.ReadItem();
+                var item = reader.ReadEntity<Item>();
                 var nextRespawn = reader.ReadDeltaTime();
 
                 if (i < m_Artifacts.Length)

--- a/Projects/UOContent/Items/Deeds/CommodityDeed.cs
+++ b/Projects/UOContent/Items/Deeds/CommodityDeed.cs
@@ -61,7 +61,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            Commodity = reader.ReadItem();
+            Commodity = reader.ReadEntity<Item>();
 
             switch (version)
             {

--- a/Projects/UOContent/Items/Deeds/DragonBardingDeed.cs
+++ b/Projects/UOContent/Items/Deeds/DragonBardingDeed.cs
@@ -162,7 +162,7 @@ namespace Server.Items
                 case 0:
                     {
                         m_Exceptional = reader.ReadBool();
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
 
                         if (version < 1)
                         {

--- a/Projects/UOContent/Items/Deeds/NewPlayerTicket.cs
+++ b/Projects/UOContent/Items/Deeds/NewPlayerTicket.cs
@@ -52,7 +52,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        Owner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<Mobile>();
                         break;
                     }
             }

--- a/Projects/UOContent/Items/Food/Beverage.cs
+++ b/Projects/UOContent/Items/Food/Beverage.cs
@@ -1128,7 +1128,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        Poisoner = reader.ReadMobile();
+                        Poisoner = reader.ReadEntity<Mobile>();
                         goto case 0;
                     }
                 case 0:

--- a/Projects/UOContent/Items/Food/Food.cs
+++ b/Projects/UOContent/Items/Food/Food.cs
@@ -168,7 +168,7 @@ namespace Server.Items
                     }
                 case 4:
                     {
-                        Poisoner = reader.ReadMobile();
+                        Poisoner = reader.ReadEntity<Mobile>();
                         goto case 3;
                     }
             }

--- a/Projects/UOContent/Items/Games/BasePiece.cs
+++ b/Projects/UOContent/Items/Games/BasePiece.cs
@@ -32,7 +32,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        Board = (BaseBoard)reader.ReadItem();
+                        Board = (BaseBoard)reader.ReadEntity<Item>();
 
                         if (Board == null || Parent == null)
                         {

--- a/Projects/UOContent/Items/Games/Mahjong/MahjongPlayers.cs
+++ b/Projects/UOContent/Items/Games/Mahjong/MahjongPlayers.cs
@@ -41,7 +41,7 @@ namespace Server.Engines.Mahjong
 
             for (var i = 0; i < seats; i++)
             {
-                m_Players[i] = reader.ReadMobile();
+                m_Players[i] = reader.ReadEntity<Mobile>();
                 m_PublicHand[i] = reader.ReadBool();
                 m_Scores[i] = reader.ReadInt();
             }

--- a/Projects/UOContent/Items/Guilds/GuildTeleporter.cs
+++ b/Projects/UOContent/Items/Guilds/GuildTeleporter.cs
@@ -44,7 +44,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        m_Stone = reader.ReadItem();
+                        m_Stone = reader.ReadEntity<Item>();
 
                         break;
                     }

--- a/Projects/UOContent/Items/Guilds/Guildstone.cs
+++ b/Projects/UOContent/Items/Guilds/Guildstone.cs
@@ -136,7 +136,7 @@ namespace Server.Items
                     }
                 case 1:
                     {
-                        Guild = reader.ReadGuild() as Guild;
+                        Guild = reader.ReadEntity<Guild>();
 
                         goto case 0;
                     }
@@ -372,7 +372,7 @@ namespace Server.Items
                         m_GuildName = reader.ReadString();
                         m_GuildAbbrev = reader.ReadString();
 
-                        Guild = reader.ReadGuild() as Guild;
+                        Guild = reader.ReadEntity<Guild>();
 
                         break;
                     }

--- a/Projects/UOContent/Items/Maps/TreasureMap.cs
+++ b/Projects/UOContent/Items/Maps/TreasureMap.cs
@@ -588,7 +588,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_CompletedBy = reader.ReadMobile();
+                        m_CompletedBy = reader.ReadEntity<Mobile>();
 
                         goto case 0;
                     }
@@ -596,7 +596,7 @@ namespace Server.Items
                     {
                         m_Level = reader.ReadInt();
                         m_Completed = reader.ReadBool();
-                        m_Decoder = reader.ReadMobile();
+                        m_Decoder = reader.ReadEntity<Mobile>();
                         m_Map = reader.ReadMap();
                         ChestLocation = reader.ReadPoint2D();
 

--- a/Projects/UOContent/Items/Misc/BulletinBoards.cs
+++ b/Projects/UOContent/Items/Misc/BulletinBoards.cs
@@ -462,12 +462,12 @@ namespace Server.Items
                 case 1:
                 case 0:
                     {
-                        Poster = reader.ReadMobile();
+                        Poster = reader.ReadEntity<Mobile>();
                         Subject = reader.ReadString();
                         Time = reader.ReadDateTime();
                         LastPostTime = reader.ReadDateTime();
                         var hasThread = reader.ReadBool();
-                        Thread = reader.ReadItem() as BulletinMessage;
+                        Thread = reader.ReadEntity<BulletinMessage>();
                         PostedName = reader.ReadString();
                         PostedBody = reader.ReadInt();
                         PostedHue = reader.ReadInt();

--- a/Projects/UOContent/Items/Misc/CommunicationCrystals.cs
+++ b/Projects/UOContent/Items/Misc/CommunicationCrystals.cs
@@ -171,7 +171,7 @@ namespace Server.Items
             writer.WriteEncodedInt(0); // version
 
             writer.WriteEncodedInt(m_Charges);
-            writer.WriteItemList(Receivers);
+            writer.Write(Receivers);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -181,7 +181,7 @@ namespace Server.Items
             var version = reader.ReadEncodedInt();
 
             m_Charges = reader.ReadEncodedInt();
-            Receivers = reader.ReadStrongItemList<ReceiverCrystal>();
+            Receivers = reader.ReadEntityList<ReceiverCrystal>();
         }
 
         private class InternalTarget : Target
@@ -394,7 +394,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 
-            writer.WriteItem(m_Sender);
+            writer.Write(m_Sender);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -403,7 +403,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            m_Sender = reader.ReadItem<BroadcastCrystal>();
+            m_Sender = reader.ReadEntity<BroadcastCrystal>();
         }
 
         private class InternalTarget : Target

--- a/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
@@ -628,7 +628,7 @@ namespace Server.Items
                     {
                         if (reader.ReadBool())
                         {
-                            RestoreEquip = reader.ReadStrongItemList();
+                            RestoreEquip = reader.ReadEntityList<Item>();
                         }
 
                         goto case 11;
@@ -644,7 +644,7 @@ namespace Server.Items
 
                         for (var i = 0; i < count; ++i)
                         {
-                            var item = reader.ReadItem();
+                            var item = reader.ReadEntity<Item>();
 
                             if (reader.ReadBool())
                             {
@@ -661,11 +661,11 @@ namespace Server.Items
                             BeginDecay(reader.ReadDeltaTime() - DateTime.UtcNow);
                         }
 
-                        Looters = reader.ReadStrongMobileList();
-                        Killer = reader.ReadMobile();
+                        Looters = reader.ReadEntityList<Mobile>();
+                        Killer = reader.ReadEntity<Mobile>();
 
-                        Aggressors = reader.ReadStrongMobileList();
-                        Owner = reader.ReadMobile();
+                        Aggressors = reader.ReadEntityList<Mobile>();
+                        Owner = reader.ReadEntity<Mobile>();
 
                         m_CorpseName = reader.ReadString();
 
@@ -673,7 +673,7 @@ namespace Server.Items
                         reader.ReadInt(); // guild reserve
                         Kills = reader.ReadInt();
 
-                        EquipItems = reader.ReadStrongItemList();
+                        EquipItems = reader.ReadEntityList<Item>();
                         break;
                     }
                 case 10:
@@ -688,7 +688,7 @@ namespace Server.Items
 
                         for (var i = 0; i < count; ++i)
                         {
-                            var item = reader.ReadItem();
+                            var item = reader.ReadEntity<Item>();
 
                             if (reader.ReadBool())
                             {
@@ -719,8 +719,8 @@ namespace Server.Items
                     }
                 case 6:
                     {
-                        Looters = reader.ReadStrongMobileList();
-                        Killer = reader.ReadMobile();
+                        Looters = reader.ReadEntityList<Mobile>();
+                        Killer = reader.ReadEntity<Mobile>();
 
                         goto case 5;
                     }
@@ -732,13 +732,13 @@ namespace Server.Items
                     }
                 case 4:
                     {
-                        Aggressors = reader.ReadStrongMobileList();
+                        Aggressors = reader.ReadEntityList<Mobile>();
 
                         goto case 3;
                     }
                 case 3:
                     {
-                        Owner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<Mobile>();
 
                         goto case 2;
                     }
@@ -781,7 +781,7 @@ namespace Server.Items
                         Kills = reader.ReadInt();
                         SetFlag(CorpseFlag.Criminal, reader.ReadBool());
 
-                        EquipItems = reader.ReadStrongItemList();
+                        EquipItems = reader.ReadEntityList<Item>();
 
                         break;
                     }

--- a/Projects/UOContent/Items/Misc/EffectController.cs
+++ b/Projects/UOContent/Items/Misc/EffectController.cs
@@ -245,7 +245,7 @@ namespace Server.Items
 
                         m_Source = ReadEntity(reader);
                         m_Target = ReadEntity(reader);
-                        Sequence = reader.ReadItem() as EffectController;
+                        Sequence = reader.ReadEntity<EffectController>();
 
                         FixedDirection = reader.ReadBool();
                         Explodes = reader.ReadBool();

--- a/Projects/UOContent/Items/Misc/Key.cs
+++ b/Projects/UOContent/Items/Misc/Key.cs
@@ -172,7 +172,7 @@ namespace Server.Items
                     }
                 case 1:
                     {
-                        Link = reader.ReadItem();
+                        Link = reader.ReadEntity<Item>();
 
                         goto case 0;
                     }

--- a/Projects/UOContent/Items/Misc/KeyRing.cs
+++ b/Projects/UOContent/Items/Misc/KeyRing.cs
@@ -155,7 +155,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 
-            writer.WriteItemList(Keys);
+            writer.Write(Keys);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -164,7 +164,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            Keys = reader.ReadStrongItemList<Key>();
+            Keys = reader.ReadEntityList<Key>();
         }
 
         private class InternalTarget : Target

--- a/Projects/UOContent/Items/Misc/PlayerBulletinBoards.cs
+++ b/Projects/UOContent/Items/Misc/PlayerBulletinBoards.cs
@@ -347,7 +347,7 @@ namespace Server.Items
                 case 0:
                     {
                         Time = reader.ReadDateTime();
-                        Poster = reader.ReadMobile();
+                        Poster = reader.ReadEntity<Mobile>();
                         Message = reader.ReadString();
                         break;
                     }

--- a/Projects/UOContent/Items/Misc/Teleporter.cs
+++ b/Projects/UOContent/Items/Misc/Teleporter.cs
@@ -930,7 +930,7 @@ namespace Server.Items
 
             for (var i = 0; i < count; ++i)
             {
-                var m = reader.ReadMobile();
+                var m = reader.ReadEntity<Mobile>();
                 var end = reader.ReadDateTime();
 
                 StartTimer(m, end - DateTime.UtcNow);
@@ -973,7 +973,7 @@ namespace Server.Items
 
             writer.Write(0); // version
 
-            writer.WriteItem(Teleporter);
+            writer.Write(Teleporter);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -982,7 +982,7 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            Teleporter = reader.ReadItem<TimeoutTeleporter>();
+            Teleporter = reader.ReadEntity<TimeoutTeleporter>();
         }
     }
 

--- a/Projects/UOContent/Items/Misc/Waypoint.cs
+++ b/Projects/UOContent/Items/Misc/Waypoint.cs
@@ -83,7 +83,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        m_Next = reader.ReadItem() as WayPoint;
+                        m_Next = reader.ReadEntity<WayPoint>();
                         break;
                     }
             }

--- a/Projects/UOContent/Items/Quivers/BaseQuiver.cs
+++ b/Projects/UOContent/Items/Quivers/BaseQuiver.cs
@@ -532,7 +532,7 @@ namespace Server.Items
 
             if (GetSaveFlag(flags, SaveFlag.Crafter))
             {
-                m_Crafter = reader.ReadMobile();
+                m_Crafter = reader.ReadEntity<Mobile>();
             }
 
             if (GetSaveFlag(flags, SaveFlag.Quality))

--- a/Projects/UOContent/Items/Resources/Fishing/BigFish.cs
+++ b/Projects/UOContent/Items/Resources/Fishing/BigFish.cs
@@ -72,7 +72,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_Fisher = reader.ReadMobile();
+                        m_Fisher = reader.ReadEntity<Mobile>();
                         break;
                     }
                 case 0:

--- a/Projects/UOContent/Items/Skill Items/Blacksmith Items/Misc/LargeForge.cs
+++ b/Projects/UOContent/Items/Skill Items/Blacksmith Items/Misc/LargeForge.cs
@@ -71,8 +71,8 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
-            m_Item2 = reader.ReadItem() as InternalItem2;
+            m_Item = reader.ReadEntity<InternalItem>();
+            m_Item2 = reader.ReadEntity<InternalItem2>();
         }
 
         [Forge]
@@ -129,7 +129,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as LargeForgeWest;
+                m_Item = reader.ReadEntity<LargeForgeWest>();
             }
         }
 
@@ -187,7 +187,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as LargeForgeWest;
+                m_Item = reader.ReadEntity<LargeForgeWest>();
             }
         }
     }
@@ -261,8 +261,8 @@ namespace Server.Items
 
             var version = reader.ReadInt();
 
-            m_Item = reader.ReadItem() as InternalItem;
-            m_Item2 = reader.ReadItem() as InternalItem2;
+            m_Item = reader.ReadEntity<InternalItem>();
+            m_Item2 = reader.ReadEntity<InternalItem2>();
         }
 
         [Forge]
@@ -319,7 +319,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as LargeForgeEast;
+                m_Item = reader.ReadEntity<LargeForgeEast>();
             }
         }
 
@@ -377,7 +377,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                m_Item = reader.ReadItem() as LargeForgeEast;
+                m_Item = reader.ReadEntity<LargeForgeEast>();
             }
         }
     }

--- a/Projects/UOContent/Items/Skill Items/Carpenter Items/TaxidermyKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Carpenter Items/TaxidermyKit.cs
@@ -293,7 +293,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_Hunter = reader.ReadMobile();
+                        m_Hunter = reader.ReadEntity<Mobile>();
                         m_AnimalWeight = reader.ReadInt();
                         goto case 0;
                     }
@@ -468,7 +468,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_Hunter = reader.ReadMobile();
+                        m_Hunter = reader.ReadEntity<Mobile>();
                         m_AnimalWeight = reader.ReadInt();
                         goto case 0;
                     }

--- a/Projects/UOContent/Items/Skill Items/Harvest Tools/BaseHarvestTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Harvest Tools/BaseHarvestTool.cs
@@ -203,7 +203,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
                         m_Quality = (ToolQuality)reader.ReadInt();
                         goto case 0;
                     }

--- a/Projects/UOContent/Items/Skill Items/Magical/Misc/RecallRune.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Misc/RecallRune.cs
@@ -119,7 +119,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_House = reader.ReadItem() as BaseHouse;
+                        m_House = reader.ReadEntity<BaseHouse>();
                         goto case 0;
                     }
                 case 0:

--- a/Projects/UOContent/Items/Skill Items/Magical/Potions/Conflagration Potions/BaseConflagrationPotion.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Potions/Conflagration Potions/BaseConflagrationPotion.cs
@@ -249,7 +249,7 @@ namespace Server.Items
 
                 var version = reader.ReadInt();
 
-                From = reader.ReadMobile();
+                From = reader.ReadEntity<Mobile>();
                 m_End = reader.ReadDateTime();
                 m_MinDamage = reader.ReadInt();
                 m_MaxDamage = reader.ReadInt();

--- a/Projects/UOContent/Items/Skill Items/Magical/Runebook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Runebook.cs
@@ -201,7 +201,7 @@ namespace Server.Items
                     }
                 case 2:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
                         goto case 1;
                     }
                 case 1:
@@ -476,7 +476,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        House = reader.ReadItem() as BaseHouse;
+                        House = reader.ReadEntity<BaseHouse>();
                         goto case 0;
                     }
                 case 0:

--- a/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
@@ -929,7 +929,7 @@ namespace Server.Items
                     }
                 case 3:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
                         goto case 2;
                     }
                 case 2:

--- a/Projects/UOContent/Items/Skill Items/Misc/RepairDeed.cs
+++ b/Projects/UOContent/Items/Skill Items/Misc/RepairDeed.cs
@@ -218,7 +218,7 @@ namespace Server.Items
                     {
                         m_Skill = (RepairSkillType)reader.ReadInt();
                         m_SkillLevel = reader.ReadDouble();
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
 
                         break;
                     }

--- a/Projects/UOContent/Items/Skill Items/Musical Instruments/BaseInstrument.cs
+++ b/Projects/UOContent/Items/Skill Items/Musical Instruments/BaseInstrument.cs
@@ -517,7 +517,7 @@ namespace Server.Items
                     }
                 case 2:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
 
                         m_Quality = (InstrumentQuality)reader.ReadEncodedInt();
                         m_Slayer = (SlayerName)reader.ReadEncodedInt();
@@ -532,7 +532,7 @@ namespace Server.Items
                     }
                 case 1:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
 
                         m_Quality = (InstrumentQuality)reader.ReadEncodedInt();
                         m_Slayer = (SlayerName)reader.ReadEncodedInt();

--- a/Projects/UOContent/Items/Skill Items/Thief/DisguisePersistance.cs
+++ b/Projects/UOContent/Items/Skill Items/Thief/DisguisePersistance.cs
@@ -58,7 +58,7 @@ namespace Server.Items
 
                         for (var i = 0; i < count; ++i)
                         {
-                            var m = reader.ReadMobile();
+                            var m = reader.ReadEntity<Mobile>();
                             DisguiseTimers.CreateTimer(m, reader.ReadTimeSpan());
                             m.NameMod = reader.ReadString();
                         }

--- a/Projects/UOContent/Items/Skill Items/Tools/BaseTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/BaseTool.cs
@@ -204,7 +204,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
                         m_Quality = (ToolQuality)reader.ReadInt();
                         goto case 0;
                     }

--- a/Projects/UOContent/Items/Special/Holiday/Christmas/HolidayTree.cs
+++ b/Projects/UOContent/Items/Special/Holiday/Christmas/HolidayTree.cs
@@ -151,7 +151,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        Placer = reader.ReadMobile();
+                        Placer = reader.ReadEntity<Mobile>();
 
                         goto case 0;
                     }
@@ -163,7 +163,7 @@ namespace Server.Items
 
                         for (var i = 0; i < count; ++i)
                         {
-                            var item = reader.ReadItem();
+                            var item = reader.ReadEntity<Item>();
 
                             if (item != null)
                             {
@@ -288,7 +288,7 @@ namespace Server.Items
                 {
                     case 0:
                         {
-                            m_Tree = reader.ReadItem() as HolidayTree;
+                            m_Tree = reader.ReadEntity<HolidayTree>();
 
                             if (m_Tree == null)
                             {

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleDeed.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleDeed.cs
@@ -148,7 +148,7 @@ namespace Server.Items
             {
                 case 1:
                     {
-                        m_Stone = reader.ReadItem<HouseRaffleStone>();
+                        m_Stone = reader.ReadEntity<HouseRaffleStone>();
 
                         goto case 0;
                     }
@@ -156,7 +156,7 @@ namespace Server.Items
                     {
                         m_PlotLocation = reader.ReadPoint3D();
                         m_Facet = reader.ReadMap();
-                        m_AwardedTo = reader.ReadMobile();
+                        m_AwardedTo = reader.ReadEntity<Mobile>();
 
                         break;
                     }

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -30,7 +30,7 @@ namespace Server.Items
                 case 1:
                 case 0:
                     {
-                        From = reader.ReadMobile();
+                        From = reader.ReadEntity<Mobile>();
                         Address = Utility.Intern(reader.ReadIPAddress());
                         Date = reader.ReadDateTime();
 
@@ -640,7 +640,7 @@ namespace Server.Items
                     }
                 case 1:
                     {
-                        Deed = reader.ReadItem<HouseRaffleDeed>();
+                        Deed = reader.ReadEntity<HouseRaffleDeed>();
 
                         goto case 0;
                     }
@@ -651,7 +651,7 @@ namespace Server.Items
                         m_Bounds = reader.ReadRect2D();
                         m_Facet = reader.ReadMap();
 
-                        m_Winner = reader.ReadMobile();
+                        m_Winner = reader.ReadEntity<Mobile>();
 
                         m_TicketPrice = reader.ReadInt();
                         m_Started = reader.ReadDateTime();

--- a/Projects/UOContent/Items/Special/Mutation Core/PlagueBeastInnard.cs
+++ b/Projects/UOContent/Items/Special/Mutation Core/PlagueBeastInnard.cs
@@ -151,7 +151,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 
-            writer.WriteItem(Organ);
+            writer.Write(Organ);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -160,7 +160,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            Organ = reader.ReadItem<PlagueBeastOrgan>();
+            Organ = reader.ReadEntity<PlagueBeastOrgan>();
         }
     }
 }

--- a/Projects/UOContent/Items/Special/Mutation Core/PlagueBeastOrgans.cs
+++ b/Projects/UOContent/Items/Special/Mutation Core/PlagueBeastOrgans.cs
@@ -90,7 +90,7 @@ namespace Server.Items
 
             writer.WriteEncodedInt(0); // version
 
-            writer.WriteItemList(Components);
+            writer.Write(Components);
             writer.Write(BrainHue);
             writer.Write(Opened);
         }
@@ -101,7 +101,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            Components = reader.ReadStrongItemList<PlagueBeastComponent>();
+            Components = reader.ReadEntityList<PlagueBeastComponent>();
             BrainHue = reader.ReadInt();
             Opened = reader.ReadBool();
         }
@@ -466,7 +466,7 @@ namespace Server.Items
 
             var version = reader.ReadEncodedInt();
 
-            m_Gland = reader.ReadItem();
+            m_Gland = reader.ReadEntity<Item>();
         }
     }
 

--- a/Projects/UOContent/Items/Special/Solen Items/BallOfSummoning.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BallOfSummoning.cs
@@ -358,7 +358,7 @@ namespace Server.Items
                 case 0:
                     {
                         m_Charges = Math.Min(reader.ReadEncodedInt(), MaxCharges);
-                        Pet = (BaseCreature)reader.ReadMobile();
+                        Pet = (BaseCreature)reader.ReadEntity<Mobile>();
                         PetName = reader.ReadString();
                         break;
                     }

--- a/Projects/UOContent/Items/Special/Solen Items/BraceletOfBinding.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BraceletOfBinding.cs
@@ -361,7 +361,7 @@ namespace Server.Items
                     {
                         m_Charges = Math.Min(reader.ReadEncodedInt(), MaxCharges);
                         m_Inscription = reader.ReadString();
-                        Bound = (BraceletOfBinding)reader.ReadItem();
+                        Bound = (BraceletOfBinding)reader.ReadEntity<Item>();
                         break;
                     }
             }

--- a/Projects/UOContent/Items/Special/Veteran Rewards/Brazier.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/Brazier.cs
@@ -134,7 +134,7 @@ namespace Server.Items
             var version = reader.ReadEncodedInt();
 
             m_IsRewardItem = reader.ReadBool();
-            m_Fire = reader.ReadItem();
+            m_Fire = reader.ReadEntity<Item>();
         }
     }
 

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -909,7 +909,7 @@ namespace Server.Items
                         // Backward compatibility
                         if (GetSaveFlag(flags, SaveFlag.Owner))
                         {
-                            BlessedFor = reader.ReadMobile();
+                            BlessedFor = reader.ReadEntity<Mobile>();
                         }
 
                         m_Protection = GetSaveFlag(flags, SaveFlag.Protection)

--- a/Projects/UOContent/Items/Traps/FlameSpurtTrap.cs
+++ b/Projects/UOContent/Items/Traps/FlameSpurtTrap.cs
@@ -162,7 +162,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        var item = reader.ReadItem();
+                        var item = reader.ReadEntity<Item>();
 
                         item?.Delete();
 

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -3906,7 +3906,7 @@ namespace Server.Items
 
                         if (GetSaveFlag(flags, SaveFlag.Crafter))
                         {
-                            m_Crafter = reader.ReadMobile();
+                            m_Crafter = reader.ReadEntity<Mobile>();
                         }
 
                         if (GetSaveFlag(flags, SaveFlag.Identified))
@@ -4165,7 +4165,7 @@ namespace Server.Items
                         m_DurabilityLevel = (WeaponDurabilityLevel)reader.ReadInt();
                         m_Quality = (WeaponQuality)reader.ReadInt();
 
-                        m_Crafter = reader.ReadMobile();
+                        m_Crafter = reader.ReadEntity<Mobile>();
 
                         m_Poison = Poison.Deserialize(reader);
                         m_PoisonCharges = reader.ReadInt();

--- a/Projects/UOContent/Misc/AutoSave.cs
+++ b/Projects/UOContent/Misc/AutoSave.cs
@@ -84,7 +84,7 @@ namespace Server.Misc
 
         public static void Save()
         {
-            if (AutoRestart.Restarting || !World.Running)
+            if (AutoRestart.Restarting || World.WorldState != WorldState.Running)
             {
                 return;
             }

--- a/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
@@ -189,8 +189,8 @@ namespace Server.Mobiles
                     }
                 case 0:
                     {
-                        m_Rider = reader.ReadMobile();
-                        InternalItem = reader.ReadItem();
+                        m_Rider = reader.ReadEntity<Mobile>();
+                        InternalItem = reader.ReadEntity<Item>();
 
                         if (InternalItem == null)
                         {
@@ -382,7 +382,7 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        m_Mount = reader.ReadMobile() as BaseMount;
+                        m_Mount = reader.ReadEntity<BaseMount>();
 
                         if (m_Mount == null)
                         {

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
@@ -256,7 +256,7 @@ namespace Server.Mobiles
                     {
                         m_MountedID = reader.ReadInt();
                         m_RegularID = reader.ReadInt();
-                        m_Rider = reader.ReadMobile();
+                        m_Rider = reader.ReadEntity<Mobile>();
 
                         if (m_MountedID == 0x3EA2)
                         {

--- a/Projects/UOContent/Mobiles/Animals/Mounts/SwampDragon.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/SwampDragon.cs
@@ -196,7 +196,7 @@ namespace Server.Mobiles
                 case 1:
                     {
                         m_BardingExceptional = reader.ReadBool();
-                        m_BardingCrafter = reader.ReadMobile();
+                        m_BardingCrafter = reader.ReadEntity<Mobile>();
                         m_HasBarding = reader.ReadBool();
                         m_BardingHP = reader.ReadInt();
                         m_BardingResource = (CraftResource)reader.ReadInt();

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -1777,7 +1777,8 @@ namespace Server.Mobiles
             writer.Write(EnergyDamage);
 
             // Version 8
-            writer.Write(Owners, true);
+            Owners.Tidy();
+            writer.Write(Owners);
 
             // Version 10
             writer.Write(IsDeadPet);
@@ -1798,7 +1799,8 @@ namespace Server.Mobiles
 
             if (hasFriends)
             {
-                writer.Write(Friends, true);
+                Friends.Tidy();
+                writer.Write(Friends);
             }
 
             // Version 14
@@ -1887,8 +1889,8 @@ namespace Server.Mobiles
                 FightMode = (FightMode)reader.ReadInt();
 
                 m_Controlled = reader.ReadBool();
-                m_ControlMaster = reader.ReadMobile();
-                ControlTarget = reader.ReadMobile();
+                m_ControlMaster = reader.ReadEntity<Mobile>();
+                ControlTarget = reader.ReadEntity<Mobile>();
                 ControlDest = reader.ReadPoint3D();
                 m_ControlOrder = (OrderType)reader.ReadInt();
 
@@ -1931,12 +1933,12 @@ namespace Server.Mobiles
 
             if (version >= 4)
             {
-                CurrentWayPoint = reader.ReadItem() as WayPoint;
+                CurrentWayPoint = reader.ReadEntity<WayPoint>();
             }
 
             if (version >= 5)
             {
-                m_SummonMaster = reader.ReadMobile();
+                m_SummonMaster = reader.ReadEntity<Mobile>();
             }
 
             if (version >= 6)
@@ -1968,7 +1970,7 @@ namespace Server.Mobiles
 
             if (version >= 8)
             {
-                Owners = reader.ReadStrongMobileList();
+                Owners = reader.ReadEntityList<Mobile>();
             }
             else
             {
@@ -2003,7 +2005,7 @@ namespace Server.Mobiles
 
             if (version >= 13 && reader.ReadBool())
             {
-                Friends = reader.ReadStrongMobileList();
+                Friends = reader.ReadEntityList<Mobile>();
             }
             else if (version < 13 && m_ControlOrder >= OrderType.Unfriend)
             {

--- a/Projects/UOContent/Mobiles/Guards/ArcherGuard.cs
+++ b/Projects/UOContent/Mobiles/Guards/ArcherGuard.cs
@@ -170,7 +170,7 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        m_Focus = reader.ReadMobile();
+                        m_Focus = reader.ReadEntity<Mobile>();
 
                         if (m_Focus != null)
                         {
@@ -309,7 +309,7 @@ namespace Server.Mobiles
                 else if (!m_Owner.CanSee( target ))
                 {
                   m_Shooting = false;
-        
+
                   if (!m_Owner.InRange( target, 2 ))
                   {
                     if (!m_Owner.Move( m_Owner.GetDirectionTo( target ) | Direction.Running ) && OutOfMaxDistance( target ))
@@ -327,7 +327,7 @@ namespace Server.Mobiles
                     m_Shooting = false;
                   else if (!m_Shooting && InMinDistance( target ))
                     m_Shooting = true;
-        
+
                   if (!m_Shooting)
                   {
                     if (m_Owner.InRange( target, 1 ))

--- a/Projects/UOContent/Mobiles/Guards/WarriorGuard.cs
+++ b/Projects/UOContent/Mobiles/Guards/WarriorGuard.cs
@@ -188,7 +188,7 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        m_Focus = reader.ReadMobile();
+                        m_Focus = reader.ReadEntity<Mobile>();
 
                         if (m_Focus != null)
                         {

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeastLord.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeastLord.cs
@@ -309,7 +309,7 @@ namespace Server.Mobiles
 
             var version = reader.ReadEncodedInt();
 
-            OpenedBy = reader.ReadMobile();
+            OpenedBy = reader.ReadEntity<Mobile>();
 
             if (reader.ReadBool())
             {

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -3005,7 +3005,7 @@ namespace Server.Mobiles
                     }
                 case 26:
                     {
-                        AutoStabled = reader.ReadStrongMobileList();
+                        AutoStabled = reader.ReadEntityList<Mobile>();
 
                         goto case 25;
                     }
@@ -3139,7 +3139,7 @@ namespace Server.Mobiles
                     {
                         if (version < 13)
                         {
-                            var paid = reader.ReadStrongItemList();
+                            var paid = reader.ReadEntityList<Item>();
 
                             for (var i = 0; i < paid.Count; ++i)
                             {
@@ -3182,7 +3182,7 @@ namespace Server.Mobiles
                     }
                 case 7:
                     {
-                        PermaFlags = reader.ReadStrongMobileList();
+                        PermaFlags = reader.ReadEntityList<Mobile>();
                         goto case 6;
                     }
                 case 6:
@@ -3198,7 +3198,7 @@ namespace Server.Mobiles
                 case 4:
                     {
                         LastJusticeLoss = reader.ReadDeltaTime();
-                        JusticeProtectors = reader.ReadStrongMobileList();
+                        JusticeProtectors = reader.ReadEntityList<Mobile>();
                         goto case 3;
                     }
                 case 3:
@@ -3318,7 +3318,8 @@ namespace Server.Mobiles
 
             writer.Write(PeacedUntil);
             writer.Write(AnkhNextUse);
-            writer.Write(AutoStabled, true);
+            AutoStabled.Tidy();
+            writer.Write(AutoStabled);
 
             if (m_AcquiredRecipes == null)
             {
@@ -3401,14 +3402,16 @@ namespace Server.Mobiles
             writer.Write(NpcGuildJoinTime);
             writer.Write(NpcGuildGameTime);
 
-            writer.Write(PermaFlags, true);
+            PermaFlags.Tidy();
+            writer.Write(PermaFlags);
 
             writer.Write(NextTailorBulkOrder);
 
             writer.Write(NextSmithBulkOrder);
 
             writer.WriteDeltaTime(LastJusticeLoss);
-            writer.Write(JusticeProtectors, true);
+            JusticeProtectors.Tidy();
+            writer.Write(JusticeProtectors);
 
             writer.WriteDeltaTime(LastSacrificeGain);
             writer.WriteDeltaTime(LastSacrificeLoss);

--- a/Projects/UOContent/Mobiles/Special/Harrower.cs
+++ b/Projects/UOContent/Mobiles/Special/Harrower.cs
@@ -221,7 +221,7 @@ namespace Server.Mobiles
 
             writer.Write(m_TrueForm);
             writer.Write(m_GateItem);
-            writer.WriteMobileList(m_Tentacles);
+            writer.Write(m_Tentacles);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -235,8 +235,8 @@ namespace Server.Mobiles
                 case 0:
                     {
                         m_TrueForm = reader.ReadBool();
-                        m_GateItem = reader.ReadItem();
-                        m_Tentacles = reader.ReadStrongMobileList<HarrowerTentacles>();
+                        m_GateItem = reader.ReadEntity<Item>();
+                        m_Tentacles = reader.ReadEntityList<HarrowerTentacles>();
 
                         m_Timer = new TeleportTimer(this);
                         m_Timer.Start();

--- a/Projects/UOContent/Mobiles/Special/HarrowerTentacles.cs
+++ b/Projects/UOContent/Mobiles/Special/HarrowerTentacles.cs
@@ -107,7 +107,7 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        Harrower = reader.ReadMobile();
+                        Harrower = reader.ReadEntity<Mobile>();
 
                         m_Timer = new DrainTimer(this);
                         m_Timer.Start();

--- a/Projects/UOContent/Mobiles/Special/LordOaks.cs
+++ b/Projects/UOContent/Mobiles/Special/LordOaks.cs
@@ -203,7 +203,7 @@ namespace Server.Mobiles
             {
                 case 0:
                     {
-                        m_Queen = reader.ReadMobile<BaseCreature>();
+                        m_Queen = reader.ReadEntity<BaseCreature>();
                         m_SpawnedQueen = reader.ReadBool();
 
                         break;

--- a/Projects/UOContent/Mobiles/Special/Neira.cs
+++ b/Projects/UOContent/Mobiles/Special/Neira.cs
@@ -270,7 +270,7 @@ namespace Server.Mobiles
 
                 var version = reader.ReadInt();
 
-                Rider = reader.ReadMobile();
+                Rider = reader.ReadEntity<Mobile>();
 
                 if (Rider == null)
                 {

--- a/Projects/UOContent/Mobiles/Vendors/GenericBuy.cs
+++ b/Projects/UOContent/Mobiles/Vendors/GenericBuy.cs
@@ -282,7 +282,7 @@ namespace Server.Mobiles
 
                 var version = reader.ReadInt();
 
-                m_Mobiles = reader.ReadStrongMobileList();
+                m_Mobiles = reader.ReadEntityList<Mobile>();
 
                 for (var i = 0; i < m_Mobiles.Count; ++i)
                 {

--- a/Projects/UOContent/Mobiles/Vendors/PlayerBarkeeper.cs
+++ b/Projects/UOContent/Mobiles/Vendors/PlayerBarkeeper.cs
@@ -584,13 +584,13 @@ namespace Server.Mobiles
             {
                 case 1:
                     {
-                        House = (BaseHouse)reader.ReadItem();
+                        House = (BaseHouse)reader.ReadEntity<Item>();
 
                         goto case 0;
                     }
                 case 0:
                     {
-                        Owner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<Mobile>();
 
                         Rumors = new BarkeeperRumor[reader.ReadEncodedInt()];
 

--- a/Projects/UOContent/Mobiles/Vendors/PlayerVendor.cs
+++ b/Projects/UOContent/Mobiles/Vendors/PlayerVendor.cs
@@ -428,13 +428,13 @@ namespace Server.Mobiles
                         newVendorSystem = reader.ReadBool();
                         m_ShopName = reader.ReadString();
                         NextPayTime = reader.ReadDeltaTime();
-                        House = (BaseHouse)reader.ReadItem();
+                        House = (BaseHouse)reader.ReadEntity<Item>();
 
                         goto case 0;
                     }
                 case 0:
                     {
-                        Owner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<Mobile>();
                         BankAccount = reader.ReadInt();
                         HoldGold = reader.ReadInt();
 
@@ -444,7 +444,7 @@ namespace Server.Mobiles
 
                         for (var i = 0; i < count; i++)
                         {
-                            var item = reader.ReadItem();
+                            var item = reader.ReadEntity<Item>();
 
                             var price = reader.ReadInt();
                             if (price > 100000000)
@@ -1714,7 +1714,7 @@ namespace Server.Mobiles
 
             var version = reader.ReadEncodedInt();
 
-            Vendor = (PlayerVendor)reader.ReadMobile();
+            Vendor = (PlayerVendor)reader.ReadEntity<Mobile>();
 
             Timer.DelayCall(Delete);
         }

--- a/Projects/UOContent/Mobiles/Vendors/VendorInventory.cs
+++ b/Projects/UOContent/Mobiles/Vendors/VendorInventory.cs
@@ -30,11 +30,11 @@ namespace Server.Mobiles
 
             var version = reader.ReadEncodedInt();
 
-            Owner = reader.ReadMobile();
+            Owner = reader.ReadEntity<Mobile>();
             VendorName = reader.ReadString();
             ShopName = reader.ReadString();
 
-            Items = reader.ReadStrongItemList();
+            Items = reader.ReadEntityList<Item>();
             Gold = reader.ReadInt();
 
             ExpireTime = reader.ReadDeltaTime();
@@ -94,7 +94,8 @@ namespace Server.Mobiles
             writer.Write(VendorName);
             writer.Write(ShopName);
 
-            writer.Write(Items, true);
+            Items.Tidy();
+            writer.Write(Items);
             writer.Write(Gold);
 
             writer.WriteDeltaTime(ExpireTime);

--- a/Projects/UOContent/Multis/BaseHouse.cs
+++ b/Projects/UOContent/Multis/BaseHouse.cs
@@ -2844,8 +2844,10 @@ namespace Server.Multis
 
             writer.Write(m_RelativeBanLocation);
 
-            writer.WriteItemList(VendorRentalContracts, true);
-            writer.WriteMobileList(InternalizedVendors, true);
+            VendorRentalContracts.Tidy();
+            writer.Write(VendorRentalContracts);
+            InternalizedVendors.Tidy();
+            writer.Write(InternalizedVendors);
 
             writer.WriteEncodedInt(RelocatedEntities.Count);
             foreach (var relEntity in RelocatedEntities)
@@ -2876,12 +2878,13 @@ namespace Server.Multis
 
             writer.Write(Price);
 
-            writer.WriteMobileList(Access);
+            writer.Write(Access);
 
             writer.Write(BuiltOn);
             writer.Write(LastTraded);
 
-            writer.WriteItemList(Addons, true);
+            Addons.Tidy();
+            writer.Write(Addons);
 
             writer.Write(Secures.Count);
 
@@ -2897,21 +2900,20 @@ namespace Server.Multis
             writer.Write(m_Owner);
 
             // Version 5 no longer serializes region coords
-            /*writer.Write( (int)m_Region.Coords.Count );
-            foreach( Rectangle2D rect in m_Region.Coords )
-            {
-              writer.Write( rect );
-            }*/
-
-            writer.WriteMobileList(CoOwners, true);
-            writer.WriteMobileList(Friends, true);
-            writer.WriteMobileList(Bans, true);
+            CoOwners.Tidy();
+            writer.Write(CoOwners);
+            Friends.Tidy();
+            writer.Write(Friends);
+            Bans.Tidy();
+            writer.Write(Bans);
 
             writer.Write(Sign);
             writer.Write(m_Trash);
 
-            writer.WriteItemList(Doors, true);
-            writer.WriteItemList(LockDowns, true);
+            Doors.Tidy();
+            writer.Write(Doors);
+            LockDowns.Tidy();
+            writer.Write(LockDowns);
             // writer.WriteItemList( m_Secures, true );
 
             writer.Write(MaxLockDowns);
@@ -2971,8 +2973,8 @@ namespace Server.Multis
                 case 13: // removed ban location serialization
                 case 12:
                     {
-                        VendorRentalContracts = reader.ReadStrongItemList<VendorRentalContract>();
-                        InternalizedVendors = reader.ReadStrongMobileList();
+                        VendorRentalContracts = reader.ReadEntityList<VendorRentalContract>();
+                        InternalizedVendors = reader.ReadEntityList<Mobile>();
 
                         var relocatedCount = reader.ReadEncodedInt();
                         for (var i = 0; i < relocatedCount; i++)
@@ -3014,7 +3016,7 @@ namespace Server.Multis
                     }
                 case 7:
                     {
-                        Access = reader.ReadStrongMobileList();
+                        Access = reader.ReadEntityList<Mobile>();
                         goto case 6;
                     }
                 case 6:
@@ -3026,7 +3028,7 @@ namespace Server.Multis
                 case 5: // just removed fields
                 case 4:
                     {
-                        Addons = reader.ReadStrongItemList();
+                        Addons = reader.ReadEntityList<Item>();
                         goto case 3;
                     }
                 case 3:
@@ -3089,7 +3091,7 @@ namespace Server.Multis
                             Price = DefaultPrice;
                         }
 
-                        m_Owner = reader.ReadMobile();
+                        m_Owner = reader.ReadEntity<Mobile>();
 
                         if (version < 5)
                         {
@@ -3103,15 +3105,15 @@ namespace Server.Multis
 
                         UpdateRegion();
 
-                        CoOwners = reader.ReadStrongMobileList();
-                        Friends = reader.ReadStrongMobileList();
-                        Bans = reader.ReadStrongMobileList();
+                        CoOwners = reader.ReadEntityList<Mobile>();
+                        Friends = reader.ReadEntityList<Mobile>();
+                        Bans = reader.ReadEntityList<Mobile>();
 
-                        Sign = reader.ReadItem() as HouseSign;
-                        m_Trash = reader.ReadItem() as TrashBarrel;
+                        Sign = reader.ReadEntity<HouseSign>();
+                        m_Trash = reader.ReadEntity<TrashBarrel>();
 
-                        Doors = reader.ReadStrongItemList<BaseDoor>();
-                        LockDowns = reader.ReadStrongItemList();
+                        Doors = reader.ReadEntityList<BaseDoor>();
+                        LockDowns = reader.ReadEntityList<Item>();
 
                         for (var i = 0; i < LockDowns.Count; ++i)
                         {
@@ -3125,7 +3127,7 @@ namespace Server.Multis
 
                         if (version < 3)
                         {
-                            var items = reader.ReadStrongItemList();
+                            var items = reader.ReadEntityList<Item>();
                             Secures = new List<SecureInfo>(items.Count);
 
                             for (var i = 0; i < items.Count; ++i)
@@ -3849,7 +3851,7 @@ namespace Server.Multis
 
         public SecureInfo(IGenericReader reader)
         {
-            Item = reader.ReadItem() as Container;
+            Item = reader.ReadEntity<Container>();
             Level = (SecureLevel)reader.ReadByte();
         }
 

--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -329,7 +329,7 @@ namespace Server.Multis
             {
                 case 3:
                     {
-                        MapItem = (MapItem)reader.ReadItem();
+                        MapItem = (MapItem)reader.ReadEntity<Item>();
                         NextNavPoint = reader.ReadInt();
 
                         goto case 2;
@@ -373,11 +373,11 @@ namespace Server.Multis
                             }
                         }
 
-                        Owner = reader.ReadMobile();
-                        PPlank = reader.ReadItem() as Plank;
-                        SPlank = reader.ReadItem() as Plank;
-                        TillerMan = reader.ReadItem() as TillerMan;
-                        Hold = reader.ReadItem() as Hold;
+                        Owner = reader.ReadEntity<Mobile>();
+                        PPlank = reader.ReadEntity<Plank>();
+                        SPlank = reader.ReadEntity<Plank>();
+                        TillerMan = reader.ReadEntity<TillerMan>();
+                        Hold = reader.ReadEntity<Hold>();
                         Anchored = reader.ReadBool();
                         m_ShipName = reader.ReadString();
 

--- a/Projects/UOContent/Multis/Boats/Hold.cs
+++ b/Projects/UOContent/Multis/Boats/Hold.cs
@@ -111,7 +111,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        m_Boat = reader.ReadItem() as BaseBoat;
+                        m_Boat = reader.ReadEntity<BaseBoat>();
 
                         if (m_Boat == null || Parent != null)
                         {

--- a/Projects/UOContent/Multis/Boats/Plank.cs
+++ b/Projects/UOContent/Multis/Boats/Plank.cs
@@ -71,7 +71,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        Boat = reader.ReadItem() as BaseBoat;
+                        Boat = reader.ReadEntity<BaseBoat>();
                         Side = (PlankSide)reader.ReadInt();
                         Locked = reader.ReadBool();
                         KeyValue = reader.ReadUInt();

--- a/Projects/UOContent/Multis/Boats/TillerMan.cs
+++ b/Projects/UOContent/Multis/Boats/TillerMan.cs
@@ -116,7 +116,7 @@ namespace Server.Items
             {
                 case 0:
                     {
-                        m_Boat = reader.ReadItem() as BaseBoat;
+                        m_Boat = reader.ReadEntity<BaseBoat>();
 
                         if (m_Boat == null)
                         {

--- a/Projects/UOContent/Multis/Camps/BaseCamp.cs
+++ b/Projects/UOContent/Multis/Camps/BaseCamp.cs
@@ -159,8 +159,10 @@ namespace Server.Multis
 
             writer.Write(0); // version
 
-            writer.Write(m_Items, true);
-            writer.Write(m_Mobiles, true);
+            m_Items.Tidy();
+            writer.Write(m_Items);
+            m_Mobiles.Tidy();
+            writer.Write(m_Mobiles);
             writer.WriteDeltaTime(m_DecayTime);
         }
 
@@ -174,8 +176,8 @@ namespace Server.Multis
             {
                 case 0:
                     {
-                        m_Items = reader.ReadStrongItemList();
-                        m_Mobiles = reader.ReadStrongMobileList();
+                        m_Items = reader.ReadEntityList<Item>();
+                        m_Mobiles = reader.ReadEntityList<Mobile>();
                         m_DecayTime = reader.ReadDeltaTime();
 
                         RefreshDecay(false);

--- a/Projects/UOContent/Multis/Camps/BrigandCamp.cs
+++ b/Projects/UOContent/Multis/Camps/BrigandCamp.cs
@@ -176,7 +176,7 @@ namespace Server.Multis
             {
                 case 0:
                     {
-                        m_Prisoner = reader.ReadMobile();
+                        m_Prisoner = reader.ReadEntity<Mobile>();
                         break;
                     }
             }

--- a/Projects/UOContent/Multis/Camps/LizardmenCamp.cs
+++ b/Projects/UOContent/Multis/Camps/LizardmenCamp.cs
@@ -190,7 +190,7 @@ namespace Server.Multis
             {
                 case 0:
                     {
-                        m_Prisoner = reader.ReadMobile();
+                        m_Prisoner = reader.ReadEntity<Mobile>();
                         break;
                     }
             }

--- a/Projects/UOContent/Multis/Camps/OrcCamp.cs
+++ b/Projects/UOContent/Multis/Camps/OrcCamp.cs
@@ -192,13 +192,13 @@ namespace Server.Multis
             {
                 case 1:
                     {
-                        m_Prisoner = reader.ReadMobile();
+                        m_Prisoner = reader.ReadEntity<Mobile>();
                         break;
                     }
                 case 0:
                     {
-                        m_Prisoner = reader.ReadMobile();
-                        reader.ReadItem();
+                        m_Prisoner = reader.ReadEntity<Mobile>();
+                        reader.ReadEntity<Item>();
                         break;
                     }
             }

--- a/Projects/UOContent/Multis/Camps/RatCamp.cs
+++ b/Projects/UOContent/Multis/Camps/RatCamp.cs
@@ -190,13 +190,13 @@ namespace Server.Multis
             {
                 case 1:
                     {
-                        m_Prisoner = reader.ReadMobile();
+                        m_Prisoner = reader.ReadEntity<Mobile>();
                         break;
                     }
                 case 0:
                     {
-                        m_Prisoner = reader.ReadMobile();
-                        reader.ReadItem();
+                        m_Prisoner = reader.ReadEntity<Mobile>();
+                        reader.ReadEntity<Item>();
                         break;
                     }
             }

--- a/Projects/UOContent/Multis/ContestHouses.cs
+++ b/Projects/UOContent/Multis/ContestHouses.cs
@@ -221,7 +221,8 @@ namespace Server.Multis
 
             if (Fixtures != null)
             {
-                writer.WriteItemList(Fixtures, true);
+                Fixtures.Tidy();
+                writer.Write(Fixtures);
             }
             else
             {
@@ -240,7 +241,7 @@ namespace Server.Multis
 
             for (var i = 0; i < count; i++)
             {
-                AddFixture(reader.ReadItem());
+                AddFixture(reader.ReadEntity<Item>());
             }
         }
     }

--- a/Projects/UOContent/Multis/HouseFoundation.cs
+++ b/Projects/UOContent/Multis/HouseFoundation.cs
@@ -908,7 +908,8 @@ namespace Server.Multis
             writer.Write(SignHanger);
 
             writer.Write(LastRevision);
-            writer.Write(Fixtures, true);
+            Fixtures.Tidy();
+            writer.Write(Fixtures);
 
             CurrentState.Serialize(writer);
             DesignState.Serialize(writer);
@@ -926,7 +927,7 @@ namespace Server.Multis
                 case 5:
                 case 4:
                     {
-                        Signpost = reader.ReadItem();
+                        Signpost = reader.ReadEntity<Item>();
                         SignpostGraphic = reader.ReadInt();
 
                         goto case 3;
@@ -939,7 +940,7 @@ namespace Server.Multis
                     }
                 case 2:
                     {
-                        SignHanger = reader.ReadItem();
+                        SignHanger = reader.ReadEntity<Item>();
 
                         goto case 1;
                     }
@@ -965,7 +966,7 @@ namespace Server.Multis
                         }
 
                         LastRevision = reader.ReadInt();
-                        Fixtures = reader.ReadStrongItemList();
+                        Fixtures = reader.ReadEntityList<Item>();
 
                         m_Current = new DesignState(this, reader);
                         m_Design = new DesignState(this, reader);

--- a/Projects/UOContent/Multis/HouseSign.cs
+++ b/Projects/UOContent/Multis/HouseSign.cs
@@ -216,8 +216,8 @@ namespace Server.Multis
             {
                 case 0:
                     {
-                        Owner = reader.ReadItem() as BaseHouse;
-                        OriginalOwner = reader.ReadMobile();
+                        Owner = reader.ReadEntity<BaseHouse>();
+                        OriginalOwner = reader.ReadEntity<Mobile>();
 
                         break;
                     }

--- a/Projects/UOContent/Multis/HouseTeleporter.cs
+++ b/Projects/UOContent/Multis/HouseTeleporter.cs
@@ -90,7 +90,7 @@ namespace Server.Items
                     }
                 case 0:
                     {
-                        Target = reader.ReadItem();
+                        Target = reader.ReadEntity<Item>();
 
                         if (version < 1)
                         {

--- a/Projects/UOContent/Multis/MovingCrate.cs
+++ b/Projects/UOContent/Multis/MovingCrate.cs
@@ -40,7 +40,7 @@ namespace Server.Multis
         public override void AddNameProperties( ObjectPropertyList list )
         {
           base.AddNameProperties( list );
-    
+
           if (House != null && House.InternalizedVendors.Count > 0)
             list.Add( 1061833, House.InternalizedVendors.Count.ToString() ); // This packing crate contains ~1_COUNT~ vendors/barkeepers.
         }
@@ -248,7 +248,7 @@ namespace Server.Multis
 
             var version = reader.ReadEncodedInt();
 
-            House = reader.ReadItem() as BaseHouse;
+            House = reader.ReadEntity<BaseHouse>();
 
             if (House != null)
             {

--- a/Projects/UOContent/Multis/PreviewHouse.cs
+++ b/Projects/UOContent/Multis/PreviewHouse.cs
@@ -120,7 +120,7 @@ namespace Server.Multis
             {
                 case 0:
                     {
-                        m_Components = reader.ReadStrongItemList();
+                        m_Components = reader.ReadEntityList<Item>();
 
                         break;
                     }

--- a/Projects/UOContent/Spells/Fifth/PoisonField.cs
+++ b/Projects/UOContent/Spells/Fifth/PoisonField.cs
@@ -142,7 +142,7 @@ namespace Server.Spells.Fifth
                 {
                     case 1:
                         {
-                            m_Caster = reader.ReadMobile();
+                            m_Caster = reader.ReadEntity<Mobile>();
 
                             goto case 0;
                         }

--- a/Projects/UOContent/Spells/Fourth/FireField.cs
+++ b/Projects/UOContent/Spells/Fourth/FireField.cs
@@ -163,7 +163,7 @@ namespace Server.Spells.Fourth
                         }
                     case 1:
                         {
-                            m_Caster = reader.ReadMobile();
+                            m_Caster = reader.ReadEntity<Mobile>();
 
                             goto case 0;
                         }

--- a/Projects/UOContent/Spells/Ninjitsu/MirrorImage.cs
+++ b/Projects/UOContent/Spells/Ninjitsu/MirrorImage.cs
@@ -237,7 +237,7 @@ namespace Server.Mobiles
 
             var version = reader.ReadEncodedInt();
 
-            m_Caster = reader.ReadMobile();
+            m_Caster = reader.ReadEntity<Mobile>();
 
             MirrorImage.AddClone(m_Caster);
         }

--- a/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
+++ b/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
@@ -167,7 +167,7 @@ namespace Server.Spells.Sixth
                 {
                     case 0:
                         {
-                            m_Caster = reader.ReadMobile();
+                            m_Caster = reader.ReadEntity<Mobile>();
                             m_End = reader.ReadDeltaTime();
 
                             m_Timer = new InternalTimer(this, m_End - DateTime.UtcNow);


### PR DESCRIPTION
- [X] Fixes an issue where a buffer smaller than 8 bytes would not double with enough space in some cases.
- [X] Fixes an issue with dupe copying the savebuffer reference (ugh).
- [X] Streamlines the IGenericWriter API to use better generics.
- [X] Streamlines the IGenericReader API to use better generics.
- [X] Forces `tidying` of a List/HashSet to be done externally since Writers/Readers should not have side effects.
- [X] Fixes an issue where Tidying a list didn't TrimExcess, causing memory leaks.
- [X] Reverted the meaning of `World.Running` to specifically refer to any world state post world loading.
  - NOTE: Do not use this if you want to block on world saves. Instead use checks against `WorldState.Saving` states.
- [X] Fixes an issue with serializing negative DateTime deltas.
- [X] Fixes a potential issue with serializing non-UTC DateTime.

TODO:
- Fix Seek(End) for BufferWriter so it properly moves backwards from Position
  - Requires separating Position from Index, where Position can never decrease unless the buffer is being resized smaller