### PR TITLE
fix(core): Fixes various issues with codegen

### DIFF
--- a/Projects/SerializationGenerator/SerializableMigration/Rules/ArrayMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/ArrayMigrationRule.cs
@@ -101,14 +101,18 @@ namespace SerializableMigration
             var arrayElementRuleArguments = new string[ruleArguments.Length - 2];
             Array.Copy(ruleArguments, 2, arrayElementRuleArguments, 0, ruleArguments.Length - 2);
 
-            var propertyIndex = $"{property.Name}Index";
-            source.AppendLine($"{indent}writer.Write({property.Name}.Length);");
-            source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {property.Name}.Length; {propertyIndex}++)");
+            var propertyName = property.Name;
+            var propertyVarPrefix = $"{char.ToLower(propertyName[0])}{propertyName.Substring(1, propertyName.Length - 1)}";
+            var propertyIndex = $"{propertyVarPrefix}Index";
+            var propertyLength = $"{propertyVarPrefix}Length";
+            source.AppendLine($"{indent}var {propertyLength} = {property.Name}?.Length ?? 0;");
+            source.AppendLine($"{indent}writer.Write({propertyLength});");
+            source.AppendLine($"{indent}for (var {propertyIndex} = 0; {propertyIndex} < {propertyLength}; {propertyIndex}++)");
             source.AppendLine($"{indent}{{");
 
             var serializableArrayElement = new SerializableProperty
             {
-                Name = $"{property.Name}[{propertyIndex}]",
+                Name = $"{property.Name}![{propertyIndex}]",
                 Type = ruleArguments[0],
                 Rule = arrayElementRule.RuleName,
                 RuleArguments = arrayElementRuleArguments

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/HashSetMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/HashSetMigrationRule.cs
@@ -116,9 +116,13 @@ namespace SerializableMigration
             var propertyName = property.Name;
             var propertyVarPrefix = $"{char.ToLower(propertyName[0])}{propertyName.Substring(1, propertyName.Length - 1)}";
             var propertyEntry = $"{propertyVarPrefix}Entry";
-            source.AppendLine($"{indent}writer.Write({property.Name}.Count);");
-            source.AppendLine($"{indent}foreach (var {propertyEntry} in {property.Name});");
+            var propertyCount = $"{propertyVarPrefix}Count";
+            source.AppendLine($"{indent}var {propertyCount} = {property.Name}?.Count ?? 0;");
+            source.AppendLine($"{indent}writer.Write({propertyCount});");
+            source.AppendLine($"{indent}if ({propertyCount} > 0)");
             source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    foreach (var {propertyEntry} in {property.Name}!)");
+            source.AppendLine($"{indent}    {{");
 
             var serializableSetElement = new SerializableProperty
             {
@@ -128,8 +132,9 @@ namespace SerializableMigration
                 RuleArguments = setElementRuleArguments
             };
 
-            setElementRule.GenerateSerializationMethod(source, $"{indent}    ", serializableSetElement);
+            setElementRule.GenerateSerializationMethod(source, $"{indent}        ", serializableSetElement);
 
+            source.AppendLine($"{indent}    }}");
             source.AppendLine($"{indent}}}");
         }
     }

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/ListMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/ListMigrationRule.cs
@@ -114,10 +114,15 @@ namespace SerializableMigration
             Array.Copy(ruleArguments, 2, listElementRuleArguments, 0, ruleArguments.Length - 2);
 
             var propertyName = property.Name;
-            var propertyEntry = $"{char.ToLower(propertyName[0])}{propertyName.Substring(1, propertyName.Length - 1)}Entry";
-            source.AppendLine($"{indent}writer.Write({propertyName}.Count);");
-            source.AppendLine($"{indent}foreach (var {propertyEntry} in {propertyName})");
+            var propertyVarPrefix = $"{char.ToLower(propertyName[0])}{propertyName.Substring(1, propertyName.Length - 1)}";
+            var propertyEntry = $"{propertyVarPrefix}Entry";
+            var propertyCount = $"{propertyVarPrefix}Count";
+            source.AppendLine($"{indent}var {propertyCount} = {property.Name}?.Count ?? 0;");
+            source.AppendLine($"{indent}writer.Write({propertyCount});");
+            source.AppendLine($"{indent}if ({propertyCount} > 0)");
             source.AppendLine($"{indent}{{");
+            source.AppendLine($"{indent}    foreach (var {propertyEntry} in {property.Name}!)");
+            source.AppendLine($"{indent}    {{");
 
             var serializableListElement = new SerializableProperty
             {
@@ -127,8 +132,9 @@ namespace SerializableMigration
                 RuleArguments = listElementRuleArguments
             };
 
-            listElementRule.GenerateSerializationMethod(source, $"{indent}    ", serializableListElement);
+            listElementRule.GenerateSerializationMethod(source, $"{indent}        ", serializableListElement);
 
+            source.AppendLine($"{indent}    }}");
             source.AppendLine($"{indent}}}");
         }
     }

--- a/Projects/Server/Serialization/IGenericReader.cs
+++ b/Projects/Server/Serialization/IGenericReader.cs
@@ -82,12 +82,12 @@ namespace Server
                         var num = ReadShort();
                         return *(T*)&num;
                     }
-                case 3:
+                case 4:
                     {
                         var num = ReadEncodedInt();
                         return *(T*)&num;
                     }
-                case 4:
+                case 8:
                     {
                         var num = ReadLong();
                         return *(T*)&num;

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,7 +34,8 @@
         <Delete Files="..\..\Distribution\$(AssemblyName).pdb" ContinueOnError="true" />
         <Delete Files="..\..\Distribution\$(AssemblyName).runtimeconfig.dev.json" ContinueOnError="true" />
         <Delete Files="..\..\Distribution\$(AssemblyName).runtimeconfig.json" ContinueOnError="true" />
-        <RemoveDir Directories="Generated" />
+        <Delete Files="Generated\**\*" ContinueOnError="true" />
+        <RemoveDir Directories="Generated" ContinueOnError="true" />
     </Target>
     <ItemGroup>
         <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.0.2" />

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -64,17 +64,17 @@ namespace Server.Accounting
         [SerializableField(10, setter: "private")]
         private List<AccountComment> _comments;
 
-        [SerializableField(10, setter: "private")]
+        [SerializableField(11, setter: "private")]
         private List<AccountTag> _tags;
 
-        [SerializableField(11)]
+        [SerializableField(12)]
         private IPAddress[] _loginIPs;
 
         /// <summary>
         ///     List of IP addresses for restricted access. '*' wildcard supported. If the array contains zero entries, all IP addresses
         ///     are allowed.
         /// </summary>
-        [SerializableField(12)]
+        [SerializableField(13)]
         private string[] _ipRestrictions;
 
         private TimeSpan _totalGameTime;
@@ -83,7 +83,7 @@ namespace Server.Accounting
         ///     Gets the total game time of this account, also considering the game time of characters
         ///     that have been deleted.
         /// </summary>
-        [SerializableField(13)]
+        [SerializableField(14)]
         public TimeSpan TotalGameTime
         {
             get
@@ -105,7 +105,7 @@ namespace Server.Accounting
             }
         }
 
-        [SerializableField(14)]
+        [SerializableField(15)]
         [SerializableFieldAttr("[CommandProperty(AccessLevel.Administrator)]")]
         private string _email;
 
@@ -345,8 +345,8 @@ namespace Server.Accounting
             _totalGold = reader.ReadInt();
             _totalPlat = reader.ReadInt();
 
-            _mobiles = new Mobile[7];
             var length = reader.ReadInt();
+            _mobiles = new Mobile[length];
             for (int i = 0; i < length; i++)
             {
                 _mobiles[i] = reader.ReadEntity<Mobile>();

--- a/Projects/UOContent/Migrations/Server.Accounting.Account.v2.json
+++ b/Projects/UOContent/Migrations/Server.Accounting.Account.v2.json
@@ -75,6 +75,15 @@
       ]
     },
     {
+      "name": "Tags",
+      "type": "System.Collections.Generic.List\u003CServer.Accounting.AccountTag\u003E",
+      "rule": "ListMigrationRule",
+      "ruleArguments": [
+        "Server.Accounting.AccountTag",
+        "SerializationMethodSignatureMigrationRule"
+      ]
+    },
+    {
       "name": "LoginIPs",
       "type": "System.Net.IPAddress[]",
       "rule": "ArrayMigrationRule",

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -30,7 +30,8 @@
         <Delete Files="..\..\Distribution\Assemblies\libz.dylib" ContinueOnError="true" />
         <Delete Files="..\..\Distribution\Assemblies\libz.so" ContinueOnError="true" />
         <Delete Files="..\..\Distribution\Assemblies\ZLib.Bindings.dll" ContinueOnError="true" />
-        <RemoveDir Directories="Generated" />
+        <Delete Files="Generated\**\*" ContinueOnError="true" />
+        <RemoveDir Directories="Generated" ContinueOnError="true" />
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Server\Server.csproj" Private="false" PrivateAssets="All" IncludeAssets="None">


### PR DESCRIPTION
- [X] Fixes bad `ReadEnum` by size
- [X] Fixes array, list, and set not handling null values properly.
  - It will be up to the user (for now) to null out empty lists using `[AfterDeserialization]`. Convenience may be added later.
- [X] Fixes errors with `dotnet clean` and non-empty generation folder
- [X] Fixes bad field indexes on `Account.cs` causing `tags` to not be serialized/deserialized.
  - This was caused by a duplicate entry. Don't have protection against this _yet_.