### PR TITLE
fix(network): Adds setting NetState.PacketEncoder only if not null

### DIFF
--- a/Projects/Server/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingAccountPackets.cs
@@ -417,7 +417,7 @@ namespace Server.Network
 
                 // Comment out these lines to turn off huffman compression
                 state.CompressionEnabled = true;
-                state.PacketEncoder = NetworkCompression.Compress;
+                state.PacketEncoder ??= NetworkCompression.Compress;
 
                 state.SendSupportedFeature();
                 state.SendCharacterList();


### PR DESCRIPTION
Allows for `EventSink.InvokeGameLogin` to set a custom packet encoder.