### PR TITLE
[WIP] Add possess command

### DIFF
--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -1858,6 +1858,9 @@ namespace Server
             }
         }
 
+        [CommandProperty(AccessLevel.GameMaster)]
+        public Container PossessContainer { get; set; } = null;
+
         public virtual bool KeepsItemsOnDeath => m_AccessLevel > AccessLevel.Player;
 
         public bool HasTrade => m_NetState?.Trades.Count > 0;

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -288,8 +288,7 @@ namespace Server
     public enum PossessType : byte
     {
         None,
-        Possessed,
-        Possessing
+        Possessed
     }
 
     [Flags]
@@ -672,6 +671,8 @@ namespace Server
         public virtual bool NewGuildDisplay => false;
 
         public List<Mobile> Stabled { get; private set; }
+
+        public Mobile PossessedMobile => Stabled.Find(mob => mob.PossessType == PossessType.Possessed);
 
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
         public VirtueInfo Virtues { get; private set; }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -70,6 +70,13 @@ namespace Server
         public override bool CheckCondition() => true;
     }
 
+    public class PossessionSkillMod : DefaultSkillMod
+    {
+        public PossessionSkillMod(SkillName skill, double value) : base(skill, false, value)
+        {
+        }
+    }
+
     public abstract class SkillMod
     {
         private bool m_ObeyCap;
@@ -667,6 +674,8 @@ namespace Server
         public List<Mobile> Stabled { get; private set; }
 
         public Mobile PossessedMobile => Stabled.Find(mob => mob.Possessed);
+
+        public bool IsPossessing => PossessedMobile != null;
 
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
         public VirtueInfo Virtues { get; private set; }
@@ -2165,6 +2174,18 @@ namespace Server
                     OnRawStatChange(StatType.Dex, oldValue);
                 }
             }
+        }
+
+        public int GetStat(StatType statType)
+        {
+            return statType switch
+            {
+                StatType.Str => Str,
+                StatType.Int => Int,
+                StatType.Dex => Dex,
+                StatType.All => Dex + Str + Int,
+                _            => 0
+            };
         }
 
         /// <summary>

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -285,12 +285,6 @@ namespace Server
         Locked
     }
 
-    public enum PossessType : byte
-    {
-        None,
-        Possessed
-    }
-
     [Flags]
     [CustomEnum(new[] { "North", "Right", "East", "Down", "South", "Left", "West", "Up" })]
     public enum Direction : byte
@@ -672,7 +666,7 @@ namespace Server
 
         public List<Mobile> Stabled { get; private set; }
 
-        public Mobile PossessedMobile => Stabled.Find(mob => mob.PossessType == PossessType.Possessed);
+        public Mobile PossessedMobile => Stabled.Find(mob => mob.Possessed);
 
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
         public VirtueInfo Virtues { get; private set; }
@@ -814,7 +808,7 @@ namespace Server
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public PossessType PossessType { get; set; } = PossessType.None;
+        public bool Possessed { get; set; }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool DisarmReady { get; set; }
@@ -2572,7 +2566,7 @@ namespace Server
 
             writer.Write(33); // version
 
-            writer.Write((byte) PossessType);
+            writer.Write(Possessed);
 
             writer.WriteDeltaTime(LastStrGain);
             writer.WriteDeltaTime(LastIntGain);
@@ -6270,8 +6264,7 @@ namespace Server
             {
                 case 33:
                     {
-                        var possessByte = reader.ReadByte();
-                        PossessType = (PossessType) Enum.ToObject(typeof(PossessType), possessByte);
+                        Possessed = reader.ReadBool();
                         goto case 32;
                     }
                 case 32:

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -553,7 +553,6 @@ namespace Server
         private DateTime m_NextWarmodeChange;
         private bool m_Paralyzed;
         private Timer m_ParaTimer;
-        private PossessType m_PossessType;
         private bool m_Player;
         private Poison m_Poison;
         private Prompt m_Prompt;
@@ -618,8 +617,6 @@ namespace Server
                 World.MobileTypes.Add(ourType);
                 TypeRef = World.MobileTypes.Count - 1;
             }
-
-            m_PossessType = PossessType.None;
         }
 
         public static bool DragEffects { get; set; } = true;
@@ -816,10 +813,7 @@ namespace Server
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public PossessType PossessType {
-            get => m_PossessType;
-            set => m_PossessType = value;
-        }
+        public PossessType PossessType { get; set; } = PossessType.None;
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool DisarmReady { get; set; }
@@ -2577,7 +2571,7 @@ namespace Server
 
             writer.Write(33); // version
 
-            writer.Write((byte) m_PossessType);
+            writer.Write((byte) PossessType);
 
             writer.WriteDeltaTime(LastStrGain);
             writer.WriteDeltaTime(LastIntGain);
@@ -6276,7 +6270,7 @@ namespace Server
                 case 33:
                     {
                         var possessByte = reader.ReadByte();
-                        m_PossessType = (PossessType) Enum.ToObject(typeof(PossessType), possessByte);
+                        PossessType = (PossessType) Enum.ToObject(typeof(PossessType), possessByte);
                         goto case 32;
                     }
                 case 32:

--- a/Projects/UOContent/Commands/Generic/Commands/Commands.cs
+++ b/Projects/UOContent/Commands/Generic/Commands/Commands.cs
@@ -67,6 +67,8 @@ namespace Server.Commands.Generic
             Register(new BringToPackCommand());
             Register(new TraceLockdownCommand());
             Register(new LocationCommand());
+            Register(new PossessCommand());
+            Register(new UnpossessCommand());
         }
 
         public static void Register(BaseCommand command)

--- a/Projects/UOContent/Commands/Possess.cs
+++ b/Projects/UOContent/Commands/Possess.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using Server.Commands.Generic;
+
+namespace Server.Commands
+{
+    public class PossessCommand : BaseCommand
+    {
+        public PossessCommand()
+        {
+            AccessLevel = AccessLevel.GameMaster;
+            Supports = CommandSupport.AllMobiles;
+            Commands = new[] { "Possess" };
+            ObjectTypes = ObjectTypes.Mobiles;
+            Usage = "Possess";
+            Description = "Takes control of a mobile";
+        }
+
+        public override void Execute(CommandEventArgs e, object obj)
+        {
+            Console.WriteLine("Executing possess command " + Core.Expansion);
+
+            var caster = e.Mobile;
+            var target = (Mobile)obj;
+
+            if (caster.PossessType == PossessType.Possessing)
+            {
+                AddResponse("You are already possessing a target!");
+                return;
+            }
+
+            if (target.Player)
+            {
+                AddResponse("You can't possess a player");
+                return;
+            }
+
+            caster.BodyMod = target.Body;
+            caster.Location = target.Location;
+            caster.Direction = target.Direction;
+
+            target.PossessType = PossessType.Possessed;
+            caster.PossessType = PossessType.Possessing;
+
+            caster.Stabled.Add(target);
+            target.Internalize();
+
+            Properties.SetValue(e.Mobile, obj, "Invul", "true");
+
+            if (caster.Hidden)
+            {
+                caster.Hidden = false;
+            }
+            BuffInfo.AddBuff(caster, new BuffInfo(BuffIcon.Incognito, 1075819, new TextDefinition("Possessing " + target.Name)));
+
+            AddResponse("You've taken control of " + target.Name);
+        }
+    }
+
+    public class UnpossessCommand : BaseCommand
+    {
+        public UnpossessCommand()
+        {
+            AccessLevel = AccessLevel.GameMaster;
+            Supports = CommandSupport.AllMobiles;
+            Commands = new[] { "Unpossess" };
+            ObjectTypes = ObjectTypes.Mobiles;
+            Usage = "Unpossess";
+            Description = "Release control of a mobile";
+        }
+
+        public override void Execute(CommandEventArgs e, object obj)
+        {
+            var caster = e.Mobile;
+
+            Mobile toRelease = null;
+
+            foreach (Mobile mob in caster.Stabled)
+            {
+                if (mob.PossessType == PossessType.Possessed)
+                {
+                    toRelease = mob;
+                }
+            }
+
+            if (toRelease == null)
+            {
+                AddResponse("You have nothing to unpossess!");
+                return;
+            }
+
+            caster.Hidden = true;
+            caster.BodyMod = 0;
+            caster.Stabled.Remove(toRelease);
+            caster.PossessType = PossessType.None;
+
+            toRelease.MoveToWorld(caster.Location, caster.Map);
+            toRelease.Direction = caster.Direction;
+            toRelease.PossessType = PossessType.None;
+
+            BuffInfo.RemoveBuff(caster, BuffIcon.Incognito);
+            AddResponse("You've released control of " + toRelease.Name);
+        }
+    }
+}

--- a/Projects/UOContent/Commands/Possess.cs
+++ b/Projects/UOContent/Commands/Possess.cs
@@ -144,7 +144,7 @@ namespace Server.Commands
                 toRelease.PossessType = PossessType.None;
 
                 BuffInfo.RemoveBuff(caster, BuffIcon.Incognito);
-                AddResponse("You've released control of " + toRelease.Name);
+                AddResponse($"You've released control of {toRelease.Name}");
             }
         }
     }

--- a/Projects/UOContent/Items/Containers/Container.cs
+++ b/Projects/UOContent/Items/Containers/Container.cs
@@ -349,6 +349,21 @@ namespace Server.Items
         }
     }
 
+    public class PossessBackpack : Backpack
+    {
+        public PossessBackpack(Container backpack, string ownerName)
+        {
+            Name = $"{ownerName} {backpack.Name}";
+            Backpack = backpack;
+        }
+
+        public Container Backpack { get; set; }
+
+        public PossessBackpack(Serial serial) : base(serial)
+        {
+        }
+    }
+
     public class Pouch : TrappableContainer
     {
         [Constructible]

--- a/Projects/UOContent/Items/Containers/Container.cs
+++ b/Projects/UOContent/Items/Containers/Container.cs
@@ -349,21 +349,6 @@ namespace Server.Items
         }
     }
 
-    public class PossessBackpack : Backpack
-    {
-        public PossessBackpack(Container backpack, string ownerName)
-        {
-            Name = $"{ownerName} {backpack.Name}";
-            Backpack = backpack;
-        }
-
-        public Container Backpack { get; set; }
-
-        public PossessBackpack(Serial serial) : base(serial)
-        {
-        }
-    }
-
     public class Pouch : TrappableContainer
     {
         [Constructible]

--- a/Projects/UOContent/Misc/SkillCheck.cs
+++ b/Projects/UOContent/Misc/SkillCheck.cs
@@ -150,7 +150,7 @@ namespace Server.Misc
 
         public static bool CheckSkill(Mobile from, Skill skill, object amObj, double chance)
         {
-            if (from.Skills.Cap == 0)
+            if (from.Skills.Cap == 0 || from.IsPossessing)
             {
                 return false;
             }


### PR DESCRIPTION
`[possess` allows GMs take control of mobs or npcs. It's a useful functionality for animating gameplay on pol implementations.

Under the hood the command stables the targeted mob and switches clothing.


TODO: 
- `[unpossess` should not be targeted
- instead of swapping items, they could be packed in a special container and stored away with the stabled mob