### PR TITLE
feat(spawners): Adds Respawn, EditSpawner, and SpawnProps commands

### DIFF
--- a/Projects/Server/Commands.cs
+++ b/Projects/Server/Commands.cs
@@ -178,8 +178,7 @@ namespace Server
     {
         public static string Prefix { get; set; } = "[";
 
-        public static Dictionary<string, CommandEntry> Entries { get; } =
-            new(StringComparer.OrdinalIgnoreCase);
+        public static Dictionary<string, CommandEntry> Entries { get; } = new(StringComparer.OrdinalIgnoreCase);
 
         public static AccessLevel BadCommandIgnoreLevel { get; set; } = AccessLevel.Player;
 

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -274,13 +274,14 @@ namespace Server
             watch.Stop();
 
             Utility.PushColor(ConsoleColor.Green);
+            Console.Write("done");
+            Utility.PopColor();
             Console.WriteLine(
-                "done ({1} items, {2} mobiles) ({0:F2} seconds)",
+                " ({1} items, {2} mobiles) ({0:F2} seconds)",
                 watch.Elapsed.TotalSeconds,
                 Items.Count,
                 Mobiles.Count
             );
-            Utility.PopColor();
 
             WorldState = WorldState.Running;
         }

--- a/Projects/UOContent/Accounting/IPLimiter.cs
+++ b/Projects/UOContent/Accounting/IPLimiter.cs
@@ -26,7 +26,9 @@ namespace Server.Misc
             for (int i = 0; i < Exemptions.Length; i++)
             {
                 if (ip.Equals(Exemptions[i]))
+                {
                     return true;
+                }
             }
 
             return false;

--- a/Projects/UOContent/Commands/Generic/Commands/BaseCommand.cs
+++ b/Projects/UOContent/Commands/Generic/Commands/BaseCommand.cs
@@ -36,16 +36,12 @@ namespace Server.Commands.Generic
                 return true;
             }
 
-            Mobile mob = null;
-
-            if (obj is Mobile m)
+            Mobile mob = obj switch
             {
-                mob = m;
-            }
-            else if (obj is Item item)
-            {
-                mob = item.RootParent as Mobile;
-            }
+                Mobile m  => m,
+                Item item => item.RootParent as Mobile,
+                _         => null
+            };
 
             return mob == null || mob == from || from.AccessLevel > mob.AccessLevel;
         }

--- a/Projects/UOContent/Commands/Object Creation/Decorate.cs
+++ b/Projects/UOContent/Commands/Object Creation/Decorate.cs
@@ -511,7 +511,7 @@ namespace Server.Commands
                     light.ItemID = m_ItemID;
                 }
             }
-            else if (item is Spawner sp)
+            else if (item is BaseSpawner sp)
             {
                 sp.NextSpawn = TimeSpan.Zero;
 

--- a/Projects/UOContent/Commands/Object Creation/DecorateMag.cs
+++ b/Projects/UOContent/Commands/Object Creation/DecorateMag.cs
@@ -508,7 +508,7 @@ namespace Server.Commands
                     light.ItemID = m_ItemID;
                 }
             }
-            else if (item is Spawner sp)
+            else if (item is BaseSpawner sp)
             {
                 sp.NextSpawn = TimeSpan.Zero;
 

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -606,32 +606,31 @@ namespace Server.Commands
 
         private class PropsTarget : Target
         {
-            bool iEdit;
-            public PropsTarget(bool iEdit = false) : base(-1, true, TargetFlags.None)
-            {
-                this.iEdit = iEdit;
-            }
+            private readonly bool _canEdit;
+
+            public PropsTarget(bool canEdit = false) : base(-1, true, TargetFlags.None) => _canEdit = canEdit;
 
             protected override void OnTarget(Mobile from, object o)
             {
                 if (!BaseCommand.IsAccessible(from, o))
                 {
                     from.SendLocalizedMessage(500447); // That is not accessible.
+                    return;
+                }
+
+                if (!_canEdit)
+                {
+                    from.SendGump(new PropertiesGump(from, o));
+                    return;
+                }
+
+                if (o is Mobile { Player: false })
+                {
+                    from.SendGump(new GlobalPropsGump(from, o));
                 }
                 else
                 {
-                    if (iEdit)
-                    {
-                        if (o is Mobile mbl && !mbl.Player)
-                        {
-                            from.SendGump(new GlobalPropsGump(from, o));
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(500447); // That is not accessible.
-                        }
-                    }
-                    else from.SendGump(new PropertiesGump(from, o));
+                    from.SendLocalizedMessage(500447); // That is not accessible.
                 }
             }
         }

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -49,8 +49,8 @@ namespace Server.Commands
             CommandSystem.Register("Props", AccessLevel.Counselor, Props_OnCommand);
         }
 
-        [Usage("Props [serial]"),
-         Description("Opens a menu where you can view and edit all properties of a targeted (or specified) object.")]
+        [Usage("Props [serial]")]
+        [Description("Opens a menu where you can view and edit all properties of a targeted (or specified) object.")]
         private static void Props_OnCommand(CommandEventArgs e)
         {
             if (e.Length == 1)

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -600,7 +600,7 @@ namespace Server.Commands
 
         private class PropsTarget : Target
         {
-            public PropsTarget(bool canEdit = false) : base(-1, true, TargetFlags.None)
+            public PropsTarget() : base(-1, true, TargetFlags.None)
             {
             }
 

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -47,12 +47,6 @@ namespace Server.Commands
         public static void Initialize()
         {
             CommandSystem.Register("Props", AccessLevel.Counselor, Props_OnCommand);
-            CommandSystem.Register("GlobalProps", AccessLevel.Counselor, GlobalProps_OnCommand);
-        }
-
-        private static void GlobalProps_OnCommand(CommandEventArgs e)
-        {
-            e.Mobile.Target = new PropsTarget(true);
         }
 
         [Usage("Props [serial]"),
@@ -606,31 +600,19 @@ namespace Server.Commands
 
         private class PropsTarget : Target
         {
-            private readonly bool _canEdit;
-
-            public PropsTarget(bool canEdit = false) : base(-1, true, TargetFlags.None) => _canEdit = canEdit;
+            public PropsTarget(bool canEdit = false) : base(-1, true, TargetFlags.None)
+            {
+            }
 
             protected override void OnTarget(Mobile from, object o)
             {
                 if (!BaseCommand.IsAccessible(from, o))
                 {
                     from.SendLocalizedMessage(500447); // That is not accessible.
-                    return;
-                }
-
-                if (!_canEdit)
-                {
-                    from.SendGump(new PropertiesGump(from, o));
-                    return;
-                }
-
-                if (o is Mobile { Player: false })
-                {
-                    from.SendGump(new GlobalPropsGump(from, o));
                 }
                 else
                 {
-                    from.SendLocalizedMessage(500447); // That is not accessible.
+                    from.SendGump(new PropertiesGump(from, o));
                 }
             }
         }

--- a/Projects/UOContent/Commands/Properties.cs
+++ b/Projects/UOContent/Commands/Properties.cs
@@ -47,6 +47,12 @@ namespace Server.Commands
         public static void Initialize()
         {
             CommandSystem.Register("Props", AccessLevel.Counselor, Props_OnCommand);
+            CommandSystem.Register("GlobalProps", AccessLevel.Counselor, GlobalProps_OnCommand);
+        }
+
+        private static void GlobalProps_OnCommand(CommandEventArgs e)
+        {
+            e.Mobile.Target = new PropsTarget(true);
         }
 
         [Usage("Props [serial]"),
@@ -597,10 +603,13 @@ namespace Server.Commands
             return result ?? SetDirect(o, p, toSet);
         }
 
+
         private class PropsTarget : Target
         {
-            public PropsTarget() : base(-1, true, TargetFlags.None)
+            bool iEdit;
+            public PropsTarget(bool iEdit = false) : base(-1, true, TargetFlags.None)
             {
+                this.iEdit = iEdit;
             }
 
             protected override void OnTarget(Mobile from, object o)
@@ -611,7 +620,18 @@ namespace Server.Commands
                 }
                 else
                 {
-                    from.SendGump(new PropertiesGump(from, o));
+                    if (iEdit)
+                    {
+                        if (o is Mobile mbl && !mbl.Player)
+                        {
+                            from.SendGump(new GlobalPropsGump(from, o));
+                        }
+                        else
+                        {
+                            from.SendLocalizedMessage(500447); // That is not accessible.
+                        }
+                    }
+                    else from.SendGump(new PropertiesGump(from, o));
                 }
             }
         }

--- a/Projects/UOContent/Engines/Harvest/Core/HarvestDefinition.cs
+++ b/Projects/UOContent/Engines/Harvest/Core/HarvestDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Server.Random;
 
 namespace Server.Engines.Harvest
@@ -83,16 +84,16 @@ namespace Server.Engines.Harvest
 
         public uint VeinWeights { get; private set; }
 
-        public Dictionary<Map, Dictionary<Point2D, HarvestBank>> Banks { get; }
-            = new();
+        public Dictionary<Map, Dictionary<Point2D, HarvestBank>> Banks { get; } = new();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SendMessageTo(Mobile from, TextDefinition message)
         {
-            if (message.Number > 0)
+            if (message?.Number > 0)
             {
                 from.SendLocalizedMessage(message.Number);
             }
-            else
+            else if (!string.IsNullOrWhiteSpace(message))
             {
                 from.SendMessage(message);
             }

--- a/Projects/UOContent/Engines/ML Quests/MLQuest.cs
+++ b/Projects/UOContent/Engines/ML Quests/MLQuest.cs
@@ -269,7 +269,7 @@ namespace Server.Engines.MLQuests
         {
             var name = $"MLQS-{GetType().Name}";
 
-            var toDelete = map.GetItemsInRange(loc, 0).Where(item => item is Spawner && item.Name == name);
+            var toDelete = map.GetItemsInRange(loc, 0).Where(item => item is BaseSpawner && item.Name == name);
 
             foreach (var item in toDelete)
             {

--- a/Projects/UOContent/Engines/Spawners/EditSpawnCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/EditSpawnCommand.cs
@@ -1,0 +1,109 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Email: hi@modernuo.com                                                *
+ * File: EditSpawnCommand.cs                                             *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using Server.Commands;
+using Server.Commands.Generic;
+using Server.Network;
+
+namespace Server.Engines.Spawners
+{
+    public class EditSpawnCommand : BaseCommand
+    {
+        public static void Initialize()
+        {
+            TargetCommands.Register(new EditSpawnCommand());
+        }
+
+        public EditSpawnCommand()
+        {
+            AccessLevel = AccessLevel.GameMaster;
+            Supports = CommandSupport.Complex | CommandSupport.Simple;
+            Commands = new[] { "EditSpawner" };
+            ObjectTypes = ObjectTypes.Items;
+            Usage = "EditSpawner <mobile> <arguments> set <properties>";
+            Description = "Modifies the given ";
+            ListOptimized = true;
+        }
+
+        public override void ExecuteList(CommandEventArgs e, List<object> list)
+        {
+            var args = e.Arguments;
+
+            if (args.Length <= 1)
+            {
+                LogFailure(Usage);
+                return;
+            }
+
+            if (list.Count == 0)
+            {
+                LogFailure("No matching objects found.");
+                return;
+            }
+
+            var name = args[0];
+
+            var type = AssemblyHandler.FindTypeByName(name);
+
+            if (!Add.IsEntity(type))
+            {
+                LogFailure("No type with that name was found.");
+                return;
+            }
+
+            var argSpan = e.ArgString.AsSpan(name.Length + 1);
+            var setIndex = argSpan.InsensitiveIndexOf("set ");
+
+            ReadOnlySpan<char> props = null;
+
+            if (setIndex > -1)
+            {
+                var start = setIndex + 4;
+                props = argSpan.Slice(start, argSpan.Length - start);
+                argSpan = argSpan.SliceToLength(setIndex);
+            }
+
+            var argStr = argSpan.ToString().DefaultIfNullOrEmpty(null);
+            var propsStr = props.ToString().DefaultIfNullOrEmpty(null);
+
+            foreach (var obj in list)
+            {
+                if (obj is BaseSpawner spawner)
+                {
+                    UpdateSpawner(spawner, name, argStr, propsStr);
+                }
+            }
+        }
+
+        public static void UpdateSpawner(BaseSpawner spawner, string name, string arguments, string properties)
+        {
+            foreach (var entry in spawner.Entries)
+            {
+                // TODO: Should cache spawn type on the entry
+                if (entry.SpawnedName.InsensitiveEquals(name))
+                {
+                    if (arguments != null)
+                    {
+                        entry.Parameters = arguments;
+                    }
+
+                    entry.Properties = properties;
+                }
+            }
+        }
+    }
+}

--- a/Projects/UOContent/Engines/Spawners/EditSpawnCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/EditSpawnCommand.cs
@@ -34,8 +34,8 @@ namespace Server.Engines.Spawners
             Supports = CommandSupport.Complex | CommandSupport.Simple;
             Commands = new[] { "EditSpawner" };
             ObjectTypes = ObjectTypes.Items;
-            Usage = "EditSpawner <mobile> <arguments> set <properties>";
-            Description = "Modifies the given ";
+            Usage = "EditSpawner <type> <arguments> set <properties>";
+            Description = "Modifies spawners arguments and properties for the given type";
             ListOptimized = true;
         }
 

--- a/Projects/UOContent/Engines/Spawners/EditSpawnCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/EditSpawnCommand.cs
@@ -80,6 +80,8 @@ namespace Server.Engines.Spawners
             var argStr = argSpan.ToString().DefaultIfNullOrEmpty(null);
             var propsStr = props.ToString().DefaultIfNullOrEmpty(null);
 
+            e.Mobile.SendMessage("Updating spawners...");
+
             foreach (var obj in list)
             {
                 if (obj is BaseSpawner spawner)
@@ -87,6 +89,8 @@ namespace Server.Engines.Spawners
                     UpdateSpawner(spawner, name, argStr, propsStr);
                 }
             }
+
+            e.Mobile.SendMessage("Update completed.");
         }
 
         public static void UpdateSpawner(BaseSpawner spawner, string name, string arguments, string properties)

--- a/Projects/UOContent/Engines/Spawners/GenerateSpawners.cs
+++ b/Projects/UOContent/Engines/Spawners/GenerateSpawners.cs
@@ -15,7 +15,57 @@ namespace Server.Engines.Spawners
         public static void Initialize()
         {
             CommandSystem.Register("GenerateSpawners", AccessLevel.Developer, GenerateSpawners_OnCommand);
+            CommandSystem.Register("RespawnSpawners", AccessLevel.GameMaster, RespawnWorld_OnCommand);
+            CommandSystem.Register("EditSpawners", AccessLevel.Developer, EditSpawnersProps_OnCommand);
+
         }
+
+        private static void EditSpawnersProps_OnCommand(CommandEventArgs e)
+        {
+            var from = e.Mobile;
+            if (e.Arguments.Length < 2)
+            {
+                //[EditSpawnersProps skeleton str 10 dex 10
+                from.SendMessage("Usage: [EditSpawnersProps <'Monster name'> <props string>");
+                return;
+            }
+            var Props = string.Join(" ", e.Arguments.Skip(1));
+            UpdateSpawners(e.Arguments[0], Props);
+        }
+
+        public static void UpdateSpawners(string Name, string Props)
+        {
+            var Monster = AssemblyHandler.FindTypeByName(Name);
+            if (Monster is null) return;
+
+            foreach (var item in World.Items)
+            {
+                if (item.Value is Spawner spwn)
+                {
+                    foreach (var entr in spwn.Entries)
+                    {
+                        if (entr.SpawnedName.Equals(Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            entr.Properties = Props;
+                        }
+                    }
+                }
+            }
+        }
+        private static void RespawnWorld_OnCommand(CommandEventArgs e)
+        {
+
+            var toRespawn = new List<Spawner>();
+            foreach (var item in World.Items)
+            {
+                if (item.Value is Spawner itm)
+                {
+                    toRespawn.Add(itm);
+                }
+            }
+            toRespawn.ForEach(_ => _.Respawn());
+        }
+
 
         private static void GenerateSpawners_OnCommand(CommandEventArgs e)
         {

--- a/Projects/UOContent/Engines/Spawners/GenerateSpawners.cs
+++ b/Projects/UOContent/Engines/Spawners/GenerateSpawners.cs
@@ -15,57 +15,7 @@ namespace Server.Engines.Spawners
         public static void Initialize()
         {
             CommandSystem.Register("GenerateSpawners", AccessLevel.Developer, GenerateSpawners_OnCommand);
-            CommandSystem.Register("RespawnSpawners", AccessLevel.GameMaster, RespawnWorld_OnCommand);
-            CommandSystem.Register("EditSpawners", AccessLevel.Developer, EditSpawnersProps_OnCommand);
-
         }
-
-        private static void EditSpawnersProps_OnCommand(CommandEventArgs e)
-        {
-            var from = e.Mobile;
-            if (e.Arguments.Length < 2)
-            {
-                //[EditSpawnersProps skeleton str 10 dex 10
-                from.SendMessage("Usage: [EditSpawnersProps <'Monster name'> <props string>");
-                return;
-            }
-            var Props = string.Join(" ", e.Arguments.Skip(1));
-            UpdateSpawners(e.Arguments[0], Props);
-        }
-
-        public static void UpdateSpawners(string Name, string Props)
-        {
-            var Monster = AssemblyHandler.FindTypeByName(Name);
-            if (Monster is null) return;
-
-            foreach (var item in World.Items)
-            {
-                if (item.Value is Spawner spwn)
-                {
-                    foreach (var entr in spwn.Entries)
-                    {
-                        if (entr.SpawnedName.Equals(Name, StringComparison.OrdinalIgnoreCase))
-                        {
-                            entr.Properties = Props;
-                        }
-                    }
-                }
-            }
-        }
-        private static void RespawnWorld_OnCommand(CommandEventArgs e)
-        {
-
-            var toRespawn = new List<Spawner>();
-            foreach (var item in World.Items)
-            {
-                if (item.Value is Spawner itm)
-                {
-                    toRespawn.Add(itm);
-                }
-            }
-            toRespawn.ForEach(_ => _.Respawn());
-        }
-
 
         private static void GenerateSpawners_OnCommand(CommandEventArgs e)
         {

--- a/Projects/UOContent/Engines/Spawners/RespawnCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/RespawnCommand.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using Server.Commands.Generic;
+using Server.Network;
 
 namespace Server.Engines.Spawners
 {
@@ -44,6 +45,10 @@ namespace Server.Engines.Spawners
                 return;
             }
 
+            e.Mobile.SendMessage("Respawning...");
+
+            NetState.FlushAll();
+
             foreach (var obj in list)
             {
                 if (obj is ISpawner spawner)
@@ -51,6 +56,8 @@ namespace Server.Engines.Spawners
                     spawner.Respawn();
                 }
             }
+
+            e.Mobile.SendMessage("Respawn completed.");
         }
     }
 }

--- a/Projects/UOContent/Engines/Spawners/RespawnCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/RespawnCommand.cs
@@ -1,0 +1,56 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Email: hi@modernuo.com                                                *
+ * File: RespawnCommand.cs                                               *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System.Collections.Generic;
+using Server.Commands.Generic;
+
+namespace Server.Engines.Spawners
+{
+    public class RespawnCommand : BaseCommand
+    {
+        public static void Initialize()
+        {
+            TargetCommands.Register(new RespawnCommand());
+        }
+
+        public RespawnCommand()
+        {
+            AccessLevel = AccessLevel.GameMaster;
+            Supports = CommandSupport.Complex | CommandSupport.Simple;
+            Commands = new[] { "Respawn" };
+            ObjectTypes = ObjectTypes.Items;
+            Usage = "Respawn";
+            Description = "Respawns the given the spawners.";
+            ListOptimized = true;
+        }
+
+        public override void ExecuteList(CommandEventArgs e, List<object> list)
+        {
+            if (list.Count == 0)
+            {
+                LogFailure("No matching objects found.");
+                return;
+            }
+
+            foreach (var obj in list)
+            {
+                if (obj is ISpawner spawner)
+                {
+                    spawner.Respawn();
+                }
+            }
+        }
+    }
+}

--- a/Projects/UOContent/Engines/Spawners/SpawnPropsGump.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnPropsGump.cs
@@ -122,6 +122,8 @@ namespace Server.Gumps
                         var name = m_Object.GetType().Name;
                         var props = propsBuilder.ToString();
 
+                        m_Mobile.SendMessage("Updating spawners...");
+
                         foreach (var obj in _spawners)
                         {
                             if (obj is BaseSpawner spawner)
@@ -129,6 +131,9 @@ namespace Server.Gumps
                                 EditSpawnCommand.UpdateSpawner(spawner, name, null, props);
                             }
                         }
+
+                        m_Mobile.SendMessage("Update completed.");
+
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/Spawners/SpawnPropsGumpCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnPropsGumpCommand.cs
@@ -47,6 +47,7 @@ namespace Server.Engines.Spawners
                 return;
             }
 
+            e.Mobile.SendMessage("Target the object you want to use as a template for modifying the spawner properties.");
             e.Mobile.Target = new InternalTarget(list);
         }
 
@@ -65,7 +66,7 @@ namespace Server.Engines.Spawners
                     from.SendMessage("No type with that name was found.");
                 }
 
-                from.SendGump(new SpawnPropsGump(from, type, _list));
+                from.SendGump(new SpawnPropsGump(from, targeted, _list));
             }
         }
     }

--- a/Projects/UOContent/Engines/Spawners/SpawnPropsGumpCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnPropsGumpCommand.cs
@@ -34,8 +34,8 @@ namespace Server.Engines.Spawners
             Supports = CommandSupport.Complex | CommandSupport.Simple;
             Commands = new[] { "SpawnProps" };
             ObjectTypes = ObjectTypes.Items;
-            Usage = "SpawnProps <type>";
-            Description = "Shows a props gump that will modify the properties of spawn entries related to the chosen type";
+            Usage = "SpawnProps";
+            Description = "Shows a props gump that will modify the properties of spawn entries related to the chosen entity";
             ListOptimized = true;
         }
 
@@ -47,25 +47,7 @@ namespace Server.Engines.Spawners
                 return;
             }
 
-            var args = e.Arguments;
-
-            if (args.Length == 0)
-            {
-                e.Mobile.Target =new InternalTarget(list);
-                return;
-            }
-
-            var name = args[0];
-
-            var type = AssemblyHandler.FindTypeByName(name);
-
-            if (!Add.IsEntity(type))
-            {
-                LogFailure("No type with that name was found.");
-                return;
-            }
-
-            e.Mobile.SendGump(new SpawnPropsGump(e.Mobile, type, list));
+            e.Mobile.Target = new InternalTarget(list);
         }
 
         private class InternalTarget : Target

--- a/Projects/UOContent/Engines/Spawners/SpawnPropsGumpCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnPropsGumpCommand.cs
@@ -1,0 +1,90 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Email: hi@modernuo.com                                                *
+ * File: SpawnPropsGump.cs                                               *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System.Collections.Generic;
+using Server.Commands;
+using Server.Commands.Generic;
+using Server.Gumps;
+using Server.Targeting;
+
+namespace Server.Engines.Spawners
+{
+    public class SpawnPropsGumpCommand : BaseCommand
+    {
+        public static void Initialize()
+        {
+            TargetCommands.Register(new SpawnPropsGumpCommand());
+        }
+
+        public SpawnPropsGumpCommand()
+        {
+            AccessLevel = AccessLevel.GameMaster;
+            Supports = CommandSupport.Complex | CommandSupport.Simple;
+            Commands = new[] { "SpawnProps" };
+            ObjectTypes = ObjectTypes.Items;
+            Usage = "SpawnProps <type>";
+            Description = "Shows a props gump that will modify the properties of spawn entries related to the chosen type";
+            ListOptimized = true;
+        }
+
+        public override void ExecuteList(CommandEventArgs e, List<object> list)
+        {
+            if (list.Count == 0)
+            {
+                LogFailure("No matching objects found.");
+                return;
+            }
+
+            var args = e.Arguments;
+
+            if (args.Length == 0)
+            {
+                e.Mobile.Target =new InternalTarget(list);
+                return;
+            }
+
+            var name = args[0];
+
+            var type = AssemblyHandler.FindTypeByName(name);
+
+            if (!Add.IsEntity(type))
+            {
+                LogFailure("No type with that name was found.");
+                return;
+            }
+
+            e.Mobile.SendGump(new SpawnPropsGump(e.Mobile, type, list));
+        }
+
+        private class InternalTarget : Target
+        {
+            private List<object> _list;
+
+            public InternalTarget(List<object> list) : base(-1, false, TargetFlags.None) =>
+                _list = list;
+
+            protected override void OnTarget(Mobile from, object targeted)
+            {
+                var type = targeted.GetType();
+                if (!Add.IsEntity(type))
+                {
+                    from.SendMessage("No type with that name was found.");
+                }
+
+                from.SendGump(new SpawnPropsGump(from, type, _list));
+            }
+        }
+    }
+}

--- a/Projects/UOContent/Gumps/Props/GlobalPropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/GlobalPropsGump.cs
@@ -1,7 +1,19 @@
-using System;
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Email: hi@modernuo.com                                                *
+ * File: GlobalPropsGump.cs                                              *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Server.Buffers;
 using Server.Commands.Generic;
 using Server.Engines.Spawners;
@@ -10,69 +22,9 @@ using CPA = Server.CommandPropertyAttribute;
 
 namespace Server.Gumps
 {
-    public class GlobalPropsGump : Gump
+    public class GlobalPropsGump : PropertiesGump
     {
-        public static readonly bool OldStyle = PropsConfig.OldStyle;
-
-        public static readonly int GumpOffsetX = PropsConfig.GumpOffsetX;
-        public static readonly int GumpOffsetY = PropsConfig.GumpOffsetY;
-
-        public static readonly int TextHue = PropsConfig.TextHue;
-        public static readonly int TextOffsetX = PropsConfig.TextOffsetX;
-
-        public static readonly int OffsetGumpID = PropsConfig.OffsetGumpID;
-        public static readonly int HeaderGumpID = PropsConfig.HeaderGumpID;
-        public static readonly int EntryGumpID = PropsConfig.EntryGumpID;
-        public static readonly int BackGumpID = PropsConfig.BackGumpID;
-        public static readonly int SetGumpID = PropsConfig.SetGumpID;
-
-        public static readonly int SetWidth = PropsConfig.SetWidth;
-        public static readonly int SetOffsetX = PropsConfig.SetOffsetX, SetOffsetY = PropsConfig.SetOffsetY;
-        public static readonly int SetButtonID1 = PropsConfig.SetButtonID1;
-        public static readonly int SetButtonID2 = PropsConfig.SetButtonID2;
-
-        public static readonly int PrevWidth = PropsConfig.PrevWidth;
-        public static readonly int PrevOffsetX = PropsConfig.PrevOffsetX, PrevOffsetY = PropsConfig.PrevOffsetY;
-        public static readonly int PrevButtonID1 = PropsConfig.PrevButtonID1;
-        public static readonly int PrevButtonID2 = PropsConfig.PrevButtonID2;
-
-        public static readonly int NextWidth = PropsConfig.NextWidth;
-        public static readonly int NextOffsetX = PropsConfig.NextOffsetX, NextOffsetY = PropsConfig.NextOffsetY;
-        public static readonly int NextButtonID1 = PropsConfig.NextButtonID1;
-        public static readonly int NextButtonID2 = PropsConfig.NextButtonID2;
-
-        public static readonly int OffsetSize = PropsConfig.OffsetSize;
-
-        public static readonly int EntryHeight = PropsConfig.EntryHeight;
-        public static readonly int BorderSize = PropsConfig.BorderSize;
-        public static readonly int ApplySize = PropsConfig.ApplySize;
-
-        private static readonly bool PrevLabel = OldStyle;
-        private static readonly bool NextLabel = OldStyle;
-        private static readonly bool TypeLabel = !OldStyle;
-
-        private static readonly int PrevLabelOffsetX = PrevWidth + 1;
-        private static readonly int PrevLabelOffsetY = 0;
-
-        private static readonly int NextLabelOffsetX = -29;
-        private static readonly int NextLabelOffsetY = 0;
-
-        private static readonly int NameWidth = 107;
-        private static readonly int ValueWidth = 128;
-
-        private static readonly int EntryCount = 15;
-
-        private static readonly int TypeWidth = NameWidth + OffsetSize + ValueWidth;
-
-        private static readonly int TotalWidth =
-            OffsetSize + NameWidth + OffsetSize + ValueWidth + OffsetSize + SetWidth + OffsetSize;
-
-        private static readonly int TotalHeight = OffsetSize + (EntryHeight + OffsetSize) * (EntryCount + 1);
-
-        private static readonly int BackWidth = BorderSize + TotalWidth + BorderSize;
-        private static readonly int BackHeight = BorderSize + TotalHeight + BorderSize;
-
-        private static readonly string[] _attrs =
+        public static readonly string[] MobileAttributes =
         {
             "Str",
             "Dex",
@@ -86,230 +38,30 @@ namespace Server.Gumps
             "VirtualArmor"
         };
 
-        private static readonly Type typeofMobile = typeof(Mobile);
-        private static readonly Type typeofItem = typeof(Item);
-        private static readonly Type typeofType = typeof(Type);
-        private static readonly Type typeofPoint3D = typeof(Point3D);
-        private static readonly Type typeofPoint2D = typeof(Point2D);
-        private static readonly Type typeofTimeSpan = typeof(TimeSpan);
-        private static readonly Type typeofCustomEnum = typeof(CustomEnumAttribute);
-        private static readonly Type typeofEnum = typeof(Enum);
-        private static readonly Type typeofBool = typeof(bool);
-        private static readonly Type typeofString = typeof(string);
-        private static readonly Type typeofText = typeof(TextDefinition);
-        private static readonly Type typeofPoison = typeof(Poison);
-        private static readonly Type typeofMap = typeof(Map);
-        private static readonly Type typeofSkills = typeof(Skills);
-        private static readonly Type typeofPropertyObject = typeof(PropertyObjectAttribute);
-        private static readonly Type typeofNoSort = typeof(NoSortAttribute);
-
-        private static readonly Type[] typeofReal =
+        public GlobalPropsGump(Mobile mobile, object o) : base(mobile, o)
         {
-            typeof(float),
-            typeof(double)
-        };
-
-        private static readonly Type[] typeofNumeric =
-        {
-            typeof(byte),
-            typeof(short),
-            typeof(int),
-            typeof(long),
-            typeof(sbyte),
-            typeof(ushort),
-            typeof(uint),
-            typeof(ulong)
-        };
-
-        private static readonly Type typeofCPA = typeof(CPA);
-        private static readonly Type typeofObject = typeof(object);
-        private readonly List<object> m_List;
-        private readonly Mobile m_Mobile;
-        private readonly object m_Object;
-        private readonly Stack<StackEntry> m_Stack;
-        private readonly Type m_Type;
-        private int m_Page;
-
-        public GlobalPropsGump(Mobile mobile, object o) : base(GumpOffsetX, GumpOffsetY)
-        {
-            m_Mobile = mobile;
-            m_Object = o;
-            m_Type = o.GetType();
-            m_List = BuildList();
-
-            Initialize(0);
         }
 
         public GlobalPropsGump(Mobile mobile, object o, Stack<StackEntry> stack, StackEntry parent) : base(
-            GumpOffsetX,
-            GumpOffsetY
+            mobile, o, stack, parent
         )
         {
-            m_Mobile = mobile;
-            m_Object = o;
-            m_Type = o.GetType();
-            m_Stack = stack;
-            m_List = BuildList();
-
-            if (parent != null)
-            {
-                m_Stack ??= new Stack<StackEntry>();
-                m_Stack.Push(parent);
-            }
-
-            Initialize(0);
         }
 
         public GlobalPropsGump(Mobile mobile, object o, Stack<StackEntry> stack, List<object> list, int page) : base(
-            GumpOffsetX,
-            GumpOffsetY
+            mobile, o, stack, list, page
         )
         {
-            m_Mobile = mobile;
-            m_Object = o;
-
-            if (o != null)
-            {
-                m_Type = o.GetType();
-            }
-
-            m_List = list;
-            m_Stack = stack;
-
-            Initialize(page);
         }
 
-        private void Initialize(int page)
+        protected override int TotalHeight => base.TotalHeight + PropsConfig.ApplySize;
+
+        protected override void Initialize(int page)
         {
-            m_Page = page;
+            base.Initialize(page);
+            var totalHeight = TotalHeight - PropsConfig.ApplySize;
 
-            var count = Math.Clamp(m_List.Count - page * EntryCount, 0, EntryCount);
-
-            var lastIndex = page * EntryCount + count - 1;
-
-            if (lastIndex >= 0 && lastIndex < m_List.Count && m_List[lastIndex] == null)
-            {
-                --count;
-            }
-
-            var totalHeight = OffsetSize + (EntryHeight + OffsetSize) * (count + 1);
-
-            AddPage(0);
-
-            AddBackground(0, 0, BackWidth, BorderSize + totalHeight + BorderSize + ApplySize, BackGumpID);
-            AddButton(BackWidth/3, BorderSize + totalHeight + BorderSize, 5204, 5205, 3);
-            AddImageTiled(
-                BorderSize,
-                BorderSize,
-                TotalWidth - (OldStyle ? SetWidth + OffsetSize : 0),
-                totalHeight,
-                OffsetGumpID
-            );
-
-            var x = BorderSize + OffsetSize;
-            var y = BorderSize + OffsetSize;
-
-            var emptyWidth = TotalWidth - PrevWidth - NextWidth - OffsetSize * 4 - (OldStyle ? SetWidth + OffsetSize : 0);
-
-            if (OldStyle)
-            {
-                AddImageTiled(x, y, TotalWidth - OffsetSize * 3 - SetWidth, EntryHeight, HeaderGumpID);
-            }
-            else
-            {
-                AddImageTiled(x, y, PrevWidth, EntryHeight, HeaderGumpID);
-            }
-
-            if (page > 0)
-            {
-                AddButton(x + PrevOffsetX, y + PrevOffsetY, PrevButtonID1, PrevButtonID2, 1);
-
-                if (PrevLabel)
-                {
-                    AddLabel(x + PrevLabelOffsetX, y + PrevLabelOffsetY, TextHue, "Previous");
-                }
-            }
-
-            x += PrevWidth + OffsetSize;
-
-            if (!OldStyle)
-            {
-                AddImageTiled(x, y, emptyWidth, EntryHeight, HeaderGumpID);
-            }
-
-            if (TypeLabel && m_Type != null)
-            {
-                AddHtml(
-                    x,
-                    y,
-                    emptyWidth,
-                    EntryHeight,
-                    $"<BASEFONT COLOR=#FAFAFA><CENTER>{m_Type.Name}</CENTER></BASEFONT>"
-                );
-            }
-
-            x += emptyWidth + OffsetSize;
-
-            if (!OldStyle)
-            {
-                AddImageTiled(x, y, NextWidth, EntryHeight, HeaderGumpID);
-            }
-
-            if ((page + 1) * EntryCount < m_List.Count)
-            {
-                AddButton(x + NextOffsetX, y + NextOffsetY, NextButtonID1, NextButtonID2, 2, GumpButtonType.Reply, 1);
-
-                if (NextLabel)
-                {
-                    AddLabel(x + NextLabelOffsetX, y + NextLabelOffsetY, TextHue, "Next");
-                }
-            }
-
-            for (int i = 0, index = page * EntryCount; i < count && index < m_List.Count; ++i, ++index)
-            {
-                x = BorderSize + OffsetSize;
-                y += EntryHeight + OffsetSize;
-
-                var o = m_List[index];
-
-                if (o == null)
-                {
-                    AddImageTiled(x - OffsetSize, y, TotalWidth, EntryHeight, BackGumpID + 4);
-                }
-                else if (o is Type type)
-                {
-                    AddImageTiled(x, y, TypeWidth, EntryHeight, EntryGumpID);
-                    AddLabelCropped(x + TextOffsetX, y, TypeWidth - TextOffsetX, EntryHeight, TextHue, type.Name);
-                    x += TypeWidth + OffsetSize;
-
-                    if (SetGumpID != 0)
-                    {
-                        AddImageTiled(x, y, SetWidth, EntryHeight, SetGumpID);
-                    }
-                }
-                else if (o is PropertyInfo prop)
-                {
-                    AddImageTiled(x, y, NameWidth, EntryHeight, EntryGumpID);
-                    AddLabelCropped(x + TextOffsetX, y, NameWidth - TextOffsetX, EntryHeight, TextHue, prop.Name);
-                    x += NameWidth + OffsetSize;
-                    AddImageTiled(x, y, ValueWidth, EntryHeight, EntryGumpID);
-                    AddLabelCropped(x + TextOffsetX, y, ValueWidth - TextOffsetX, EntryHeight, TextHue, ValueToString(prop));
-                    x += ValueWidth + OffsetSize;
-
-                    if (SetGumpID != 0)
-                    {
-                        AddImageTiled(x, y, SetWidth, EntryHeight, SetGumpID);
-                    }
-
-                    var cpa = GetCPA(prop);
-
-                    if ((!prop.GetType().IsValueType || prop.CanWrite) && cpa != null &&
-                        m_Mobile.AccessLevel >= cpa.WriteLevel && !cpa.ReadOnly)
-                    {
-                        AddButton(x + SetOffsetX, y + SetOffsetY, SetButtonID1, SetButtonID2, i + 3);
-                    }
-                }
-            }
+            AddButton(BackWidth / 3, PropsConfig.BorderSize + totalHeight + PropsConfig.BorderSize, 5204, 5205, 3);
         }
 
         public static object GetPropValue(object src, string propName) =>
@@ -327,46 +79,27 @@ namespace Server.Gumps
 
             switch (info.ButtonID)
             {
-                case 0: // Closed
+                default:
                     {
-                        if (m_Stack?.Count > 0)
-                        {
-                            var entry = m_Stack.Pop();
-                            from.SendGump(new PropertiesGump(from, entry.m_Object, m_Stack, null));
-                        }
-
-                        break;
-                    }
-                case 1: // Previous
-                    {
-                        if (m_Page > 0)
-                        {
-                            from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page - 1));
-                        }
-
-                        break;
-                    }
-                case 2: // Next
-                    {
-                        if ((m_Page + 1) * EntryCount < m_List.Count)
-                        {
-                            from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page + 1));
-                        }
-
+                        base.OnResponse(state, info);
                         break;
                     }
                 case 3: // Apply
                     {
-                        if (_attrs?.Length > 0)
+                        if (MobileAttributes?.Length > 0)
                         {
                             using var propsBuilder = new ValueStringBuilder(64);
-                            for (var i = 0; i < _attrs.Length; i++)
+                            for (var i = 0; i < MobileAttributes.Length; i++)
                             {
-                                var attr = _attrs[i];
+                                var attr = MobileAttributes[i];
                                 var prop = GetPropValue(m_Object, attr);
                                 if (prop != null)
                                 {
-                                    propsBuilder.Append(' ');
+                                    if (i > 0)
+                                    {
+                                        propsBuilder.Append(' ');
+                                    }
+
                                     propsBuilder.Append(attr);
                                     propsBuilder.Append(' ');
                                     propsBuilder.Append(prop.ToString()); // TODO: Replace with ZString, or IFormatter code
@@ -386,561 +119,20 @@ namespace Server.Gumps
                         }
                         break;
                     }
-                default:
-                    {
-                        var index = m_Page * EntryCount + (info.ButtonID - 3);
-
-                        if (index >= 0 && index < m_List.Count)
-                        {
-                            var prop = m_List[index] as PropertyInfo;
-
-                            if (prop == null)
-                            {
-                                return;
-                            }
-
-                            var attr = GetCPA(prop);
-
-                            if (prop.GetType().IsValueType && !prop.CanWrite || attr == null ||
-                                from.AccessLevel < attr.WriteLevel || attr.ReadOnly)
-                            {
-                                return;
-                            }
-
-                            var type = prop.PropertyType;
-
-                            if (IsType(type, typeofMobile) || IsType(type, typeofItem))
-                            {
-                                from.SendGump(new SetObjectGump(prop, from, m_Object, m_Stack, type, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofType))
-                            {
-                                from.Target = new SetObjectTarget(prop, from, m_Object, m_Stack, type, m_Page, m_List);
-                            }
-                            else if (IsType(type, typeofPoint3D))
-                            {
-                                from.SendGump(new SetPoint3DGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofPoint2D))
-                            {
-                                from.SendGump(new SetPoint2DGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofTimeSpan))
-                            {
-                                from.SendGump(new SetTimeSpanGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsCustomEnum(type))
-                            {
-                                from.SendGump(
-                                    new SetCustomEnumGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        GetCustomEnumNames(type)
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofEnum))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        Enum.GetNames(type),
-                                        GetObjects(Enum.GetValues(type))
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofBool))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        PropertiesGump.m_BoolNames,
-                                        PropertiesGump.m_BoolValues
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofString) || IsType(type, typeofReal) || IsType(type, typeofNumeric) ||
-                                     IsType(type, typeofText))
-                            {
-                                from.SendGump(new SetGump(prop, from, m_Object, m_Stack, m_Page, m_List,true));
-                            }
-                            else if (IsType(type, typeofPoison))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        PropertiesGump.m_PoisonNames,
-                                        PropertiesGump.m_PoisonValues
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofMap))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        Map.GetMapNames(),
-                                        Map.GetMapValues().ToArray<object>()
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofSkills) && m_Object is Mobile mobile)
-                            {
-                                from.SendGump(new PropertiesGump(from, mobile, m_Stack, m_List, m_Page));
-                                from.SendGump(new SkillsGump(from, mobile));
-                            }
-                            else if (HasAttribute(type, typeofPropertyObject, true))
-                            {
-                                var obj = prop.GetValue(m_Object, null);
-
-                                if (obj != null)
-                                {
-                                    from.SendGump(new PropertiesGump(from, obj, m_Stack, new StackEntry(m_Object, prop)));
-                                }
-                                else
-                                {
-                                    from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page));
-                                }
-                            }
-                        }
-
-                        break;
-                    }
             }
         }
 
-        private static object[] GetObjects(Array a)
+        protected override bool ShowAttribute(string name)
         {
-            var list = new object[a.Length];
-
-            for (var i = 0; i < list.Length; ++i)
+            foreach (var item in MobileAttributes)
             {
-                list[i] = a.GetValue(i);
-            }
-
-            return list;
-        }
-
-        private static bool IsCustomEnum(Type type) => type.IsDefined(typeofCustomEnum, false);
-
-        public static void OnValueChanged(object obj, PropertyInfo prop, Stack<StackEntry> stack)
-        {
-            if (stack == null || stack.Count == 0)
-            {
-                return;
-            }
-
-            if (!prop.PropertyType.IsValueType)
-            {
-                return;
-            }
-
-            var peek = stack.Peek();
-
-            if (peek.m_Property.CanWrite)
-            {
-                peek.m_Property.SetValue(peek.m_Object, obj, null);
-            }
-        }
-
-        private static string[] GetCustomEnumNames(Type type)
-        {
-            var attrs = type.GetCustomAttributes(typeofCustomEnum, false);
-
-            if (attrs.Length == 0)
-            {
-                return Array.Empty<string>();
-            }
-
-            if (!(attrs[0] is CustomEnumAttribute ce))
-            {
-                return Array.Empty<string>();
-            }
-
-            return ce.Names;
-        }
-
-        private static bool HasAttribute(Type type, Type check, bool inherit) =>
-            type.GetCustomAttributes(check, inherit).Length > 0;
-
-        private static bool IsType(Type type, Type check) => type == check || type.IsSubclassOf(check);
-
-        private static bool IsType(Type type, Type[] check)
-        {
-            for (var i = 0; i < check.Length; ++i)
-            {
-                if (IsType(type, check[i]))
+                if (item.InsensitiveEquals(name))
                 {
                     return true;
                 }
             }
 
             return false;
-        }
-
-        private string ValueToString(PropertyInfo prop) => ValueToString(m_Object, prop);
-
-        public static string ValueToString(object obj, PropertyInfo prop)
-        {
-            try
-            {
-                return ValueToString(prop.GetValue(obj, null));
-            }
-            catch (Exception e)
-            {
-                return $"!{e.GetType()}!";
-            }
-        }
-
-        public static string ValueToString(object o)
-        {
-            if (o == null)
-            {
-                return "-null-";
-            }
-
-            if (o is string s)
-            {
-                return $"\"{s}\"";
-            }
-
-            if (o is bool)
-            {
-                return o.ToString();
-            }
-
-            if (o is char c)
-            {
-                return $"0x{(int)c:X} '{c}'";
-            }
-
-            if (o is Serial serial)
-            {
-                if (serial.IsValid)
-                {
-                    if (serial.IsItem)
-                    {
-                        return $"(I) 0x{serial.Value:X}";
-                    }
-
-                    if (serial.IsMobile)
-                    {
-                        return $"(M) 0x{serial.Value:X}";
-                    }
-                }
-
-                return $"(?) 0x{serial.Value:X}";
-            }
-
-            if (o is byte || o is sbyte || o is short || o is ushort || o is int || o is uint || o is long || o is ulong)
-            {
-                return $"{o} (0x{o:X})";
-            }
-
-            if (o is Mobile mobile)
-            {
-                return $"(M) 0x{mobile.Serial.Value:X} \"{mobile.Name}\"";
-            }
-
-            if (o is Item item)
-            {
-                return $"(I) 0x{item.Serial.Value:X}";
-            }
-
-            if (o is Type type)
-            {
-                return type.Name;
-            }
-
-            if (o is TextDefinition definition)
-            {
-                return definition.Format(true);
-            }
-
-            return o.ToString();
-        }
-
-        private List<object> BuildList()
-        {
-            var list = new List<object>();
-
-            if (m_Type == null)
-            {
-                return list;
-            }
-
-            var props = m_Type.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
-
-            var groups = GetGroups(m_Type, props);
-
-            for (var i = 0; i < groups.Count; ++i)
-            {
-                var kvp = groups[i];
-                if (!HasAttribute(kvp.Key, typeofNoSort, false))
-                {
-                    kvp.Value.Sort(PropertySorter.Instance);
-                }
-
-                if (i != 0)
-                {
-                    list.Add(null);
-                }
-                list.Add(kvp.Key);
-                foreach (var item in kvp.Value)
-                {
-                    if (CompareAttr(item.Name))
-                    {
-                        list.Add(item);
-                    }
-                }
-            }
-            return list;
-        }
-
-        private static bool CompareAttr(string name)
-        {
-            foreach (var item in _attrs)
-            {
-                if (item.Equals(name,StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private static CPA GetCPA(PropertyInfo prop)
-        {
-            var attrs = prop.GetCustomAttributes(typeofCPA, false);
-
-            if (attrs.Length > 0)
-            {
-                return attrs[0] as CPA;
-            }
-
-            return null;
-        }
-
-        private List<KeyValuePair<Type, List<PropertyInfo>>> GetGroups(Type objectType, PropertyInfo[] props)
-        {
-            var groups = new Dictionary<Type, List<PropertyInfo>>();
-
-            for (var i = 0; i < props.Length; ++i)
-            {
-                var prop = props[i];
-
-                if (prop.CanRead)
-                {
-                    var attr = GetCPA(prop);
-
-                    if (attr != null && m_Mobile.AccessLevel >= attr.ReadLevel)
-                    {
-                        var type = prop.DeclaringType;
-
-                        while (true)
-                        {
-                            var baseType = type?.BaseType;
-
-                            if (baseType == typeofObject || baseType?.GetProperty(prop.Name, prop.PropertyType) == null)
-                            {
-                                break;
-                            }
-
-                            type = baseType;
-                        }
-
-                        if (type != null)
-                        {
-                            if (groups.TryGetValue(type, out var result))
-                            {
-                                result.Add(prop);
-                            }
-                            else
-                            {
-                                groups[type] = new List<PropertyInfo> { prop };
-                            }
-                        }
-                    }
-                }
-            }
-
-            var list = groups.ToList();
-            list.Sort(new GroupComparer(objectType));
-
-            return list;
-        }
-
-        public static object GetObjectFromString(Type t, string s)
-        {
-            if (t == typeof(string))
-            {
-                return s;
-            }
-
-            if (t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort) || t == typeof(int) ||
-                t == typeof(uint) || t == typeof(long) || t == typeof(ulong))
-            {
-                if (s.StartsWithOrdinal("0x"))
-                {
-                    if (t == typeof(ulong) || t == typeof(uint) || t == typeof(ushort) || t == typeof(byte))
-                    {
-                        return Convert.ChangeType(Convert.ToUInt64(s.Substring(2), 16), t);
-                    }
-
-                    return Convert.ChangeType(Convert.ToInt64(s.Substring(2), 16), t);
-                }
-
-                return Convert.ChangeType(s, t);
-            }
-
-            if (t == typeof(double) || t == typeof(float))
-            {
-                return Convert.ChangeType(s, t);
-            }
-
-            if (t.IsDefined(typeof(ParsableAttribute), false))
-            {
-                var parseMethod = t.GetMethod("Parse", new[] { typeof(string) });
-
-                return parseMethod?.Invoke(null, new object[] { s });
-            }
-
-            throw new Exception("bad");
-        }
-
-        private static string GetStringFromObject(object o)
-        {
-            if (o == null)
-            {
-                return "-null-";
-            }
-
-            if (o is string s)
-            {
-                return $"\"{s}\"";
-            }
-
-            if (o is bool)
-            {
-                return o.ToString();
-            }
-
-            if (o is char c)
-            {
-                return $"0x{(int)c:X} '{c}'";
-            }
-
-            if (o is Serial serial)
-            {
-                if (serial.IsValid)
-                {
-                    if (serial.IsItem)
-                    {
-                        return $"(I) 0x{serial.Value:X}";
-                    }
-
-                    if (serial.IsMobile)
-                    {
-                        return $"(M) 0x{serial.Value:X}";
-                    }
-                }
-
-                return $"(?) 0x{serial.Value:X}";
-            }
-
-            if (o is byte || o is sbyte || o is short || o is ushort || o is int || o is uint || o is long || o is ulong)
-            {
-                return $"{o} (0x{o:X})";
-            }
-
-            if (o is Mobile mobile)
-            {
-                return $"(M) 0x{mobile.Serial.Value:X} \"{mobile.Name}\"";
-            }
-
-            if (o is Item item)
-            {
-                return $"(I) 0x{item.Serial.Value:X}";
-            }
-
-            if (o is Type type)
-            {
-                return type.Name;
-            }
-
-            return o.ToString();
-        }
-
-        private class PropertySorter : IComparer<PropertyInfo>
-        {
-            public static readonly PropertySorter Instance = new();
-
-            private PropertySorter()
-            {
-            }
-
-            public int Compare(PropertyInfo x, PropertyInfo y)
-            {
-                if (x == null && y == null)
-                {
-                    return 0;
-                }
-
-                if (x == null)
-                {
-                    return -1;
-                }
-
-                return x.Name.CompareOrdinal(y?.Name);
-            }
-        }
-
-        private class GroupComparer : IComparer<KeyValuePair<Type, List<PropertyInfo>>>
-        {
-            private readonly Type m_Start;
-
-            public GroupComparer(Type start) => m_Start = start;
-
-            public int Compare(KeyValuePair<Type, List<PropertyInfo>> x, KeyValuePair<Type, List<PropertyInfo>> y) =>
-                GetDistance(x.Key).CompareTo(GetDistance(y.Key));
-
-            private int GetDistance(Type type)
-            {
-                var current = m_Start;
-
-                int dist;
-
-                for (dist = 0; current != null && current != typeofObject && current != type; ++dist)
-                {
-                    current = current.BaseType;
-                }
-
-                return dist;
-            }
         }
     }
 }

--- a/Projects/UOContent/Gumps/Props/GlobalPropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/GlobalPropsGump.cs
@@ -1,0 +1,942 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Server.Commands.Generic;
+using Server.Engines.Spawners;
+using Server.Network;
+using CPA = Server.CommandPropertyAttribute;
+
+namespace Server.Gumps
+{
+  
+
+    public class GlobalPropsGump : Gump
+    {
+        public static readonly bool OldStyle = PropsConfig.OldStyle;
+
+        public static readonly int GumpOffsetX = PropsConfig.GumpOffsetX;
+        public static readonly int GumpOffsetY = PropsConfig.GumpOffsetY;
+
+        public static readonly int TextHue = PropsConfig.TextHue;
+        public static readonly int TextOffsetX = PropsConfig.TextOffsetX;
+
+        public static readonly int OffsetGumpID = PropsConfig.OffsetGumpID;
+        public static readonly int HeaderGumpID = PropsConfig.HeaderGumpID;
+        public static readonly int EntryGumpID = PropsConfig.EntryGumpID;
+        public static readonly int BackGumpID = PropsConfig.BackGumpID;
+        public static readonly int SetGumpID = PropsConfig.SetGumpID;
+
+        public static readonly int SetWidth = PropsConfig.SetWidth;
+        public static readonly int SetOffsetX = PropsConfig.SetOffsetX, SetOffsetY = PropsConfig.SetOffsetY;
+        public static readonly int SetButtonID1 = PropsConfig.SetButtonID1;
+        public static readonly int SetButtonID2 = PropsConfig.SetButtonID2;
+
+        public static readonly int PrevWidth = PropsConfig.PrevWidth;
+        public static readonly int PrevOffsetX = PropsConfig.PrevOffsetX, PrevOffsetY = PropsConfig.PrevOffsetY;
+        public static readonly int PrevButtonID1 = PropsConfig.PrevButtonID1;
+        public static readonly int PrevButtonID2 = PropsConfig.PrevButtonID2;
+
+        public static readonly int NextWidth = PropsConfig.NextWidth;
+        public static readonly int NextOffsetX = PropsConfig.NextOffsetX, NextOffsetY = PropsConfig.NextOffsetY;
+        public static readonly int NextButtonID1 = PropsConfig.NextButtonID1;
+        public static readonly int NextButtonID2 = PropsConfig.NextButtonID2;
+
+        public static readonly int OffsetSize = PropsConfig.OffsetSize;
+
+        public static readonly int EntryHeight = PropsConfig.EntryHeight;
+        public static readonly int BorderSize = PropsConfig.BorderSize;
+        public static readonly int ApplySize = PropsConfig.ApplySize;
+
+        private static readonly bool PrevLabel = OldStyle;
+        private static readonly bool NextLabel = OldStyle;
+        private static readonly bool TypeLabel = !OldStyle;
+
+        private static readonly int PrevLabelOffsetX = PrevWidth + 1;
+        private static readonly int PrevLabelOffsetY = 0;
+
+        private static readonly int NextLabelOffsetX = -29;
+        private static readonly int NextLabelOffsetY = 0;
+
+        private static readonly int NameWidth = 107;
+        private static readonly int ValueWidth = 128;
+
+        private static readonly int EntryCount = 15;
+
+        private static readonly int TypeWidth = NameWidth + OffsetSize + ValueWidth;
+
+        private static readonly int TotalWidth =
+            OffsetSize + NameWidth + OffsetSize + ValueWidth + OffsetSize + SetWidth + OffsetSize;
+
+        private static readonly int TotalHeight = OffsetSize + (EntryHeight + OffsetSize) * (EntryCount + 1);
+
+        private static readonly int BackWidth = BorderSize + TotalWidth + BorderSize;
+        private static readonly int BackHeight = BorderSize + TotalHeight + BorderSize;
+
+        public static string[] m_BoolNames = { "True", "False" };
+        public static object[] m_BoolValues = { true, false };
+
+        public static string[] m_PoisonNames = { "None", "Lesser", "Regular", "Greater", "Deadly", "Lethal" };
+        private static string[] M_attr ={ "Str", "Dex","Int",  "HitsMaxSeed", "Hits", "DamageMin",  "DamageMax", "ActiveSpeed","PassiveSpeed", "VirtualArmor" };
+
+
+
+
+
+
+
+
+
+
+
+
+        public static object[] m_PoisonValues =
+            { null, Poison.Lesser, Poison.Regular, Poison.Greater, Poison.Deadly, Poison.Lethal };
+
+        private static readonly Type typeofMobile = typeof(Mobile);
+        private static readonly Type typeofItem = typeof(Item);
+        private static readonly Type typeofType = typeof(Type);
+        private static readonly Type typeofPoint3D = typeof(Point3D);
+        private static readonly Type typeofPoint2D = typeof(Point2D);
+        private static readonly Type typeofTimeSpan = typeof(TimeSpan);
+        private static readonly Type typeofCustomEnum = typeof(CustomEnumAttribute);
+        private static readonly Type typeofEnum = typeof(Enum);
+        private static readonly Type typeofBool = typeof(bool);
+        private static readonly Type typeofString = typeof(string);
+        private static readonly Type typeofText = typeof(TextDefinition);
+        private static readonly Type typeofPoison = typeof(Poison);
+        private static readonly Type typeofMap = typeof(Map);
+        private static readonly Type typeofSkills = typeof(Skills);
+        private static readonly Type typeofPropertyObject = typeof(PropertyObjectAttribute);
+        private static readonly Type typeofNoSort = typeof(NoSortAttribute);
+
+        private static readonly Type[] typeofReal =
+        {
+            typeof(float),
+            typeof(double)
+        };
+
+        private static readonly Type[] typeofNumeric =
+        {
+            typeof(byte),
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(sbyte),
+            typeof(ushort),
+            typeof(uint),
+            typeof(ulong)
+        };
+
+        private static readonly Type typeofCPA = typeof(CPA);
+        private static readonly Type typeofObject = typeof(object);
+        private readonly List<object> m_List;
+        private readonly Mobile m_Mobile;
+        private readonly object m_Object;
+        private readonly Stack<StackEntry> m_Stack;
+        private readonly Type m_Type;
+        private int m_Page;
+       
+
+        public GlobalPropsGump(Mobile mobile, object o) : base(GumpOffsetX, GumpOffsetY)
+        {
+            m_Mobile = mobile;
+            m_Object = o;
+            m_Type = o.GetType();
+            m_List = BuildList();
+
+            Initialize(0);
+        }
+
+        public GlobalPropsGump(Mobile mobile, object o, Stack<StackEntry> stack, StackEntry parent) : base(
+            GumpOffsetX,
+            GumpOffsetY
+        )
+        {
+            m_Mobile = mobile;
+            m_Object = o;
+            m_Type = o.GetType();
+            m_Stack = stack;
+            m_List = BuildList();
+
+            if (parent != null)
+            {
+                m_Stack ??= new Stack<StackEntry>();
+                m_Stack.Push(parent);
+            }
+
+            Initialize(0);
+        }
+
+        public GlobalPropsGump(Mobile mobile, object o, Stack<StackEntry> stack, List<object> list, int page) : base(
+            GumpOffsetX,
+            GumpOffsetY
+        )
+        {
+            m_Mobile = mobile;
+            m_Object = o;
+
+            if (o != null)
+            {
+                m_Type = o.GetType();
+            }
+
+            m_List = list;
+            m_Stack = stack;
+
+            Initialize(page);
+        }
+
+        private void Initialize(int page)
+        {
+            m_Page = page;
+
+            var count = Math.Clamp(m_List.Count - page * EntryCount, 0, EntryCount);
+
+            var lastIndex = page * EntryCount + count - 1;
+
+            if (lastIndex >= 0 && lastIndex < m_List.Count && m_List[lastIndex] == null)
+            {
+                --count;
+            }
+
+            var totalHeight = OffsetSize + (EntryHeight + OffsetSize) * (count + 1);
+
+            AddPage(0);
+
+         
+            AddBackground(0, 0, BackWidth, BorderSize + totalHeight + BorderSize + ApplySize, BackGumpID);
+            AddButton(BackWidth/3, BorderSize + totalHeight + BorderSize, 5204, 5205, 3);
+            AddImageTiled(
+                BorderSize,
+                BorderSize,
+                TotalWidth - (OldStyle ? SetWidth + OffsetSize : 0),
+                totalHeight,
+                OffsetGumpID
+            );
+
+            var x = BorderSize + OffsetSize;
+            var y = BorderSize + OffsetSize;
+
+            var emptyWidth = TotalWidth - PrevWidth - NextWidth - OffsetSize * 4 - (OldStyle ? SetWidth + OffsetSize : 0);
+
+            if (OldStyle)
+            {
+                AddImageTiled(x, y, TotalWidth - OffsetSize * 3 - SetWidth, EntryHeight, HeaderGumpID);
+            }
+            else
+            {
+                AddImageTiled(x, y, PrevWidth, EntryHeight, HeaderGumpID);
+            }
+
+            if (page > 0)
+            {
+                AddButton(x + PrevOffsetX, y + PrevOffsetY, PrevButtonID1, PrevButtonID2, 1);
+
+                if (PrevLabel)
+                {
+                    AddLabel(x + PrevLabelOffsetX, y + PrevLabelOffsetY, TextHue, "Previous");
+                }
+            }
+          
+            x += PrevWidth + OffsetSize;
+
+            if (!OldStyle)
+            {
+                AddImageTiled(x, y, emptyWidth, EntryHeight, HeaderGumpID);
+            }
+
+            if (TypeLabel && m_Type != null)
+            {
+                AddHtml(
+                    x,
+                    y,
+                    emptyWidth,
+                    EntryHeight,
+                    $"<BASEFONT COLOR=#FAFAFA><CENTER>{m_Type.Name}</CENTER></BASEFONT>"
+                );
+            }
+
+            x += emptyWidth + OffsetSize;
+
+            if (!OldStyle)
+            {
+                AddImageTiled(x, y, NextWidth, EntryHeight, HeaderGumpID);
+            }
+
+            if ((page + 1) * EntryCount < m_List.Count)
+            {
+                AddButton(x + NextOffsetX, y + NextOffsetY, NextButtonID1, NextButtonID2, 2, GumpButtonType.Reply, 1);
+
+                if (NextLabel)
+                {
+                    AddLabel(x + NextLabelOffsetX, y + NextLabelOffsetY, TextHue, "Next");
+                }
+            }
+
+            for (int i = 0, index = page * EntryCount; i < count && index < m_List.Count; ++i, ++index)
+            {
+                x = BorderSize + OffsetSize;
+                y += EntryHeight + OffsetSize;
+
+                var o = m_List[index];
+
+                if (o == null)
+                {
+                    AddImageTiled(x - OffsetSize, y, TotalWidth, EntryHeight, BackGumpID + 4);
+                }
+                else if (o is Type type)
+                {
+                    AddImageTiled(x, y, TypeWidth, EntryHeight, EntryGumpID);
+                    AddLabelCropped(x + TextOffsetX, y, TypeWidth - TextOffsetX, EntryHeight, TextHue, type.Name);
+                    x += TypeWidth + OffsetSize;
+
+                    if (SetGumpID != 0)
+                    {
+                        AddImageTiled(x, y, SetWidth, EntryHeight, SetGumpID);
+                    }
+                }
+                else if (o is PropertyInfo prop)
+                {
+                    AddImageTiled(x, y, NameWidth, EntryHeight, EntryGumpID);
+                    AddLabelCropped(x + TextOffsetX, y, NameWidth - TextOffsetX, EntryHeight, TextHue, prop.Name);
+                    x += NameWidth + OffsetSize;
+                    AddImageTiled(x, y, ValueWidth, EntryHeight, EntryGumpID);
+                    AddLabelCropped(x + TextOffsetX, y, ValueWidth - TextOffsetX, EntryHeight, TextHue, ValueToString(prop));
+                    x += ValueWidth + OffsetSize;
+
+                    if (SetGumpID != 0)
+                    {
+                        AddImageTiled(x, y, SetWidth, EntryHeight, SetGumpID);
+                    }
+
+                    var cpa = GetCPA(prop);
+
+                    if ((!prop.GetType().IsValueType || prop.CanWrite) && cpa != null &&
+                        m_Mobile.AccessLevel >= cpa.WriteLevel && !cpa.ReadOnly)
+                    {
+                        AddButton(x + SetOffsetX, y + SetOffsetY, SetButtonID1, SetButtonID2, i + 3);
+                    }
+                }
+            }
+        }
+
+        public static object GetPropValue(object src, string propName)
+        {
+            return src.GetType().GetProperty(propName)?.GetValue(src, null);
+        }
+
+        public override void OnResponse(NetState state, RelayInfo info)
+        {
+            var from = state.Mobile;
+
+            if (!BaseCommand.IsAccessible(from, m_Object))
+            {
+                from.SendMessage("You may no longer access their properties.");
+                return;
+            }
+           
+            switch (info.ButtonID)
+            {
+                case 0: // Closed
+                    {
+                        if (m_Stack?.Count > 0)
+                        {
+                            var entry = m_Stack.Pop();
+                            from.SendGump(new PropertiesGump(from, entry.m_Object, m_Stack, null));
+                        }
+
+                        break;
+                    }
+                case 1: // Previous
+                    {
+                        if (m_Page > 0)
+                        {
+                            from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page - 1));
+                        }
+
+                        break;
+                    }
+                case 2: // Next
+                    {
+                        if ((m_Page + 1) * EntryCount < m_List.Count)
+                        {
+                            from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page + 1));
+                        }
+
+                        break;
+                    }
+                case 3: // Apply
+                    {
+                        if (M_attr?.Length > 0)
+                        {
+                            var Props = string.Empty;
+                            foreach (var item in M_attr)
+                            {
+                                var prop = GetPropValue(m_Object, item);
+                                if (prop != null) Props += " " + item + " " + prop;
+                            }
+                            GenerateSpawners.UpdateSpawners(m_Object.GetType().Name, Props);
+                        }
+                        break;
+                    }
+                default:
+                    {
+                        var index = m_Page * EntryCount + (info.ButtonID - 3);
+
+                        if (index >= 0 && index < m_List.Count)
+                        {
+                            var prop = m_List[index] as PropertyInfo;
+
+                            if (prop == null)
+                            {
+                                return;
+                            }
+
+                            var attr = GetCPA(prop);
+
+                            if (prop.GetType().IsValueType && !prop.CanWrite || attr == null ||
+                                from.AccessLevel < attr.WriteLevel || attr.ReadOnly)
+                            {
+                                return;
+                            }
+
+                            var type = prop.PropertyType;
+
+                            if (IsType(type, typeofMobile) || IsType(type, typeofItem))
+                            {
+                                from.SendGump(new SetObjectGump(prop, from, m_Object, m_Stack, type, m_Page, m_List));
+                            }
+                            else if (IsType(type, typeofType))
+                            {
+                                from.Target = new SetObjectTarget(prop, from, m_Object, m_Stack, type, m_Page, m_List);
+                            }
+                            else if (IsType(type, typeofPoint3D))
+                            {
+                                from.SendGump(new SetPoint3DGump(prop, from, m_Object, m_Stack, m_Page, m_List));
+                            }
+                            else if (IsType(type, typeofPoint2D))
+                            {
+                                from.SendGump(new SetPoint2DGump(prop, from, m_Object, m_Stack, m_Page, m_List));
+                            }
+                            else if (IsType(type, typeofTimeSpan))
+                            {
+                                from.SendGump(new SetTimeSpanGump(prop, from, m_Object, m_Stack, m_Page, m_List));
+                            }
+                            else if (IsCustomEnum(type))
+                            {
+                                from.SendGump(
+                                    new SetCustomEnumGump(
+                                        prop,
+                                        from,
+                                        m_Object,
+                                        m_Stack,
+                                        m_Page,
+                                        m_List,
+                                        GetCustomEnumNames(type)
+                                    )
+                                );
+                            }
+                            else if (IsType(type, typeofEnum))
+                            {
+                                from.SendGump(
+                                    new SetListOptionGump(
+                                        prop,
+                                        from,
+                                        m_Object,
+                                        m_Stack,
+                                        m_Page,
+                                        m_List,
+                                        Enum.GetNames(type),
+                                        GetObjects(Enum.GetValues(type))
+                                    )
+                                );
+                            }
+                            else if (IsType(type, typeofBool))
+                            {
+                                from.SendGump(
+                                    new SetListOptionGump(
+                                        prop,
+                                        from,
+                                        m_Object,
+                                        m_Stack,
+                                        m_Page,
+                                        m_List,
+                                        m_BoolNames,
+                                        m_BoolValues
+                                    )
+                                );
+                            }
+                            else if (IsType(type, typeofString) || IsType(type, typeofReal) || IsType(type, typeofNumeric) ||
+                                     IsType(type, typeofText))
+                            {
+                                from.SendGump(new SetGump(prop, from, m_Object, m_Stack, m_Page, m_List,true));
+                            }
+                            else if (IsType(type, typeofPoison))
+                            {
+                                from.SendGump(
+                                    new SetListOptionGump(
+                                        prop,
+                                        from,
+                                        m_Object,
+                                        m_Stack,
+                                        m_Page,
+                                        m_List,
+                                        m_PoisonNames,
+                                        m_PoisonValues
+                                    )
+                                );
+                            }
+                            else if (IsType(type, typeofMap))
+                            {
+                                from.SendGump(
+                                    new SetListOptionGump(
+                                        prop,
+                                        from,
+                                        m_Object,
+                                        m_Stack,
+                                        m_Page,
+                                        m_List,
+                                        Map.GetMapNames(),
+                                        Map.GetMapValues().ToArray<object>()
+                                    )
+                                );
+                            }
+                            else if (IsType(type, typeofSkills) && m_Object is Mobile mobile)
+                            {
+                                from.SendGump(new PropertiesGump(from, mobile, m_Stack, m_List, m_Page));
+                                from.SendGump(new SkillsGump(from, mobile));
+                            }
+                            else if (HasAttribute(type, typeofPropertyObject, true))
+                            {
+                                var obj = prop.GetValue(m_Object, null);
+
+                                if (obj != null)
+                                {
+                                    from.SendGump(new PropertiesGump(from, obj, m_Stack, new StackEntry(m_Object, prop)));
+                                }
+                                else
+                                {
+                                    from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page));
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+            }
+        }
+
+        private static object[] GetObjects(Array a)
+        {
+            var list = new object[a.Length];
+
+            for (var i = 0; i < list.Length; ++i)
+            {
+                list[i] = a.GetValue(i);
+            }
+
+            return list;
+        }
+
+        private static bool IsCustomEnum(Type type) => type.IsDefined(typeofCustomEnum, false);
+
+        public static void OnValueChanged(object obj, PropertyInfo prop, Stack<StackEntry> stack)
+        {
+            if (stack == null || stack.Count == 0)
+            {
+                return;
+            }
+
+            if (!prop.PropertyType.IsValueType)
+            {
+                return;
+            }
+
+            var peek = stack.Peek();
+
+            if (peek.m_Property.CanWrite)
+            {
+                peek.m_Property.SetValue(peek.m_Object, obj, null);
+            }
+        }
+
+        private static string[] GetCustomEnumNames(Type type)
+        {
+            var attrs = type.GetCustomAttributes(typeofCustomEnum, false);
+
+            if (attrs.Length == 0)
+            {
+                return Array.Empty<string>();
+            }
+
+            if (!(attrs[0] is CustomEnumAttribute ce))
+            {
+                return Array.Empty<string>();
+            }
+
+            return ce.Names;
+        }
+
+        private static bool HasAttribute(Type type, Type check, bool inherit) =>
+            type.GetCustomAttributes(check, inherit).Length > 0;
+
+        private static bool IsType(Type type, Type check) => type == check || type.IsSubclassOf(check);
+
+        private static bool IsType(Type type, Type[] check)
+        {
+            for (var i = 0; i < check.Length; ++i)
+            {
+                if (IsType(type, check[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private string ValueToString(PropertyInfo prop) => ValueToString(m_Object, prop);
+
+        public static string ValueToString(object obj, PropertyInfo prop)
+        {
+            try
+            {
+                return ValueToString(prop.GetValue(obj, null));
+            }
+            catch (Exception e)
+            {
+                return $"!{e.GetType()}!";
+            }
+        }
+
+        public static string ValueToString(object o)
+        {
+            if (o == null)
+            {
+                return "-null-";
+            }
+
+            if (o is string s)
+            {
+                return $"\"{s}\"";
+            }
+
+            if (o is bool)
+            {
+                return o.ToString();
+            }
+
+            if (o is char c)
+            {
+                return $"0x{(int)c:X} '{c}'";
+            }
+
+            if (o is Serial serial)
+            {
+                if (serial.IsValid)
+                {
+                    if (serial.IsItem)
+                    {
+                        return $"(I) 0x{serial.Value:X}";
+                    }
+
+                    if (serial.IsMobile)
+                    {
+                        return $"(M) 0x{serial.Value:X}";
+                    }
+                }
+
+                return $"(?) 0x{serial.Value:X}";
+            }
+
+            if (o is byte || o is sbyte || o is short || o is ushort || o is int || o is uint || o is long || o is ulong)
+            {
+                return $"{o} (0x{o:X})";
+            }
+
+            if (o is Mobile mobile)
+            {
+                return $"(M) 0x{mobile.Serial.Value:X} \"{mobile.Name}\"";
+            }
+
+            if (o is Item item)
+            {
+                return $"(I) 0x{item.Serial.Value:X}";
+            }
+
+            if (o is Type type)
+            {
+                return type.Name;
+            }
+
+            if (o is TextDefinition definition)
+            {
+                return definition.Format(true);
+            }
+
+            return o.ToString();
+        }
+
+        private List<object> BuildList()
+        {
+            var list = new List<object>();
+
+            if (m_Type == null)
+            {
+                return list;
+            }
+
+            var props = m_Type.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public);
+
+            var groups = GetGroups(m_Type, props);
+
+            for (var i = 0; i < groups.Count; ++i)
+            {
+                var kvp = groups[i];
+                if (!HasAttribute(kvp.Key, typeofNoSort, false))
+                {
+                    kvp.Value.Sort(PropertySorter.Instance);
+                }
+
+                if (i != 0)
+                {
+                    list.Add(null);
+                }
+                list.Add(kvp.Key);
+                foreach (var item in kvp.Value)
+                {
+                    if (CompareAttr(item.Name))
+                    {
+                        list.Add(item);
+                    }
+                }
+            }
+            return list;
+        }
+
+        private static bool CompareAttr(string name)
+        {
+            foreach (var item in M_attr)
+            {
+                if(item.Equals(name,StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+
+        private static CPA GetCPA(PropertyInfo prop)
+        {
+            var attrs = prop.GetCustomAttributes(typeofCPA, false);
+
+            if (attrs.Length > 0)
+            {
+                return attrs[0] as CPA;
+            }
+
+            return null;
+        }
+
+        private List<KeyValuePair<Type, List<PropertyInfo>>> GetGroups(Type objectType, PropertyInfo[] props)
+        {
+            var groups = new Dictionary<Type, List<PropertyInfo>>();
+
+            for (var i = 0; i < props.Length; ++i)
+            {
+                var prop = props[i];
+
+                if (prop.CanRead)
+                {
+                    var attr = GetCPA(prop);
+
+                    if (attr != null && m_Mobile.AccessLevel >= attr.ReadLevel)
+                    {
+                        var type = prop.DeclaringType;
+
+                        while (true)
+                        {
+                            var baseType = type?.BaseType;
+
+                            if (baseType == typeofObject || baseType?.GetProperty(prop.Name, prop.PropertyType) == null)
+                            {
+                                break;
+                            }
+
+                            type = baseType;
+                        }
+
+                        if (type != null)
+                        {
+                            if (groups.TryGetValue(type, out var result))
+                            {
+                                result.Add(prop);
+                            }
+                            else
+                            {
+                                groups[type] = new List<PropertyInfo> { prop };
+                            }
+                        }
+                    }
+                }
+            }
+
+            var list = groups.ToList();
+            list.Sort(new GroupComparer(objectType));
+
+            return list;
+        }
+
+        public static object GetObjectFromString(Type t, string s)
+        {
+            if (t == typeof(string))
+            {
+                return s;
+            }
+
+            if (t == typeof(byte) || t == typeof(sbyte) || t == typeof(short) || t == typeof(ushort) || t == typeof(int) ||
+                t == typeof(uint) || t == typeof(long) || t == typeof(ulong))
+            {
+                if (s.StartsWithOrdinal("0x"))
+                {
+                    if (t == typeof(ulong) || t == typeof(uint) || t == typeof(ushort) || t == typeof(byte))
+                    {
+                        return Convert.ChangeType(Convert.ToUInt64(s.Substring(2), 16), t);
+                    }
+
+                    return Convert.ChangeType(Convert.ToInt64(s.Substring(2), 16), t);
+                }
+
+                return Convert.ChangeType(s, t);
+            }
+
+            if (t == typeof(double) || t == typeof(float))
+            {
+                return Convert.ChangeType(s, t);
+            }
+
+            if (t.IsDefined(typeof(ParsableAttribute), false))
+            {
+                var parseMethod = t.GetMethod("Parse", new[] { typeof(string) });
+
+                return parseMethod?.Invoke(null, new object[] { s });
+            }
+
+            throw new Exception("bad");
+        }
+
+        private static string GetStringFromObject(object o)
+        {
+            if (o == null)
+            {
+                return "-null-";
+            }
+
+            if (o is string s)
+            {
+                return $"\"{s}\"";
+            }
+
+            if (o is bool)
+            {
+                return o.ToString();
+            }
+
+            if (o is char c)
+            {
+                return $"0x{(int)c:X} '{c}'";
+            }
+
+            if (o is Serial serial)
+            {
+                if (serial.IsValid)
+                {
+                    if (serial.IsItem)
+                    {
+                        return $"(I) 0x{serial.Value:X}";
+                    }
+
+                    if (serial.IsMobile)
+                    {
+                        return $"(M) 0x{serial.Value:X}";
+                    }
+                }
+
+                return $"(?) 0x{serial.Value:X}";
+            }
+
+            if (o is byte || o is sbyte || o is short || o is ushort || o is int || o is uint || o is long || o is ulong)
+            {
+                return $"{o} (0x{o:X})";
+            }
+
+            if (o is Mobile mobile)
+            {
+                return $"(M) 0x{mobile.Serial.Value:X} \"{mobile.Name}\"";
+            }
+
+            if (o is Item item)
+            {
+                return $"(I) 0x{item.Serial.Value:X}";
+            }
+
+            if (o is Type type)
+            {
+                return type.Name;
+            }
+
+            return o.ToString();
+        }
+
+        private class PropertySorter : IComparer<PropertyInfo>
+        {
+            public static readonly PropertySorter Instance = new();
+
+            private PropertySorter()
+            {
+            }
+
+            public int Compare(PropertyInfo x, PropertyInfo y)
+            {
+                if (x == null && y == null)
+                {
+                    return 0;
+                }
+
+                if (x == null)
+                {
+                    return -1;
+                }
+
+                return y == null ? 1 : string.CompareOrdinal(x.Name, x.Name);
+            }
+        }
+
+        private class GroupComparer : IComparer<KeyValuePair<Type, List<PropertyInfo>>>
+        {
+            private readonly Type m_Start;
+
+            public GroupComparer(Type start) => m_Start = start;
+
+            public int Compare(KeyValuePair<Type, List<PropertyInfo>> x, KeyValuePair<Type, List<PropertyInfo>> y) =>
+                GetDistance(x.Key).CompareTo(GetDistance(y.Key));
+
+            private int GetDistance(Type type)
+            {
+                var current = m_Start;
+
+                int dist;
+
+                for (dist = 0; current != null && current != typeofObject && current != type; ++dist)
+                {
+                    current = current.BaseType;
+                }
+
+                return dist;
+            }
+        }
+    }
+}

--- a/Projects/UOContent/Gumps/Props/PropsConfig.cs
+++ b/Projects/UOContent/Gumps/Props/PropsConfig.cs
@@ -38,5 +38,6 @@ namespace Server.Gumps
 
         public static readonly int EntryHeight = 20;
         public static readonly int BorderSize = 10;
+        public static readonly int ApplySize = 30;
     }
 }

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -868,7 +868,7 @@ namespace Server.Gumps
                     return -1;
                 }
 
-                return y == null ? 1 : string.CompareOrdinal(x.Name, x.Name);
+                return x.Name.CompareOrdinal(y?.Name);
             }
         }
 

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Server.Commands.Generic;
 using Server.Network;
 using CPA = Server.CommandPropertyAttribute;
@@ -61,7 +60,7 @@ namespace Server.Gumps
         private static readonly bool NextLabel = OldStyle;
         private static readonly bool TypeLabel = !OldStyle;
 
-        private static readonly int PrevLabelOffsetX = PrevWidth + 1;
+        public static readonly int PrevLabelOffsetX = PrevWidth + 1;
         private static readonly int PrevLabelOffsetY = 0;
 
         private static readonly int NextLabelOffsetX = -29;
@@ -70,7 +69,7 @@ namespace Server.Gumps
         private static readonly int NameWidth = 107;
         private static readonly int ValueWidth = 128;
 
-        private static readonly int MaxEntriesPerPage = 15;
+        public static readonly int MaxEntriesPerPage = 15;
 
         private static readonly int TypeWidth = NameWidth + OffsetSize + ValueWidth;
 
@@ -90,22 +89,22 @@ namespace Server.Gumps
         public static readonly object[] PoisonValues =
             { null, Poison.Lesser, Poison.Regular, Poison.Greater, Poison.Deadly, Poison.Lethal };
 
-        private static readonly Type typeofMobile = typeof(Mobile);
-        private static readonly Type typeofItem = typeof(Item);
-        private static readonly Type typeofType = typeof(Type);
-        private static readonly Type typeofPoint3D = typeof(Point3D);
-        private static readonly Type typeofPoint2D = typeof(Point2D);
-        private static readonly Type typeofTimeSpan = typeof(TimeSpan);
-        private static readonly Type typeofCustomEnum = typeof(CustomEnumAttribute);
-        private static readonly Type typeofEnum = typeof(Enum);
-        private static readonly Type typeofBool = typeof(bool);
-        private static readonly Type typeofString = typeof(string);
-        private static readonly Type typeofText = typeof(TextDefinition);
-        private static readonly Type typeofPoison = typeof(Poison);
-        private static readonly Type typeofMap = typeof(Map);
-        private static readonly Type typeofSkills = typeof(Skills);
-        private static readonly Type typeofPropertyObject = typeof(PropertyObjectAttribute);
-        private static readonly Type typeofNoSort = typeof(NoSortAttribute);
+        public static readonly Type TypeofMobile = typeof(Mobile);
+        public static readonly Type TypeofItem = typeof(Item);
+        public static readonly Type TypeofType = typeof(Type);
+        public static readonly Type TypeofPoint3D = typeof(Point3D);
+        public static readonly Type TypeofPoint2D = typeof(Point2D);
+        public static readonly Type TypeofTimeSpan = typeof(TimeSpan);
+        public static readonly Type TypeofCustomEnum = typeof(CustomEnumAttribute);
+        public static readonly Type TypeofEnum = typeof(Enum);
+        public static readonly Type TypeofBool = typeof(bool);
+        public static readonly Type TypeofString = typeof(string);
+        public static readonly Type TypeofText = typeof(TextDefinition);
+        public static readonly Type TypeofPoison = typeof(Poison);
+        public static readonly Type TypeofMap = typeof(Map);
+        public static readonly Type TypeofSkills = typeof(Skills);
+        public static readonly Type TypeofPropertyObject = typeof(PropertyObjectAttribute);
+        public static readonly Type TypeofNoSort = typeof(NoSortAttribute);
 
         public static readonly Type[] DecimalTypes =
         {
@@ -113,7 +112,7 @@ namespace Server.Gumps
             typeof(double)
         };
 
-        private static readonly Type[] NumericTypes =
+        public static readonly Type[] NumericTypes =
         {
             typeof(byte),
             typeof(short),
@@ -125,8 +124,8 @@ namespace Server.Gumps
             typeof(ulong)
         };
 
-        private static readonly Type typeofCPA = typeof(CPA);
-        private static readonly Type typeofObject = typeof(object);
+        private static readonly Type TypeofCPA = typeof(CPA);
+        private static readonly Type TypeofObject = typeof(object);
 
         protected readonly List<object> m_List;
         protected readonly Mobile m_Mobile;
@@ -271,7 +270,7 @@ namespace Server.Gumps
                 }
             }
 
-            for (int i = 0, index = page * MaxEntriesPerPage; i < count && index < m_List.Count; ++i, ++index)
+            for (int i = 0, index = page * MaxEntriesPerPage; i < m_EntryCount && index < m_List.Count; ++i, ++index)
             {
                 x = BorderSize + OffsetSize;
                 y += EntryHeight + OffsetSize;
@@ -362,141 +361,134 @@ namespace Server.Gumps
                     {
                         var index = m_Page * MaxEntriesPerPage + (info.ButtonID - 3);
 
-                        if (index >= 0 && index < m_List.Count)
+                        if (index < 0 || index >= m_List.Count)
                         {
-                            var prop = m_List[index] as PropertyInfo;
+                            break;
+                        }
 
-                            if (prop == null)
-                            {
-                                return;
-                            }
+                        var prop = m_List[index] as PropertyInfo;
 
-                            var attr = GetCPA(prop);
+                        if (prop == null)
+                        {
+                            return;
+                        }
 
-                            if (prop.GetType().IsValueType && !prop.CanWrite || attr == null ||
-                                from.AccessLevel < attr.WriteLevel || attr.ReadOnly)
-                            {
-                                return;
-                            }
+                        var attr = GetCPA(prop);
 
-                            var type = prop.PropertyType;
+                        if (prop.GetType().IsValueType && !prop.CanWrite || attr == null ||
+                            from.AccessLevel < attr.WriteLevel || attr.ReadOnly)
+                        {
+                            return;
+                        }
 
-                            if (IsType(type, typeofMobile) || IsType(type, typeofItem))
-                            {
-                                from.SendGump(new SetObjectGump(prop, from, m_Object, m_Stack, type, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofType))
-                            {
-                                from.Target = new SetObjectTarget(prop, from, m_Object, m_Stack, type, m_Page, m_List);
-                            }
-                            else if (IsType(type, typeofPoint3D))
-                            {
-                                from.SendGump(new SetPoint3DGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofPoint2D))
-                            {
-                                from.SendGump(new SetPoint2DGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofTimeSpan))
-                            {
-                                from.SendGump(new SetTimeSpanGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsCustomEnum(type))
-                            {
-                                from.SendGump(
-                                    new SetCustomEnumGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        GetCustomEnumNames(type)
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofEnum))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        Enum.GetNames(type),
-                                        GetObjects(Enum.GetValues(type))
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofBool))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        BoolNames,
-                                        BoolValues
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofString) || IsType(type, DecimalTypes) || IsType(type, NumericTypes) ||
-                                     IsType(type, typeofText))
-                            {
-                                from.SendGump(new SetGump(prop, from, m_Object, m_Stack, m_Page, m_List));
-                            }
-                            else if (IsType(type, typeofPoison))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        PoisonNames,
-                                        PoisonValues
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofMap))
-                            {
-                                from.SendGump(
-                                    new SetListOptionGump(
-                                        prop,
-                                        from,
-                                        m_Object,
-                                        m_Stack,
-                                        m_Page,
-                                        m_List,
-                                        Map.GetMapNames(),
-                                        Map.GetMapValues().ToArray<object>()
-                                    )
-                                );
-                            }
-                            else if (IsType(type, typeofSkills) && m_Object is Mobile mobile)
-                            {
-                                from.SendGump(new PropertiesGump(from, mobile, m_Stack, m_List, m_Page));
-                                from.SendGump(new SkillsGump(from, mobile));
-                            }
-                            else if (HasAttribute(type, typeofPropertyObject, true))
-                            {
-                                var obj = prop.GetValue(m_Object, null);
+                        var type = prop.PropertyType;
 
-                                if (obj != null)
-                                {
-                                    from.SendGump(new PropertiesGump(from, obj, m_Stack, new StackEntry(m_Object, prop)));
-                                }
-                                else
-                                {
-                                    from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page));
-                                }
+                        if (IsType(type, TypeofMobile) || IsType(type, TypeofItem))
+                        {
+                            from.SendGump(new SetObjectGump(prop, from, m_Object, type, this));
+                        }
+                        else if (IsType(type, TypeofType))
+                        {
+                            from.Target = new SetObjectTarget(prop, from, m_Object, type, this);
+                        }
+                        else if (IsType(type, TypeofPoint3D))
+                        {
+                            from.SendGump(new SetPoint3DGump(prop, from, m_Object, this));
+                        }
+                        else if (IsType(type, TypeofPoint2D))
+                        {
+                            from.SendGump(new SetPoint2DGump(prop, from, m_Object, this));
+                        }
+                        else if (IsType(type, TypeofTimeSpan))
+                        {
+                            from.SendGump(new SetTimeSpanGump(prop, from, m_Object, this));
+                        }
+                        else if (IsCustomEnum(type))
+                        {
+                            from.SendGump(
+                                new SetCustomEnumGump(
+                                    prop,
+                                    from,
+                                    m_Object,
+                                    this,
+                                    GetCustomEnumNames(type)
+                                )
+                            );
+                        }
+                        else if (IsType(type, TypeofEnum))
+                        {
+                            from.SendGump(
+                                new SetListOptionGump(
+                                    prop,
+                                    from,
+                                    m_Object,
+                                    this,
+                                    Enum.GetNames(type),
+                                    GetObjects(Enum.GetValues(type))
+                                )
+                            );
+                        }
+                        else if (IsType(type, TypeofBool))
+                        {
+                            from.SendGump(
+                                new SetListOptionGump(
+                                    prop,
+                                    from,
+                                    m_Object,
+                                    this,
+                                    BoolNames,
+                                    BoolValues
+                                )
+                            );
+                        }
+                        else if (IsType(type, TypeofString) || IsType(type, DecimalTypes) ||
+                                 IsType(type, NumericTypes) ||
+                                 IsType(type, TypeofText))
+                        {
+                            from.SendGump(new SetGump(prop, from, m_Object, this));
+                        }
+                        else if (IsType(type, TypeofPoison))
+                        {
+                            from.SendGump(
+                                new SetListOptionGump(
+                                    prop,
+                                    from,
+                                    m_Object,
+                                    this,
+                                    PoisonNames,
+                                    PoisonValues
+                                )
+                            );
+                        }
+                        else if (IsType(type, TypeofMap))
+                        {
+                            from.SendGump(
+                                new SetListOptionGump(
+                                    prop,
+                                    from,
+                                    m_Object,
+                                    this,
+                                    Map.GetMapNames(),
+                                    Map.GetMapValues().ToArray<object>()
+                                )
+                            );
+                        }
+                        else if (IsType(type, TypeofSkills) && m_Object is Mobile mobile)
+                        {
+                            from.SendGump(new PropertiesGump(from, mobile, m_Stack, m_List, m_Page));
+                            from.SendGump(new SkillsGump(from, mobile));
+                        }
+                        else if (HasAttribute(type, TypeofPropertyObject, true))
+                        {
+                            var obj = prop.GetValue(m_Object, null);
+
+                            if (obj != null)
+                            {
+                                from.SendGump(new PropertiesGump(from, obj, m_Stack, new StackEntry(m_Object, prop)));
+                            }
+                            else
+                            {
+                                from.SendGump(new PropertiesGump(from, m_Object, m_Stack, m_List, m_Page));
                             }
                         }
 
@@ -504,6 +496,9 @@ namespace Server.Gumps
                     }
             }
         }
+
+        public virtual void SendPropertiesGump() =>
+            m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
 
         private static object[] GetObjects(Array a)
         {
@@ -517,11 +512,11 @@ namespace Server.Gumps
             return list;
         }
 
-        private static bool IsCustomEnum(Type type) => type.IsDefined(typeofCustomEnum, false);
+        private static bool IsCustomEnum(Type type) => type.IsDefined(TypeofCustomEnum, false);
 
-        public static void OnValueChanged(object obj, PropertyInfo prop, Stack<StackEntry> stack)
+        public void OnValueChanged(object obj, PropertyInfo prop)
         {
-            if (stack == null || stack.Count == 0)
+            if (m_Stack == null || m_Stack.Count == 0)
             {
                 return;
             }
@@ -531,7 +526,7 @@ namespace Server.Gumps
                 return;
             }
 
-            var peek = stack.Peek();
+            var peek = m_Stack.Peek();
 
             if (peek.m_Property.CanWrite)
             {
@@ -541,7 +536,7 @@ namespace Server.Gumps
 
         private static string[] GetCustomEnumNames(Type type)
         {
-            var attrs = type.GetCustomAttributes(typeofCustomEnum, false);
+            var attrs = type.GetCustomAttributes(TypeofCustomEnum, false);
 
             if (attrs.Length == 0)
             {
@@ -556,12 +551,12 @@ namespace Server.Gumps
             return ce.Names;
         }
 
-        private static bool HasAttribute(Type type, Type check, bool inherit) =>
+        public static bool HasAttribute(Type type, Type check, bool inherit) =>
             type.GetCustomAttributes(check, inherit).Length > 0;
 
-        private static bool IsType(Type type, Type check) => type == check || type.IsSubclassOf(check);
+        public static bool IsType(Type type, Type check) => type == check || type.IsSubclassOf(check);
 
-        private static bool IsType(Type type, Type[] check)
+        public static bool IsType(Type type, Type[] check)
         {
             for (var i = 0; i < check.Length; ++i)
             {
@@ -574,7 +569,7 @@ namespace Server.Gumps
             return false;
         }
 
-        private string ValueToString(PropertyInfo prop) => ValueToString(m_Object, prop);
+        public string ValueToString(PropertyInfo prop) => ValueToString(m_Object, prop);
 
         public static string ValueToString(object obj, PropertyInfo prop)
         {
@@ -673,7 +668,7 @@ namespace Server.Gumps
             {
                 var kvp = groups[i];
 
-                if (!HasAttribute(kvp.Key, typeofNoSort, false))
+                if (!HasAttribute(kvp.Key, TypeofNoSort, false))
                 {
                     kvp.Value.Sort(PropertySorter.Instance);
                 }
@@ -699,9 +694,9 @@ namespace Server.Gumps
 
         protected virtual bool ShowAttribute(string name) => true;
 
-        private static CPA GetCPA(PropertyInfo prop)
+        public static CPA GetCPA(PropertyInfo prop)
         {
-            var attrs = prop.GetCustomAttributes(typeofCPA, false);
+            var attrs = prop.GetCustomAttributes(TypeofCPA, false);
 
             if (attrs.Length > 0)
             {
@@ -731,7 +726,7 @@ namespace Server.Gumps
                         {
                             var baseType = type?.BaseType;
 
-                            if (baseType == typeofObject || baseType?.GetProperty(prop.Name, prop.PropertyType) == null)
+                            if (baseType == TypeofObject || baseType?.GetProperty(prop.Name, prop.PropertyType) == null)
                             {
                                 break;
                             }
@@ -900,7 +895,7 @@ namespace Server.Gumps
 
                 int dist;
 
-                for (dist = 0; current != null && current != typeofObject && current != type; ++dist)
+                for (dist = 0; current != null && current != TypeofObject && current != type; ++dist)
                 {
                     current = current.BaseType;
                 }

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -207,7 +207,7 @@ namespace Server.Gumps
                 BorderSize,
                 BorderSize,
                 TotalWidth - (OldStyle ? SetWidth + OffsetSize : 0),
-                totalHeight,
+                OffsetSize + (EntryHeight + OffsetSize) * (m_EntryCount + 1),
                 OffsetGumpID
             );
 

--- a/Projects/UOContent/Gumps/Props/SetBodyGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetBodyGump.cs
@@ -24,28 +24,24 @@ namespace Server.Gumps
         private const int TextColor32 = 0xFFFFFF;
 
         private static List<InternalEntry> m_Monster, m_Animal, m_Sea, m_Human;
-        private readonly List<object> m_List;
         private readonly Mobile m_Mobile;
         private readonly object m_Object;
         private readonly List<InternalEntry> m_OurList;
         private readonly int m_OurPage;
         private readonly ModelBodyType m_OurType;
-        private readonly int m_Page;
         private readonly PropertyInfo m_Property;
-        private readonly Stack<StackEntry> m_Stack;
+        private readonly PropertiesGump m_PropertiesGump;
 
         public SetBodyGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list,
+            PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump,
             int ourPage = 0, List<InternalEntry> ourList = null, ModelBodyType ourType = ModelBodyType.Invalid
         )
             : base(20, 30)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
-            m_Page = page;
-            m_List = list;
             m_OurPage = ourPage;
             m_OurList = ourList;
             m_OurType = ourType;
@@ -131,7 +127,7 @@ namespace Server.Gumps
 
             if (index == -1)
             {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                m_PropertiesGump.SendPropertiesGump();
             }
             else if (index >= 0 && index < 4)
             {
@@ -163,7 +159,7 @@ namespace Server.Gumps
                         break;
                 }
 
-                m_Mobile.SendGump(new SetBodyGump(m_Property, m_Mobile, m_Object, m_Stack, m_Page, m_List, 0, list, type));
+                m_Mobile.SendGump(new SetBodyGump(m_Property, m_Mobile, m_Object, m_PropertiesGump, 0, list, type));
             }
             else if (m_OurList != null)
             {
@@ -176,9 +172,7 @@ namespace Server.Gumps
                             m_Property,
                             m_Mobile,
                             m_Object,
-                            m_Stack,
-                            m_Page,
-                            m_List,
+                            m_PropertiesGump,
                             m_OurPage - 1,
                             m_OurList,
                             m_OurType
@@ -192,9 +186,7 @@ namespace Server.Gumps
                             m_Property,
                             m_Mobile,
                             m_Object,
-                            m_Stack,
-                            m_Page,
-                            m_List,
+                            m_PropertiesGump,
                             m_OurPage + 1,
                             m_OurList,
                             m_OurType
@@ -213,7 +205,7 @@ namespace Server.Gumps
 
                             CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, entry.Body.ToString());
                             m_Property.SetValue(m_Object, entry.Body, null);
-                            PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                            m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                         }
                         catch
                         {
@@ -225,9 +217,7 @@ namespace Server.Gumps
                                 m_Property,
                                 m_Mobile,
                                 m_Object,
-                                m_Stack,
-                                m_Page,
-                                m_List,
+                                m_PropertiesGump,
                                 m_OurPage,
                                 m_OurList,
                                 m_OurType

--- a/Projects/UOContent/Gumps/Props/SetCustomEnumGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetCustomEnumGump.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Network;
@@ -11,9 +10,8 @@ namespace Server.Gumps
         private readonly string[] m_Names;
 
         public SetCustomEnumGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int propspage,
-            List<object> list, string[] names
-        ) : base(prop, mobile, o, stack, propspage, list, names, null) =>
+            PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump, string[] names
+        ) : base(prop, mobile, o, propertiesGump, names, null) =>
             m_Names = names;
 
         public override void OnResponse(NetState sender, RelayInfo relayInfo)
@@ -61,7 +59,7 @@ namespace Server.Gumps
 
                     if (result == "Property has been set.")
                     {
-                        PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                        m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                     }
                 }
                 catch
@@ -70,7 +68,7 @@ namespace Server.Gumps
                 }
             }
 
-            m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+            m_PropertiesGump.SendPropertiesGump();
         }
     }
 }

--- a/Projects/UOContent/Gumps/Props/SetGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetGump.cs
@@ -55,16 +55,16 @@ namespace Server.Gumps
         private readonly int m_Page;
         private readonly PropertyInfo m_Property;
         private readonly Stack<StackEntry> m_Stack;
-        private bool m_Edit = false;
+        private readonly bool m_Edit;
 
         public SetGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list, bool IsEdit = false
+            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list, bool edit = false
         ) : base(
             GumpOffsetX,
             GumpOffsetY
         )
         {
-            m_Edit = IsEdit;
+            m_Edit = edit;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
@@ -276,8 +276,10 @@ namespace Server.Gumps
                 {
                     m_Mobile.SendGump(new GlobalPropsGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
                 }
-                else m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
-
+                else
+                {
+                    m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                }
             }
         }
 

--- a/Projects/UOContent/Gumps/Props/SetGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetGump.cs
@@ -55,14 +55,16 @@ namespace Server.Gumps
         private readonly int m_Page;
         private readonly PropertyInfo m_Property;
         private readonly Stack<StackEntry> m_Stack;
+        private bool m_Edit = false;
 
         public SetGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list
+            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list, bool IsEdit = false
         ) : base(
             GumpOffsetX,
             GumpOffsetY
         )
         {
+            m_Edit = IsEdit;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
@@ -77,9 +79,9 @@ namespace Server.Gumps
             var val = prop.GetValue(m_Object, null);
             var initialText = val switch
             {
-                null                      => "",
+                null => "",
                 TextDefinition definition => definition.GetValue(),
-                _                         => val.ToString()
+                _ => val.ToString()
             };
 
             AddPage(0);
@@ -179,6 +181,7 @@ namespace Server.Gumps
             }
         }
 
+
         public override void OnResponse(NetState sender, RelayInfo info)
         {
             object toSet;
@@ -269,7 +272,12 @@ namespace Server.Gumps
 
             if (shouldSend)
             {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                if (m_Edit)
+                {
+                    m_Mobile.SendGump(new GlobalPropsGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                }
+                else m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+
             }
         }
 

--- a/Projects/UOContent/Gumps/Props/SetListOptionGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetListOptionGump.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Network;
@@ -58,24 +57,19 @@ namespace Server.Gumps
         private static readonly int NextLabelOffsetY = 0;
 
         private readonly object[] m_Values;
-        protected List<object> m_List;
         protected Mobile m_Mobile;
         protected object m_Object;
-        protected int m_Page;
         protected PropertyInfo m_Property;
-        protected Stack<StackEntry> m_Stack;
+        protected PropertiesGump m_PropertiesGump;
 
         public SetListOptionGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int propspage,
-            List<object> list, string[] names, object[] values
+            PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump, string[] names, object[] values
         ) : base(GumpOffsetX, GumpOffsetY)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
-            m_Page = propspage;
-            m_List = list;
 
             m_Values = values;
 
@@ -224,7 +218,7 @@ namespace Server.Gumps
 
                     if (result == "Property has been set.")
                     {
-                        PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                        m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                     }
                 }
                 catch
@@ -233,7 +227,7 @@ namespace Server.Gumps
                 }
             }
 
-            m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+            m_PropertiesGump.SendPropertiesGump();
         }
     }
 }

--- a/Projects/UOContent/Gumps/Props/SetObjectGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetObjectGump.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Commands.Generic;
@@ -51,26 +50,21 @@ namespace Server.Gumps
 
         private static readonly int BackWidth = BorderSize + TotalWidth + BorderSize;
         private static readonly int BackHeight = BorderSize + TotalHeight + BorderSize;
-        private readonly List<object> m_List;
         private readonly Mobile m_Mobile;
         private readonly object m_Object;
-        private readonly int m_Page;
         private readonly PropertyInfo m_Property;
-        private readonly Stack<StackEntry> m_Stack;
         private readonly Type m_Type;
+        private readonly PropertiesGump m_PropertiesGump;
 
         public SetObjectGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, Type type, int page,
-            List<object> list
+            PropertyInfo prop, Mobile mobile, object o, Type type, PropertiesGump propertiesGump
         ) : base(GumpOffsetX, GumpOffsetY)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
             m_Type = type;
-            m_Page = page;
-            m_List = list;
 
             var initialText = PropertiesGump.ValueToString(o, prop);
 
@@ -163,7 +157,7 @@ namespace Server.Gumps
             {
                 case 0: // closed
                     {
-                        m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                        m_PropertiesGump.SendPropertiesGump();
                         shouldSend = false;
                         break;
                     }
@@ -173,10 +167,8 @@ namespace Server.Gumps
                             m_Property,
                             m_Mobile,
                             m_Object,
-                            m_Stack,
                             m_Type,
-                            m_Page,
-                            m_List
+                            m_PropertiesGump
                         );
                         shouldSend = false;
                         break;
@@ -190,10 +182,8 @@ namespace Server.Gumps
                             m_Property,
                             m_Mobile,
                             m_Object,
-                            m_Stack,
                             m_Type,
-                            m_Page,
-                            m_List
+                            m_PropertiesGump
                         );
 
                         break;
@@ -204,7 +194,7 @@ namespace Server.Gumps
                         {
                             CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, "(null)");
                             m_Property.SetValue(m_Object, null, null);
-                            PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                            m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                         }
                         catch
                         {
@@ -236,7 +226,7 @@ namespace Server.Gumps
 
             if (shouldSend)
             {
-                m_Mobile.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Stack, m_Type, m_Page, m_List));
+                m_Mobile.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Type, m_PropertiesGump));
             }
 
             if (viewProps != null)
@@ -247,31 +237,26 @@ namespace Server.Gumps
 
         private class InternalPrompt : Prompt
         {
-            private readonly List<object> m_List;
             private readonly Mobile m_Mobile;
             private readonly object m_Object;
-            private readonly int m_Page;
             private readonly PropertyInfo m_Property;
-            private readonly Stack<StackEntry> m_Stack;
             private readonly Type m_Type;
+            private readonly PropertiesGump m_PropertiesGump;
 
             public InternalPrompt(
-                PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, Type type, int page,
-                List<object> list
+                PropertyInfo prop, Mobile mobile, object o, Type type, PropertiesGump propertiesGump
             )
             {
+                m_PropertiesGump = propertiesGump;
                 m_Property = prop;
                 m_Mobile = mobile;
                 m_Object = o;
-                m_Stack = stack;
                 m_Type = type;
-                m_Page = page;
-                m_List = list;
             }
 
             public override void OnCancel(Mobile from)
             {
-                m_Mobile.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Stack, m_Type, m_Page, m_List));
+                m_Mobile.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Type, m_PropertiesGump));
             }
 
             public override void OnResponse(Mobile from, string text)
@@ -304,7 +289,7 @@ namespace Server.Gumps
                                 toSet.ToString()
                             );
                             m_Property.SetValue(m_Object, toSet, null);
-                            PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                            m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                         }
                         catch
                         {
@@ -317,7 +302,7 @@ namespace Server.Gumps
                     m_Mobile.SendMessage("Bad format");
                 }
 
-                m_Mobile.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Stack, m_Type, m_Page, m_List));
+                m_Mobile.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Type, m_PropertiesGump));
             }
         }
     }

--- a/Projects/UOContent/Gumps/Props/SetObjectTarget.cs
+++ b/Projects/UOContent/Gumps/Props/SetObjectTarget.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Items;
@@ -9,26 +8,21 @@ namespace Server.Gumps
 {
     public class SetObjectTarget : Target
     {
-        private readonly List<object> m_List;
         private readonly Mobile m_Mobile;
         private readonly object m_Object;
-        private readonly int m_Page;
         private readonly PropertyInfo m_Property;
-        private readonly Stack<StackEntry> m_Stack;
         private readonly Type m_Type;
+        private readonly PropertiesGump m_PropertiesGump;
 
         public SetObjectTarget(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, Type type, int page,
-            List<object> list
+            PropertyInfo prop, Mobile mobile, object o, Type type, PropertiesGump propertiesGump
         ) : base(-1, false, TargetFlags.None)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
             m_Type = type;
-            m_Page = page;
-            m_List = list;
         }
 
         protected override void OnTarget(Mobile from, object targeted)
@@ -49,7 +43,7 @@ namespace Server.Gumps
                 {
                     CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, targeted.ToString());
                     m_Property.SetValue(m_Object, targeted, null);
-                    PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                    m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                 }
                 else
                 {
@@ -66,11 +60,11 @@ namespace Server.Gumps
         {
             if (m_Type == typeof(Type))
             {
-                from.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                m_PropertiesGump.SendPropertiesGump();
             }
             else
             {
-                from.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Stack, m_Type, m_Page, m_List));
+                from.SendGump(new SetObjectGump(m_Property, m_Mobile, m_Object, m_Type, m_PropertiesGump));
             }
         }
     }

--- a/Projects/UOContent/Gumps/Props/SetPoint2DGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetPoint2DGump.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Network;
@@ -50,24 +49,20 @@ namespace Server.Gumps
 
         private static readonly int BackWidth = BorderSize + TotalWidth + BorderSize;
         private static readonly int BackHeight = BorderSize + TotalHeight + BorderSize;
-        private readonly List<object> m_List;
         private readonly Mobile m_Mobile;
         private readonly object m_Object;
-        private readonly int m_Page;
         private readonly PropertyInfo m_Property;
-        private readonly Stack<StackEntry> m_Stack;
+        private readonly PropertiesGump m_PropertiesGump;
 
         public SetPoint2DGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list
+            PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump
         )
             : base(GumpOffsetX, GumpOffsetY)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
-            m_Page = page;
-            m_List = list;
 
             var p = (Point2D)(prop?.GetValue(o, null) ?? new Point2D());
 
@@ -160,7 +155,7 @@ namespace Server.Gumps
                     }
                 case 2: // Pick location
                     {
-                        m_Mobile.Target = new InternalTarget(m_Property, m_Mobile, m_Object, m_Stack, m_Page, m_List);
+                        m_Mobile.Target = new InternalTarget(m_Property, m_Mobile, m_Object, m_PropertiesGump);
 
                         toSet = Point2D.Zero;
                         shouldSet = false;
@@ -198,7 +193,7 @@ namespace Server.Gumps
                 {
                     CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, toSet.ToString());
                     m_Property.SetValue(m_Object, toSet, null);
-                    PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                    m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                 }
                 catch
                 {
@@ -208,30 +203,25 @@ namespace Server.Gumps
 
             if (shouldSend)
             {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                m_PropertiesGump.SendPropertiesGump();
             }
         }
 
         private class InternalTarget : Target
         {
-            private readonly List<object> m_List;
             private readonly Mobile m_Mobile;
             private readonly object m_Object;
-            private readonly int m_Page;
             private readonly PropertyInfo m_Property;
-            private readonly Stack<StackEntry> m_Stack;
+            private readonly PropertiesGump m_PropertiesGump;
 
             public InternalTarget(
-                PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page,
-                List<object> list
+                PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump
             ) : base(-1, true, TargetFlags.None)
             {
                 m_Property = prop;
                 m_Mobile = mobile;
                 m_Object = o;
-                m_Stack = stack;
-                m_Page = page;
-                m_List = list;
+                m_PropertiesGump = propertiesGump;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
@@ -242,7 +232,7 @@ namespace Server.Gumps
                     {
                         CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, new Point2D(p).ToString());
                         m_Property.SetValue(m_Object, new Point2D(p), null);
-                        PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                        m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                     }
                     catch
                     {
@@ -253,7 +243,7 @@ namespace Server.Gumps
 
             protected override void OnTargetFinish(Mobile from)
             {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                m_PropertiesGump.SendPropertiesGump();
             }
         }
     }

--- a/Projects/UOContent/Gumps/Props/SetPoint3DGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetPoint3DGump.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Network;
@@ -50,24 +49,20 @@ namespace Server.Gumps
 
         private static readonly int BackWidth = BorderSize + TotalWidth + BorderSize;
         private static readonly int BackHeight = BorderSize + TotalHeight + BorderSize;
-        private readonly List<object> m_List;
         private readonly Mobile m_Mobile;
         private readonly object m_Object;
-        private readonly int m_Page;
         private readonly PropertyInfo m_Property;
-        private readonly Stack<StackEntry> m_Stack;
+        private readonly PropertiesGump m_PropertiesGump;
 
         public SetPoint3DGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list
+            PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump
         )
             : base(GumpOffsetX, GumpOffsetY)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
-            m_Page = page;
-            m_List = list;
 
             var p = (Point3D)(prop?.GetValue(o, null) ?? new Point3D());
 
@@ -165,7 +160,7 @@ namespace Server.Gumps
                     }
                 case 2: // Pick location
                     {
-                        m_Mobile.Target = new InternalTarget(m_Property, m_Mobile, m_Object, m_Stack, m_Page, m_List);
+                        m_Mobile.Target = new InternalTarget(m_Property, m_Mobile, m_Object, m_PropertiesGump);
 
                         toSet = Point3D.Zero;
                         shouldSet = false;
@@ -205,7 +200,7 @@ namespace Server.Gumps
                 {
                     CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, toSet.ToString());
                     m_Property.SetValue(m_Object, toSet, null);
-                    PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                    m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                 }
                 catch
                 {
@@ -215,30 +210,25 @@ namespace Server.Gumps
 
             if (shouldSend)
             {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                m_PropertiesGump.SendPropertiesGump();
             }
         }
 
         private class InternalTarget : Target
         {
-            private readonly List<object> m_List;
             private readonly Mobile m_Mobile;
             private readonly object m_Object;
-            private readonly int m_Page;
             private readonly PropertyInfo m_Property;
-            private readonly Stack<StackEntry> m_Stack;
+            private readonly PropertiesGump m_PropertiesGump;
 
             public InternalTarget(
-                PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page,
-                List<object> list
+                PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump
             ) : base(-1, true, TargetFlags.None)
             {
+                m_PropertiesGump = propertiesGump;
                 m_Property = prop;
                 m_Mobile = mobile;
                 m_Object = o;
-                m_Stack = stack;
-                m_Page = page;
-                m_List = list;
             }
 
             protected override void OnTarget(Mobile from, object targeted)
@@ -249,7 +239,7 @@ namespace Server.Gumps
                     {
                         CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, new Point3D(p).ToString());
                         m_Property.SetValue(m_Object, new Point3D(p), null);
-                        PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                        m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                     }
                     catch
                     {
@@ -258,10 +248,7 @@ namespace Server.Gumps
                 }
             }
 
-            protected override void OnTargetFinish(Mobile from)
-            {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
-            }
+            protected override void OnTargetFinish(Mobile from) => m_PropertiesGump.SendPropertiesGump();
         }
     }
 }

--- a/Projects/UOContent/Gumps/Props/SetTimeSpanGump.cs
+++ b/Projects/UOContent/Gumps/Props/SetTimeSpanGump.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Server.Commands;
 using Server.Network;
@@ -49,24 +48,20 @@ namespace Server.Gumps
 
         private static readonly int BackWidth = BorderSize + TotalWidth + BorderSize;
         private static readonly int BackHeight = BorderSize + TotalHeight + BorderSize;
-        private readonly List<object> m_List;
         private readonly Mobile m_Mobile;
         private readonly object m_Object;
-        private readonly int m_Page;
         private readonly PropertyInfo m_Property;
-        private readonly Stack<StackEntry> m_Stack;
+        private readonly PropertiesGump m_PropertiesGump;
 
         public SetTimeSpanGump(
-            PropertyInfo prop, Mobile mobile, object o, Stack<StackEntry> stack, int page, List<object> list
+            PropertyInfo prop, Mobile mobile, object o, PropertiesGump propertiesGump
         )
             : base(GumpOffsetX, GumpOffsetY)
         {
+            m_PropertiesGump = propertiesGump;
             m_Property = prop;
             m_Mobile = mobile;
             m_Object = o;
-            m_Stack = stack;
-            m_Page = page;
-            m_List = list;
 
             var ts = (TimeSpan)(prop?.GetValue(o, null) ?? new TimeSpan());
 
@@ -239,7 +234,7 @@ namespace Server.Gumps
                 {
                     CommandLogging.LogChangeProperty(m_Mobile, m_Object, m_Property.Name, toSet.ToString());
                     m_Property.SetValue(m_Object, toSet, null);
-                    PropertiesGump.OnValueChanged(m_Object, m_Property, m_Stack);
+                    m_PropertiesGump.OnValueChanged(m_Object, m_Property);
                 }
                 catch
                 {
@@ -249,7 +244,7 @@ namespace Server.Gumps
 
             if (shouldSend)
             {
-                m_Mobile.SendGump(new PropertiesGump(m_Mobile, m_Object, m_Stack, m_List, m_Page));
+                m_PropertiesGump.SendPropertiesGump();
             }
         }
     }


### PR DESCRIPTION
- [X] Adds Respawn command
- [X] Adds EditSpawner command
  - Usage: `[global editspawner <type> <arguments> set <properties>`
  - This command replaces the arguments (optional) and properties of the affected spawners for that type
- [X] Adds SpawnProps command
  - Usage: `[area spawnprops`
  - This command brings up a gump to modify targeted spawners based on the targeted entity.
  - To do this, the props/values are copied and then used to construct a properties list for the spawner entry.

Closes #531 