### PR TITLE
fix: Uses client bug to make addon containers work

### DIFF
--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -763,7 +763,7 @@ namespace Server.Items
             {
                 if (Core.ML)
                 {
-                    if (ParentsContain<BankBox>()) // Root Parent is the Mobile.  Parent could be another containter.
+                    if (ParentsContain<BankBox>()) // Root Parent is the Mobile. Parent could be another container.
                     {
                         list.Add(
                             1073841, // Contents: ~1_COUNT~/~2_MAXCOUNT~ items, ~3_WEIGHT~ stones

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -552,9 +552,6 @@ namespace Server
         public virtual int PoisonResistance => 0;
         public virtual int EnergyResistance => 0;
 
-        // Used to exploit a bug that allows flag caching by sending two world item packets
-        public virtual int SpoofedItemID => -1;
-
         [CommandProperty(AccessLevel.GameMaster)]
         public virtual int ItemID
         {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1332,39 +1332,36 @@ namespace Server
 
                 if (openers != null)
                 {
-                    lock (openers)
+                    for (var i = 0; i < openers.Count; ++i)
                     {
-                        for (var i = 0; i < openers.Count; ++i)
+                        var mob = openers[i];
+
+                        var range = GetUpdateRange(mob);
+
+                        if (mob.Map != map || !mob.InRange(worldLoc, range))
                         {
-                            var mob = openers[i];
-
-                            var range = GetUpdateRange(mob);
-
-                            if (mob.Map != map || !mob.InRange(worldLoc, range))
+                            openers.RemoveAt(i--);
+                        }
+                        else
+                        {
+                            if (mob == rootParent || mob == tradeRecip)
                             {
-                                openers.RemoveAt(i--);
+                                continue;
                             }
-                            else
+
+                            var ns = mob.NetState;
+
+                            if (ns != null && mob.CanSee(this))
                             {
-                                if (mob == rootParent || mob == tradeRecip)
-                                {
-                                    continue;
-                                }
-
-                                var ns = mob.NetState;
-
-                                if (ns != null && mob.CanSee(this))
-                                {
-                                    ns.SendContainerContentUpdate(this);
-                                    SendOPLPacketTo(ns);
-                                }
+                                ns.SendContainerContentUpdate(this);
+                                SendOPLPacketTo(ns);
                             }
                         }
+                    }
 
-                        if (openers.Count == 0)
-                        {
-                            contParent.Openers = null;
-                        }
+                    if (openers.Count == 0)
+                    {
+                        contParent.Openers = null;
                     }
                 }
 
@@ -1719,6 +1716,7 @@ namespace Server
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool GetFlag(ImplFlag flag) => (m_Flags & flag) != 0;
 
         public BounceInfo GetBounce() => LookupCompactInfo()?.m_Bounce;
@@ -2408,7 +2406,7 @@ namespace Server
         }
 
 #nullable enable
-        public void InvalidateProperties()
+        public virtual void InvalidateProperties()
         {
             if (!ObjectPropertyList.Enabled)
             {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -552,6 +552,9 @@ namespace Server
         public virtual int PoisonResistance => 0;
         public virtual int EnergyResistance => 0;
 
+        // Used to exploit a bug that allows flag caching by sending two world item packets
+        public virtual int SpoofedItemID => -1;
+
         [CommandProperty(AccessLevel.GameMaster)]
         public virtual int ItemID
         {

--- a/Projects/Server/Network/Packets/OutgoingItemPackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingItemPackets.cs
@@ -21,7 +21,7 @@ namespace Server.Network
 {
     public static class OutgoingItemPackets
     {
-        public static int CreateWorldItem(Span<byte> buffer, Item item)
+        public static int CreateWorldItem(Span<byte> buffer, Item item, int itemIdOverride = -1)
         {
             if (buffer[0] != 0)
             {
@@ -29,7 +29,9 @@ namespace Server.Network
                 return buffer.Length;
             }
 
-            var itemID = item is BaseMulti ? item.ItemID | 0x4000 : item.ItemID & 0x3FFF;
+            // Used to exploit UO client caching to spoof non-containers that need container flags
+            var itemID = itemIdOverride > -1 ? itemIdOverride : item.ItemID;
+
             var amount = item.Amount;
             var hasAmount = amount != 0;
             var serial = hasAmount ? item.Serial.Value | 0x80000000 : item.Serial.Value & 0x7FFFFFFF;
@@ -51,7 +53,7 @@ namespace Server.Network
             writer.Write((byte)0x1A); // Packet ID
             writer.Write((ushort)length);
             writer.Write(serial);
-            writer.Write((ushort)itemID);
+            writer.Write((ushort)(item is BaseMulti ? itemID | 0x4000 : itemID & 0x3FFF));
 
             if (hasAmount)
             {
@@ -89,8 +91,18 @@ namespace Server.Network
             }
 
             Span<byte> buffer = stackalloc byte[OutgoingEntityPackets.MaxWorldEntityPacketLength].InitializePacket();
+            int length;
 
-            var length = ns.StygianAbyss ?
+            if (item.SpoofedItemID > -1)
+            {
+                length = CreateWorldItem(buffer, item, item.SpoofedItemID);
+
+                ns.Send(buffer[..length]);
+
+                buffer[0] = 0; // Reinitialize packet
+            }
+
+            length = ns.StygianAbyss ?
                 OutgoingEntityPackets.CreateWorldEntity(buffer, item, ns.HighSeas) :
                 CreateWorldItem(buffer, item);
 

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -2696,9 +2696,9 @@ namespace Server.Gumps
                         {
                             case 0:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_Information,
                                             0,
                                             null,
@@ -2710,9 +2710,9 @@ namespace Server.Gumps
                                 }
                             case 1:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_Characters,
                                             0,
                                             null,
@@ -2724,9 +2724,9 @@ namespace Server.Gumps
                                 }
                             case 2:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_Comments,
                                             0,
                                             null,
@@ -2738,23 +2738,23 @@ namespace Server.Gumps
                                 }
                             case 3:
                                 {
-                                    @from.SendGump(
-                                        new AdminGump(@from, AdminGumpPage.AccountDetails_Tags, 0, null, null, m_State)
+                                    from.SendGump(
+                                        new AdminGump(from, AdminGumpPage.AccountDetails_Tags, 0, null, null, m_State)
                                     );
                                     break;
                                 }
                             case 13:
                                 {
-                                    @from.SendGump(
-                                        new AdminGump(@from, AdminGumpPage.AccountDetails_Access, 0, null, null, m_State)
+                                    from.SendGump(
+                                        new AdminGump(from, AdminGumpPage.AccountDetails_Access, 0, null, null, m_State)
                                     );
                                     break;
                                 }
                             case 14:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_Access_ClientIPs,
                                             0,
                                             null,
@@ -2766,9 +2766,9 @@ namespace Server.Gumps
                                 }
                             case 15:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_Access_Restrictions,
                                             0,
                                             null,
@@ -2780,14 +2780,14 @@ namespace Server.Gumps
                                 }
                             case 4:
                                 {
-                                    @from.Prompt = new AddCommentPrompt(m_State as Account);
-                                    @from.SendMessage("Enter the new account comment.");
+                                    from.Prompt = new AddCommentPrompt(m_State as Account);
+                                    from.SendMessage("Enter the new account comment.");
                                     break;
                                 }
                             case 5:
                                 {
-                                    @from.Prompt = new AddTagNamePrompt(m_State as Account);
-                                    @from.SendMessage("Enter the new tag name.");
+                                    from.Prompt = new AddTagNamePrompt(m_State as Account);
+                                    from.SendMessage("Enter the new tag name.");
                                     break;
                                 }
                             case 6:
@@ -2897,9 +2897,9 @@ namespace Server.Gumps
                                 }
                             case 8:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_ChangePassword,
                                             0,
                                             null,
@@ -2911,9 +2911,9 @@ namespace Server.Gumps
                                 }
                             case 9:
                                 {
-                                    @from.SendGump(
+                                    from.SendGump(
                                         new AdminGump(
-                                            @from,
+                                            from,
                                             AdminGumpPage.AccountDetails_ChangeAccess,
                                             0,
                                             null,

--- a/Projects/UOContent/Items/Addons/AddonComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonComponent.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Server.ContextMenus;
 using Server.Engines.Craft;
 
 namespace Server.Items
@@ -95,6 +97,8 @@ namespace Server.Items
             new(LightType.Circle150, 5703, 6587)
         };
 
+        public override string DefaultName => _addon?.DefaultName;
+
         [Constructible]
         public AddonComponent(int itemID) : base(itemID)
         {
@@ -141,10 +145,7 @@ namespace Server.Items
             }
         }
 
-        public override void OnDoubleClick(Mobile from)
-        {
-            _addon?.OnComponentUsed(this, from);
-        }
+        public override void OnDoubleClick(Mobile from) => _addon?.OnComponentUsed(this, @from);
 
         public override void OnLocationChange(Point3D old)
         {
@@ -161,6 +162,11 @@ namespace Server.Items
                 _addon.Map = Map;
             }
         }
+
+        public override void GetProperties(ObjectPropertyList list) => Addon?.GetProperties(list);
+
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
+            _addon?.GetContextMenuEntries(from, list);
 
         public override void OnAfterDelete()
         {

--- a/Projects/UOContent/Items/Addons/AddonComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonComponent.cs
@@ -97,8 +97,6 @@ namespace Server.Items
             new(LightType.Circle150, 5703, 6587)
         };
 
-        public override string DefaultName => _addon?.DefaultName;
-
         [Constructible]
         public AddonComponent(int itemID) : base(itemID)
         {
@@ -145,7 +143,7 @@ namespace Server.Items
             }
         }
 
-        public override void OnDoubleClick(Mobile from) => _addon?.OnComponentUsed(this, @from);
+        public override void OnDoubleClick(Mobile from) => _addon?.OnComponentUsed(this, from);
 
         public override void OnLocationChange(Point3D old)
         {
@@ -163,7 +161,7 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list) => Addon?.GetProperties(list);
+        public override void GetProperties(ObjectPropertyList list) => _addon?.GetProperties(list);
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
             _addon?.GetContextMenuEntries(from, list);

--- a/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
@@ -65,6 +65,12 @@ namespace Server.Items
             }
         }
 
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            // base.GetProperties(list);
+            Addon?.GetProperties(list);
+        }
+
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
             _addon?.GetContextMenuEntries(from, list);
 

--- a/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
@@ -6,6 +6,9 @@ namespace Server.Items
     [Serializable(0, false)]
     public partial class AddonContainerComponent : Item, IChoppable
     {
+        public override string DefaultName => _addon?.DefaultName;
+        public override int SpoofedItemID => 0x9AB; // Metal chest, real container
+
         [Constructible]
         public AddonContainerComponent(int itemID) : base(itemID)
         {
@@ -65,15 +68,6 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
-        {
-            // base.GetProperties(list);
-            Addon?.GetProperties(list);
-        }
-
-        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
-            _addon?.GetContextMenuEntries(from, list);
-
         public override void OnMapChange()
         {
             if (_addon != null)
@@ -81,6 +75,14 @@ namespace Server.Items
                 _addon.Map = Map;
             }
         }
+
+        public override void GetProperties(ObjectPropertyList list)
+        {
+            Addon?.GetProperties(list);
+        }
+
+        public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
+            _addon?.GetContextMenuEntries(from, list);
 
         public override void OnAfterDelete()
         {

--- a/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
@@ -78,10 +78,8 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list)
-        {
+        public override void GetProperties(ObjectPropertyList list) =>
             Addon?.GetProperties(list);
-        }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
             _addon?.GetContextMenuEntries(from, list);

--- a/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
+++ b/Projects/UOContent/Items/Addons/AddonContainerComponent.cs
@@ -9,8 +9,6 @@ namespace Server.Items
     [Serializable(0, false)]
     public partial class AddonContainerComponent : Item, IChoppable
     {
-        public override string DefaultName => _addon?.DefaultName;
-
         [Constructible]
         public AddonContainerComponent(int itemID) : base(itemID)
         {
@@ -24,11 +22,11 @@ namespace Server.Items
 
         [SerializableField(0)]
         [SerializableFieldAttr("[CommandProperty(AccessLevel.GameMaster)]")]
-        public BaseAddonContainer _addon;
+        private BaseAddonContainer _addon;
 
         [SerializableField(1)]
         [SerializableFieldAttr("[CommandProperty(AccessLevel.GameMaster)]")]
-        public Point3D _offset;
+        private Point3D _offset;
 
         [Hue]
         [CommandProperty(AccessLevel.GameMaster)]
@@ -78,8 +76,7 @@ namespace Server.Items
             }
         }
 
-        public override void GetProperties(ObjectPropertyList list) =>
-            Addon?.GetProperties(list);
+        public override void GetProperties(ObjectPropertyList list) => _addon?.GetProperties(list);
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list) =>
             _addon?.GetContextMenuEntries(from, list);
@@ -96,7 +93,7 @@ namespace Server.Items
             Span<byte> buffer = stackalloc byte[OutgoingEntityPackets.MaxWorldEntityPacketLength].InitializePacket();
             var length = OutgoingItemPackets.CreateWorldItem(buffer, this);
             // Use an itemid of a real container
-            BinaryPrimitives.WriteUInt16BigEndian(buffer[7..9], 0x9AB);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer[7..9], (ushort)(_addon?.ItemID ?? 0x9AB));
             ns.Send(buffer[..length]);
 
             base.SendWorldPacketTo(ns, world);

--- a/Projects/UOContent/Items/Addons/ArcaneBookshelfEastAddon.cs
+++ b/Projects/UOContent/Items/Addons/ArcaneBookshelfEastAddon.cs
@@ -1,27 +1,29 @@
 namespace Server.Items
 {
     [Serializable(0)]
-    public partial class ArcaneBookshelfEastAddon : BaseAddon
+    public partial class ArcaneBookshelfEastAddon : BaseAddonContainer
     {
         [Constructible]
-        public ArcaneBookshelfEastAddon()
+        public ArcaneBookshelfEastAddon() : base(0x3084)
         {
-            AddComponent(new AddonComponent(0x3084), 0, 0, 0);
-            AddComponent(new AddonComponent(0x3085), -1, 0, 0);
+            AddComponent(new AddonContainerComponent(0x3085), -1, 0, 0);
         }
 
-        public override BaseAddonDeed Deed => new ArcaneBookshelfEastDeed();
+        public override BaseAddonContainerDeed Deed => new ArcaneBookshelfEastDeed();
+        public override bool RetainDeedHue => true;
+        public override int DefaultGumpID => 0x107;
+        public override int DefaultDropSound => 0x42;
     }
 
     [Serializable(0)]
-    public partial class ArcaneBookshelfEastDeed : BaseAddonDeed
+    public partial class ArcaneBookshelfEastDeed : BaseAddonContainerDeed
     {
         [Constructible]
         public ArcaneBookshelfEastDeed()
         {
         }
 
-        public override BaseAddon Addon => new ArcaneBookshelfEastAddon();
+        public override BaseAddonContainer Addon => new ArcaneBookshelfEastAddon();
         public override int LabelNumber => 1073371; // arcane bookshelf (east)
     }
 }

--- a/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
@@ -332,6 +332,10 @@ namespace Server.Items
 
         public virtual void OnComponentUsed(AddonContainerComponent c, Mobile from)
         {
+            if (!Deleted)
+            {
+                OnDoubleClick(from);
+            }
         }
     }
 }

--- a/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
@@ -187,6 +187,19 @@ namespace Server.Items
             }
         }
 
+        public override void InvalidateProperties()
+        {
+            base.InvalidateProperties();
+
+            if (_components != null)
+            {
+                foreach (var component in _components)
+                {
+                    component.InvalidateProperties();
+                }
+            }
+        }
+
         // Handles v0 with old Enum -> Int casting
         private void Deserialize(IGenericReader reader, int version)
         {

--- a/Projects/UOContent/Items/Containers/Container.cs
+++ b/Projects/UOContent/Items/Containers/Container.cs
@@ -16,28 +16,9 @@ namespace Server.Items
         {
         }
 
-        public override int DefaultMaxWeight
-        {
-            get
-            {
-                if (IsSecure)
-                {
-                    return 0;
-                }
+        public override int DefaultMaxWeight => IsSecure ? 0 : base.DefaultMaxWeight;
 
-                return base.DefaultMaxWeight;
-            }
-        }
-
-        public override bool IsAccessibleTo(Mobile m)
-        {
-            if (!BaseHouse.CheckAccessible(m, this))
-            {
-                return false;
-            }
-
-            return base.IsAccessibleTo(m);
-        }
+        public override bool IsAccessibleTo(Mobile m) => BaseHouse.CheckAccessible(m, this) && base.IsAccessibleTo(m);
 
         public override bool CheckHold(Mobile m, Item item, bool message, bool checkItems, int plusItems, int plusWeight)
         {


### PR DESCRIPTION
* Fixes tooltip for container furniture so it works. This doesn't work on ClassicUO.
* Fixes double click opening container furniture by double clicking the addon component.
* Fixes the context menu not showing up sometimes on the addon piece.

<img width="444" alt="Screen_Shot_2021-09-12_at_4 27 28_PM" src="https://user-images.githubusercontent.com/3953314/133011752-c5b54cf2-2c7b-45c0-882d-0365ef62e686.png">