### PR TITLE
fix(codegen): Fixes codegenning timers when they are null.

### DIFF
--- a/Projects/SerializationGenerator/SerializableMigration/Rules/TimerMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/TimerMigrationRule.cs
@@ -80,7 +80,7 @@ namespace SerializableMigration
             var driftTimer = ruleArguments![0].Contains("@TimerDrift");
 
             var writerMethod = driftTimer ? "WriteDeltaTime" : "Write";
-            source.AppendLine($"{indent}writer.{writerMethod}({propertyName}.Next);");
+            source.AppendLine($"{indent}writer.{writerMethod}({propertyName}?.Next ?? TimeSpan.MinValue);");
         }
 
         public void PostDeserializeMethod(

--- a/Projects/SerializationGenerator/SerializableMigration/Rules/TimerMigrationRule.cs
+++ b/Projects/SerializationGenerator/SerializableMigration/Rules/TimerMigrationRule.cs
@@ -63,7 +63,8 @@ namespace SerializableMigration
             var driftTimer = ruleArguments![0].Contains("@TimerDrift");
 
             var readTimer = driftTimer ? "reader.ReadDeltaTime()" : "reader.ReadDateTime()";
-            source.AppendLine($"{indent}var {propertyName}Delay = {readTimer} - Core.Now;");
+            source.AppendLine($"{indent}var {propertyName}Next = {readTimer};");
+            source.AppendLine($"{indent}var {propertyName}Delay = {propertyName}Next == System.DateTime.MinValue ? System.TimeSpan.MinValue : {propertyName}Next - Core.Now;");
         }
 
         public void GenerateSerializationMethod(StringBuilder source, string indent, SerializableProperty property)
@@ -80,7 +81,7 @@ namespace SerializableMigration
             var driftTimer = ruleArguments![0].Contains("@TimerDrift");
 
             var writerMethod = driftTimer ? "WriteDeltaTime" : "Write";
-            source.AppendLine($"{indent}writer.{writerMethod}({propertyName}?.Next ?? TimeSpan.MinValue);");
+            source.AppendLine($"{indent}writer.{writerMethod}({propertyName}?.Next ?? System.DateTime.MinValue);");
         }
 
         public void PostDeserializeMethod(

--- a/Projects/Server/NativeReader.cs
+++ b/Projects/Server/NativeReader.cs
@@ -57,6 +57,6 @@ namespace Server
             InternalRead(source, buffer, bufferIndex, length);
 
         internal unsafe int InternalRead(FileStream source, void* buffer, int bufferIndex, int length) =>
-            UnsafeNativeMethods.read(source.SafeFileHandle.DangerousGetHandle(), (byte*)buffer + bufferIndex, length);
+            UnsafeNativeMethods.read(source.SafeFileHandle!.DangerousGetHandle(), (byte*)buffer + bufferIndex, length);
     }
 }


### PR DESCRIPTION
When a timer is null, the code generator will use `TimeSpan.MinValue` as the delay.