### PR TITLE
feat(codegen): Adds opt-in with existing properties for sourcegen

### DIFF
--- a/Projects/SerializationGenerator/EntitySerializationGenerator.cs
+++ b/Projects/SerializationGenerator/EntitySerializationGenerator.cs
@@ -13,7 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -64,7 +63,7 @@ namespace SerializationGenerator
             {
                 string classSource = SerializableEntityGeneration.GenerateSerializationPartialClass(
                     kvp.Key,
-                    kvp.Value,
+                    kvp.Value.ToImmutableArray(),
                     context,
                     migrationPath,
                     jsonOptions,

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.DeserializeMethod.cs
@@ -31,7 +31,7 @@ namespace SerializationGenerator
             int version,
             bool encodedVersion,
             List<SerializableMetadata> migrations,
-            List<SerializableProperty> properties
+            ImmutableArray<SerializableProperty> properties
         )
         {
             var genericReaderInterface = compilation.GetTypeByMetadataName(GENERIC_READER_INTERFACE);
@@ -106,12 +106,11 @@ namespace SerializationGenerator
                         m.ReturnsVoid &&
                         m.Parameters.Length == 0 &&
                         m.GetAttributes()
-                            .OfType<AttributeData>()
                             .Any(
-                                attr => attr.AttributeClass?.Equals(
-                                    compilation.GetTypeByMetadataName(AFTERDESERIALIZATION_ATTRIBUTE),
-                                    SymbolEqualityComparer.Default
-                                ) ?? false
+                                attr => SymbolEqualityComparer.Default.Equals(
+                                    attr.AttributeClass,
+                                    compilation.GetTypeByMetadataName(AFTERDESERIALIZATION_ATTRIBUTE)
+                                )
                             )
                 );
 

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
@@ -13,7 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -27,7 +26,7 @@ namespace SerializationGenerator
             Compilation compilation,
             bool isOverride,
             bool encodedVersion,
-            List<SerializableProperty> properties
+            ImmutableArray<SerializableProperty> properties
         )
         {
             var genericWriterInterface = compilation.GetTypeByMetadataName(GENERIC_WRITER_INTERFACE);

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/ArrayMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/ArrayMigrationRule.cs
@@ -42,6 +42,7 @@ namespace SerializationGenerator
                 compilation,
                 "ArrayEntry",
                 arrayTypeSymbol.ElementType,
+                0,
                 attributes,
                 serializableTypes
             );

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/HashSetMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/HashSetMigrationRule.cs
@@ -44,6 +44,7 @@ namespace SerializationGenerator
                 compilation,
                 "SetEntry",
                 setTypeSymbol,
+                0,
                 attributes,
                 serializableTypes
             );

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/KeyValuePairMigrationRule.cs
@@ -44,6 +44,7 @@ namespace SerializationGenerator
                 compilation,
                 "key",
                 typeArguments[0],
+                0,
                 attributes,
                 serializableTypes
             );
@@ -52,6 +53,7 @@ namespace SerializationGenerator
                 compilation,
                 "value",
                 typeArguments[1],
+                1,
                 attributes,
                 serializableTypes
             );

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/ListMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/ListMigrationRule.cs
@@ -44,6 +44,7 @@ namespace SerializationGenerator
                 compilation,
                 "ListEntry",
                 listTypeSymbol,
+                0,
                 attributes,
                 serializableTypes
             );

--- a/Projects/SerializationGenerator/SerializableMigration/SerializableMetadata.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/SerializableMetadata.cs
@@ -13,20 +13,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text.Json.Serialization;
 
 namespace SerializationGenerator
 {
-    public class SerializableMetadata
+    public record SerializableMetadata
     {
         [JsonPropertyName("version")]
-        public int Version { get; set; }
+        public int Version { get; init; }
 
         [JsonPropertyName("type")]
-        public string Type { get; set; }
+        public string Type { get; init; }
 
         [JsonPropertyName("properties")]
-        public List<SerializableProperty> Properties { get; set; }
+        public ImmutableArray<SerializableProperty> Properties { get; init; }
     }
 }

--- a/Projects/SerializationGenerator/SerializableMigration/SerializableMigrationRulesEngine.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/SerializableMigrationRulesEngine.cs
@@ -49,6 +49,7 @@ namespace SerializationGenerator
             Compilation compilation,
             string propertyName,
             ISymbol propertyType,
+            int order,
             ImmutableArray<AttributeData> attributes,
             ImmutableArray<INamedTypeSymbol> serializableTypes
         )

--- a/Projects/SerializationGenerator/SerializableMigration/SerializableProperty.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/SerializableProperty.cs
@@ -17,7 +17,7 @@ using System.Text.Json.Serialization;
 
 namespace SerializationGenerator
 {
-    public class SerializableProperty
+    public record SerializableProperty
     {
         [JsonPropertyName("name")]
         public string Name { get; init; }
@@ -30,5 +30,8 @@ namespace SerializationGenerator
 
         [JsonPropertyName("ruleArguments")]
         public string[] RuleArguments { get; init; }
+
+        [JsonIgnore]
+        public int Order { get; init; }
     }
 }

--- a/Projects/SerializationGenerator/SerializableMigration/SerializablePropertyComparer.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/SerializablePropertyComparer.cs
@@ -1,8 +1,8 @@
 /*************************************************************************
  * ModernUO                                                              *
- * Copyright (C) 2019-2021 - ModernUO Development Team                   *
+ * Copyright 2019-2021 - ModernUO Development Team                       *
  * Email: hi@modernuo.com                                                *
- * File: SerializablePropertyAttribute.cs                                *
+ * File: SerializablePropertyComparer.cs                                 *
  *                                                                       *
  * This program is free software: you can redistribute it and/or modify  *
  * it under the terms of the GNU General Public License as published by  *
@@ -13,18 +13,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System;
+using System.Collections.Generic;
 
-namespace Server
+namespace SerializationGenerator
 {
-    /// <summary>
-    /// Marks a property as serializable. Requires a call to ISerializable.MarkDirty()
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Property)]
-    public sealed class SerializablePropertyAttribute : Attribute
+    public class SerializablePropertyComparer : IComparer<SerializableProperty>
     {
-        public int Order { get; }
+        public int Compare(SerializableProperty x, SerializableProperty y)
+        {
+            if (Equals(x, y))
+            {
+                return 0;
+            }
 
-        public SerializablePropertyAttribute(int order) => Order = order;
+            if (Equals(null, y))
+            {
+                return 1;
+            }
+
+            if (Equals(null, x))
+            {
+                return -1;
+            }
+
+            return x.Order.CompareTo(y.Order);
+        }
     }
 }

--- a/Projects/SerializationGenerator/SourceGeneration/SourceGeneration.Namespace.cs
+++ b/Projects/SerializationGenerator/SourceGeneration/SourceGeneration.Namespace.cs
@@ -23,19 +23,6 @@ namespace SerializationGenerator
 {
     public static partial class SourceGeneration
     {
-        public static void GenerateUsings(this StringBuilder source, IImmutableList<ITypeSymbol> typesUsed)
-        {
-            var enumerable = typesUsed
-                .Select(t => t.ContainingNamespace.Name)
-                .Distinct()
-                .OrderByDescending(t => t);
-
-            foreach (var t in enumerable)
-            {
-                source.Insert(0, $"using {t}{Environment.NewLine}");
-            }
-        }
-
         public static void GenerateNamespaceStart(this StringBuilder source, string namespaceName)
         {
             source.AppendLine($@"namespace {namespaceName}

--- a/Projects/Server/Serialization/SerializableFieldAttribute.cs
+++ b/Projects/Server/Serialization/SerializableFieldAttribute.cs
@@ -17,7 +17,12 @@ using System;
 
 namespace Server
 {
-    [AttributeUsage(AttributeTargets.Field)]
+    /// <summary>
+    /// Hints to the source generator that this field or property should be serialized.
+    /// When used on a field, the source generator will generate the property entirely.
+    /// When used on a property, the user must call ((ISerializable)this).MarkDirty().
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public sealed class SerializableFieldAttribute : Attribute
     {
         public int Order { get; }

--- a/Projects/Server/Serialization/SerializableFieldAttributeAttribute.cs
+++ b/Projects/Server/Serialization/SerializableFieldAttributeAttribute.cs
@@ -17,6 +17,12 @@ using System;
 
 namespace Server
 {
+    /// <summary>
+    /// Hints to the source generator that this field will need this attribute on the generated property
+    /// [SerializableFieldAttr("[CommandProperty(AccessLevel.GameMaster)]")]
+    /// -or-
+    /// [SerializableFieldAttr(typeof(CommandPropertyAttribute), AccessLevel.GameMaster)]
+    /// </summary>
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class SerializableFieldAttrAttribute : Attribute
     {


### PR DESCRIPTION
- [X] Fixes an issue with ordering of properties in serialization.
- [X] Adds opt-in with existing properties.

Example:
```cs
private int _myExistingField;

[SerializableField(1)]
public int MyExistingProperty
{
    get => _myExistingField;
    set
    {
        if (value == 0)
        {
            Parent = null;
        }
        
        if (value != _myExistingField)
        {
            ((ISerializable)this).MarkDirty();
            _myExistingField = value;
        }
    }
}
```