### PR TITLE
fix(core): Fixes OPL packets

### DIFF
--- a/Projects/Server/Buffers/SpanWriter.cs
+++ b/Projects/Server/Buffers/SpanWriter.cs
@@ -365,7 +365,7 @@ namespace System.Buffers
                 Grow(newPosition - _buffer.Length + 1);
             }
 
-            return _position = newPosition;
+            return Position = newPosition;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1152,7 +1152,7 @@ namespace Server
                     Span<byte> opl = ObjectPropertyList.Enabled ? stackalloc byte[OutgoingEntityPackets.OPLPacketLength] : null;
                     if (opl != null)
                     {
-                        OutgoingEntityPackets.CreateOPLInfo(opl, this);
+                        opl.InitializePacket();
                     }
 
                     var eable = m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange());
@@ -1163,6 +1163,11 @@ namespace Server
 
                         if (m.CanSee(this) && m.InRange(m_Location, GetUpdateRange(m)))
                         {
+                            if (opl[0] == 0)
+                            {
+                                OutgoingEntityPackets.CreateOPLInfo(opl, this);
+                            }
+
                             if (state.HighSeas)
                             {
                                 if (hsWorldItem[0] == 0)

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1163,11 +1163,6 @@ namespace Server
 
                         if (m.CanSee(this) && m.InRange(m_Location, GetUpdateRange(m)))
                         {
-                            if (opl[0] == 0)
-                            {
-                                OutgoingEntityPackets.CreateOPLInfo(opl, this);
-                            }
-
                             if (state.HighSeas)
                             {
                                 if (hsWorldItem[0] == 0)
@@ -3099,8 +3094,13 @@ namespace Server
 
         public virtual int GetUpdateRange(Mobile m) => 18;
 
-        public virtual void SendInfoTo(NetState ns, ReadOnlySpan<byte> world, ReadOnlySpan<byte> opl = default)
+        public virtual void SendInfoTo(NetState ns, ReadOnlySpan<byte> world, Span<byte> opl)
         {
+            if (opl != null && opl[0] == 0)
+            {
+                OutgoingEntityPackets.CreateOPLInfo(opl, this);
+            }
+
             SendWorldPacketTo(ns, world);
             SendOPLPacketTo(ns, opl);
         }

--- a/Projects/Server/Network/Packets/IncomingEntityPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingEntityPackets.cs
@@ -13,6 +13,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System;
+
 namespace Server.Network
 {
     public static class IncomingEntityPackets

--- a/Projects/Server/ObjectPropertyList.cs
+++ b/Projects/Server/ObjectPropertyList.cs
@@ -117,19 +117,23 @@ namespace Server
                 AddHash(arguments.GetHashCode(StringComparison.Ordinal));
             }
 
-            int strLength = Utility.Unicode.GetByteCount(arguments);
-
+            int strLength = arguments.Length * 2;
             int length = _position + 6 + strLength;
             while (length > _buffer.Length)
             {
                 Flush();
             }
 
-            var writer = new SpanWriter(_buffer);
-            writer.Seek(_position, SeekOrigin.Begin);
+            var writer = new SpanWriter(_buffer.AsSpan(_position));
             writer.Write(number);
             writer.Write((ushort)strLength);
-            writer.WriteBigUni(arguments);
+
+            if (strLength > 0)
+            {
+                writer.WriteLittleUni(arguments);
+            }
+
+            _position += writer.BytesWritten;
         }
 
         public void Add(int number, string format, object arg0)

--- a/Projects/Server/ObjectPropertyList.cs
+++ b/Projects/Server/ObjectPropertyList.cs
@@ -127,11 +127,7 @@ namespace Server
             var writer = new SpanWriter(_buffer.AsSpan(_position));
             writer.Write(number);
             writer.Write((ushort)strLength);
-
-            if (strLength > 0)
-            {
-                writer.WriteLittleUni(arguments);
-            }
+            writer.WriteLittleUni(arguments);
 
             _position += writer.BytesWritten;
         }

--- a/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
@@ -825,7 +825,7 @@ namespace Server.Items
             }
         }
 
-        public override void SendInfoTo(NetState ns, ReadOnlySpan<byte> world, ReadOnlySpan<byte> opl = default)
+        public override void SendInfoTo(NetState ns, ReadOnlySpan<byte> world, Span<byte> opl)
         {
             base.SendInfoTo(ns, world, opl);
 

--- a/Projects/UOContent/Multis/HouseFoundation.cs
+++ b/Projects/UOContent/Multis/HouseFoundation.cs
@@ -888,7 +888,7 @@ namespace Server.Multis
             stateToSend.SendGeneralInfoTo(ns);
         }
 
-        public override void SendInfoTo(NetState ns, ReadOnlySpan<byte> world, ReadOnlySpan<byte> opl = default)
+        public override void SendInfoTo(NetState ns, ReadOnlySpan<byte> world, Span<byte> opl)
         {
             base.SendInfoTo(ns, world, opl);
 


### PR DESCRIPTION
- [X] Fixes an issue with OPL packets using the wrong endianness and not updating the position properly.
- [X] Fixes an issue with SpanWriter not updating bytes written when it is used adhoc.
- [X] Moves packet creation for OPL inside the SendInfoTo function.