### PR TITLE
fix(core): Fixes generic persistence

### DIFF
--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -46,7 +46,7 @@ namespace Server
                 using var bin = new BinaryFileWriter(binPath, true);
 
                 saveBuffer!.Resize((int)saveBuffer.Position);
-                bin.Write(saveBuffer.Buffer.AsSpan());
+                bin.Write(saveBuffer.Buffer);
             }
 
             void Deserialize(string savePath)

--- a/Projects/Server/World/EntityPersistence.cs
+++ b/Projects/Server/World/EntityPersistence.cs
@@ -276,10 +276,12 @@ namespace Server
         private static void SerializeTo(this ISerializable entity, IGenericWriter writer)
         {
             var saveBuffer = entity.SaveBuffer;
-            writer.Write(saveBuffer.Buffer.AsSpan(0, (int)saveBuffer.Position));
 
-            // Resize to exact buffer size
-            entity.SaveBuffer.Resize((int)entity.SaveBuffer.Position);
+            // Resize to the exact size
+            saveBuffer.Resize((int)saveBuffer.Position);
+
+            // Write that amount
+            writer.Write(saveBuffer.Buffer);
         }
     }
 }


### PR DESCRIPTION
- [X] Fixes generic persistence, making the API for writing from a static class much easier.

Example:
```cs
namespace Server
{
    public static class ExampleSystem
    {
        public static void Configure()
        {
            GenericPersistence.Register("ExampleSystem", Serialize, Deserialize);
        }
        
        public static void Serialize(IGenericWriter writer)
        {
            // Do serialization here
            writer.WriteEncodedInt(0); // version
        }

        public static void Deserialize(IGenericReader reader)
        {
            // Do deserialization here
            var version = reader.ReadEncodedInt();
        }
    }
}
```