### PR TITLE
fix(core): Fixes netstate dropping late

### DIFF
--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -1056,6 +1056,13 @@ namespace Server.Network
                 return;
             }
 
+            var m = Mobile;
+            if (m != null)
+            {
+                m.NetState = null;
+                Mobile = null;
+            }
+
             try
             {
                 if (_disconnectReason != string.Empty)
@@ -1104,14 +1111,7 @@ namespace Server.Network
             RecvPipe.Writer.Close();
             SendPipe.Writer.Close();
 
-            var m = Mobile;
             var a = Account;
-
-            if (m != null)
-            {
-                m.NetState = null;
-                Mobile = null;
-            }
 
             Gumps.Clear();
             Menus.Clear();


### PR DESCRIPTION
- [X] Fixes the new netstate being nulled, causing some packets to not get sent through `m.NetSate` reference.

Thanks to @jaedan for this fix.