### PR TITLE
fix(core): Removes 6017 handler

### DIFF
--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -693,8 +693,7 @@ namespace Server.Network
             return false;
         }
 
-        public PacketHandler GetHandler(int packetID) =>
-            ContainerGridLines ? IncomingPackets.Get6017Handler(packetID) : IncomingPackets.GetHandler(packetID);
+        public PacketHandler GetHandler(int packetID) => IncomingPackets.GetHandler(packetID);
 
         public static void TraceException(Exception ex)
         {

--- a/Projects/Server/Network/PacketHandler.cs
+++ b/Projects/Server/Network/PacketHandler.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Server.Network
 {
-    public delegate void OnPacketReceive(NetState state, CircularBufferReader reader);
+    public delegate void OnPacketReceive(NetState state, CircularBufferReader reader, ref int packetLength);
 
     public delegate TimeSpan ThrottlePacketCallback(NetState state);
 

--- a/Projects/Server/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingAccountPackets.cs
@@ -55,7 +55,7 @@ namespace Server.Network
             IncomingPackets.Register(0xF8, 106, false, CreateCharacter);
         }
 
-        public static void CreateCharacter(NetState state, CircularBufferReader reader)
+        public static void CreateCharacter(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var unk1 = reader.ReadInt32();
             var unk2 = reader.ReadInt32();
@@ -202,7 +202,7 @@ namespace Server.Network
             }
         }
 
-        public static void DeleteCharacter(NetState state, CircularBufferReader reader)
+        public static void DeleteCharacter(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             reader.Seek(30, SeekOrigin.Current);
             var index = reader.ReadInt32();
@@ -210,24 +210,24 @@ namespace Server.Network
             EventSink.InvokeDeleteRequest(state, index);
         }
 
-        public static void AccountID(NetState state, CircularBufferReader reader)
+        public static void AccountID(NetState state, CircularBufferReader reader, ref int packetLength)
         {
         }
 
-        public static void AssistVersion(NetState state, CircularBufferReader reader)
+        public static void AssistVersion(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var unk = reader.ReadInt32();
             var av = reader.ReadAscii();
         }
 
-        public static void ClientVersion(NetState state, CircularBufferReader reader)
+        public static void ClientVersion(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var version = state.Version = new CV(reader.ReadAscii());
 
             EventSink.InvokeClientVersionReceived(state, version);
         }
 
-        public static void ClientType(NetState state, CircularBufferReader reader)
+        public static void ClientType(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             reader.ReadUInt16();
 
@@ -237,7 +237,7 @@ namespace Server.Network
             EventSink.InvokeClientVersionReceived(state, version);
         }
 
-        public static void PlayCharacter(NetState state, CircularBufferReader reader)
+        public static void PlayCharacter(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             reader.ReadInt32(); // 0xEDEDEDED
 
@@ -381,7 +381,7 @@ namespace Server.Network
             return authID;
         }
 
-        public static void GameLogin(NetState state, CircularBufferReader reader)
+        public static void GameLogin(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (state.SentFirstPacket)
             {
@@ -431,7 +431,7 @@ namespace Server.Network
             }
         }
 
-        public static void PlayServer(NetState state, CircularBufferReader reader)
+        public static void PlayServer(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int index = reader.ReadInt16();
             var info = state.ServerInfo;
@@ -452,7 +452,7 @@ namespace Server.Network
             }
         }
 
-        public static void LoginServerSeed(NetState state, CircularBufferReader reader)
+        public static void LoginServerSeed(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             state.m_Seed = reader.ReadInt32();
             state.Seeded = true;
@@ -472,7 +472,7 @@ namespace Server.Network
             state.Version = new ClientVersion(clientMaj, clientMin, clientRev, clientPat);
         }
 
-        public static void AccountLogin(NetState state, CircularBufferReader reader)
+        public static void AccountLogin(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (state.SentFirstPacket)
             {

--- a/Projects/Server/Network/Packets/IncomingEntityPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingEntityPackets.cs
@@ -27,7 +27,7 @@ namespace Server.Network
             IncomingPackets.Register(0xD6, 0, true, BatchQueryProperties);
         }
 
-        public static void ObjectHelpRequest(NetState state, CircularBufferReader reader)
+        public static void ObjectHelpRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -56,7 +56,7 @@ namespace Server.Network
             }
         }
 
-        public static void UseReq(NetState state, CircularBufferReader reader)
+        public static void UseReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -100,7 +100,7 @@ namespace Server.Network
             }
         }
 
-        public static void LookReq(NetState state, CircularBufferReader reader)
+        public static void LookReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -149,7 +149,7 @@ namespace Server.Network
             }
         }
 
-        public static void BatchQueryProperties(NetState state, CircularBufferReader reader)
+        public static void BatchQueryProperties(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (!ObjectPropertyList.Enabled)
             {

--- a/Projects/Server/Network/Packets/IncomingExtendedCommandPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingExtendedCommandPackets.cs
@@ -61,11 +61,11 @@ namespace Server.Network
             RegisterExtended(0x32, true, ToggleFlying);
         }
 
-        private static void UnhandledBF(NetState state, CircularBufferReader reader)
+        private static void UnhandledBF(NetState state, CircularBufferReader reader, ref int packetLength)
         {
         }
 
-        public static void Empty(NetState state, CircularBufferReader reader)
+        public static void Empty(NetState state, CircularBufferReader reader, ref int packetLength)
         {
         }
 
@@ -104,7 +104,7 @@ namespace Server.Network
             }
         }
 
-        public static void ExtendedCommand(NetState state, CircularBufferReader reader)
+        public static void ExtendedCommand(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int packetID = reader.ReadUInt16();
 
@@ -130,18 +130,18 @@ namespace Server.Network
             }
             else
             {
-                ph.OnReceive(state, reader);
+                ph.OnReceive(state, reader, ref packetLength);
             }
         }
 
-        public static void ScreenSize(NetState state, CircularBufferReader reader)
+        public static void ScreenSize(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var width = reader.ReadInt32();
             var unk = reader.ReadInt32();
         }
 
         // TODO: Move out of the core
-        public static void PartyMessage(NetState state, CircularBufferReader reader)
+        public static void PartyMessage(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (state.Mobile == null)
             {
@@ -151,25 +151,25 @@ namespace Server.Network
             switch (reader.ReadByte())
             {
                 case 0x01:
-                    PartyMessage_AddMember(state, reader);
+                    PartyMessage_AddMember(state, reader, ref packetLength);
                     break;
                 case 0x02:
-                    PartyMessage_RemoveMember(state, reader);
+                    PartyMessage_RemoveMember(state, reader, ref packetLength);
                     break;
                 case 0x03:
-                    PartyMessage_PrivateMessage(state, reader);
+                    PartyMessage_PrivateMessage(state, reader, ref packetLength);
                     break;
                 case 0x04:
-                    PartyMessage_PublicMessage(state, reader);
+                    PartyMessage_PublicMessage(state, reader, ref packetLength);
                     break;
                 case 0x06:
-                    PartyMessage_SetCanLoot(state, reader);
+                    PartyMessage_SetCanLoot(state, reader, ref packetLength);
                     break;
                 case 0x08:
-                    PartyMessage_Accept(state, reader);
+                    PartyMessage_Accept(state, reader, ref packetLength);
                     break;
                 case 0x09:
-                    PartyMessage_Decline(state, reader);
+                    PartyMessage_Decline(state, reader, ref packetLength);
                     break;
                 default:
                     reader.Trace(state);
@@ -177,17 +177,17 @@ namespace Server.Network
             }
         }
 
-        public static void PartyMessage_AddMember(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_AddMember(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnAdd(state.Mobile);
         }
 
-        public static void PartyMessage_RemoveMember(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_RemoveMember(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnRemove(state.Mobile, World.FindMobile(reader.ReadUInt32()));
         }
 
-        public static void PartyMessage_PrivateMessage(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_PrivateMessage(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnPrivateMessage(
                 state.Mobile,
@@ -196,27 +196,27 @@ namespace Server.Network
             );
         }
 
-        public static void PartyMessage_PublicMessage(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_PublicMessage(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnPublicMessage(state.Mobile, reader.ReadBigUniSafe());
         }
 
-        public static void PartyMessage_SetCanLoot(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_SetCanLoot(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnSetCanLoot(state.Mobile, reader.ReadBoolean());
         }
 
-        public static void PartyMessage_Accept(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_Accept(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnAccept(state.Mobile, World.FindMobile(reader.ReadUInt32()));
         }
 
-        public static void PartyMessage_Decline(NetState state, CircularBufferReader reader)
+        public static void PartyMessage_Decline(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             PartyCommands.Handler?.OnDecline(state.Mobile, World.FindMobile(reader.ReadUInt32()));
         }
 
-        public static void Animate(NetState state, CircularBufferReader reader)
+        public static void Animate(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -240,7 +240,7 @@ namespace Server.Network
             }
         }
 
-        public static void CastSpell(NetState state, CircularBufferReader reader)
+        public static void CastSpell(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -255,12 +255,12 @@ namespace Server.Network
             EventSink.InvokeCastSpellRequest(from, spellID, spellbook);
         }
 
-        public static void ToggleFlying(NetState state, CircularBufferReader reader)
+        public static void ToggleFlying(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             state.Mobile?.ToggleFlying();
         }
 
-        public static void StunRequest(NetState state, CircularBufferReader reader)
+        public static void StunRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -272,7 +272,7 @@ namespace Server.Network
             EventSink.InvokeStunRequest(from);
         }
 
-        public static void DisarmRequest(NetState state, CircularBufferReader reader)
+        public static void DisarmRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -284,7 +284,7 @@ namespace Server.Network
             EventSink.InvokeDisarmRequest(from);
         }
 
-        public static void StatLockChange(NetState state, CircularBufferReader reader)
+        public static void StatLockChange(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -315,12 +315,12 @@ namespace Server.Network
             }
         }
 
-        public static void CloseStatus(NetState state, CircularBufferReader reader)
+        public static void CloseStatus(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             Serial serial = reader.ReadUInt32();
         }
 
-        public static void Language(NetState state, CircularBufferReader reader)
+        public static void Language(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -332,7 +332,7 @@ namespace Server.Network
             from.Language = reader.ReadAscii(4);
         }
 
-        public static void QueryProperties(NetState state, CircularBufferReader reader)
+        public static void QueryProperties(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (!ObjectPropertyList.Enabled)
             {
@@ -364,7 +364,7 @@ namespace Server.Network
             }
         }
 
-        public static void ContextMenuResponse(NetState state, CircularBufferReader reader)
+        public static void ContextMenuResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -420,7 +420,7 @@ namespace Server.Network
             }
         }
 
-        public static void ContextMenuRequest(NetState state, CircularBufferReader reader)
+        public static void ContextMenuRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
             var target = World.FindEntity(reader.ReadUInt32());
@@ -455,7 +455,7 @@ namespace Server.Network
             }
         }
 
-        public static void BandageTarget(NetState state, CircularBufferReader reader)
+        public static void BandageTarget(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -490,21 +490,21 @@ namespace Server.Network
             }
         }
 
-        public static void TargetedSpell(NetState state, CircularBufferReader reader)
+        public static void TargetedSpell(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var spellId = (short)(reader.ReadInt16() - 1); // zero based;
 
             EventSink.InvokeTargetedSpell(state.Mobile, World.FindEntity(reader.ReadUInt32()), spellId);
         }
 
-        public static void TargetedSkillUse(NetState state, CircularBufferReader reader)
+        public static void TargetedSkillUse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var skillId = reader.ReadInt16();
 
             EventSink.InvokeTargetedSkillUse(state.Mobile, World.FindEntity(reader.ReadUInt32()), skillId);
         }
 
-        public static void TargetByResourceMacro(NetState state, CircularBufferReader reader)
+        public static void TargetByResourceMacro(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             Serial serial = reader.ReadUInt32();
 

--- a/Projects/Server/Network/Packets/IncomingHousePackets.cs
+++ b/Projects/Server/Network/Packets/IncomingHousePackets.cs
@@ -22,7 +22,7 @@ namespace Server.Network
             IncomingPackets.Register(0xFB, 2, false, ShowPublicHouseContent);
         }
 
-        public static void ShowPublicHouseContent(NetState state, CircularBufferReader reader)
+        public static void ShowPublicHouseContent(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var showPublicHouseContent = reader.ReadBoolean();
         }

--- a/Projects/Server/Network/Packets/IncomingMessagePackets.cs
+++ b/Projects/Server/Network/Packets/IncomingMessagePackets.cs
@@ -46,7 +46,7 @@ namespace Server.Network
             IncomingPackets.Register(0xAD, 0, true, UnicodeSpeech);
         }
 
-        public static void AsciiSpeech(NetState state, CircularBufferReader reader)
+        public static void AsciiSpeech(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -73,7 +73,7 @@ namespace Server.Network
             from.DoSpeech(text, Array.Empty<int>(), type, Utility.ClipDyedHue(hue));
         }
 
-        public static void UnicodeSpeech(NetState state, CircularBufferReader reader)
+        public static void UnicodeSpeech(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 

--- a/Projects/Server/Network/Packets/IncomingMobilePackets.cs
+++ b/Projects/Server/Network/Packets/IncomingMobilePackets.cs
@@ -27,7 +27,7 @@ namespace Server.Network
             IncomingPackets.Register(0x6F, 0, true, SecureTrade);
         }
 
-        public static void RenameRequest(NetState state, CircularBufferReader reader)
+        public static void RenameRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
             var targ = World.FindMobile(reader.ReadUInt32());
@@ -38,7 +38,7 @@ namespace Server.Network
             }
         }
 
-        public static void MobileNameRequest(NetState state, CircularBufferReader reader)
+        public static void MobileNameRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var m = World.FindMobile(reader.ReadUInt32());
 
@@ -48,7 +48,7 @@ namespace Server.Network
             }
         }
 
-        public static void ProfileReq(NetState state, CircularBufferReader reader)
+        public static void ProfileReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int type = reader.ReadByte();
             Serial serial = reader.ReadUInt32();
@@ -88,7 +88,7 @@ namespace Server.Network
             }
         }
 
-        public static void SecureTrade(NetState state, CircularBufferReader reader)
+        public static void SecureTrade(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             switch (reader.ReadByte())
             {

--- a/Projects/Server/Network/Packets/IncomingMovementPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingMovementPackets.cs
@@ -78,7 +78,7 @@ namespace Server.Network
             ns.SendTimeSyncResponse();
         }
 
-        public static void MovementReq(NetState state, CircularBufferReader reader)
+        public static void MovementReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 

--- a/Projects/Server/Network/Packets/IncomingPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPackets.cs
@@ -127,7 +127,9 @@ namespace Server.Network
                 return -1;
             }
 
+            // We use this for failing fast where we already know the length, but may not read it entirely
             var packetLength = handler.Length;
+
             if (handler.Length <= 0 && reader.Length >= 3)
             {
                 packetLength = reader.ReadUInt16();
@@ -156,6 +158,8 @@ namespace Server.Network
                 ns.ThrottledUntil = DateTime.UtcNow + throttled;
             }
 
+            // The packet length is sent in as a ref to support situations where a smaller/larger packet is read.
+            // Example is DropReq to support 6.0.1.7+ where the packet is 1 byte larger
             handler.OnReceive(ns, reader, ref packetLength);
 
             return packetLength;

--- a/Projects/Server/Network/Packets/IncomingPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPackets.cs
@@ -37,13 +37,6 @@ namespace Server.Network
 
         public static PacketHandler GetHandler(int packetID) => Handlers[packetID];
 
-        public static void Register6017(int packetID, int length, bool ingame, OnPacketReceive onReceive)
-        {
-            m_6017Handlers[packetID] = new PacketHandler(packetID, length, ingame, onReceive);
-        }
-
-        public static PacketHandler Get6017Handler(int packetID) => m_6017Handlers[packetID];
-
         public static void RegisterEncoded(int packetID, bool ingame, OnEncodedPacketReceive onReceive)
         {
             if (packetID >= 0 && packetID < 0x100)
@@ -82,13 +75,6 @@ namespace Server.Network
         public static void RegisterThrottler(int packetID, ThrottlePacketCallback t)
         {
             var ph = GetHandler(packetID);
-
-            if (ph != null)
-            {
-                ph.ThrottleCallback = t;
-            }
-
-            ph = Get6017Handler(packetID);
 
             if (ph != null)
             {
@@ -170,7 +156,7 @@ namespace Server.Network
                 ns.ThrottledUntil = DateTime.UtcNow + throttled;
             }
 
-            handler.OnReceive(ns, reader);
+            handler.OnReceive(ns, reader, ref packetLength);
 
             return packetLength;
         }

--- a/Projects/Server/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPlayerPackets.cs
@@ -51,18 +51,18 @@ namespace Server.Network
             IncomingPackets.RegisterEncoded(0x32, true, QuestGumpRequest);
         }
 
-        public static void DeathStatusResponse(NetState state, CircularBufferReader reader)
+        public static void DeathStatusResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             // Ignored
         }
 
-        public static void RequestScrollWindow(NetState state, CircularBufferReader reader)
+        public static void RequestScrollWindow(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int lastTip = reader.ReadInt16();
             int type = reader.ReadByte();
         }
 
-        public static void AttackReq(NetState state, CircularBufferReader reader)
+        public static void AttackReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -79,7 +79,7 @@ namespace Server.Network
             }
         }
 
-        public static void HuePickerResponse(NetState state, CircularBufferReader reader)
+        public static void HuePickerResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var serial = reader.ReadUInt32();
             _ = reader.ReadInt16(); // Item ID
@@ -96,7 +96,7 @@ namespace Server.Network
             }
         }
 
-        public static void SystemInfo(NetState state, CircularBufferReader reader)
+        public static void SystemInfo(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int v1 = reader.ReadByte();
             int v2 = reader.ReadUInt16();
@@ -112,7 +112,7 @@ namespace Server.Network
             var v8 = reader.ReadInt32();
         }
 
-        public static void TextCommand(NetState state, CircularBufferReader reader)
+        public static void TextCommand(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -207,7 +207,7 @@ namespace Server.Network
             }
         }
 
-        public static void AsciiPromptResponse(NetState state, CircularBufferReader reader)
+        public static void AsciiPromptResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -243,7 +243,7 @@ namespace Server.Network
             }
         }
 
-        public static void UnicodePromptResponse(NetState state, CircularBufferReader reader)
+        public static void UnicodePromptResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -280,7 +280,7 @@ namespace Server.Network
             }
         }
 
-        public static void MenuResponse(NetState state, CircularBufferReader reader)
+        public static void MenuResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var serial = reader.ReadUInt32();
             int menuID = reader.ReadInt16(); // unused in our implementation
@@ -310,33 +310,33 @@ namespace Server.Network
             }
         }
 
-        public static void Disconnect(NetState state, CircularBufferReader reader)
+        public static void Disconnect(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var minusOne = reader.ReadInt32();
         }
 
-        public static void ConfigurationFile(NetState state, CircularBufferReader reader)
+        public static void ConfigurationFile(NetState state, CircularBufferReader reader, ref int packetLength)
         {
         }
 
-        public static void LogoutReq(NetState state, CircularBufferReader reader)
+        public static void LogoutReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             state.SendLogoutAck();
         }
 
-        public static void ChangeSkillLock(NetState state, CircularBufferReader reader)
+        public static void ChangeSkillLock(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var s = state.Mobile.Skills[reader.ReadInt16()];
 
             s?.SetLockNoRelay((SkillLock)reader.ReadByte());
         }
 
-        public static void HelpRequest(NetState state, CircularBufferReader reader)
+        public static void HelpRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             EventSink.InvokeHelpRequest(state.Mobile);
         }
 
-        public static void DisplayGumpResponse(NetState state, CircularBufferReader reader)
+        public static void DisplayGumpResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var serial = reader.ReadUInt32();
             var typeID = reader.ReadInt32();
@@ -458,13 +458,13 @@ namespace Server.Network
             }
         }
 
-        public static void SetWarMode(NetState state, CircularBufferReader reader)
+        public static void SetWarMode(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             state.Mobile?.DelayChangeWarmode(reader.ReadBoolean());
         }
 
         // TODO: Throttle/make this more safe
-        public static void Resynchronize(NetState state, CircularBufferReader reader)
+        public static void Resynchronize(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -481,17 +481,17 @@ namespace Server.Network
             state.Sequence = 0;
         }
 
-        public static void PingReq(NetState state, CircularBufferReader reader)
+        public static void PingReq(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             state.SendPingAck(reader.ReadByte());
         }
 
-        public static void SetUpdateRange(NetState state, CircularBufferReader reader)
+        public static void SetUpdateRange(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             state.SendChangeUpdateRange(18);
         }
 
-        public static void MobileQuery(NetState state, CircularBufferReader reader)
+        public static void MobileQuery(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
             if (from == null)
@@ -528,7 +528,7 @@ namespace Server.Network
             }
         }
 
-        public static void CrashReport(NetState state, CircularBufferReader reader)
+        public static void CrashReport(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var clientMaj = reader.ReadByte();
             var clientMin = reader.ReadByte();
@@ -577,7 +577,7 @@ namespace Server.Network
             EventSink.InvokeQuestGumpRequest(state.Mobile);
         }
 
-        public static void EncodedCommand(NetState state, CircularBufferReader reader)
+        public static void EncodedCommand(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var e = World.FindEntity(reader.ReadUInt32());
             int packetId = reader.ReadUInt16();

--- a/Projects/Server/Network/Packets/IncomingTargetingPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingTargetingPackets.cs
@@ -25,7 +25,7 @@ namespace Server.Network
             IncomingPackets.Register(0x6C, 19, true, TargetResponse);
         }
 
-        public static void TargetResponse(NetState state, CircularBufferReader reader)
+        public static void TargetResponse(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int type = reader.ReadByte();
             var targetID = reader.ReadInt32();

--- a/Projects/Server/Network/Packets/IncomingVendorPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingVendorPackets.cs
@@ -25,7 +25,7 @@ namespace Server.Network
             IncomingPackets.Register(0x9F, 0, true, VendorSellReply);
         }
 
-        public static void VendorBuyReply(NetState state, CircularBufferReader reader)
+        public static void VendorBuyReply(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var vendor = World.FindMobile(reader.ReadUInt32());
 
@@ -65,7 +65,7 @@ namespace Server.Network
             state.SendEndVendorBuy(vendor.Serial);
         }
 
-        public static void VendorSellReply(NetState state, CircularBufferReader reader)
+        public static void VendorSellReply(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             Serial serial = reader.ReadUInt32();
             var vendor = World.FindMobile(serial);

--- a/Projects/UOContent/Engines/Chat/Chat.cs
+++ b/Projects/UOContent/Engines/Chat/Chat.cs
@@ -23,7 +23,7 @@ namespace Server.Engines.Chat
             to?.Send(new ChatMessagePacket(null, (int)type + 20, param1, param2));
         }
 
-        public static void OpenChatWindowRequest(NetState state, CircularBufferReader reader)
+        public static void OpenChatWindowRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -56,7 +56,7 @@ namespace Server.Engines.Chat
             return user;
         }
 
-        public static void ChatAction(NetState state, CircularBufferReader reader)
+        public static void ChatAction(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (!Enabled)
             {

--- a/Projects/UOContent/Engines/MLQuests/Gumps/RaceChangeGump.cs
+++ b/Projects/UOContent/Engines/MLQuests/Gumps/RaceChangeGump.cs
@@ -193,7 +193,7 @@ namespace Server.Engines.MLQuests.Gumps
             return false;
         }
 
-        private static void RaceChangeReply(NetState state, CircularBufferReader reader)
+        private static void RaceChangeReply(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (!m_Pending.TryGetValue(state, out var raceChangeState))
             {

--- a/Projects/UOContent/Items/Books/BaseBook.cs
+++ b/Projects/UOContent/Items/Books/BaseBook.cs
@@ -367,7 +367,7 @@ namespace Server.Items
             IncomingPackets.Register(0x93, 99, true, OldHeaderChange);
         }
 
-        public static void OldHeaderChange(NetState state, CircularBufferReader reader)
+        public static void OldHeaderChange(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -386,7 +386,7 @@ namespace Server.Items
             book.Author = Utility.FixHtml(author);
         }
 
-        public static void HeaderChange(NetState state, CircularBufferReader reader)
+        public static void HeaderChange(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 
@@ -420,7 +420,7 @@ namespace Server.Items
             book.Author = Utility.FixHtml(author);
         }
 
-        public static void ContentChange(NetState state, CircularBufferReader reader)
+        public static void ContentChange(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Items/Bulletin Boards/BulletinBoard.cs
+++ b/Projects/UOContent/Items/Bulletin Boards/BulletinBoard.cs
@@ -217,7 +217,7 @@ namespace Server.Items
             IncomingPackets.Register(0x71, 0, true, BBClientRequest);
         }
 
-        public static void BBClientRequest(NetState state, CircularBufferReader reader)
+        public static void BBClientRequest(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Items/Games/Mahjong/MahjongPacketHandlers.cs
+++ b/Projects/UOContent/Items/Games/Mahjong/MahjongPacketHandlers.cs
@@ -41,7 +41,7 @@ namespace Server.Engines.Mahjong
             RegisterSubCommand(0x18, MoveDealerIndicator);
         }
 
-        public static void OnPacket(NetState state,CircularBufferReader reader)
+        public static void OnPacket(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var game = World.FindItem(reader.ReadUInt32()) as MahjongGame;
 

--- a/Projects/UOContent/Items/Maps/MapItem.cs
+++ b/Projects/UOContent/Items/Maps/MapItem.cs
@@ -326,7 +326,7 @@ namespace Server.Items
             IncomingPackets.Register(0x56, 11, true, OnMapCommand);
         }
 
-        private static void OnMapCommand(NetState state, CircularBufferReader reader)
+        private static void OnMapCommand(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Misc/HardwareInfo.cs
+++ b/Projects/UOContent/Misc/HardwareInfo.cs
@@ -141,7 +141,7 @@ namespace Server
             }
         }
 
-        public static void OnReceive(NetState state, CircularBufferReader reader)
+        public static void OnReceive(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             reader.ReadByte(); // 1: <4.0.1a, 2>=4.0.1a
 

--- a/Projects/UOContent/Multis/HouseFoundation.cs
+++ b/Projects/UOContent/Multis/HouseFoundation.cs
@@ -1768,7 +1768,7 @@ namespace Server.Multis
             context.Foundation.SendInfoTo(state);
         }
 
-        public static void QueryDesignDetails(NetState state, CircularBufferReader reader)
+        public static void QueryDesignDetails(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Network/ProtocolExtensions.cs
+++ b/Projects/UOContent/Network/ProtocolExtensions.cs
@@ -25,7 +25,7 @@ namespace Server.Network
         public static PacketHandler GetHandler(int packetID) =>
             packetID >= 0 && packetID < _handlers.Length ? _handlers[packetID] : null;
 
-        public static void DecodeBundledPacket(NetState state, CircularBufferReader reader)
+        public static void DecodeBundledPacket(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             int packetID = reader.ReadByte();
 
@@ -47,25 +47,25 @@ namespace Server.Network
             }
             else
             {
-                ph.OnReceive(state, reader);
+                ph.OnReceive(state, reader, ref packetLength);
             }
         }
 
-        public static void QueryGuildMemberLocations(NetState ns, CircularBufferReader reader)
+        public static void QueryGuildMemberLocations(NetState state, CircularBufferReader reader, ref int packetLength)
         {
-            Mobile from = ns.Mobile;
+            Mobile from = state.Mobile;
 
-            ns.SendGuildMemberLocations(from, from.Guild as Guild, reader.ReadBoolean());
+            state.SendGuildMemberLocations(from, from.Guild as Guild, reader.ReadBoolean());
         }
 
-        public static void QueryPartyMemberLocations(NetState ns, CircularBufferReader reader)
+        public static void QueryPartyMemberLocations(NetState state, CircularBufferReader reader, ref int packetLength)
         {
-            Mobile from = ns.Mobile;
+            Mobile from = state.Mobile;
             var party = Party.Get(from);
 
             if (party != null)
             {
-                ns.SendPartyMemberLocations(from, party);
+                state.SendPartyMemberLocations(from, party);
             }
         }
 

--- a/Projects/UOContent/Skills/Tracking/Tracking.cs
+++ b/Projects/UOContent/Skills/Tracking/Tracking.cs
@@ -19,7 +19,7 @@ namespace Server.SkillHandlers
             SkillInfo.Table[(int)SkillName.Tracking].Callback = OnUse;
         }
 
-        public static void QuestArrow(NetState state, CircularBufferReader reader)
+        public static void QuestArrow(NetState state, CircularBufferReader reader, ref int packetLength)
         {
             if (state.Mobile is PlayerMobile from)
             {


### PR DESCRIPTION
- [X] Removes 6017 handler since it is only used in one place
- [X] Exposes a ref int to modify the packet length. This is acceptable since we technically have access to the entire reader/buffer.