### PR TITLE
fix(core): Fixes some properties that cannot be modified ingame

### DIFF
--- a/Projects/Server/Attributes.cs
+++ b/Projects/Server/Attributes.cs
@@ -122,14 +122,14 @@ namespace Server
     [AttributeUsage(AttributeTargets.Property)]
     public class CommandPropertyAttribute : Attribute
     {
-        public CommandPropertyAttribute(AccessLevel level, bool readOnly)
+        public CommandPropertyAttribute(
+            AccessLevel level,
+            bool readOnly = false,
+            bool canModify = false
+        ) : this(level, level)
         {
-            ReadLevel = level;
             ReadOnly = readOnly;
-        }
-
-        public CommandPropertyAttribute(AccessLevel level) : this(level, level)
-        {
+            CanModify = canModify;
         }
 
         public CommandPropertyAttribute(AccessLevel readLevel, AccessLevel writeLevel)
@@ -139,9 +139,8 @@ namespace Server
         }
 
         public AccessLevel ReadLevel { get; }
-
         public AccessLevel WriteLevel { get; }
-
         public bool ReadOnly { get; }
+        public bool CanModify { get; }
     }
 }

--- a/Projects/Server/Skills.cs
+++ b/Projects/Server/Skills.cs
@@ -630,178 +630,178 @@ namespace Server
             }
         }
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Alchemy => this[SkillName.Alchemy];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Anatomy => this[SkillName.Anatomy];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill AnimalLore => this[SkillName.AnimalLore];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill ItemID => this[SkillName.ItemID];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill ArmsLore => this[SkillName.ArmsLore];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Parry => this[SkillName.Parry];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Begging => this[SkillName.Begging];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Blacksmith => this[SkillName.Blacksmith];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Fletching => this[SkillName.Fletching];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Peacemaking => this[SkillName.Peacemaking];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Camping => this[SkillName.Camping];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Carpentry => this[SkillName.Carpentry];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Cartography => this[SkillName.Cartography];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Cooking => this[SkillName.Cooking];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill DetectHidden => this[SkillName.DetectHidden];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Discordance => this[SkillName.Discordance];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill EvalInt => this[SkillName.EvalInt];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Healing => this[SkillName.Healing];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Fishing => this[SkillName.Fishing];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Forensics => this[SkillName.Forensics];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Herding => this[SkillName.Herding];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Hiding => this[SkillName.Hiding];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Provocation => this[SkillName.Provocation];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Inscribe => this[SkillName.Inscribe];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Lockpicking => this[SkillName.Lockpicking];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Magery => this[SkillName.Magery];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill MagicResist => this[SkillName.MagicResist];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Tactics => this[SkillName.Tactics];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Snooping => this[SkillName.Snooping];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Musicianship => this[SkillName.Musicianship];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Poisoning => this[SkillName.Poisoning];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Archery => this[SkillName.Archery];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill SpiritSpeak => this[SkillName.SpiritSpeak];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Stealing => this[SkillName.Stealing];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Tailoring => this[SkillName.Tailoring];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill AnimalTaming => this[SkillName.AnimalTaming];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill TasteID => this[SkillName.TasteID];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Tinkering => this[SkillName.Tinkering];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Tracking => this[SkillName.Tracking];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Veterinary => this[SkillName.Veterinary];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Swords => this[SkillName.Swords];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Macing => this[SkillName.Macing];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Fencing => this[SkillName.Fencing];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Wrestling => this[SkillName.Wrestling];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Lumberjacking => this[SkillName.Lumberjacking];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Mining => this[SkillName.Mining];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Meditation => this[SkillName.Meditation];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Stealth => this[SkillName.Stealth];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill RemoveTrap => this[SkillName.RemoveTrap];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Necromancy => this[SkillName.Necromancy];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Focus => this[SkillName.Focus];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Chivalry => this[SkillName.Chivalry];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Bushido => this[SkillName.Bushido];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Ninjitsu => this[SkillName.Ninjitsu];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Spellweaving => this[SkillName.Spellweaving];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Mysticism => this[SkillName.Mysticism];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Imbuing => this[SkillName.Imbuing];
 
-        [CommandProperty(AccessLevel.Counselor)]
+        [CommandProperty(AccessLevel.Counselor, canModify: true)]
         public Skill Throwing => this[SkillName.Throwing];
 
         public override string ToString() => "...";

--- a/Projects/UOContent/Engines/ConPVP/Arena.cs
+++ b/Projects/UOContent/Engines/ConPVP/Arena.cs
@@ -23,7 +23,7 @@ namespace Server.Engines.ConPVP
         {
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public Arena Arena { get; private set; }
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -475,7 +475,7 @@ namespace Server.Engines.ConPVP
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsOccupied => Players.Count > 0;
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public ArenaStartPoints Points { get; }
 
         public Item Teleporter { get; set; }

--- a/Projects/UOContent/Engines/ConPVP/Ladder.cs
+++ b/Projects/UOContent/Engines/ConPVP/Ladder.cs
@@ -20,7 +20,7 @@ namespace Server.Engines.ConPVP
         {
         }
 
-        [CommandProperty(AccessLevel.Administrator)]
+        [CommandProperty(AccessLevel.Administrator, canModify: true)]
         public Ladder Ladder { get; private set; }
 
         public override string DefaultName => "ladder controller";

--- a/Projects/UOContent/Engines/ConPVP/Preferences.cs
+++ b/Projects/UOContent/Engines/ConPVP/Preferences.cs
@@ -28,7 +28,7 @@ namespace Server.Engines.ConPVP
         {
         }
 
-        [CommandProperty(AccessLevel.Administrator)]
+        [CommandProperty(AccessLevel.Administrator, canModify: true)]
         public Preferences Preferences { get; private set; }
 
         public override string DefaultName => "preferences controller";

--- a/Projects/UOContent/Engines/ConPVP/Tournament.cs
+++ b/Projects/UOContent/Engines/ConPVP/Tournament.cs
@@ -996,10 +996,11 @@ namespace Server.Engines.ConPVP
             {
                 for (var j = 0; j < alerts.Length; ++j)
                 {
-                    var alert = alerts[j];
                     Timer.DelayCall(
                         TimeSpan.FromSeconds(Math.Max(j - 0.5, 0.0)),
-                        () => arena.Announcer.PublicOverheadMessage(MessageType.Regular, 0x35, false, alert)
+                        (announcer, alert) => announcer.PublicOverheadMessage(MessageType.Regular, 0x35, false, alert),
+                        arena.Announcer,
+                        alerts[j]
                     );
                 }
             }

--- a/Projects/UOContent/Engines/ConPVP/TournamentController.cs
+++ b/Projects/UOContent/Engines/ConPVP/TournamentController.cs
@@ -23,7 +23,7 @@ namespace Server.Engines.ConPVP
         {
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public Tournament Tournament { get; private set; }
 
         public static bool IsActive

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -229,9 +229,7 @@ namespace Server.Gumps
 
                     var cpa = GetCPA(prop);
 
-                    // !prop.GetType().IsValueType
-
-                    if (prop.CanWrite && m_Mobile.AccessLevel >= cpa?.WriteLevel && !cpa.ReadOnly)
+                    if (cpa?.ReadOnly == false && m_Mobile.AccessLevel >= cpa.WriteLevel && (prop.CanWrite || cpa.CanModify))
                     {
                         AddButton(x + SetOffsetX, y + SetOffsetY, SetButtonID1, SetButtonID2, i + 3);
                     }
@@ -295,10 +293,10 @@ namespace Server.Gumps
                             return;
                         }
 
-                        var attr = GetCPA(prop);
+                        var cpa = GetCPA(prop);
 
-                        if (!prop.CanWrite || attr == null ||
-                            from.AccessLevel < attr.WriteLevel || attr.ReadOnly)
+                        if (cpa == null || !(prop.CanWrite || cpa.CanModify) || cpa.ReadOnly ||
+                            from.AccessLevel < cpa.WriteLevel)
                         {
                             return;
                         }

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -357,13 +357,13 @@ namespace Server.Items
             }
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosAttributes Attributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosArmorAttributes ArmorAttributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses SkillBonuses { get; private set; }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Armor/Glasses/ElvenGlasses.cs
+++ b/Projects/UOContent/Items/Armor/Glasses/ElvenGlasses.cs
@@ -35,7 +35,7 @@ namespace Server.Items
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosWeaponAttributes WeaponAttributes { get; private set; }
 
         public override void AppendChildNameProperties(ObjectPropertyList list)

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -104,16 +104,16 @@ namespace Server.Items
             }
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosAttributes Attributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosArmorAttributes ClothingAttributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses SkillBonuses { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosElementAttributes Resistances { get; private set; }
 
         public virtual int BasePhysicalResistance => 0;

--- a/Projects/UOContent/Items/Jewels/BaseJewel.cs
+++ b/Projects/UOContent/Items/Jewels/BaseJewel.cs
@@ -76,12 +76,13 @@ namespace Server.Items
             }
         }
 
-        [CommandProperty(AccessLevel.Player)] public AosAttributes Attributes { get; private set; }
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
+        public AosAttributes Attributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosElementAttributes Resistances { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses SkillBonuses { get; private set; }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Quivers/BaseQuiver.cs
+++ b/Projects/UOContent/Items/Quivers/BaseQuiver.cs
@@ -38,7 +38,7 @@ namespace Server.Items
         public override int DefaultMaxWeight => 50;
         public override double DefaultWeight => 2.0;
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosAttributes Attributes { get; private set; }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
@@ -119,10 +119,10 @@ namespace Server.Items
 
         public override bool DisplayWeight => false;
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosAttributes Attributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses SkillBonuses { get; private set; }
 
         public virtual SpellbookType SpellbookType => SpellbookType.Regular;

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -320,10 +320,10 @@ namespace Server.Items
             }
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosAttributes Attributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses SkillBonuses { get; private set; }
 
         public static void Initialize()

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -183,16 +183,16 @@ namespace Server.Items
 
         public virtual SkillName AccuracySkill => SkillName.Tactics;
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosAttributes Attributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosWeaponAttributes WeaponAttributes { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses SkillBonuses { get; private set; }
 
-        [CommandProperty(AccessLevel.GameMaster)]
+        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosElementAttributes AosElementDamages { get; private set; }
 
         [CommandProperty(AccessLevel.GameMaster)]


### PR DESCRIPTION
- [X] Adds a property to `CommandProperty` to allow modifying `PropertyObject` where there is no property setter that is accessible.
- [X] Updates AosAttributes and friends

Example of how to make this work:
```cs
        [CommandProperty(AccessLevel.GameMaster, canModify: true)]
        public AosWeaponAttributes WeaponAttributes { get; private set; }
```

This fix is necessary because in release mode the optimizer will sometimes _entirely remove the setter_ because it knows it can do something that is more efficient _when the property setter is private_. RunUO got around this by declaring a public setter explicitly that _was empty_.

### Screenshot
<img width="313" alt="Screen Shot 2021-05-15 at 11 34 01 PM" src="https://user-images.githubusercontent.com/3953314/118387955-49293c00-b5d6-11eb-8f31-a3b5e31bd18b.png">
