### PR TITLE
fix(boats): Fixes boat movement issues

### DIFF
--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -450,16 +450,13 @@ namespace Server.Multis
         public override void OnAfterDelete()
         {
             TillerMan?.Delete();
-
             Hold?.Delete();
-
             PPlank?.Delete();
-
             SPlank?.Delete();
-
             m_TurnTimer?.Stop();
-
+            m_TurnTimer = null;
             m_MoveTimer?.Stop();
+            m_MoveTimer = null;
 
             Boats.Remove(this);
         }
@@ -2048,13 +2045,8 @@ namespace Server.Multis
 
         public static void Initialize()
         {
-            new UpdateAllTimer().Start();
-            EventSink.WorldSave += EventSink_WorldSave;
-        }
-
-        private static void EventSink_WorldSave()
-        {
-            new UpdateAllTimer().Start();
+            EventSink.WorldLoad += UpdateAllComponents;
+            EventSink.WorldSave += UpdateAllComponents;
         }
 
         private class DecayTimer : Timer
@@ -2103,18 +2095,6 @@ namespace Server.Multis
                 {
                     m_Boat.StopMove(false);
                 }
-            }
-        }
-
-        public class UpdateAllTimer : Timer
-        {
-            public UpdateAllTimer() : base(TimeSpan.FromSeconds(1.0))
-            {
-            }
-
-            protected override void OnTick()
-            {
-                UpdateAllComponents();
             }
         }
 

--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -1971,15 +1971,15 @@ namespace Server.Multis
 
             m_Facing = facing;
 
-            int xOffset = 0, yOffset = 0;
-            Movement.Movement.Offset(facing, ref xOffset, ref yOffset);
-
-            var count = ((m_Facing - old) & 0x7) / 2;
-
             TillerMan?.SetFacing(facing);
             Hold?.SetFacing(facing);
             PPlank?.SetFacing(facing);
             SPlank?.SetFacing(facing);
+
+            int xOffset = 0, yOffset = 0;
+            Movement.Movement.Offset(facing, ref xOffset, ref yOffset);
+
+            var count = ((m_Facing - old) & 0x7) / 2;
 
             foreach (var e in GetMovingEntities())
             {

--- a/Projects/UOContent/Multis/Boats/BoatPackets.cs
+++ b/Projects/UOContent/Multis/Boats/BoatPackets.cs
@@ -48,6 +48,8 @@ namespace Server.Multis.Boats
 
             foreach (var ent in ents)
             {
+                // If we assume that the entities list contains everything a player can see,
+                // then this can be removed and the packet can be written once and copied to improve performance
                 if (!beholder.CanSee(ent))
                 {
                     continue;


### PR DESCRIPTION
- [X] Fixes entity enumerator short circuiting when it hit a bad case
- [X] Fixes order of moving entities because boat pieces that constitute tiles must be moved after objects that stand on them. (The llama problem).

TODO: Implement packet of packets for displaying boats

Notes:
- In the future, we will have z-sorted lists, and we can iterate from highest to lowest, which will avoid the llama problem naturally.