### PR TITLE
feat(core): Makes spanwriter resizable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -52,14 +52,7 @@
         <AnalysisLevel>latest</AnalysisLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    <ItemGroup Condition="'$(Configuration)'=='Analyze'">
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-            <Version>3.3.1</Version>
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.165-alpha">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Projects/Server.Tests/Server.Tests.csproj
+++ b/Projects/Server.Tests/Server.Tests.csproj
@@ -3,7 +3,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201123-03" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/Projects/Server.Tests/Tests/Buffers/SpanWriterTests.cs
+++ b/Projects/Server.Tests/Tests/Buffers/SpanWriterTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace Server.Tests
+{
+    public class SpanWriterTests
+    {
+        [Fact]
+        public unsafe void TestSpanWriterResizes()
+        {
+            Span<byte> smallStack = stackalloc byte[8];
+            using var writer = new SpanWriter(smallStack, true);
+            writer.Write(0x1024L);
+            writer.Write(0x1024L);
+
+            var span = writer.RawBuffer;
+            fixed (byte* spanPtr = span)
+            {
+                fixed (byte* stackPtr = smallStack)
+                {
+                    Assert.True(spanPtr != stackPtr);
+                }
+            }
+
+            Assert.True(span.Length > smallStack.Length);
+        }
+
+        [Fact]
+        public unsafe void TestSpanWriterOnlyStackAlloc()
+        {
+            Span<byte> smallStack = stackalloc byte[8];
+            using var writer = new SpanWriter(smallStack, true);
+            writer.Write(0x1024L);
+
+            var span = writer.RawBuffer;
+            fixed (byte* spanPtr = span)
+            {
+                fixed (byte* stackPtr = smallStack)
+                {
+                    Assert.True(spanPtr == stackPtr);
+                }
+            }
+
+            Assert.True(span.Length == smallStack.Length);
+            AssertThat.Equal(smallStack, stackalloc byte[] { 0, 0, 0, 0, 0, 0, 0x10, 0x24 });
+        }
+
+        [Fact]
+        public void TestSpanWriterNoResizeThrows()
+        {
+            Assert.Throws<OutOfMemoryException>(
+                () =>
+                {
+                    Span<byte> smallStack = stackalloc byte[8];
+                    using var writer = new SpanWriter(smallStack);
+                    writer.Write(0x1024L);
+                    writer.Write(0x1024L);
+                }
+            );
+        }
+    }
+}

--- a/Projects/Server/Buffers/CircularBufferReader.cs
+++ b/Projects/Server/Buffers/CircularBufferReader.cs
@@ -370,7 +370,7 @@ namespace Server.Network
             Position = origin switch
             {
                 SeekOrigin.Begin => offset,
-                SeekOrigin.End   => Length - offset,
+                SeekOrigin.End   => Length + offset,
                 _                => Position + offset // Current
             };
     }

--- a/Projects/Server/Buffers/CircularBufferWriter.cs
+++ b/Projects/Server/Buffers/CircularBufferWriter.cs
@@ -528,7 +528,7 @@ namespace System.Buffers
             Position = origin switch
             {
                 SeekOrigin.Begin => offset,
-                SeekOrigin.End   => Length - offset,
+                SeekOrigin.End   => Length + offset,
                 _                => Position + offset // Current
             };
     }

--- a/Projects/Server/Buffers/SpanReader.cs
+++ b/Projects/Server/Buffers/SpanReader.cs
@@ -181,7 +181,7 @@ namespace System.Buffers
         {
             Debug.Assert(
                 origin != SeekOrigin.End || offset <= 0,
-                "Attempting to seek to a position beyond capacity using SeekOrigin.End without resize"
+                "Attempting to seek to a position beyond capacity using SeekOrigin.End"
             );
 
             Debug.Assert(
@@ -196,7 +196,7 @@ namespace System.Buffers
 
             Debug.Assert(
                 origin != SeekOrigin.Begin || offset <= _buffer.Length,
-                "Attempting to seek to a position beyond the capacity using SeekOrigin.Begin without resize"
+                "Attempting to seek to a position beyond the capacity using SeekOrigin.Begin"
             );
 
             Debug.Assert(
@@ -206,7 +206,7 @@ namespace System.Buffers
 
             Debug.Assert(
                 origin != SeekOrigin.Current || Position + offset <= _buffer.Length,
-                "Attempting to seek to a position beyond the capacity using SeekOrigin.Current without resize"
+                "Attempting to seek to a position beyond the capacity using SeekOrigin.Current"
             );
 
             return Position = Math.Max(0, origin switch

--- a/Projects/Server/Buffers/SpanReader.cs
+++ b/Projects/Server/Buffers/SpanReader.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -176,12 +177,27 @@ namespace System.Buffers
         public string ReadAscii() => ReadString(Encoding.ASCII);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Seek(int offset, SeekOrigin origin) =>
-            Position = origin switch
+        public int Seek(int offset, SeekOrigin origin)
+        {
+            Debug.Assert(
+                origin != SeekOrigin.End || offset <= 0 && offset > -_buffer.Length,
+                "Attempting to seek to an invalid position using SeekOrigin.End"
+            );
+            Debug.Assert(
+                origin != SeekOrigin.Begin || offset >= 0 && offset < _buffer.Length,
+                "Attempting to seek to an invalid position using SeekOrigin.Begin"
+            );
+            Debug.Assert(
+                origin != SeekOrigin.Current || Position + offset >= 0 && Position + offset < _buffer.Length,
+                "Attempting to seek to an invalid position using SeekOrigin.Current"
+            );
+
+            return Position = Math.Max(0, origin switch
             {
-                SeekOrigin.Begin => offset,
-                SeekOrigin.End   => Length - offset,
-                _                => Position + offset // Current
-            };
+                SeekOrigin.Current => Position + offset,
+                SeekOrigin.End     => _buffer.Length + offset,
+                _                  => offset // Begin
+            });
+        }
     }
 }

--- a/Projects/Server/Buffers/SpanReader.cs
+++ b/Projects/Server/Buffers/SpanReader.cs
@@ -180,16 +180,33 @@ namespace System.Buffers
         public int Seek(int offset, SeekOrigin origin)
         {
             Debug.Assert(
-                origin != SeekOrigin.End || offset <= 0 && offset > -_buffer.Length,
-                "Attempting to seek to an invalid position using SeekOrigin.End"
+                origin != SeekOrigin.End || offset <= 0,
+                "Attempting to seek to a position beyond capacity using SeekOrigin.End without resize"
             );
+
             Debug.Assert(
-                origin != SeekOrigin.Begin || offset >= 0 && offset < _buffer.Length,
-                "Attempting to seek to an invalid position using SeekOrigin.Begin"
+                origin != SeekOrigin.End || offset >= -_buffer.Length,
+                "Attempting to seek to a negative position using SeekOrigin.End"
             );
+
             Debug.Assert(
-                origin != SeekOrigin.Current || Position + offset >= 0 && Position + offset < _buffer.Length,
-                "Attempting to seek to an invalid position using SeekOrigin.Current"
+                origin != SeekOrigin.Begin || offset >= 0,
+                "Attempting to seek to a negative position using SeekOrigin.Begin"
+            );
+
+            Debug.Assert(
+                origin != SeekOrigin.Begin || offset <= _buffer.Length,
+                "Attempting to seek to a position beyond the capacity using SeekOrigin.Begin without resize"
+            );
+
+            Debug.Assert(
+                origin != SeekOrigin.Current || Position + offset >= 0,
+                "Attempting to seek to a negative position using SeekOrigin.Current"
+            );
+
+            Debug.Assert(
+                origin != SeekOrigin.Current || Position + offset <= _buffer.Length,
+                "Attempting to seek to a position beyond the capacity using SeekOrigin.Current without resize"
             );
 
             return Position = Math.Max(0, origin switch

--- a/Projects/Server/Buffers/SpanWriter.cs
+++ b/Projects/Server/Buffers/SpanWriter.cs
@@ -18,6 +18,7 @@ using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using Server;
 
@@ -99,6 +100,8 @@ namespace System.Buffers
                 Grow(count);
             }
         }
+
+        public ref byte GetPinnableReference() => ref MemoryMarshal.GetReference(_buffer);
 
         public void EnsureCapacity(int capacity)
         {

--- a/Projects/UOContent.Tests/UOContent.Tests.csproj
+++ b/Projects/UOContent.Tests/UOContent.Tests.csproj
@@ -3,7 +3,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.0-preview-20201123-03" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageReference Include="coverlet.collector" Version="1.3.0" />

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/WarDeclarationGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/WarDeclarationGump.cs
@@ -45,7 +45,7 @@ namespace Server.Guilds
                 return;
             }
 
-            var playerRank = pm.GuildRank;
+            var playerRank = pm!.GuildRank;
 
             switch (info.ButtonID)
             {

--- a/Projects/UOContent/Gumps/Props/SetPoint2DGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetPoint2DGump.cs
@@ -69,7 +69,7 @@ namespace Server.Gumps
             m_Page = page;
             m_List = list;
 
-            var p = (Point2D)prop.GetValue(o, null);
+            var p = (Point2D)(prop?.GetValue(o, null) ?? new Point2D());
 
             AddPage(0);
 
@@ -86,7 +86,7 @@ namespace Server.Gumps
             var y = BorderSize + OffsetSize;
 
             AddImageTiled(x, y, EntryWidth, EntryHeight, EntryGumpID);
-            AddLabelCropped(x + TextOffsetX, y, EntryWidth - TextOffsetX, EntryHeight, TextHue, prop.Name);
+            AddLabelCropped(x + TextOffsetX, y, EntryWidth - TextOffsetX, EntryHeight, TextHue, prop?.Name);
             x += EntryWidth + OffsetSize;
 
             if (SetGumpID != 0)

--- a/Projects/UOContent/Gumps/Props/SetPoint3DGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetPoint3DGump.cs
@@ -69,7 +69,7 @@ namespace Server.Gumps
             m_Page = page;
             m_List = list;
 
-            var p = (Point3D)prop.GetValue(o, null);
+            var p = (Point3D)(prop?.GetValue(o, null) ?? new Point3D());
 
             AddPage(0);
 
@@ -86,7 +86,7 @@ namespace Server.Gumps
             var y = BorderSize + OffsetSize;
 
             AddImageTiled(x, y, EntryWidth, EntryHeight, EntryGumpID);
-            AddLabelCropped(x + TextOffsetX, y, EntryWidth - TextOffsetX, EntryHeight, TextHue, prop.Name);
+            AddLabelCropped(x + TextOffsetX, y, EntryWidth - TextOffsetX, EntryHeight, TextHue, prop?.Name);
             x += EntryWidth + OffsetSize;
 
             if (SetGumpID != 0)

--- a/Projects/UOContent/Gumps/Props/SetTimeSpanGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetTimeSpanGump.cs
@@ -68,7 +68,7 @@ namespace Server.Gumps
             m_Page = page;
             m_List = list;
 
-            var ts = (TimeSpan)prop.GetValue(o, null);
+            var ts = (TimeSpan)(prop?.GetValue(o, null) ?? new TimeSpan());
 
             AddPage(0);
 
@@ -81,7 +81,7 @@ namespace Server.Gumps
                 OffsetGumpID
             );
 
-            AddRect(0, prop.Name, 0, -1);
+            AddRect(0, prop?.Name, 0, -1);
             AddRect(1, ts.ToString(), 0, -1);
             AddRect(2, "Zero", 1, -1);
             AddRect(3, "From H:M:S", 2, -1);

--- a/Projects/UOContent/Items/Skill Items/Specialized/GlassblowingBook.cs
+++ b/Projects/UOContent/Items/Skill Items/Specialized/GlassblowingBook.cs
@@ -29,24 +29,22 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            var pm = from as PlayerMobile;
-
             if (!IsChildOf(from.Backpack))
             {
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
             }
-            else if (pm == null || from.Skills.Alchemy.Base < 100.0)
+            else if (from is not PlayerMobile pm || from.Skills.Alchemy.Base < 100.0)
             {
-                pm.SendMessage("Only a Grandmaster Alchemist can learn from this book.");
+                from.SendMessage("Only a Grandmaster Alchemist can learn from this book.");
             }
             else if (pm.Glassblowing)
             {
-                pm.SendMessage("You have already learned this information.");
+                from.SendMessage("You have already learned this information.");
             }
             else
             {
                 pm.Glassblowing = true;
-                pm.SendMessage(
+                from.SendMessage(
                     "You have learned to make items from glass. You will need to find miners to mine find sand for you to make these items."
                 );
                 Delete();

--- a/Projects/UOContent/Items/Skill Items/Specialized/MasonryBook.cs
+++ b/Projects/UOContent/Items/Skill Items/Specialized/MasonryBook.cs
@@ -29,24 +29,22 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            var pm = from as PlayerMobile;
-
             if (!IsChildOf(from.Backpack))
             {
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
             }
-            else if (pm == null || from.Skills.Carpentry.Base < 100.0)
+            else if (from is not PlayerMobile pm || from.Skills.Carpentry.Base < 100.0)
             {
-                pm.SendMessage("Only a Grandmaster Carpenter can learn from this book.");
+                from.SendMessage("Only a Grandmaster Carpenter can learn from this book.");
             }
             else if (pm.Masonry)
             {
-                pm.SendMessage("You have already learned this information.");
+                from.SendMessage("You have already learned this information.");
             }
             else
             {
                 pm.Masonry = true;
-                pm.SendMessage(
+                from.SendMessage(
                     "You have learned to make items from stone. You will need miners to gather stones for you to make these items."
                 );
                 Delete();

--- a/Projects/UOContent/Items/Skill Items/Specialized/SandMiningBook.cs
+++ b/Projects/UOContent/Items/Skill Items/Specialized/SandMiningBook.cs
@@ -29,24 +29,22 @@ namespace Server.Items
 
         public override void OnDoubleClick(Mobile from)
         {
-            var pm = from as PlayerMobile;
-
             if (!IsChildOf(from.Backpack))
             {
                 from.SendLocalizedMessage(1042001); // That must be in your pack for you to use it.
             }
-            else if (pm == null || from.Skills.Mining.Base < 100.0)
+            else if (from is not PlayerMobile pm || from.Skills.Mining.Base < 100.0)
             {
-                pm.SendMessage("Only a Grandmaster Miner can learn from this book.");
+                from.SendMessage("Only a Grandmaster Miner can learn from this book.");
             }
             else if (pm.SandMining)
             {
-                pm.SendMessage("You have already learned this information.");
+                from.SendMessage("You have already learned this information.");
             }
             else
             {
                 pm.SandMining = true;
-                pm.SendMessage(
+                from.SendMessage(
                     "You have learned how to mine fine sand. Target sand areas when mining to look for fine sand."
                 );
                 Delete();

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -156,10 +156,6 @@ namespace Server.Items
 
         protected virtual bool CheckUse(Mobile from)
         {
-            // DateTime now = DateTime.UtcNow;
-
-            var pm = from as PlayerMobile;
-
             if (Deleted || !IsAccessibleTo(from))
             {
                 return false;
@@ -235,11 +231,10 @@ namespace Server.Items
                 return false;
             }
 
-            if (pm.AcceleratedStart > DateTime.UtcNow)
+            if ((from as PlayerMobile)?.AcceleratedStart > DateTime.UtcNow)
             {
-                from.SendLocalizedMessage(
-                    1078115
-                ); // You may not use a soulstone while your character is under the effects of a Scroll of Alacrity.
+                // You may not use a soulstone while your character is under the effects of a Scroll of Alacrity.
+                from.SendLocalizedMessage(1078115);
                 return false;
             }
 
@@ -748,8 +743,7 @@ namespace Server.Items
                     return;
                 }
 
-                var pm = from as PlayerMobile;
-                if (pm.AcceleratedStart > DateTime.UtcNow)
+                if ((from as PlayerMobile)?.AcceleratedStart > DateTime.UtcNow)
                 {
                     // <CENTER>Unable to Absorb Selected Skill from Soulstone</CENTER>
 

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/MLDryad.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/MLDryad.cs
@@ -103,14 +103,12 @@ namespace Server.Mobiles
 
             foreach (var m in GetMobilesInRange(RangePerception))
             {
-                var p = m as PlayerMobile;
-
-                if (IsValidTarget(p))
+                if (m is PlayerMobile pm && IsValidTarget(pm))
                 {
-                    p.PeacedUntil = DateTime.UtcNow + duration;
-                    p.SendLocalizedMessage(1072065); // You gaze upon the dryad's beauty, and forget to continue battling!
-                    p.FixedParticles(0x376A, 1, 20, 0x7F5, EffectLayer.Waist);
-                    p.Combatant = null;
+                    pm.PeacedUntil = DateTime.UtcNow + duration;
+                    m.SendLocalizedMessage(1072065); // You gaze upon the dryad's beauty, and forget to continue battling!
+                    m.FixedParticles(0x376A, 1, 20, 0x7F5, EffectLayer.Waist);
+                    m.Combatant = null;
                 }
             }
 

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -28,7 +28,7 @@
         <ProjectReference Include="..\Server\Server.csproj" Private="false" PrivateAssets="All" IncludeAssets="None">
             <IncludeInPackage>false</IncludeInPackage>
         </ProjectReference>
-        <PackageReference Include="MailKit" Version="2.8.0" />
+        <PackageReference Include="MailKit" Version="2.10.0" />
         <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.0.0-preview4" />
         <PackageReference Include="Zlib.Bindings" Version="1.4.0" />
         <PackageReference Include="Argon2.Bindings" Version="1.8.0" />


### PR DESCRIPTION
SpanWriter now has an argument that allows it to be resizable.
```cs
public SpanWriter(Span<byte> initialBuffer, bool resize = false)
public SpanWriter(int initialCapacity, bool resize = false)
```

If a SpanWriter is set to be resizable, or given an initial capacity instead of a buffer, it must be disposed:
```cs
public static void SomeMethod()
{
    using var writer = new SpanWriter(stackalloc byte[512], true);
    // stuff
    
    // Automatic Dispose of writer
}
```

This is because the SpanWriter uses `ArrayPool<byte>.Shared` _rented buffers_ to resize. If the writer is not disposed, those buffers will never be reused resulting in a _memory leak_.

It is possible that the SpanWriter will outright ditch the initial buffer if resize is set to true and growing is needed. To check/account for that we can do the following:

```cs
public static void SomeMethod()
{
    Span<byte> span = stackalloc byte[512];
    using var writer = new SpanWriter(span, true);
    // write some stuff that causes the span to grow
    
    span = writer.RawBuffer;
    // Do stuff with the span
}
```

Make sure you don't accidentally `Dispose()` the writer or use the `RawBuffer` outside of the `using` block. If you do, bad things will happen! (NullPointerException, or a fresh SpanWriter with no buffer, depending on the situation).

SpanWriter can also now be used with a fixed statement since it has a `PinnableReference()` function.