### PR TITLE
fix(serialization): Updates serialization flow & fixes serializing accounts

### DIFF
--- a/Projects/Server/IAccount.cs
+++ b/Projects/Server/IAccount.cs
@@ -88,7 +88,7 @@ namespace Server.Accounting
         long GetTotalGold();
     }
 
-    public interface IAccount : IGoldAccount, IComparable<IAccount>
+    public interface IAccount : IGoldAccount, IComparable<IAccount>, ISerializable
     {
         string Username { get; set; }
         string Email { get; set; }

--- a/Projects/Server/Network/Pipe.cs
+++ b/Projects/Server/Network/Pipe.cs
@@ -141,7 +141,7 @@ namespace Server.Network
             {
                 if (_pipe._writeAwaitBeginning)
                 {
-                    throw new Exception("Double await on reader");
+                    throw new Exception("Double await on writer");
                 }
 
                 return this;

--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -1,0 +1,54 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Email: hi@modernuo.com                                                *
+ * File: GenericPersistence.cs                                           *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.IO;
+
+namespace Server
+{
+    public static class GenericPersistence
+    {
+        public static void Serialize(Action<IGenericWriter> serializer) => serializer(new BufferWriter(true));
+
+        public static void WriteSnapshot(string path, Action<IGenericWriter> serializer)
+        {
+            AssemblyHandler.EnsureDirectory(Path.GetDirectoryName(path));
+
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.None);
+            serializer(new BinaryFileWriter(fs, true));
+        }
+
+        public static void Deserialize(string path, Action<IGenericReader> deserializer, bool ensure = true)
+        {
+            AssemblyHandler.EnsureDirectory(Path.GetDirectoryName(path));
+
+            if (!File.Exists(path))
+            {
+                if (ensure)
+                {
+                    new FileInfo(path).Create().Close();
+                }
+
+                return;
+            }
+
+            using FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            // TODO: Support files larger than 2GB
+            var buffer = GC.AllocateUninitializedArray<byte>((int)fs.Length);
+
+            deserializer(new BufferReader(buffer));
+        }
+    }
+}

--- a/Projects/Server/World/EntityPersistence.cs
+++ b/Projects/Server/World/EntityPersistence.cs
@@ -1,0 +1,285 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Email: hi@modernuo.com                                                *
+ * File: EntityPersistence.cs                                            *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Server
+{
+    public static class EntityPersistence
+    {
+        public static void WriteEntities<I, T>(
+            IIndexInfo<I> indexInfo,
+            Dictionary<I, T> entities,
+            List<Type> types,
+            string savePath,
+            out Dictionary<string, int> counts
+        ) where T : class, ISerializable
+        {
+            counts = new Dictionary<string, int>();
+
+            var typeName = indexInfo.TypeName;
+
+            var path = Path.Combine(savePath, typeName);
+
+            AssemblyHandler.EnsureDirectory(path);
+
+            string idxPath = Path.Combine(path, $"{typeName}.idx");
+            string tdbPath = Path.Combine(path, $"{typeName}.tdb");
+            string binPath = Path.Combine(path, $"{typeName}.bin");
+
+            using var idx = new BinaryFileWriter(idxPath, false);
+            using var tdb = new BinaryFileWriter(tdbPath, false);
+            using var bin = new BinaryFileWriter(binPath, true);
+
+            idx.Write(entities.Count);
+            foreach (var e in entities.Values)
+            {
+                long start = bin.Position;
+
+                idx.Write(e.TypeRef);
+                idx.Write(e.Serial);
+                idx.Write(start);
+
+                e.SerializeTo(bin);
+
+                idx.Write((int)(bin.Position - start));
+
+                var type = e.GetType().FullName;
+                if (type != null)
+                {
+                    counts[type] = (counts.TryGetValue(type, out var count) ? count : 0) + 1;
+                }
+            }
+
+            tdb.Write(types.Count);
+            for (int i = 0; i < types.Count; ++i)
+            {
+                tdb.Write(types[i].FullName);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SaveEntities<T>(
+            IEnumerable<T> list,
+            Action<T> serializer
+        ) where T : class, ISerializable => Parallel.ForEach(list, serializer);
+
+        public static Dictionary<I, T> LoadIndex<I, T>(
+            string path,
+            IIndexInfo<I> indexInfo,
+            out List<EntityIndex<T>> entities
+        ) where T : class, ISerializable
+        {
+            var map = new Dictionary<I, T>();
+            object[] ctorArgs = new object[1];
+
+            var indexType = indexInfo.TypeName;
+
+            string indexPath = Path.Combine(path, indexType, $"{indexType}.idx");
+            string typesPath = Path.Combine(path, indexType, $"{indexType}.tdb");
+
+            entities = new List<EntityIndex<T>>();
+
+            if (!File.Exists(indexPath) || !File.Exists(typesPath))
+            {
+                return map;
+            }
+
+            using FileStream idx = new FileStream(indexPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            BinaryReader idxReader = new BinaryReader(idx);
+
+            using FileStream tdb = new FileStream(typesPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            BinaryReader tdbReader = new BinaryReader(tdb);
+
+            List<Tuple<ConstructorInfo, string>> types = ReadTypes<I>(tdbReader);
+
+            var count = idxReader.ReadInt32();
+
+            for (int i = 0; i < count; ++i)
+            {
+                var typeID = idxReader.ReadInt32();
+                var number = idxReader.ReadUInt32();
+                var pos = idxReader.ReadInt64();
+                var length = idxReader.ReadInt32();
+
+                Tuple<ConstructorInfo, string> objs = types[typeID];
+
+                if (objs == null)
+                {
+                    continue;
+                }
+
+                T t;
+                ConstructorInfo ctor = objs.Item1;
+                I indexer = indexInfo.CreateIndex(number);
+
+                ctorArgs[0] = indexer;
+                t = ctor.Invoke(ctorArgs) as T;
+
+                if (t != null)
+                {
+                    entities.Add(new EntityIndex<T>(t, typeID, pos, length));
+                    map[indexer] = t;
+                }
+            }
+
+            tdbReader.Close();
+            idxReader.Close();
+
+            return map;
+        }
+
+        public static void LoadData<I, T>(
+            string path,
+            IIndexInfo<I> indexInfo,
+            List<EntityIndex<T>> entities
+        ) where T : class, ISerializable
+        {
+            var indexType = indexInfo.TypeName;
+
+            string dataPath = Path.Combine(path, indexType, $"{indexType}.bin");
+
+            if (!File.Exists(dataPath))
+            {
+                return;
+            }
+
+            using FileStream bin = new FileStream(dataPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            BufferReader br = null;
+
+            foreach (var entry in entities)
+            {
+                T t = entry.Entity;
+
+                // Skip this entry
+                if (t == null)
+                {
+                    bin.Seek(entry.Length, SeekOrigin.Current);
+                    continue;
+                }
+
+                var buffer = GC.AllocateUninitializedArray<byte>(entry.Length);
+                if (br == null)
+                {
+                    br = new BufferReader(buffer);
+                }
+                else
+                {
+                    br.SwapBuffers(buffer, out _);
+                }
+
+                bin.Read(buffer.AsSpan());
+                string error;
+
+                try
+                {
+                    t.Deserialize(br);
+
+                    error = br.Position != entry.Length
+                        ? $"Serialized object was {entry.Length} bytes, but {br.Position} bytes deserialized"
+                        : null;
+                }
+                catch (Exception e)
+                {
+                    error = e.ToString();
+                }
+
+                if (error == null)
+                {
+                    t.InitializeSaveBuffer(buffer);
+                }
+                else
+                {
+                    Utility.PushColor(ConsoleColor.Red);
+                    Persistence.WriteConsoleLine($"***** Bad deserialize of {t.GetType()} *****");
+                    Persistence.WriteConsoleLine(error);
+                    Utility.PopColor();
+
+                    Persistence.WriteConsoleLine("Delete the object and continue? (y/n)");
+
+                    if (Console.ReadKey(true).Key != ConsoleKey.Y)
+                    {
+                        throw new Exception("Deserialization failed.");
+                    }
+                    t.Delete();
+                }
+            }
+        }
+
+        private static List<Tuple<ConstructorInfo, string>> ReadTypes<I>(BinaryReader tdbReader)
+        {
+            var constructorTypes = new[] { typeof(I) };
+
+            var count = tdbReader.ReadInt32();
+
+            var types = new List<Tuple<ConstructorInfo, string>>(count);
+
+            for (var i = 0; i < count; ++i)
+            {
+                var typeName = tdbReader.ReadString();
+
+                var t = AssemblyHandler.FindTypeByFullName(typeName, false);
+
+                if (t?.IsAbstract != false)
+                {
+                    Persistence.WriteConsoleLine("failed");
+
+                    var issue = t?.IsAbstract == true ? "marked abstract" : "not found";
+
+                    Persistence.WriteConsoleLine($"Error: Type '{typeName}' was {issue}. Delete all of those types? (y/n)");
+
+                    if (Console.ReadKey(true).Key == ConsoleKey.Y)
+                    {
+                        types.Add(null);
+                        Persistence.WriteConsole("Loading...");
+                        continue;
+                    }
+
+                    Persistence.WriteConsoleLine("Types will not be deleted. An exception will be thrown.");
+
+                    throw new Exception($"Bad type '{typeName}'");
+                }
+
+                var ctor = t.GetConstructor(constructorTypes);
+
+                if (ctor != null)
+                {
+                    types.Add(new Tuple<ConstructorInfo, string>(ctor, typeName));
+                }
+                else
+                {
+                    throw new Exception($"Type '{t}' does not have a serialization constructor");
+                }
+            }
+
+            return types;
+        }
+
+        private static void SerializeTo(this ISerializable entity, IGenericWriter writer)
+        {
+            var saveBuffer = entity.SaveBuffer;
+            writer.Write(saveBuffer.Buffer.AsSpan(0, (int)saveBuffer.Position));
+
+            // Resize to exact buffer size
+            entity.SaveBuffer.Resize((int)entity.SaveBuffer.Position);
+        }
+    }
+}

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -25,7 +25,7 @@ namespace Server.Accounting
         private Timer m_YoungTimer;
         private BufferWriter _saveBuffer;
 
-        public Account(string username, string password)
+        public Account(string username, string password) : this(Accounts.NewAccount)
         {
             Username = username;
 
@@ -41,16 +41,6 @@ namespace Server.Accounting
             IPRestrictions = Array.Empty<string>();
             LoginIPs = Array.Empty<IPAddress>();
 
-            var ourType = GetType();
-            TypeRef = Accounts.Types.IndexOf(ourType);
-
-            if (TypeRef == -1)
-            {
-                Accounts.Types.Add(ourType);
-                TypeRef = Accounts.Types.Count - 1;
-            }
-
-            Serial = Accounts.NewAccount;
             Accounts.Add(this);
         }
 

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -15,15 +15,15 @@ namespace Server.Accounting
         public static readonly TimeSpan YoungDuration = TimeSpan.FromHours(40.0);
         public static readonly TimeSpan InactiveDuration = TimeSpan.FromDays(180.0);
         public static readonly TimeSpan EmptyInactiveDuration = TimeSpan.FromDays(30.0);
-        private readonly Mobile[] m_Mobiles;
 
+        private Mobile[] m_Mobiles;
         private AccessLevel m_AccessLevel;
         private List<AccountComment> m_Comments;
         private PasswordProtectionAlgorithm m_PasswordAlgorithm;
         private List<AccountTag> m_Tags;
         private TimeSpan m_TotalGameTime;
-
         private Timer m_YoungTimer;
+        private BufferWriter _saveBuffer;
 
         public Account(string username, string password)
         {
@@ -41,11 +41,28 @@ namespace Server.Accounting
             IPRestrictions = Array.Empty<string>();
             LoginIPs = Array.Empty<IPAddress>();
 
+            var ourType = GetType();
+            TypeRef = Accounts.Types.IndexOf(ourType);
+
+            if (TypeRef == -1)
+            {
+                Accounts.Types.Add(ourType);
+                TypeRef = Accounts.Types.Count - 1;
+            }
+
+            Serial = Accounts.NewAccount;
             Accounts.Add(this);
+        }
+
+        public Account(Serial serial)
+        {
+            Serial = serial;
         }
 
         public Account(XmlElement node)
         {
+            Serial = Accounts.NewAccount;
+
             Username = Utility.GetText(node["username"], "empty");
 
             Enum.TryParse(Utility.GetText(node["passwordAlgorithm"], null), true, out m_PasswordAlgorithm);
@@ -199,7 +216,7 @@ namespace Server.Accounting
         /// <summary>
         ///     The date and time of when this account was created.
         /// </summary>
-        public DateTime Created { get; }
+        public DateTime Created { get; private set; }
 
         /// <summary>
         ///     Gets or sets the date and time when this account was last accessed.
@@ -245,6 +262,140 @@ namespace Server.Accounting
             }
         }
 
+        BufferWriter ISerializable.SaveBuffer
+        {
+            get => _saveBuffer;
+            set => _saveBuffer = value;
+        }
+
+        public int TypeRef { get; private set; }
+
+        public Serial Serial { get; set; }
+
+        public void Deserialize(IGenericReader reader)
+        {
+            Username = reader.ReadString();
+            m_PasswordAlgorithm = (PasswordProtectionAlgorithm)reader.ReadInt();
+            Password = reader.ReadString();
+            m_AccessLevel = (AccessLevel)reader.ReadInt();
+            Flags = reader.ReadInt();
+            Created = reader.ReadDateTime();
+            LastLogin = reader.ReadDateTime();
+
+            TotalGold = reader.ReadInt();
+            TotalPlat = reader.ReadInt();
+
+            m_Mobiles = new Mobile[7];
+            var length = reader.ReadInt();
+            for (int i = 0; i < length; i++)
+            {
+                m_Mobiles[i] = reader.ReadEntity<Mobile>();
+            }
+
+            length = reader.ReadInt();
+            m_Comments = new List<AccountComment>(length);
+            for (int i = 0; i < length; i++)
+            {
+                m_Comments.Add(new AccountComment(reader));
+            }
+
+            length = reader.ReadInt();
+            m_Tags = new List<AccountTag>(length);
+            for (int i = 0; i < length; i++)
+            {
+                m_Tags.Add(new AccountTag(reader));
+            }
+
+            length = reader.ReadInt();
+            LoginIPs = new IPAddress[length];
+            for (int i = 0; i < length; i++)
+            {
+                if (IPAddress.TryParse(reader.ReadString(), out var address))
+                {
+                    LoginIPs[i] = Utility.Intern(address);
+                }
+            }
+
+            length = reader.ReadInt();
+            IPRestrictions = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                IPRestrictions[i] = reader.ReadString();
+            }
+
+            for (var i = 0; i < m_Mobiles.Length; ++i)
+            {
+                if (m_Mobiles[i] != null)
+                {
+                    m_Mobiles[i].Account = this;
+                }
+            }
+
+            var totalGameTime = reader.ReadTimeSpan();
+            if (totalGameTime == TimeSpan.Zero)
+            {
+                for (var i = 0; i < m_Mobiles.Length; i++)
+                {
+                    if (m_Mobiles[i] is PlayerMobile m)
+                    {
+                        totalGameTime += m.GameTime;
+                    }
+                }
+            }
+
+            m_TotalGameTime = totalGameTime;
+
+            if (Young)
+            {
+                CheckYoung();
+            }
+        }
+
+        public void Serialize(IGenericWriter writer)
+        {
+            writer.Write(Username);
+            writer.Write((int)m_PasswordAlgorithm);
+            writer.Write(Password);
+            writer.Write((int)m_AccessLevel);
+            writer.Write(Flags);
+            writer.Write(Created);
+            writer.Write(LastLogin);
+            writer.Write(TotalGold);
+            writer.Write(TotalPlat);
+
+            writer.Write(Count);
+            for (int i = 0; i < m_Mobiles.Length; i++)
+            {
+                writer.Write(m_Mobiles[i]);
+            }
+
+            writer.Write(m_Comments.Count);
+            for (int i = 0; i < m_Mobiles.Length; i++)
+            {
+                m_Comments[i].Serialize(writer);
+            }
+
+            writer.Write(m_Tags.Count);
+            for (int i = 0; i < m_Tags.Count; i++)
+            {
+                m_Tags[i].Serialize(writer);
+            }
+
+            writer.Write(LoginIPs.Length);
+            for (int i = 0; i < LoginIPs.Length; i++)
+            {
+                writer.Write(LoginIPs[i].ToString());
+            }
+
+            writer.Write(IPRestrictions.Length);
+            for (int i = 0; i < IPRestrictions.Length; i++)
+            {
+                writer.Write(IPRestrictions[i].ToString());
+            }
+
+            writer.Write(TotalGameTime);
+        }
+
         /// <summary>
         ///     Deletes the account, all characters of the account, and all houses of those characters
         /// </summary>
@@ -277,8 +428,11 @@ namespace Server.Accounting
                 --AccountHandler.IPTable[LoginIPs[0]];
             }
 
-            Accounts.Remove(Username);
+            Deleted = true;
+            Accounts.Remove(this);
         }
+
+        public bool Deleted { get; private set; }
 
         /// <summary>
         ///     Account username. Case insensitive validation.
@@ -784,7 +938,7 @@ namespace Server.Accounting
         /// </summary>
         /// <param name="node">The XmlElement from which to deserialize.</param>
         /// <returns>String list. Value will never be null.</returns>
-        public static string[] LoadAccessCheck(XmlElement node)
+        private static string[] LoadAccessCheck(XmlElement node)
         {
             string[] stringList;
             var accessCheck = node["accessCheck"];
@@ -818,7 +972,7 @@ namespace Server.Accounting
         /// </summary>
         /// <param name="node">The XmlElement from which to deserialize.</param>
         /// <returns>Address list. Value will never be null.</returns>
-        public static IPAddress[] LoadAddressList(XmlElement node)
+        private static IPAddress[] LoadAddressList(XmlElement node)
         {
             IPAddress[] list;
             var addressList = node["addressList"];
@@ -867,7 +1021,7 @@ namespace Server.Accounting
         /// </summary>
         /// <param name="node">The XmlElement instance from which to deserialize.</param>
         /// <returns>Mobile list. Value will never be null.</returns>
-        public static Mobile[] LoadMobiles(XmlElement node)
+        private static Mobile[] LoadMobiles(XmlElement node)
         {
             var list = new Mobile[7];
             var chars = node["chars"];
@@ -905,7 +1059,7 @@ namespace Server.Accounting
         /// </summary>
         /// <param name="node">The XmlElement from which to deserialize.</param>
         /// <returns>Comment list. Value will never be null.</returns>
-        public static List<AccountComment> LoadComments(XmlElement node)
+        private static List<AccountComment> LoadComments(XmlElement node)
         {
             List<AccountComment> list = null;
             var comments = node["comments"];
@@ -935,7 +1089,7 @@ namespace Server.Accounting
         /// </summary>
         /// <param name="node">The XmlElement from which to deserialize.</param>
         /// <returns>Tag list. Value will never be null.</returns>
-        public static List<AccountTag> LoadTags(XmlElement node)
+        private static List<AccountTag> LoadTags(XmlElement node)
         {
             List<AccountTag> list = null;
             var tags = node["tags"];

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -311,17 +311,17 @@ namespace Server.Accounting
             }
 
             length = reader.ReadInt();
-            m_Comments = new List<AccountComment>(length);
+            m_Comments = length > 0 ? new List<AccountComment>(length) : null;
             for (int i = 0; i < length; i++)
             {
-                m_Comments.Add(new AccountComment(reader));
+                m_Comments!.Add(new AccountComment(reader));
             }
 
             length = reader.ReadInt();
-            m_Tags = new List<AccountTag>(length);
+            m_Tags = length > 0 ? new List<AccountTag>(length) : null;
             for (int i = 0; i < length; i++)
             {
-                m_Tags.Add(new AccountTag(reader));
+                m_Tags!.Add(new AccountTag(reader));
             }
 
             length = reader.ReadInt();
@@ -384,7 +384,11 @@ namespace Server.Accounting
             writer.Write(Count);
             for (int i = 0; i < m_Mobiles.Length; i++)
             {
-                writer.Write(m_Mobiles[i]);
+                var m = m_Mobiles[i];
+                if (m != null)
+                {
+                    writer.Write(m);
+                }
             }
 
             var length = m_Comments?.Count ?? 0;

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -57,11 +57,29 @@ namespace Server.Accounting
         public Account(Serial serial)
         {
             Serial = serial;
+
+            var ourType = GetType();
+            TypeRef = Accounts.Types.IndexOf(ourType);
+
+            if (TypeRef == -1)
+            {
+                Accounts.Types.Add(ourType);
+                TypeRef = Accounts.Types.Count - 1;
+            }
         }
 
         public Account(XmlElement node)
         {
             Serial = Accounts.NewAccount;
+
+            var ourType = GetType();
+            TypeRef = Accounts.Types.IndexOf(ourType);
+
+            if (TypeRef == -1)
+            {
+                Accounts.Types.Add(ourType);
+                TypeRef = Accounts.Types.Count - 1;
+            }
 
             Username = Utility.GetText(node["username"], "empty");
 
@@ -369,16 +387,18 @@ namespace Server.Accounting
                 writer.Write(m_Mobiles[i]);
             }
 
-            writer.Write(m_Comments.Count);
-            for (int i = 0; i < m_Mobiles.Length; i++)
+            var length = m_Comments?.Count ?? 0;
+            writer.Write(length);
+            for (int i = 0; i < length; i++)
             {
-                m_Comments[i].Serialize(writer);
+                m_Comments![i].Serialize(writer);
             }
 
-            writer.Write(m_Tags.Count);
-            for (int i = 0; i < m_Tags.Count; i++)
+            length = m_Tags?.Count ?? 0;
+            writer.Write(length);
+            for (int i = 0; i < length; i++)
             {
-                m_Tags[i].Serialize(writer);
+                m_Tags![i].Serialize(writer);
             }
 
             writer.Write(LoginIPs.Length);
@@ -390,7 +410,7 @@ namespace Server.Accounting
             writer.Write(IPRestrictions.Length);
             for (int i = 0; i < IPRestrictions.Length; i++)
             {
-                writer.Write(IPRestrictions[i].ToString());
+                writer.Write(IPRestrictions[i]);
             }
 
             writer.Write(TotalGameTime);

--- a/Projects/UOContent/Accounting/AccountComment.cs
+++ b/Projects/UOContent/Accounting/AccountComment.cs
@@ -31,6 +31,17 @@ namespace Server.Accounting
         }
 
         /// <summary>
+        ///     Deserializes an AccountComment instance.
+        /// </summary>
+        /// <param name="node">The deserialization reader</param>
+        public AccountComment(IGenericReader reader)
+        {
+            AddedBy = reader.ReadString();
+            LastModified = reader.ReadDateTime();
+            m_Content = reader.ReadString();
+        }
+
+        /// <summary>
         ///     A string representing who added this comment.
         /// </summary>
         public string AddedBy { get; }
@@ -68,6 +79,17 @@ namespace Server.Accounting
             xml.WriteString(m_Content);
 
             xml.WriteEndElement();
+        }
+
+        /// <summary>
+        ///     Serializes this AccountComment instance.
+        /// </summary>
+        /// <param name="xml">The serialization writer.</param>
+        public void Serialize(IGenericWriter writer)
+        {
+            writer.Write(AddedBy ?? "empty");
+            writer.Write(LastModified);
+            writer.Write(m_Content);
         }
     }
 }

--- a/Projects/UOContent/Accounting/AccountTag.cs
+++ b/Projects/UOContent/Accounting/AccountTag.cs
@@ -26,6 +26,16 @@ namespace Server.Accounting
         }
 
         /// <summary>
+        ///     Deserializes an AccountTag instance .
+        /// </summary>
+        /// <param name="node">The deserialization reader</param>
+        public AccountTag(IGenericReader reader)
+        {
+            Name = reader.ReadString();
+            Value = reader.ReadString();
+        }
+
+        /// <summary>
         ///     Gets or sets the name of this tag.
         /// </summary>
         public string Name { get; set; }
@@ -45,6 +55,16 @@ namespace Server.Accounting
             xml.WriteAttributeString("name", Name);
             xml.WriteString(Value);
             xml.WriteEndElement();
+        }
+
+        /// <summary>
+        ///     Serializes this AccountTag instance to an XmlTextWriter.
+        /// </summary>
+        /// <param name="xml">The serialization writer.</param>
+        public void Serialize(IGenericWriter writer)
+        {
+            writer.Write(Name ?? "empty");
+            writer.Write(Value);
         }
     }
 }

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -69,7 +69,7 @@ namespace Server.Accounting
             _accountsById.Remove(a.Serial);
         }
 
-        public static void Deserialize(string path)
+        internal static void Deserialize(string path)
         {
             var filePath = Path.Combine(path, "Accounts", "accounts.xml");
 

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -20,7 +20,7 @@ namespace Server.Accounting
             {
                 uint last = _lastAccount;
 
-                for (int i = 0; i < uint.MaxValue; i++)
+                for (uint i = 0; i < uint.MaxValue; i++)
                 {
                     last++;
 

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -7,50 +7,92 @@ namespace Server.Accounting
 {
     public static class Accounts
     {
-        private static Dictionary<string, IAccount> m_Accounts = new();
+        private static readonly Dictionary<string, IAccount> _accountsByName = new(32, StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<Serial, IAccount> _accountsById = new(32);
+        private static Serial _lastAccount;
+        internal static List<Type> Types { get; } = new();
 
-        static Accounts()
+        private static void OutOfMemory(string message) => throw new OutOfMemoryException(message);
+
+        public static Serial NewAccount
         {
+            get
+            {
+                uint last = _lastAccount;
+
+                for (int i = 0; i < uint.MaxValue; i++)
+                {
+                    last++;
+
+                    if (FindAccount(last) == null)
+                    {
+                        return _lastAccount = last;
+                    }
+                }
+
+                OutOfMemory("No serials left to allocate for accounts");
+                return Serial.MinusOne;
+            }
         }
 
-        public static int Count => m_Accounts.Count;
+        public static int Count => _accountsByName.Count;
 
-        public static void Configure()
+        public static void Configure() =>
+            Persistence.Register(Serialize, WriteSnapshot, Deserialize);
+
+        internal static void Serialize() =>
+            EntityPersistence.SaveEntities(_accountsById.Values, account => account.Serialize());
+
+        internal static void WriteSnapshot(string basePath)
         {
-            EventSink.WorldLoad += Load;
-            EventSink.WorldSave += Save;
+            IIndexInfo<Serial> indexInfo = new EntityTypeIndex("Accounts");
+            EntityPersistence.WriteEntities(indexInfo, _accountsById, Types, basePath, out _);
         }
 
-        public static IEnumerable<IAccount> GetAccounts() => m_Accounts.Values;
+        public static IEnumerable<IAccount> GetAccounts() => _accountsByName.Values;
 
         public static IAccount GetAccount(string username)
         {
-            m_Accounts.TryGetValue(username, out var a);
-
+            _accountsByName.TryGetValue(username, out var a);
             return a;
         }
 
         public static void Add(IAccount a)
         {
-            m_Accounts[a.Username] = a;
+            _accountsByName[a.Username] = a;
+            _accountsById[a.Serial] = a;
         }
 
-        public static void Remove(string username)
+        public static void Remove(IAccount a)
         {
-            m_Accounts.Remove(username);
+            _accountsByName.Remove(a.Username);
+            _accountsById.Remove(a.Serial);
         }
 
-        public static void Load()
+        public static void Deserialize(string path)
         {
-            m_Accounts = new Dictionary<string, IAccount>(32, StringComparer.OrdinalIgnoreCase);
+            var filePath = Path.Combine(path, "Accounts", "accounts.xml");
 
-            var filePath = Path.Combine("Saves/Accounts", "accounts.xml");
-
-            if (!File.Exists(filePath))
+            // Backward Compatibility
+            if (File.Exists(filePath))
             {
+                DeserializeXml(filePath);
                 return;
             }
 
+            IIndexInfo<Serial> indexInfo = new EntityTypeIndex("Accounts");
+
+            _accountsById = EntityPersistence.LoadIndex(path, indexInfo, out List<EntityIndex<IAccount>> accounts);
+            EntityPersistence.LoadData(path, indexInfo, accounts);
+
+            foreach (var a in _accountsById.Values)
+            {
+                _accountsByName[a.Username] = a;
+            }
+        }
+
+        private static void DeserializeXml(string filePath)
+        {
             var doc = new XmlDocument();
             doc.Load(filePath);
 
@@ -74,29 +116,10 @@ namespace Server.Accounting
             }
         }
 
-        public static void Save()
+        public static IAccount FindAccount(Serial serial)
         {
-            AssemblyHandler.EnsureDirectory("Saves/Accounts");
-
-            var filePath = Path.Combine("Saves/Accounts", "accounts.xml");
-
-            using var op = new StreamWriter(filePath);
-            var xml = new XmlTextWriter(op) { Formatting = Formatting.Indented, IndentChar = '\t', Indentation = 1 };
-
-            xml.WriteStartDocument(true);
-
-            xml.WriteStartElement("accounts");
-
-            xml.WriteAttributeString("count", m_Accounts.Count.ToString());
-
-            foreach (Account a in GetAccounts())
-            {
-                a.Save(xml);
-            }
-
-            xml.WriteEndElement();
-
-            xml.Close();
+            _accountsById.TryGetValue(serial, out var account);
+            return account;
         }
     }
 }


### PR DESCRIPTION
- [X] Extends the serialization to allow for custom Entity based serialization like Mobiles and Items.
- [X] Adds the ability to register custom persistence to the Persistence static class.
- [X] Fixes accounts not serializing properly.
- [X] Moves RunUO `Persistence` to `GenericPersistence`.
- [X] Changes Accounts from XML to binary.

## POSSIBLE BREAKING CODE CHANGE
If you get a compile error due to `Persistence.Serialize`, you must switch to `GenericPersistence`.
World serialization is now broken up into two phases, Serialization (to memory), and Snapshotting (to disk).
Look at `UOContent/Accounting/Accounts.cs` as an example. Contact us on [discord](https://discord.gg/NUhe7Pq9gF) for help.