### PR TITLE
fix(core): Fixes BufferWriter Seek and removes World.SaveBuffers

### DIFF
--- a/Projects/Server/Serialization/BinaryFileWriter.cs
+++ b/Projects/Server/Serialization/BinaryFileWriter.cs
@@ -36,7 +36,7 @@ namespace Server
         public override long Position => _position + Index;
 
 
-        protected override int BufferSize => 0x1000000; // 1MB
+        protected override int BufferSize => 81920;
 
         public override void Flush()
         {

--- a/Projects/Server/Serialization/BinaryFileWriter.cs
+++ b/Projects/Server/Serialization/BinaryFileWriter.cs
@@ -19,19 +19,20 @@ namespace Server
 {
     public class BinaryFileWriter : BufferWriter
     {
-        private readonly Stream m_File;
-        private long m_Position;
+        private readonly Stream _file;
+        private long _position;
 
-        public BinaryFileWriter(string filename, bool prefixStr) : base(prefixStr) =>
-            m_File = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None);
+        public BinaryFileWriter(string filename, bool prefixStr) :
+            this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None), prefixStr)
+        {}
 
         public BinaryFileWriter(Stream stream, bool prefixStr) : base(prefixStr)
         {
-            m_File = stream;
-            m_Position = m_File.Position;
+            _file = stream;
+            _position = _file.Position;
         }
 
-        public override long Position => m_Position + Index;
+        public override long Position => _position + Index;
 
 
         protected override int BufferSize => 512;
@@ -40,9 +41,9 @@ namespace Server
         {
             if (Index > 0)
             {
-                m_Position += Index;
+                _position += Index;
 
-                m_File.Write(Buffer, 0, (int)Index);
+                _file.Write(Buffer, 0, (int)Index);
                 Index = 0;
             }
         }
@@ -54,14 +55,14 @@ namespace Server
                 Flush();
             }
 
-            m_File.Close();
+            _file.Close();
         }
 
         public override long Seek(long offset, SeekOrigin origin)
         {
             Flush();
 
-            return m_Position = m_File.Seek(offset, origin);
+            return _position = _file.Seek(offset, origin);
         }
     }
 }

--- a/Projects/Server/Serialization/BinaryFileWriter.cs
+++ b/Projects/Server/Serialization/BinaryFileWriter.cs
@@ -36,7 +36,7 @@ namespace Server
         public override long Position => _position + Index;
 
 
-        protected override int BufferSize => 0x10000;
+        protected override int BufferSize => 0x1000000; // 1MB
 
         public override void Flush()
         {

--- a/Projects/Server/Serialization/BinaryFileWriter.cs
+++ b/Projects/Server/Serialization/BinaryFileWriter.cs
@@ -13,11 +13,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System;
 using System.IO;
 
 namespace Server
 {
-    public class BinaryFileWriter : BufferWriter
+    public class BinaryFileWriter : BufferWriter, IDisposable
     {
         private readonly Stream _file;
         private long _position;
@@ -35,7 +36,7 @@ namespace Server
         public override long Position => _position + Index;
 
 
-        protected override int BufferSize => 512;
+        protected override int BufferSize => 0x10000;
 
         public override void Flush()
         {
@@ -63,6 +64,11 @@ namespace Server
             Flush();
 
             return _position = _file.Seek(offset, origin);
+        }
+
+        public void Dispose()
+        {
+            Close();
         }
     }
 }

--- a/Projects/Server/Serialization/BufferReader.cs
+++ b/Projects/Server/Serialization/BufferReader.cs
@@ -26,7 +26,7 @@ namespace Server
     public class BufferReader : IGenericReader
     {
         private readonly Encoding _encoding;
-        private byte[] _buffer;
+        private readonly byte[] _buffer;
         public int Position { get; private set; }
 
         public BufferReader(byte[] buffer)

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -95,7 +95,11 @@ namespace Server
                 _bytesWritten = size;
             }
 
-            Array.Resize(ref _buffer, size);
+            var newBuffer = GC.AllocateUninitializedArray<byte>(size);
+            _buffer.AsSpan(0, Math.Min(size, _buffer.Length)).CopyTo(newBuffer);
+            _buffer = newBuffer;
+
+            // Array.Resize(ref _buffer, size);
         }
 
         public virtual void Flush()

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -523,9 +523,9 @@ namespace Server
             string tdbPath = Path.Combine(path, $"{typeName}.tdb");
             string binPath = Path.Combine(path, $"{typeName}.bin");
 
-            var idx = new BinaryFileWriter(idxPath, false);
-            var tdb = new BinaryFileWriter(tdbPath, false);
-            var bin = new BinaryFileWriter(binPath, true);
+            using var idx = new BinaryFileWriter(idxPath, false);
+            using var tdb = new BinaryFileWriter(tdbPath, false);
+            using var bin = new BinaryFileWriter(binPath, true);
 
             idx.Write(entities.Count);
             foreach (var e in entities.Values)
@@ -546,10 +546,6 @@ namespace Server
             {
                 tdb.Write(types[i].FullName);
             }
-
-            idx.Close();
-            tdb.Close();
-            bin.Close();
         }
 
         private static void SaveEntities<T>(IEnumerable<T> list, DateTime serializeStart) where T : class, ISerializable


### PR DESCRIPTION
- [X] Fixes an issue in BufferWriter where if SeekOrigin.End is used, it will yield the wrong index.
- [X] Changes BinaryFileWriter to dispose pattern
- [X] Removes World.SaveBuffers. They were dangerous and should be done in-line while the world is loading, even if it is slower
- [X] Fixes BufferReader Seek too
- [X] Changes BufferWriter to use uninitialized arrays to speed up resizing
- [X] Changes World loading so it doesn't buffer the whole file, even if it makes things slower. It lowers allocations/fragmentation over all which is good.
- [X] Changes World Loading to use uninitialized arrays and directly saves them to the SaveBuffer which eliminates having to open/load the files _again_ which is dangerous. Also looping through items while the world is running is dangerous since async references can and will cause exceptions.