### PR TITLE
fix(build): Fixes building with VS 2019 16.10+

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -56,7 +56,7 @@
     <ItemGroup>
         <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Projects/SerializationGenerator/SerializationGenerator.csproj
+++ b/Projects/SerializationGenerator/SerializationGenerator.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
-        <PackageReference Include="Humanizer.Core" Version="2.10.1" GeneratePathProperty="true" PrivateAssets="all" />
+        <PackageReference Include="Humanizer.Core" Version="2.11.10" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="System.Text.Json" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
         <PackageReference Include="System.Text.Encodings.Web" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     </ItemGroup>

--- a/Projects/SerializationSchemaGenerator/SerializationSchemaGenerator.csproj
+++ b/Projects/SerializationSchemaGenerator/SerializationSchemaGenerator.csproj
@@ -14,8 +14,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.10.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -10,8 +10,6 @@
         <PublishDir>..\..\Distribution</PublishDir>
         <OutDir>..\..\Distribution</OutDir>
         <Version>0.0.0</Version>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
     </PropertyGroup>
     <Target Name="CleanPub" AfterTargets="Clean">
         <Message Text="Deleting source generated files..." />
@@ -57,17 +55,21 @@
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
     </ItemGroup>
-    <Target Name="RemoveSourceGeneratedFiles" BeforeTargets="CoreCompile">
+    <ItemGroup>
+        <AdditionalFiles Include="Migrations/*.v*.json" />
+    </ItemGroup>
+    <PropertyGroup Condition="'$(RiderVersion)' != '' AND $([MSBuild]::VersionLessThan($(RiderVersion), '2021.2.0'))">
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+    <Target Name="RemoveSourceGeneratedFiles" BeforeTargets="CoreCompile" Condition="'$(RiderVersion)' != '' AND $([MSBuild]::VersionLessThan($(RiderVersion), '2021.2.0'))">
         <ItemGroup>
             <Compile Remove="Generated\**" />
         </ItemGroup>
     </Target>
-    <Target Name="AddSourceGeneratedFiles" AfterTargets="CoreCompile">
+    <Target Name="AddSourceGeneratedFiles" AfterTargets="CoreCompile" Condition="'$(RiderVersion)' != '' AND $([MSBuild]::VersionLessThan($(RiderVersion), '2021.2.0'))">
         <ItemGroup>
             <Compile Include="Generated\**" />
         </ItemGroup>
     </Target>
-    <ItemGroup>
-        <AdditionalFiles Include="Migrations/*.v*.json" />
-    </ItemGroup>
 </Project>

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -6,8 +6,8 @@
         <Product>ModernUO Content</Product>
         <PublishDir>..\..\Distribution\Assemblies</PublishDir>
         <OutDir>..\..\Distribution\Assemblies</OutDir>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+<!--        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
+<!--        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
     </PropertyGroup>
     <Target Name="CleanPub" AfterTargets="Clean">
         <Message Text="Deleting source generated files..." />
@@ -50,17 +50,21 @@
             <PrivateAssets>all</PrivateAssets>
         </ProjectReference>
     </ItemGroup>
-    <Target Name="RemoveSourceGeneratedFiles" BeforeTargets="CoreCompile">
+    <ItemGroup>
+        <AdditionalFiles Include="Migrations/*.v*.json" />
+    </ItemGroup>
+    <PropertyGroup Condition="'$(RiderVersion)' != '' AND $([MSBuild]::VersionLessThan($(RiderVersion), '2021.2.0'))">
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+    </PropertyGroup>
+    <Target Name="RemoveSourceGeneratedFiles" BeforeTargets="CoreCompile" Condition="'$(RiderVersion)' != '' AND $([MSBuild]::VersionLessThan($(RiderVersion), '2021.2.0'))">
         <ItemGroup>
             <Compile Remove="Generated\**" />
         </ItemGroup>
     </Target>
-    <Target Name="AddSourceGeneratedFiles" AfterTargets="CoreCompile">
+    <Target Name="AddSourceGeneratedFiles" AfterTargets="CoreCompile" Condition="'$(RiderVersion)' != '' AND $([MSBuild]::VersionLessThan($(RiderVersion), '2021.2.0'))">
         <ItemGroup>
             <Compile Include="Generated\**" />
         </ItemGroup>
     </Target>
-    <ItemGroup>
-        <AdditionalFiles Include="Migrations/*.v*.json" />
-    </ItemGroup>
 </Project>

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -6,8 +6,6 @@
         <Product>ModernUO Content</Product>
         <PublishDir>..\..\Distribution\Assemblies</PublishDir>
         <OutDir>..\..\Distribution\Assemblies</OutDir>
-<!--        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
-<!--        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>-->
     </PropertyGroup>
     <Target Name="CleanPub" AfterTargets="Clean">
         <Message Text="Deleting source generated files..." />


### PR DESCRIPTION
**Note for Rider users** Code generation only works with Rider v2021.1+. For Rider 2021.1.x you must set a global msbuild attribute so that the IDE can recognize generated code after building. JetBrains claims this will be fixed in Rider 2021.2.

**Rider 2021.1 Required Setting for Code Generation**
<img width="945" alt="Screen Shot 2021-07-19 at 9 36 30 PM" src="https://user-images.githubusercontent.com/3953314/126262725-a4d58dd0-e9e0-400f-a172-0b29ef7a00d7.png">

**Note for VS 2019+ users**: Code generation requires completely cleaning your solution, doing a full build, closing VS 2019, and then opening the solution. This is a known issue and there are no plans to fix this multiple restart requirement for VS 2022 at this time.
