### PR TITLE
fix(core): Fixes threading issue and adds threadguard

### DIFF
--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -1453,6 +1453,7 @@ namespace Server
                 Utility.PushColor(ConsoleColor.Red);
                 Console.WriteLine("Attempting to set Mobile.NetState value from an invalid thread!");
                 Console.WriteLine(new StackTrace());
+                Utility.PopColor();
                 return;
             }
 #endif
@@ -7933,6 +7934,7 @@ namespace Server
                 Utility.PushColor(ConsoleColor.Red);
                 Console.WriteLine("Attempting to queue a delta change from an invalid thread!");
                 Console.WriteLine(new StackTrace());
+                Utility.PopColor();
                 return;
             }
 #endif

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -1447,6 +1447,11 @@ namespace Server
             }
             set
             {
+                if (m_NetState == value)
+                {
+                    return;
+                }
+
 #if THREADGUARD
             if (Thread.CurrentThread != Core.Thread)
             {
@@ -1458,17 +1463,9 @@ namespace Server
             }
 #endif
 
-                if (m_NetState == value)
-                {
-                    return;
-                }
-
                 m_Map?.OnClientChange(m_NetState, value, this);
-
                 m_Target?.Cancel(this, TargetCancelType.Disconnected);
-
                 m_Spell?.OnConnectionChanged();
-
                 m_NetState?.CancelAllTrades();
 
                 var box = FindBankNoCreate();

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -460,6 +460,7 @@ namespace Server.Network
                 Utility.PushColor(ConsoleColor.Red);
                 Console.WriteLine("Attempting to get pipe buffer from wrong thread!");
                 Console.WriteLine(new StackTrace());
+                Utility.PopColor();
                 return;
             }
 #endif
@@ -1117,6 +1118,7 @@ namespace Server.Network
                 Utility.PushColor(ConsoleColor.Red);
                 Console.WriteLine("Attempting to dispose a netstate from an invalid thread!");
                 Console.WriteLine(new StackTrace());
+                Utility.PopColor();
                 return;
             }
 #endif


### PR DESCRIPTION
Setting `m.NetState = null` from a different thread caused `Mobile.Delta` and `NetState.Send` to run from a separate thread which cannot happen.
- [X] Fixes this issue
- [X] Adds THREADGUARD compiler constant as an option to trace this in the future.