### PR TITLE
fix(core): Fixes encoded int. Adds dirty checking opt-out

### DIFF
--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -101,9 +101,7 @@ namespace SerializationGenerator
 
             source.GenerateClassStart(
                 className,
-                isOverride ?
-                    ImmutableArray<ITypeSymbol>.Empty :
-                    ImmutableArray.Create<ITypeSymbol>(serializableInterface)
+                ImmutableArray<ITypeSymbol>.Empty
             );
 
             const string indent = "        ";
@@ -211,7 +209,6 @@ namespace SerializationGenerator
                     indent,
                     defaultValue: "-1"
                 );
-                source.AppendLine();
 
                 // BufferWriter ISerializable.SaveBuffer { get; set; }
                 source.GenerateAutoProperty(
@@ -222,7 +219,6 @@ namespace SerializationGenerator
                     AccessModifier.None,
                     indent
                 );
-                source.AppendLine();
 
                 // bool ISerializable.UseDirtyChecking { get; } = true;
                 source.GenerateAutoProperty(

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Class.cs
@@ -106,6 +106,8 @@ namespace SerializationGenerator
                     ImmutableArray.Create<ITypeSymbol>(serializableInterface)
             );
 
+            const string indent = "        ";
+
             source.GenerateClassField(
                 AccessModifier.Private,
                 InstanceModifier.Const,
@@ -199,13 +201,15 @@ namespace SerializationGenerator
             // If we are not inheriting ISerializable, then we need to define some stuff
             if (!isOverride)
             {
-                // long ISerializable.SavePosition { get; set; }
+                // long ISerializable.SavePosition { get; set; } = -1;
                 source.GenerateAutoProperty(
                     AccessModifier.None,
                     "long",
                     "ISerializable.SavePosition",
                     AccessModifier.None,
-                    AccessModifier.None
+                    AccessModifier.None,
+                    indent,
+                    defaultValue: "-1"
                 );
                 source.AppendLine();
 
@@ -215,7 +219,36 @@ namespace SerializationGenerator
                     "BufferWriter",
                     "ISerializable.SaveBuffer",
                     AccessModifier.None,
-                    AccessModifier.None
+                    AccessModifier.None,
+                    indent
+                );
+                source.AppendLine();
+
+                // bool ISerializable.UseDirtyChecking { get; } = true;
+                source.GenerateAutoProperty(
+                    AccessModifier.None,
+                    "bool",
+                    "ISerializable.UseDirtyChecking",
+                    AccessModifier.None,
+                    null,
+                    indent,
+                    defaultValue: "true"
+                );
+                source.AppendLine();
+            }
+            else
+            {
+                // If this type does not *directly* inherit `ISerializable`, then we assume it has an overridable `UseDirtyChecking`
+                // public override bool ISerializable.UseDirtyChecking { get; } = true;
+                source.GenerateAutoProperty(
+                    AccessModifier.Public,
+                    "bool",
+                    "UseDirtyChecking",
+                    AccessModifier.None,
+                    null,
+                    indent,
+                    defaultValue: "true",
+                    isOverride: true
                 );
                 source.AppendLine();
             }

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Property.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.Property.cs
@@ -47,7 +47,7 @@ namespace SerializationGenerator
             // Setter
             source.GeneratePropertySetterStart(false);
             const string indent = "                ";
-            source.AppendLine($"{indent}if(value != {fieldName})");
+            source.AppendLine($"{indent}if (value != {fieldName})");
             source.AppendLine($"{indent}{{");
             source.AppendLine($"{indent}    {fieldName} = value;");
             source.AppendLine($"{indent}    ((ISerializable)this).MarkDirty();");

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.SerialCtor.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.SerialCtor.cs
@@ -40,7 +40,7 @@ namespace SerializationGenerator
 
             if (!isOverride)
             {
-                source.Append(@$"            Serial = serial;
+                source.AppendLine(@$"            Serial = serial;
             SetTypeRef(typeof({className}));");
             }
 

--- a/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
+++ b/Projects/SerializationGenerator/SerializableEntityGeneration/SerializableEntityGeneration.SerializeMethod.cs
@@ -41,13 +41,6 @@ namespace SerializationGenerator
 
             const string indent = "            ";
 
-            source.AppendLine($"{indent}var savePosition = ((Server.ISerializable)this).SavePosition;");
-            source.AppendLine(@$"{indent}if (savePosition > -1)
-{indent}{{
-{indent}    writer.Seek(savePosition, System.IO.SeekOrigin.Begin);
-{indent}    return;
-{indent}}}");
-
             if (isOverride)
             {
                 source.AppendLine();

--- a/Projects/SerializationGenerator/SourceGeneration/SourceGeneration.Property.cs
+++ b/Projects/SerializationGenerator/SourceGeneration/SourceGeneration.Property.cs
@@ -81,13 +81,14 @@ namespace SerializationGenerator
                 ? ""
                 : $"{setAccessor.Value.ToFriendlyString() ?? ""} ";
 
-            var setter = setterAccessor == "" ? "" : $"{getterSpace}{setterAccessor}{setOrInit}";
+            var setter = setAccessor == null ? "" : $"{getterSpace}{setterAccessor}{setOrInit}";
 
             var propertyAccessor = accessors == AccessModifier.None ? "" : $"{accessors.ToFriendlyString()} ";
-            var printOverride = isOverride ? "override " : " ";
-            var printDefaultValue = defaultValue != null ? $" = {defaultValue};" : "";
+            var printOverride = isOverride ? "override " : "";
+            var printDefaultValue = defaultValue != null ? $"{(setAccessor != null ? " =" : "")} {defaultValue};" : "";
+            var printGetterSetter = setAccessor == null ? "=>" : $"{{ {getter}{setter} }}";
 
-            source.AppendLine($"{indent}{propertyAccessor}{printOverride}{type} {propertyName} {{ {getter}{setter} }}{printDefaultValue}");
+            source.AppendLine($"{indent}{propertyAccessor}{printOverride}{type} {propertyName} {printGetterSetter}{printDefaultValue}");
         }
 
         public static void GeneratePropertyEnd(this StringBuilder source) => source.AppendLine("        }");

--- a/Projects/SerializationGenerator/SourceGeneration/SourceGeneration.Property.cs
+++ b/Projects/SerializationGenerator/SourceGeneration/SourceGeneration.Property.cs
@@ -59,7 +59,10 @@ namespace SerializationGenerator
             string propertyName,
             AccessModifier? getAccessor,
             AccessModifier? setAccessor,
-            bool useInit = false
+            string indent,
+            bool useInit = false,
+            string defaultValue = null,
+            bool isOverride = false
         )
         {
             if (getAccessor == null && setAccessor == null)
@@ -74,12 +77,17 @@ namespace SerializationGenerator
             var getterSpace = getAccessor != null ? " " : "";
             var setOrInit = useInit ? "init;" : "set;";
 
-            var setterAccessor = setAccessor != AccessModifier.None ? $"{setAccessor?.ToFriendlyString() ?? ""} " : "";
+            var setterAccessor = setAccessor is null or AccessModifier.None
+                ? ""
+                : $"{setAccessor.Value.ToFriendlyString() ?? ""} ";
+
             var setter = setterAccessor == "" ? "" : $"{getterSpace}{setterAccessor}{setOrInit}";
 
             var propertyAccessor = accessors == AccessModifier.None ? "" : $"{accessors.ToFriendlyString()} ";
+            var printOverride = isOverride ? "override " : " ";
+            var printDefaultValue = defaultValue != null ? $" = {defaultValue};" : "";
 
-            source.AppendLine($"{propertyAccessor}{type} {propertyName} {{ {getter}{setter} }}");
+            source.AppendLine($"{indent}{propertyAccessor}{printOverride}{type} {propertyName} {{ {getter}{setter} }}{printDefaultValue}");
         }
 
         public static void GeneratePropertyEnd(this StringBuilder source) => source.AppendLine("        }");

--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -33,7 +33,6 @@ namespace Server.Guilds
             World.AddGuild(this);
 
             SetTypeRef(GetType());
-            ((ISerializable)this).MarkDirty();
         }
 
         protected BaseGuild(Serial serial)
@@ -64,7 +63,9 @@ namespace Server.Guilds
         [CommandProperty(AccessLevel.Counselor)]
         public Serial Serial { get; }
 
-        long ISerializable.SavePosition { get; set; }
+        bool ISerializable.UseDirtyChecking => false;
+
+        long ISerializable.SavePosition { get; set; } = -1;
 
         BufferWriter ISerializable.SaveBuffer { get; set; }
 

--- a/Projects/Server/IEntity.cs
+++ b/Projects/Server/IEntity.cs
@@ -48,7 +48,9 @@ namespace Server
         {
         }
 
-        long ISerializable.SavePosition { get; set; }
+        bool ISerializable.UseDirtyChecking => false;
+
+        long ISerializable.SavePosition { get; set; } = -1;
 
         BufferWriter ISerializable.SaveBuffer { get; set; }
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -231,7 +231,6 @@ namespace Server
 
             World.AddEntity(this);
             SetTypeRef(GetType());
-            ((ISerializable)this).MarkDirty();
         }
 
         public Item(Serial serial)
@@ -784,7 +783,9 @@ namespace Server
             AddNameProperties(list);
         }
 
-        long ISerializable.SavePosition { get; set; }
+        public virtual bool UseDirtyChecking => false;
+
+        long ISerializable.SavePosition { get; set; } = -1;
 
         BufferWriter ISerializable.SaveBuffer { get; set; }
 

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -560,7 +560,6 @@ namespace Server
 
             World.AddEntity(this);
             SetTypeRef(GetType());
-            ((ISerializable)this).MarkDirty();
         }
 
         public Mobile(Serial serial)
@@ -2522,7 +2521,9 @@ namespace Server
             AddNameProperties(list);
         }
 
-        long ISerializable.SavePosition { get; set; }
+        public virtual bool UseDirtyChecking => false;
+
+        long ISerializable.SavePosition { get; set; } = -1;
 
         BufferWriter ISerializable.SaveBuffer { get; set; }
 

--- a/Projects/Server/Serialization/ISerializable.cs
+++ b/Projects/Server/Serialization/ISerializable.cs
@@ -20,6 +20,10 @@ namespace Server
 {
     public interface ISerializable
     {
+        // Make sure all properties that will be serialized are calling `MarkDirty()` when they get modified.
+        // This should be done manually or via code gen through SerializedField attribute.
+        // This attribute should be virtual for any base serializalbe type (Item, Mobile, etc) that can be opt-in per type.
+        bool UseDirtyChecking { get; }
         long SavePosition { get; protected set; }
         BufferWriter SaveBuffer { get; protected internal set; }
         int TypeRef { get; }
@@ -39,7 +43,7 @@ namespace Server
         public void InitializeSaveBuffer(byte[] buffer)
         {
             SaveBuffer = new BufferWriter(buffer, true);
-            if (World.DirtyTrackingEnabled)
+            if (UseDirtyChecking)
             {
                 SavePosition = SaveBuffer.Position;
             }
@@ -63,7 +67,7 @@ namespace Server
             SaveBuffer.Seek(0, SeekOrigin.Begin);
             Serialize(SaveBuffer);
 
-            if (World.DirtyTrackingEnabled)
+            if (UseDirtyChecking)
             {
                 SavePosition = SaveBuffer.Position;
             }

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -48,7 +48,6 @@ namespace Server
         private static string _tempSavePath; // Path to the temporary folder for the save
         private static string _savePath; // Path to "Saves" folder
 
-        public const bool DirtyTrackingEnabled = false;
         public const uint ItemOffset = 0x40000000;
         public const uint MaxItemSerial = 0x7FFFFFFF;
         public const uint MaxMobileSerial = ItemOffset - 1;

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -265,6 +265,8 @@ namespace Server.Accounting
             }
         }
 
+        bool ISerializable.UseDirtyChecking => false;
+
         long ISerializable.SavePosition { get; set; }
 
         BufferWriter ISerializable.SaveBuffer { get; set; }


### PR DESCRIPTION
### Additions
- Automatically opts-out `Item/Mobile/Guild/Accounts` from dirty checking with a new property `UseDirtyChecking`
- Codegen now enables `UseDirtyChecking` via getter. This requires that the property is `virtual` for derived types.

### Fixes
- Fixes `EncodedInt` being broken
- Fixes issues with new custom serializable types that are not derived from Item/Mobile/etc.
- Removes double dirty checking.

### Example of a brand new serializable type that isn't an Item/Mobile/etc.
User created code:
```cs
using System;

namespace Server.Items
{
    [Serializable(0)]
    public partial class NewTestEntityObject : ISerializable
    {
        [EncodedInt]
        [SerializableField(0)]
        private int _someProperty;

        public NewTestEntityObject()
        {
            SetTypeRef(GetType());
            // Add to serial tracking like World.Item
            /*
            Serial = World.NewEntity;
            World.AddEntity(this);
            */
        }

        [AfterDeserialization]
        private void AfterDeserialization()
        {
            Console.WriteLine("This ran!");
        }

        public int TypeRef { get; }
        public Serial Serial { get; }
        public void Delete()
        {
        }

        public bool Deleted { get; set; }
        public void SetTypeRef(Type type)
        {
            // Type tracking for persistence goes here
            /*
            TypeRef = World.NewEntityTypes.IndexOf(type);
            if (TypeRef == -1)
            {
                World.NewEntityTypes.Add(type);
                TypeRef = World.NewEntityTypes.Count - 1;
            }
            */
        }
    }
}
```

Generated code:
```cs
namespace Server.Items
{
    public partial class NewTestEntityObject
    {
#pragma warning disable 0414
        private const int _version = 0;
#pragma warning restore 0414

        public int SomeProperty
        {
            get => _someProperty;
            set
            {
                if (value != _someProperty)
                {
                    _someProperty = value;
                    ((ISerializable)this).MarkDirty();
                }
            }
        }

        long ISerializable.SavePosition { get; set; } = -1;
        BufferWriter ISerializable.SaveBuffer { get; set; }
        bool ISerializable.UseDirtyChecking => true;

        public NewTestEntityObject(Serial serial)
        {
            Serial = serial;
            SetTypeRef(typeof(NewTestEntityObject));
        }

        public void Serialize(IGenericWriter writer)
        {

            writer.WriteEncodedInt(_version);

            writer.WriteEncodedInt(SomeProperty);
        }

        public void Deserialize(IGenericReader reader)
        {
            var version = reader.ReadEncodedInt();

            SomeProperty = reader.ReadEncodedInt();

            Timer.DelayCall(AfterDeserialization);
        }
    }
}
```