### PR TITLE
fix: Configure expansion from config

### DIFF
--- a/Projects/Server/Configuration/ServerConfiguration.cs
+++ b/Projects/Server/Configuration/ServerConfiguration.cs
@@ -232,6 +232,8 @@ namespace Server
                 m_Settings.Expansion = expansion;
             }
 
+            Core.Expansion = m_Settings.Expansion.Value;
+
             if (updated)
             {
                 Save();


### PR DESCRIPTION
Expansion was not being set when reading ServerConfiguration, causing it to be always `Expansion.None` and many features to not work.