### PR TITLE
fix: Fixes assembly loading.

### DIFF
--- a/Distribution/Data/assemblies.json
+++ b/Distribution/Data/assemblies.json
@@ -1,9 +1,3 @@
 [
-  "Argon2.Bindings.dll",
-  "BouncyCastle.Crypto.dll",
-  "MailKit.dll",
-  "MimeKit.dll",
-  "Microsoft.Extensions.FileSystemGlobbing.dll",
-  "Zlib.Bindings.dll",
   "UOContent.dll"
 ]

--- a/Projects/Server/Configuration/ServerConfiguration.cs
+++ b/Projects/Server/Configuration/ServerConfiguration.cs
@@ -32,6 +32,8 @@ namespace Server
         private static ServerSettings m_Settings;
         private static bool m_Mocked;
 
+        public static List<string> AssemblyDirectories => m_Settings.AssemblyDirectories;
+
         public static List<string> DataDirectories => m_Settings.DataDirectories;
 
         public static List<IPEndPoint> Listeners => m_Settings.Listeners;

--- a/Projects/Server/Configuration/ServerSettings.cs
+++ b/Projects/Server/Configuration/ServerSettings.cs
@@ -21,6 +21,9 @@ namespace Server
 {
     public class ServerSettings
     {
+        [JsonPropertyName("assemblyDirectories")]
+        public List<string> AssemblyDirectories { get; set; } = new();
+
         [JsonPropertyName("dataDirectories")]
         public List<string> DataDirectories { get; set; } = new();
 

--- a/Projects/Server/Main.cs
+++ b/Projects/Server/Main.cs
@@ -365,6 +365,7 @@ namespace Server
         {
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+            AppDomain.CurrentDomain.AssemblyResolve += AssemblyHandler.AssemblyResolver;
 
             LoopContext = new EventLoopContext();
 
@@ -463,7 +464,7 @@ namespace Server
                 assemblyFiles[i] = Path.Join(BaseDirectory, "Assemblies", assemblyFiles[i]);
             }
 
-            AssemblyHandler.LoadScripts(assemblyFiles);
+            AssemblyHandler.LoadAssemblies(assemblyFiles);
 
             VerifySerialization();
 


### PR DESCRIPTION
* `AssemblyHandler.Assemblies` will now only contain assemblies listed in `assemblies.json`
* `assemblies.json` has been updated to only contain asssemblies directly loaded by the server. Namely, only `UOContent.dll`.
  * Specifically assemblies loaded by assemblies.json are subject to check for `Configure` and `Initialize` methods.
* `modernuo.json` now has a new property called `assemblyDirectories`. This will be automatically set to `Distribution/Assemblies` (absolute path on your machine).
  * You can add more directories to this list.
* All assemblies in assemblies.json _AND_ dependents of any assembly will be searched for in the directories specified by `assemblyDirectories`.