### PR TITLE
fix: Fixes timer wheel edge cases

### DIFF
--- a/Projects/Server/Timer/Timer.DelayCall.cs
+++ b/Projects/Server/Timer/Timer.DelayCall.cs
@@ -157,7 +157,7 @@ namespace Server
             {
                 if (Running)
                 {
-                    logger.Error($"Timer is returned while still running! {new StackTrace()}");
+                    logger.Error($"Timer is returned while still running!\n{new StackTrace()}");
                     return;
                 }
 

--- a/Projects/Server/Timer/Timer.TimerWheel.cs
+++ b/Projects/Server/Timer/Timer.TimerWheel.cs
@@ -59,13 +59,13 @@ namespace Server
             return events;
         }
 
-        private static readonly Timer[] _executingRings = new Timer[_ringLayers];
-
         private static bool Turn()
         {
             bool events = false;
             _timerWheelExecuting = true;
             var turnNextWheel = false;
+
+            var _executingRings = new Timer[_ringLayers];
 
             // Detach the chain from the timer wheel. This allows adding timers to the same slot during execution.
             for (var i = 0; i < _ringLayers; i++)

--- a/Projects/Server/Timer/Timer.cs
+++ b/Projects/Server/Timer/Timer.cs
@@ -102,13 +102,18 @@ namespace Server
                 return;
             }
 
-            // We are at the head
-            if (_rings[_ring][_slot] == this)
+            // Do not detach if we are in the middle of executing the timer wheel for this ring/slot
+            if (!_timerWheelExecuting || _ringIndexes[_ring] != _slot)
             {
-                _rings[_ring][_slot] = _nextTimer;
+                // We are at the head
+                if (_rings[_ring][_slot] == this)
+                {
+                    _rings[_ring][_slot] = _nextTimer;
+                }
+
+                Detach();
             }
 
-            Detach();
             Running = false;
             Version++;
             var prof = GetProfile();


### PR DESCRIPTION
1. Stopping a different timer, on the same slot as the timer being executed during OnTick
    * Adds a check for the timer wheel currently being executed and does not detach the timer on Stop().
1. Timers are added to the current slot if they need 4095 slots, before the chain is fully detached/executed
    * Removes all chains that will be executed from the timer wheel before executing.

Closes #781 