### PR TITLE
feat(mobile): Allow Criminal and ExpireCriminalTimer properties to be…

### DIFF
--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -494,7 +494,6 @@ namespace Server
 
         private Timer m_ExpireAggrTimer;
         private Timer m_ExpireCombatant;
-        private Timer m_ExpireCriminal;
         private FacialHairInfo m_FacialHair;
         private int m_Fame, m_Karma;
         private bool m_Female, m_Warmode, m_Hidden, m_Blessed, m_Flying;
@@ -1889,8 +1888,10 @@ namespace Server
             }
         }
 
+        public virtual Timer ExpireCriminalTimer { get; set; }
+
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
-        public bool Criminal
+        public virtual bool Criminal
         {
             get => m_Criminal;
             set
@@ -1904,21 +1905,21 @@ namespace Server
 
                 if (m_Criminal)
                 {
-                    if (m_ExpireCriminal == null)
+                    if (ExpireCriminalTimer == null)
                     {
-                        m_ExpireCriminal = Timer.DelayCall(ExpireCriminalDelay, ExpireCriminal);
+                        ExpireCriminalTimer = Timer.DelayCall(ExpireCriminalDelay, ExpireCriminal);
                     }
                     else
                     {
-                        m_ExpireCriminal.Stop();
+                        ExpireCriminalTimer.Stop();
                     }
 
-                    m_ExpireCriminal.Start();
+                    ExpireCriminalTimer.Start();
                 }
-                else if (m_ExpireCriminal != null)
+                else if (ExpireCriminalTimer != null)
                 {
-                    m_ExpireCriminal.Stop();
-                    m_ExpireCriminal = null;
+                    ExpireCriminalTimer.Stop();
+                    ExpireCriminalTimer = null;
                 }
             }
         }
@@ -4809,7 +4810,7 @@ namespace Server
             m_CombatTimer?.Stop();
             m_ExpireCombatant?.Stop();
             m_LogoutTimer?.Stop();
-            m_ExpireCriminal?.Stop();
+            ExpireCriminalTimer?.Stop();
             m_WarmodeTimer?.Stop();
             m_ParaTimer?.Stop();
             m_FrozenTimer?.Stop();
@@ -6567,8 +6568,8 @@ namespace Server
 
                         if (m_Criminal)
                         {
-                            m_ExpireCriminal ??= Timer.DelayCall(ExpireCriminalDelay, ExpireCriminal);
-                            m_ExpireCriminal.Start();
+                            ExpireCriminalTimer ??= Timer.DelayCall(ExpireCriminalDelay, ExpireCriminal);
+                            ExpireCriminalTimer.Start();
                         }
 
                         if (ShouldCheckStatTimers)

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -1888,7 +1888,7 @@ namespace Server
             }
         }
 
-        public virtual Timer ExpireCriminalTimer { get; set; }
+        public Timer ExpireCriminalTimer { get; set; }
 
         [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
         public virtual bool Criminal


### PR DESCRIPTION
… overridden

This change allows the Criminal and CriminalTimer
properties to be overridden in derived classes ie:
PlayerMobile.

We have a use-case where we need to access the
ExpireCriminalTimer property and override Criminal
to display the data in a custom CUO status gump.