### PR TITLE
fix: Updates races to properly support gargoyle equipment.

### DIFF
--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2104,6 +2104,47 @@ namespace Server
 
         public virtual bool CheckConflictingLayer(Mobile m, Item item, Layer layer) => m_Layer == layer;
 
+        // Uses Race.RaceFlag
+        public virtual int RequiredRaces => Race.AllowAllRaces;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool CheckRace(Race race) => Race.IsAllowedRace(race, RequiredRaces);
+
+        public bool CheckRace(Mobile from, bool message = true)
+        {
+            var race = from.Race;
+            var requiredRaces = RequiredRaces;
+
+            if (Race.IsAllowedRace(race, requiredRaces))
+            {
+                return true;
+            }
+
+            if (!message)
+            {
+                return false;
+            }
+
+            if (race == Race.Gargoyle)
+            {
+                from.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1111708); // Gargoyles can't wear this.
+            }
+            else if (requiredRaces == Race.AllowGargoylesOnly)
+            {
+                from.LocalOverheadMessage(Network.MessageType.Regular, 0x3B2, 1111707); // Only gargoyles can wear this.
+            }
+            else if (race != Race.Elf)
+            {
+                from.SendLocalizedMessage(1072203); // Only Elves may use this.
+            }
+            else if (race != Race.Human)
+            {
+                from.SendMessage($"Only {race.PluralName} may use this.");
+            }
+
+            return false;
+        }
+
         public virtual bool CanEquip(Mobile m) => m_Layer != Layer.Invalid && m.FindItemOnLayer(m_Layer) == null;
 
         public virtual void GetChildContextMenuEntries(Mobile from, List<ContextMenuEntry> list, Item item)

--- a/Projects/Server/Race.cs
+++ b/Projects/Server/Race.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Server
 {
@@ -16,6 +17,7 @@ namespace Server
         {
             RaceID = raceID;
             RaceIndex = raceIndex;
+            RaceFlag = 1 << raceIndex;
 
             Name = name;
 
@@ -38,6 +40,11 @@ namespace Server
 
         public static List<Race> AllRaces { get; } = new();
 
+        public const int AllowAllRaces = 0x7;      // Race.Human.RaceFlag | Race.Elf.RaceFlag | Race.Gargoyle.RaceFlag
+        public const int AllowHumanOrElves = 0x3;  // Race.Human.RaceFlag | Race.Elf.RaceFlag
+        public const int AllowElvesOnly = 0x2;     // Race.Elf.RaceFlag
+        public const int AllowGargoylesOnly = 0x4; // Race.Gargoyle.RaceFlag
+
         public Expansion RequiredExpansion { get; }
 
         public int MaleBody { get; }
@@ -52,9 +59,14 @@ namespace Server
 
         public int RaceIndex { get; }
 
+        public int RaceFlag { get; }
+
         public string Name { get; set; }
 
         public string PluralName { get; set; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAllowedRace(Race race, int allowedRaceFlags) => (allowedRaceFlags & race.RaceFlag) != 0;
 
         public static string[] GetRaceNames()
         {

--- a/Projects/UOContent/Items/Armor/ArmorEnums.cs
+++ b/Projects/UOContent/Items/Armor/ArmorEnums.cs
@@ -50,7 +50,9 @@ namespace Server.Items
         Ringmail,
         Chainmail,
         Plate,
-        Dragon // On OSI, Dragon is seen and considered its own type.
+        Dragon,
+        Wood,
+        Stone
     }
 
     public enum ArmorMeditationAllowance

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -564,7 +564,6 @@ namespace Server.Items
 
         public virtual CraftResource DefaultResource => CraftResource.Iron;
 
-        public virtual Race RequiredRace => null;
 
         [Hue]
         [CommandProperty(AccessLevel.GameMaster)]
@@ -988,17 +987,8 @@ namespace Server.Items
 
                 if (item is BaseArmor armor)
                 {
-                    if (armor.RequiredRace != null && m.Race != armor.RequiredRace)
+                    if (!armor.CheckRace(m))
                     {
-                        if (armor.RequiredRace == Race.Elf)
-                        {
-                            m.SendLocalizedMessage(1072203); // Only Elves may use this.
-                        }
-                        else
-                        {
-                            m.SendMessage("Only {0} may use this.", armor.RequiredRace.PluralName);
-                        }
-
                         m.AddToBackpack(armor);
                     }
                     else if (!armor.AllowMaleWearer && !m.Female && m.AccessLevel < AccessLevel.GameMaster)
@@ -1287,17 +1277,8 @@ namespace Server.Items
 
             if (from.AccessLevel < AccessLevel.GameMaster)
             {
-                if (RequiredRace != null && from.Race != RequiredRace)
+                if (!CheckRace(from))
                 {
-                    if (RequiredRace == Race.Elf)
-                    {
-                        from.SendLocalizedMessage(1072203); // Only Elves may use this.
-                    }
-                    else
-                    {
-                        from.SendMessage("Only {0} may use this.", RequiredRace.PluralName);
-                    }
-
                     return false;
                 }
 
@@ -1503,12 +1484,12 @@ namespace Server.Items
                 list.Add(1041350); // faction item
             }
 
-            if (RequiredRace == Race.Elf)
+            if (RequiredRaces == Race.AllowElvesOnly)
             {
                 list.Add(1075086); // Elves Only
             }
 
-            if (RequiredRace == Race.Gargoyle)
+            if (RequiredRaces == Race.AllowGargoylesOnly)
             {
                 list.Add(1111709); // Gargoyles Only
             }

--- a/Projects/UOContent/Items/Armor/Helmets/Circlet.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/Circlet.cs
@@ -25,6 +25,6 @@ namespace Server.Items
 
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Armor/Helmets/GemmedCirclet.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/GemmedCirclet.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GemmedCirclet() : base(0x2B70) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 1;
         public override int BaseFireResistance => 5;

--- a/Projects/UOContent/Items/Armor/Helmets/RavenHelm.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/RavenHelm.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public RavenHelm() : base(0x2B71) => Weight = 5.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 1;

--- a/Projects/UOContent/Items/Armor/Helmets/RoyalCirclet.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/RoyalCirclet.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public RoyalCirclet() : base(0x2B6F) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 1;
         public override int BaseFireResistance => 5;

--- a/Projects/UOContent/Items/Armor/Helmets/VultureHelm.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/VultureHelm.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public VultureHelm() : base(0x2B72) => Weight = 5.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 1;

--- a/Projects/UOContent/Items/Armor/Helmets/WingedHelm.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/WingedHelm.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public WingedHelm() : base(0x2B73) => Weight = 5.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 1;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherArmsType1.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherArmsType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherArmsType1() : base(0x301) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherArmsType2.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherArmsType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherArmsType2() : base(0x302) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherChestType1.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherChestType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherChestType1() : base(0x0304) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherChestType2.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherChestType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherChestType2() : base(0x303) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherKiltType1.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherKiltType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherKiltType1() : base(0x311) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherKiltType2.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherKiltType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherKiltType2() : base(0x310) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherLegsType1.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherLegsType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherLegsType1() : base(0x305) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherLegsType2.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherLegsType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherLegsType2() : base(0x306) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 5;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 7;

--- a/Projects/UOContent/Items/Armor/Leather/GargishLeatherWingArmor.cs
+++ b/Projects/UOContent/Items/Armor/Leather/GargishLeatherWingArmor.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishLeatherWingArmor() : base(0x457E) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int PhysicalResistance => 0;
         public override int FireResistance => 0;
         public override int ColdResistance => 0;

--- a/Projects/UOContent/Items/Armor/Leather/LeafArms.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafArms.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public LeafArms() : base(0x2FC8) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Projects/UOContent/Items/Armor/Leather/LeafChest.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafChest.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public LeafChest() : base(0x2FC5) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Projects/UOContent/Items/Armor/Leather/LeafGloves.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafGloves.cs
@@ -10,7 +10,7 @@ namespace Server.Items
         [Constructible]
         public LeafGloves() : base(0x2FC6) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Projects/UOContent/Items/Armor/Leather/LeafGorget.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafGorget.cs
@@ -6,7 +6,7 @@ namespace Server.Items
         [Constructible]
         public LeafGorget() : base(0x2FC7) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Projects/UOContent/Items/Armor/Leather/LeafLegs.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafLegs.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public LeafLegs() : base(0x2FC9) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Armor/Leather/LeafTonlet.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafTonlet.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public LeafTonlet() : base(0x2FCA) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
         public override int BasePhysicalResistance => 2;
         public override int BaseFireResistance => 3;
         public override int BaseColdResistance => 2;

--- a/Projects/UOContent/Items/Armor/Plate/FemaleWoodlandChest.cs
+++ b/Projects/UOContent/Items/Armor/Plate/FemaleWoodlandChest.cs
@@ -23,6 +23,6 @@ namespace Server.Items
 
         public override int ArmorBase => 30;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
     }
 }

--- a/Projects/UOContent/Items/Armor/Plate/WoodlandArms.cs
+++ b/Projects/UOContent/Items/Armor/Plate/WoodlandArms.cs
@@ -21,7 +21,7 @@ namespace Server.Items
 
         public override int ArmorBase => 40;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
-        public override Race RequiredRace => Race.Elf;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Armor/Plate/WoodlandChest.cs
+++ b/Projects/UOContent/Items/Armor/Plate/WoodlandChest.cs
@@ -21,7 +21,7 @@ namespace Server.Items
 
         public override int ArmorBase => 40;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
-        public override Race RequiredRace => Race.Elf;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Armor/Plate/WoodlandGloves.cs
+++ b/Projects/UOContent/Items/Armor/Plate/WoodlandGloves.cs
@@ -21,7 +21,7 @@ namespace Server.Items
 
         public override int ArmorBase => 40;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
-        public override Race RequiredRace => Race.Elf;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Armor/Plate/WoodlandGorget.cs
+++ b/Projects/UOContent/Items/Armor/Plate/WoodlandGorget.cs
@@ -23,7 +23,7 @@ namespace Server.Items
 
         public override int ArmorBase => 40;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
-        public override Race RequiredRace => Race.Elf;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Armor/Plate/WoodlandLegs.cs
+++ b/Projects/UOContent/Items/Armor/Plate/WoodlandLegs.cs
@@ -21,7 +21,7 @@ namespace Server.Items
 
         public override int ArmorBase => 40;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
-        public override Race RequiredRace => Race.Elf;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedArmsType1.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedArmsType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedArmsType1() : base(0x284) => Weight = 10.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedArmsType2.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedArmsType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedArmsType2() : base(0x283) => Weight = 10.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedChestType1.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedChestType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedChestType1() : base(0x286) => Weight = 15.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedChestType2.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedChestType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedChestType2() : base(0x285) => Weight = 15.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedKiltType1.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedKiltType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedKiltType1() : base(0x288) => Weight = 10.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedKiltType2.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedKiltType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedKiltType2() : base(0x287) => Weight = 10.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedLegsType1.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedLegsType1.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedLegsType1() : base(0x28A) => Weight = 15.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/GargishStuddedLegsType2.cs
+++ b/Projects/UOContent/Items/Armor/Studded/GargishStuddedLegsType2.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public GargishStuddedLegsType2() : base(0x289) => Weight = 15.0;
 
-        public override Race RequiredRace => Race.Gargoyle;
+        public override int RequiredRaces => Race.AllowGargoylesOnly;
         public override int BasePhysicalResistance => 6;
         public override int BaseFireResistance => 6;
         public override int BaseColdResistance => 4;

--- a/Projects/UOContent/Items/Armor/Studded/HideChest.cs
+++ b/Projects/UOContent/Items/Armor/Studded/HideChest.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public HideChest() : base(0x2B74) => Weight = 6.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Armor/Studded/HideFemaleChest.cs
+++ b/Projects/UOContent/Items/Armor/Studded/HideFemaleChest.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public HideFemaleChest() : base(0x2B79) => Weight = 6.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Armor/Studded/HideGloves.cs
+++ b/Projects/UOContent/Items/Armor/Studded/HideGloves.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public HideGloves() : base(0x2B75) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Armor/Studded/HideGorget.cs
+++ b/Projects/UOContent/Items/Armor/Studded/HideGorget.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public HideGorget() : base(0x2B76) => Weight = 3.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Armor/Studded/HidePants.cs
+++ b/Projects/UOContent/Items/Armor/Studded/HidePants.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public HidePants() : base(0x2B78) => Weight = 5.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Armor/Studded/HidePauldrons.cs
+++ b/Projects/UOContent/Items/Armor/Studded/HidePauldrons.cs
@@ -7,7 +7,7 @@ namespace Server.Items
         [Constructible]
         public HidePauldrons() : base(0x2B77) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override int BasePhysicalResistance => 3;
         public override int BaseFireResistance => 3;

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -713,9 +713,14 @@ namespace Server.Items
                 list.Add(1060636); // exceptional
             }
 
-            if (RequiredRace == Race.Elf)
+            if (RequiredRaces == Race.AllowElvesOnly)
             {
                 list.Add(1075086); // Elves Only
+            }
+
+            if (RequiredRaces == Race.AllowGargoylesOnly)
+            {
+                list.Add(1111709); // Gargoyles Only
             }
 
             SkillBonuses?.GetProperties(list);

--- a/Projects/UOContent/Items/Clothing/OuterTorso.cs
+++ b/Projects/UOContent/Items/Clothing/OuterTorso.cs
@@ -479,7 +479,7 @@ namespace Server.Items
         [Constructible]
         public FemaleElvenRobe(int hue = 0) : base(0x2FBA, hue) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override bool AllowMaleWearer => false;
     }

--- a/Projects/UOContent/Items/Clothing/Pants.cs
+++ b/Projects/UOContent/Items/Clothing/Pants.cs
@@ -39,6 +39,6 @@ namespace Server.Items
         [Constructible]
         public ElvenPants(int hue = 0) : base(0x2FC3, hue) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 }

--- a/Projects/UOContent/Items/Clothing/Shirts.cs
+++ b/Projects/UOContent/Items/Clothing/Shirts.cs
@@ -42,7 +42,7 @@ namespace Server.Items
         [Constructible]
         public ElvenShirt(int hue = 0) : base(0x3175, hue) => Weight = 2.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
     }
 
     [Serializable(0)]

--- a/Projects/UOContent/Items/Clothing/Shoes.cs
+++ b/Projects/UOContent/Items/Clothing/Shoes.cs
@@ -194,7 +194,7 @@ namespace Server.Items
 
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override bool Dye(Mobile from, DyeTub sender) => false;
     }

--- a/Projects/UOContent/Items/Clothing/Waist.cs
+++ b/Projects/UOContent/Items/Clothing/Waist.cs
@@ -31,7 +31,7 @@ namespace Server.Items
         [Constructible]
         public WoodlandBelt(int hue = 0) : base(0x2B68, hue) => Weight = 4.0;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override bool Dye(Mobile from, DyeTub sender)
         {

--- a/Projects/UOContent/Items/Minor Artifacts/ML/AegisOfGrace.cs
+++ b/Projects/UOContent/Items/Minor Artifacts/ML/AegisOfGrace.cs
@@ -30,7 +30,7 @@ namespace Server.Items
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override void Serialize(IGenericWriter writer)
         {

--- a/Projects/UOContent/Items/Minor Artifacts/ML/FeyLeggings.cs
+++ b/Projects/UOContent/Items/Minor Artifacts/ML/FeyLeggings.cs
@@ -26,7 +26,7 @@ namespace Server.Items
         public override int InitMinHits => 255;
         public override int InitMaxHits => 255;
 
-        public override Race RequiredRace => Race.Elf;
+        public override int RequiredRaces => Race.AllowElvesOnly;
 
         public override void Serialize(IGenericWriter writer)
         {

--- a/Projects/UOContent/Items/Skill Items/Tools/BaseRunicTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/BaseRunicTool.cs
@@ -607,12 +607,10 @@ namespace Server.Items
                 m_Props.Set(2, true); // remove durability bonus from possible properties
             }
 
-            if (armor.RequiredRace == Race.Elf)
+            if (armor.RequiredRaces == Race.AllowElvesOnly)
             {
-                m_Props.Set(
-                    7,
-                    true
-                ); // elves inherently have night sight and elf only armor doesn't get night sight as a mod
+                // elves inherently have night sight and elf only armor doesn't get night sight as a mod
+                m_Props.Set(7, true);
             }
 
             for (var i = 0; i < attributeCount; ++i)
@@ -628,7 +626,7 @@ namespace Server.Items
 
                 switch (random)
                 {
-                    /* Begin Sheilds */
+                    /* Begin Shields */
                     case 0:
                         ApplyAttribute(primary, min, max, AosAttribute.SpellChanneling, 1, 1);
                         break;

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -114,9 +114,6 @@ namespace Server.Items
             }
         }
 
-        public virtual Race RequiredRace =>
-            null; // On OSI, there are no weapons with race requirements, this is for custom stuff
-
         public virtual bool UseSkillMod => !Core.AOS;
 
         public static bool InDoubleStrike { get; set; }
@@ -915,17 +912,8 @@ namespace Server.Items
                 return false;
             }
 
-            if (RequiredRace != null && from.Race != RequiredRace)
+            if (!CheckRace(from))
             {
-                if (RequiredRace == Race.Elf)
-                {
-                    from.SendLocalizedMessage(1072203); // Only Elves may use this.
-                }
-                else
-                {
-                    from.SendMessage("Only {0} may use this.", RequiredRace.PluralName);
-                }
-
                 return false;
             }
 
@@ -2945,9 +2933,14 @@ namespace Server.Items
                 list.Add(1060636); // exceptional
             }
 
-            if (RequiredRace == Race.Elf)
+            if (RequiredRaces == Race.AllowElvesOnly)
             {
                 list.Add(1075086); // Elves Only
+            }
+
+            if (RequiredRaces == Race.AllowGargoylesOnly)
+            {
+                list.Add(1111709); // Gargoyles Only
             }
 
             if (ArtifactRarity > 0)

--- a/Projects/UOContent/Misc/RaceDefinitions.cs
+++ b/Projects/UOContent/Misc/RaceDefinitions.cs
@@ -42,12 +42,12 @@ namespace Server.Misc
                     return false; // Buns & Receding Hair
                 }
 
-                if (itemID >= 0x203B && itemID <= 0x203D)
+                if (itemID is >= 0x203B and <= 0x203D)
                 {
                     return true;
                 }
 
-                if (itemID >= 0x2044 && itemID <= 0x204A)
+                if (itemID is >= 0x2044 and <= 0x204A)
                 {
                     return true;
                 }
@@ -83,12 +83,12 @@ namespace Server.Misc
                     return false;
                 }
 
-                if (itemID >= 0x203E && itemID <= 0x2041)
+                if (itemID is >= 0x203E and <= 0x2041)
                 {
                     return true;
                 }
 
-                if (itemID >= 0x204B && itemID <= 0x204D)
+                if (itemID is >= 0x204B and <= 0x204D)
                 {
                     return true;
                 }
@@ -166,17 +166,17 @@ namespace Server.Misc
                     return true;
                 }
 
-                if (female && (itemID == 0x2FCD || itemID == 0x2FBF) || !female && (itemID == 0x2FCC || itemID == 0x2FD0))
+                if (female && itemID is 0x2FCD or 0x2FBF || !female && itemID is 0x2FCC or 0x2FD0)
                 {
                     return false;
                 }
 
-                if (itemID >= 0x2FBF && itemID <= 0x2FC2)
+                if (itemID is >= 0x2FBF and <= 0x2FC2)
                 {
                     return true;
                 }
 
-                if (itemID >= 0x2FCC && itemID <= 0x2FD1)
+                if (itemID is >= 0x2FCC and <= 0x2FD1)
                 {
                     return true;
                 }
@@ -236,17 +236,6 @@ namespace Server.Misc
 
         private class Gargoyle : Race
         {
-            // Todo Finish body hues
-            private static readonly int[] m_BodyHues =
-            {
-                0x86DB, 0x86DC, 0x86DD, 0x86DE,
-                0x86DF, 0x86E0, 0x86E1, 0x86E2,
-                0x86E3, 0x86E4, 0x86E5, 0x86E6
-                // 0x, 0x, 0x, 0x, // 86E7/86E8/86E9/86EA?
-                // 0x, 0x, 0x, 0x, // 86EB/86EC/86ED/86EE?
-                // 0x86F3, 0x86DB, 0x86DC, 0x86DD
-            };
-
             private static readonly int[] m_HornHues =
             {
                 0x709, 0x70B, 0x70D, 0x70F, 0x711, 0x763,
@@ -263,11 +252,10 @@ namespace Server.Misc
             {
                 if (female == false)
                 {
-                    return itemID >= 0x4258 && itemID <= 0x425F;
+                    return itemID is >= 0x4258 and <= 0x425F;
                 }
 
-                return itemID == 0x4261 || itemID == 0x4262 || itemID >= 0x4273 && itemID <= 0x4275 || itemID == 0x42B0 ||
-                       itemID == 0x42B1 || itemID == 0x42AA || itemID == 0x42AB;
+                return itemID is 0x4261 or 0x4262 or >= 0x4273 and <= 0x4275 or 0x42B0 or 0x42B1 or 0x42AA or 0x42AB;
             }
 
             public override int RandomHair(bool female)
@@ -298,14 +286,14 @@ namespace Server.Misc
             }
 
             public override bool ValidateFacialHair(bool female, int itemID) =>
-                !female && itemID >= 0x42AD && itemID <= 0x42B0;
+                !female && itemID is >= 0x42AD and <= 0x42B0;
 
             public override int RandomFacialHair(bool female) =>
                 female ? 0 : Utility.RandomList(0, 0x42AD, 0x42AE, 0x42AF, 0x42B0);
 
             public override int ClipSkinHue(int hue) => hue;
 
-            public override int RandomSkinHue() => m_BodyHues.RandomElement() | 0x8000;
+            public override int RandomSkinHue() => Utility.Random(1755, 25) | 0x8000;
 
             public override int ClipHairHue(int hue)
             {

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -1379,7 +1379,7 @@ namespace Server.Mobiles
                         {
                             drop = true;
                         }
-                        else if (weapon.RequiredRace != null && weapon.RequiredRace != Race)
+                        else if (!weapon.CheckRace(Race))
                         {
                             drop = true;
                         }
@@ -1404,7 +1404,7 @@ namespace Server.Mobiles
                         {
                             drop = true;
                         }
-                        else if (armor.RequiredRace != null && armor.RequiredRace != Race)
+                        else if (!armor.CheckRace(Race))
                         {
                             drop = true;
                         }

--- a/Projects/UOContent/Skills/Stealth.cs
+++ b/Projects/UOContent/Skills/Stealth.cs
@@ -25,7 +25,9 @@ namespace Server.SkillHandlers
             /* Ring */ { 0, 5, 0, 10, 15, 25, 0 },
             /* Chain */ { 0, 0, 10, 0, 15, 25, 0 },
             /* Plate */ { 5, 5, 10, 10, 15, 25, 0 },
-            /* Dragon */ { 0, 5, 10, 10, 15, 25, 0 }
+            /* Dragon */ { 5, 5, 10, 10, 15, 25, 0 },
+            /* Wood */ { 5, 5, 10, 10, 15, 25, 0 },
+            /* Stone */ { 5, 5, 10, 10, 15, 25, 0 }
         };
 
         public static void Initialize()
@@ -44,7 +46,7 @@ namespace Server.SkillHandlers
 
             for (var i = 0; i < m.Items.Count; i++)
             {
-                if (!(m.Items[i] is BaseArmor armor))
+                if (m.Items[i] is not BaseArmor armor)
                 {
                     continue;
                 }


### PR DESCRIPTION
* Adds `RaceFlag` to the `Race` object. This is `1 << RaceIndex`
* Replaces `RequiredRace`  with `RequiredRaces` for items.
* Adds convenience flags for `RequiredRaces`
  ```cs
  
  public const int AllowAllRaces = 0x7;      // Race.Human.RaceFlag | Race.Elf.RaceFlag | Race.Gargoyle.RaceFlag
  public const int AllowHumanOrElves = 0x3;  // Race.Human.RaceFlag | Race.Elf.RaceFlag
  public const int AllowElvesOnly = 0x2;     // Race.Elf.RaceFlag
  public const int AllowGargoylesOnly = 0x4; // Race.Gargoyle.RaceFlag
  ```
* Example usage on an item:
  ```cs
  public override int RequiredRaces => Race.AllowHumanOrElves;
  ```
* Adds Wood and Stone armor material types
* Updates Woodland armor to Wood
* Adds proper messaging for race restrictions
* Adds gargoyle only for object properties
* Adds `CheckRace` functions for validating if a race or mobile can use the item:
  ```cs
  bool CheckRace(Race race);
  bool CheckRace(Mobile from, bool message = true);
  ```