### PR TITLE
feat(codegen): Adds AfterDeserialization support

### DIFF
--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -236,6 +236,7 @@ namespace SerializationGenerator
             // Deserialize Method
             source.GenerateDeserializeMethod(
                 compilation,
+                classSymbol,
                 isOverride,
                 version,
                 encodedVersion,

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
@@ -49,6 +49,7 @@ namespace SerializationGenerator
             if (isOverride)
             {
                 source.AppendLine($"{indent}base.Deserialize(reader);");
+                source.AppendLine();
             }
 
             // Version
@@ -116,7 +117,8 @@ namespace SerializationGenerator
 
             if (afterDeserialization != null)
             {
-                source.AppendLine($"{indent}Timer.DelayCall({afterDeserialization.Name})");
+                source.AppendLine();
+                source.AppendLine($"{indent}Timer.DelayCall({afterDeserialization.Name});");
             }
 
             source.GenerateMethodEnd();

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
@@ -15,6 +15,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -25,6 +26,7 @@ namespace SerializationGenerator
         public static void GenerateDeserializeMethod(
             this StringBuilder source,
             Compilation compilation,
+            INamedTypeSymbol classSymbol,
             bool isOverride,
             int version,
             bool encodedVersion,
@@ -93,6 +95,28 @@ namespace SerializationGenerator
                     indent,
                     property
                 );
+            }
+
+            var afterDeserialization = classSymbol
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(
+                    m =>
+                        m.ReturnsVoid &&
+                        m.Parameters.Length == 0 &&
+                        m.GetAttributes()
+                            .OfType<AttributeData>()
+                            .Any(
+                                attr => attr.AttributeClass?.Equals(
+                                    compilation.GetTypeByMetadataName(AFTERDESERIALIZATION_ATTRIBUTE),
+                                    SymbolEqualityComparer.Default
+                                ) ?? false
+                            )
+                );
+
+            if (afterDeserialization != null)
+            {
+                source.AppendLine($"{indent}Timer.DelayCall({afterDeserialization.Name})");
             }
 
             source.GenerateMethodEnd();

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.MetadataTypes.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.MetadataTypes.cs
@@ -26,6 +26,7 @@ namespace SerializationGenerator
         public const string IPADDRESS_CLASS = "System.Net.IPAddress";
         public const string KEYVALUEPAIR_STRUCT = "System.Collections.Generic.KeyValuePair";
 
+        public const string AFTERDESERIALIZATION_ATTRIBUTE = "Server.AfterDeserializationAttribute";
         public const string SERIALIZABLE_ATTRIBUTE = "Server.SerializableAttribute";
         public const string SERIALIZABLE_FIELD_ATTRIBUTE = "Server.SerializableFieldAttribute";
         public const string SERIALIZABLE_FIELD_ATTR_ATTRIBUTE = "Server.SerializableFieldAttrAttribute";

--- a/Projects/Server/Serialization/AfterDeserialization.cs
+++ b/Projects/Server/Serialization/AfterDeserialization.cs
@@ -1,0 +1,27 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2021 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: AfterDeserialization.cs                                         *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+
+namespace Server
+{
+    /// <summary>
+    /// Hints to the source generator that a serializable DateTime field or property is for delta time (duration)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class AfterDeserialization : Attribute
+    {
+    }
+}

--- a/Projects/Server/Serialization/AfterDeserialization.cs
+++ b/Projects/Server/Serialization/AfterDeserialization.cs
@@ -21,7 +21,7 @@ namespace Server
     /// Hints to the source generator that a serializable DateTime field or property is for delta time (duration)
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class AfterDeserialization : Attribute
+    public class AfterDeserializationAttribute : Attribute
     {
     }
 }

--- a/Projects/Server/Serialization/AfterDeserialization.cs
+++ b/Projects/Server/Serialization/AfterDeserialization.cs
@@ -18,7 +18,8 @@ using System;
 namespace Server
 {
     /// <summary>
-    /// Hints to the source generator that a serializable DateTime field or property is for delta time (duration)
+    /// Hints to the source generator that this method should be executed after deserializing the object.
+    /// Method must have no parameters and return void.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class AfterDeserializationAttribute : Attribute


### PR DESCRIPTION
Added the ability to execute arbitrary code after deserialization.

Example, let's say you want to delete an item after you deserialize it:
```cs
        [AfterDeserialization]
        private void OnAfterDeserialization()
        {
            Delete();
        }
```

Generates this:
```cs
        public override void Deserialize(IGenericReader reader)
        {
            base.Deserialize(reader);

            var version = reader.ReadEncodedInt();

            Timer.DelayCall(OnAfterDeserialization);
        }
```