### PR TITLE
fix(core): Fixes displaying some doubles

### DIFF
--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -555,9 +555,9 @@ namespace Server
 
         public static string FixHtml(string str)
         {
-            if (str == null)
+            if (string.IsNullOrEmpty(str))
             {
-                return "";
+                return str;
             }
 
             using var sb = new ValueStringBuilder(str, stackalloc char[Math.Min(40960, str.Length)]);

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
@@ -886,7 +886,7 @@ namespace Server.Engines.CannedEvil
 
                 list.Add(
                     1060660, // ~1_val~: ~2_val~
-                    "Kills\t{0} of {1} ({2:F1}%)",
+                    "Kills\t{0} of {1} ({2:0.#}%)",
                     m_Kills,
                     MaxKills,
                     100.0 * ((double)m_Kills / MaxKills)

--- a/Projects/UOContent/Engines/ML Quests/Objectives/GainSkillObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/GainSkillObjective.cs
@@ -71,11 +71,7 @@ namespace Server.Engines.MLQuests.Objectives
         public override void WriteToGump(Gump g, ref int y)
         {
             var skillLabel = AosSkillBonuses.GetLabel(Skill);
-            string args;
-
-            args = ThresholdFixed % 10 == 0
-                ? $"#{skillLabel}\t{ThresholdFixed / 10}"
-                : $"#{skillLabel}\t{(double)ThresholdFixed / 10:0.0}";
+            var args = $"#{skillLabel}\t{ThresholdFixed / 10.0:0.#}";
 
             g.AddHtmlLocalized(98, y, 312, 16, 1077485, args, 0x15F90); // Increase ~1_SKILL~ to ~2_VALUE~
             y += 16;

--- a/Projects/UOContent/Items/Addons/SHTeleporter.cs
+++ b/Projects/UOContent/Items/Addons/SHTeleporter.cs
@@ -201,7 +201,7 @@ namespace Server.Items
             World.Broadcast(
                 0x35,
                 true,
-                "{0} solen hives teleporters have been created. The entire process took {1:F1} seconds.",
+                "{0} solen hives teleporters have been created. The entire process took {1:0.#} seconds.",
                 count,
                 (endTime - startTime).TotalSeconds
             );

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -130,7 +130,7 @@ namespace Server.Items
             {
                 list.Add(
                     1070721,
-                    "#{0}\t{1:0.0}",
+                    "#{0}\t{1:F1}",
                     AosSkillBonuses.GetLabel(Skill),
                     SkillValue
                 ); // Skill stored: ~1_skillname~ ~2_skillamount~
@@ -461,10 +461,10 @@ namespace Server.Items
                 AddHtmlLocalized(210, 200, 390, 20, AosSkillBonuses.GetLabel(skill.SkillName), 0x7FFF);
 
                 AddHtmlLocalized(10, 220, 390, 20, 1062298, 0x7FFF); // Current Value:
-                AddLabel(210, 220, 0x481, skill.Base.ToString("0.0"));
+                AddLabel(210, 220, 0x481, skill.Base.ToString("F1"));
 
                 AddHtmlLocalized(10, 240, 390, 20, 1062299, 0x7FFF); // Current Cap:
-                AddLabel(210, 240, 0x481, skill.Cap.ToString("0.0"));
+                AddLabel(210, 240, 0x481, skill.Cap.ToString("F1"));
 
                 AddHtmlLocalized(10, 260, 390, 20, 1062300, 0x7FFF); // New Value:
                 AddLabel(210, 260, 0x481, "0.0");
@@ -611,13 +611,13 @@ namespace Server.Items
                 var fromSkill = from.Skills[stone.Skill];
 
                 AddHtmlLocalized(10, 220, 390, 20, 1062298, 0x7FFF); // Current Value:
-                AddLabel(210, 220, 0x481, fromSkill.Base.ToString("0.0"));
+                AddLabel(210, 220, 0x481, fromSkill.Base.ToString("F1"));
 
                 AddHtmlLocalized(10, 240, 390, 20, 1062299, 0x7FFF); // Current Cap:
-                AddLabel(210, 240, 0x481, fromSkill.Cap.ToString("0.0"));
+                AddLabel(210, 240, 0x481, fromSkill.Cap.ToString("F1"));
 
                 AddHtmlLocalized(10, 260, 390, 20, 1062300, 0x7FFF); // New Value:
-                AddLabel(210, 260, 0x481, stone.SkillValue.ToString("0.0"));
+                AddLabel(210, 260, 0x481, stone.SkillValue.ToString("F1"));
 
                 AddButton(10, 360, 0xFA5, 0xFA6, 2);
                 AddHtmlLocalized(

--- a/Projects/UOContent/Items/Special/Special Scrolls/ScrollofTranscendence.cs
+++ b/Projects/UOContent/Items/Special/Special Scrolls/ScrollofTranscendence.cs
@@ -36,15 +36,7 @@ namespace Server.Items
         public override void GetProperties(ObjectPropertyList list)
         {
             base.GetProperties(list);
-
-            if (Value == 1)
-            {
-                list.Add(1076759, "{0}\t{1}.0 Skill Points", GetName(), Value);
-            }
-            else
-            {
-                list.Add(1076759, "{0}\t{1} Skill Points", GetName(), Value);
-            }
+            list.Add(1076759, $"{GetName()}\t{Value:0.#} Skill Points");
         }
 
         public override bool CanUse(Mobile from)

--- a/Projects/UOContent/Spells/Bushido/SamuraiSpell.cs
+++ b/Projects/UOContent/Spells/Bushido/SamuraiSpell.cs
@@ -45,7 +45,7 @@ namespace Server.Spells.Bushido
 
             if (Caster.Skills[CastSkill].Value < RequiredSkill)
             {
-                var args = $"{RequiredSkill:F1}\t{CastSkill.ToString()}\t ";
+                var args = $"{RequiredSkill:0.#}\t{CastSkill.ToString()}\t ";
                 Caster.SendLocalizedMessage(
                     1063013,
                     args


### PR DESCRIPTION
Note:
- I am not going to go through the entire code base and fix rounding errors for doubles. It is true that most of the variables _should have been integers anyway_ and then divided into the appropriate value w/ truncation when displayed. I'll leave that up to others to make PRs to fix if they feel the need.