### PR TITLE
feat(codegen): Adds InvalidateProperties

### DIFF
--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -155,7 +155,7 @@ namespace SerializationGenerator
                         }
                     }
 
-                    source.GenerateSerializableProperty(fieldSymbol);
+                    source.GenerateSerializableProperty(fieldSymbol, compilation);
                     source.AppendLine();
 
                     var serializableProperty = SerializableMigrationRulesEngine.GenerateSerializableProperty(

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.MetadataTypes.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.MetadataTypes.cs
@@ -26,6 +26,7 @@ namespace SerializationGenerator
         public const string IPADDRESS_CLASS = "System.Net.IPAddress";
         public const string KEYVALUEPAIR_STRUCT = "System.Collections.Generic.KeyValuePair";
 
+        public const string INVALIDATEPROPERTIES_ATTRIBUTE = "Server.InvalidatePropertiesAttribute";
         public const string AFTERDESERIALIZATION_ATTRIBUTE = "Server.AfterDeserializationAttribute";
         public const string SERIALIZABLE_ATTRIBUTE = "Server.SerializableAttribute";
         public const string SERIALIZABLE_FIELD_ATTRIBUTE = "Server.SerializableFieldAttribute";

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Property.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Property.cs
@@ -13,6 +13,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -22,10 +23,21 @@ namespace SerializationGenerator
     {
         public static void GenerateSerializableProperty(
             this StringBuilder source,
-            IFieldSymbol fieldSymbol
+            IFieldSymbol fieldSymbol,
+            Compilation compilation
         )
         {
             var fieldName = fieldSymbol.Name;
+
+            var invalidatePropertiesAttribute = fieldSymbol
+                .GetAttributes()
+                .OfType<AttributeData>()
+                .FirstOrDefault(
+                    attr => attr.AttributeClass?.Equals(
+                        compilation.GetTypeByMetadataName(INVALIDATEPROPERTIES_ATTRIBUTE),
+                        SymbolEqualityComparer.Default
+                    ) ?? false
+                );
 
             source.GeneratePropertyStart(AccessModifier.Public, fieldSymbol);
 
@@ -34,13 +46,18 @@ namespace SerializationGenerator
 
             // Setter
             source.GeneratePropertySetterStart(false);
-            source.AppendLine(
-                $@"                if (value != {fieldName})
-                {{
-                    ((ISerializable)this).MarkDirty();
-                    {fieldName} = value;
-                }}"
-            );
+            const string indent = "                ";
+            source.AppendLine($"{indent}if(value != {fieldName})");
+            source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    ((ISerializable)this).MarkDirty();");
+
+            if (invalidatePropertiesAttribute != null)
+            {
+                source.AppendLine($"{indent}    InvalidateProperties();");
+            }
+
+            source.AppendLine($"{indent}    {fieldName} = value;");
+            source.AppendLine($"{indent}}}");
             source.GeneratePropertyGetSetEnd(false);
 
             source.GeneratePropertyEnd();

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Property.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Property.cs
@@ -49,14 +49,13 @@ namespace SerializationGenerator
             const string indent = "                ";
             source.AppendLine($"{indent}if(value != {fieldName})");
             source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    {fieldName} = value;");
             source.AppendLine($"{indent}    ((ISerializable)this).MarkDirty();");
 
             if (invalidatePropertiesAttribute != null)
             {
                 source.AppendLine($"{indent}    InvalidateProperties();");
             }
-
-            source.AppendLine($"{indent}    {fieldName} = value;");
             source.AppendLine($"{indent}}}");
             source.GeneratePropertyGetSetEnd(false);
 

--- a/Projects/Server/Serialization/InvalidatePropertiesAttribute.cs
+++ b/Projects/Server/Serialization/InvalidatePropertiesAttribute.cs
@@ -1,0 +1,28 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2021 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: InvalidatePropertiesAttribute.cs                                *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+
+namespace Server
+{
+    /// <summary>
+    /// Hints to the source generator that this field will execute an InvalidateProperties when the value is set
+    /// and the value is different from the current value.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class InvalidatePropertiesAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
Adds invalidate properties to code genned fields.

Example:
```cs
[InvalidateProperties]
[EncodedInt]
private int _number; // Cliloc
```

Generates:
```cs
public int Number
{
    get => _number;
    set
    {
        if (value != _number)
        {
            _number = value;
            ((ISerializable)this).MarkDirty();
            InvalidateProperties();
        }
    }
}
```