### PR TITLE
Make MapDefinition packets configure before Account packets

### DIFF
--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -78,6 +78,7 @@ namespace Server.Misc
             }
         }
 
+        [CallPriority(99)]
         public static void Configure()
         {
             MaxAccountsPerIP = ServerConfiguration.GetOrUpdateSetting("accountHandler.maxAccountsPerIP", 1);

--- a/Projects/UOContent/Misc/MapDefinitions.cs
+++ b/Projects/UOContent/Misc/MapDefinitions.cs
@@ -2,6 +2,7 @@ namespace Server.Misc
 {
     public static class MapDefinitions
     {
+        [CallPriority(100)]
         public static void Configure()
         {
             /* Here we configure all maps. Some notes:


### PR DESCRIPTION
This is my attempt to make the MapDefinition packets configure themselves before the account packets since there is an issue with the Maps not being loaded by the time the Account packets are configured and sent as arguments to the new character creation handler.