### PR TITLE
Modified quick-start to correctly invoke dotnet in *Nix

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -16,13 +16,13 @@ If you are familiar with RunUO, then follow these steps to get your ModernUO ser
     1. Download and install the [.NET 5 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0)
     1. Download and extract [ModernUO](https://github.com/modernuo/ModernUO/releases/latest) to a folder.
     1. Using _terminal_, navigate to the _Distribution_ folder.
-    1. Run `./dotnet ModernUO.dll`
+    1. Run `dotnet ModernUO.dll`
 
 === "Linux"
     1. Download and install the [.NET 5 Runtime](instructions [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux))
     1. Download and extract [ModernUO](https://github.com/modernuo/ModernUO/releases/latest) to a folder.
     1. Using _bash_, navigate to the _Distribution_ folder.
-    1. Run `./dotnet ModernUO.dll`
+    1. Run `dotnet ModernUO.dll`
 
 !!! Note
     Follow the rest of the [Get Started](../installation) guide to learn how to connect, configure, and customize, your server.


### PR DESCRIPTION
Current documentation incorrectly states that to run **ModernUO** you must use the ``./dotnet ModernUO.dll``.

This is untrue, since ``./dotnet`` will treat this as an instruction to execute the ``dotnet`` file in current context. This is true for the following shell types: **zsh** (Mac OS X Default), **bash** (Linux default), **sh** (Linux default on minimal distributions).

This small PR fixes this inconsistency.