### PR TITLE
fix(core): Adds ability to store null value in ordered hash set

### DIFF
--- a/Projects/Server.Tests/Tests/Collections/OrderedHashSetTests.cs
+++ b/Projects/Server.Tests/Tests/Collections/OrderedHashSetTests.cs
@@ -9,11 +9,33 @@ namespace Server.Tests
         [Fact]
         public void TestOrderedHashSet()
         {
-            var set = new OrderedHashSet<string>(1) { "random string1", "another random string1", "another random string2", "another random string3" };
+            var set = new OrderedHashSet<string>(1)
+            {
+                "random string1", "another random string1", "another random string2", "another random string3"
+            };
             set.Remove("another random string1");
             var list = set.ToList();
 
             string[] arr = { "random string1", "another random string2", "another random string3" };
+            int i = 0;
+            foreach (var entry in list)
+            {
+                Assert.Equal(entry, arr[i++]);
+            }
+        }
+
+        [Fact]
+        public void TestOrderedHashWithNull()
+        {
+            var set = new OrderedHashSet<string>(1)
+            {
+                "random string1", null, "another random string2", "another random string3"
+            };
+
+            set.Remove("another random string1");
+            var list = set.ToList();
+
+            string[] arr = { "random string1", null, "another random string2", "another random string3" };
             int i = 0;
             foreach (var entry in list)
             {

--- a/Projects/Server/Collections/HashHelpers.cs
+++ b/Projects/Server/Collections/HashHelpers.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Collections.Extensions
 {
@@ -97,6 +98,28 @@ namespace Microsoft.Collections.Extensions
             }
 
             return GetPrime(newSize);
+        }
+
+        /// <summary>Returns approximate reciprocal of the divisor: ceil(2**64 / divisor).</summary>
+        /// <remarks>This should only be used on 64-bit.</remarks>
+        public static ulong GetFastModMultiplier(uint divisor) =>
+            ulong.MaxValue / divisor + 1;
+
+        /// <summary>Performs a mod operation using the multiplier pre-computed with <see cref="GetFastModMultiplier"/>.</summary>
+        /// <remarks>This should only be used on 64-bit.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint FastMod(uint value, uint divisor, ulong multiplier)
+        {
+            // We use modified Daniel Lemire's fastmod algorithm (https://github.com/dotnet/runtime/pull/406),
+            // which allows to avoid the long multiplication if the divisor is less than 2**31.
+            Debug.Assert(divisor <= int.MaxValue);
+
+            // This is equivalent of (uint)Math.BigMul(multiplier * value, divisor, out _). This version
+            // is faster than BigMul currently because we only need the high bits.
+            uint highbits = (uint)(((((multiplier * value) >> 32) + 1) * divisor) >> 32);
+
+            Debug.Assert(highbits == value % divisor);
+            return highbits;
         }
     }
 }


### PR DESCRIPTION
- [X] Adds the ability to store a null value in an ordered hash set

TODO:
Optimized the OrderedHashSet. See this:
* https://github.com/dotnet/runtime/issues/10050
Looks like the OrderedDictionary that I based this structure from was not updated.
See the source for diffing:
https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs

Difference between a HashSet and an OrderedHashSet is updating the indexes of the entries after fixing the chain to preserve insertion order.