### PR TITLE
fix: Cleans up file system paths and archiving

### DIFF
--- a/Projects/Server/AssemblyHandler.cs
+++ b/Projects/Server/AssemblyHandler.cs
@@ -173,28 +173,6 @@ namespace Server
 
             return null;
         }
-
-        public static string EnsureDirectory(string dir)
-        {
-            var path = Path.Combine(Core.BaseDirectory, dir);
-            Directory.CreateDirectory(path);
-
-            return path;
-        }
-
-        public static void EnsureDirectory(FileInfo fi)
-        {
-            var dir = fi.DirectoryName;
-            if (dir != null)
-            {
-                Directory.CreateDirectory(dir);
-            }
-        }
-
-        public static void EnsureDirectory(DirectoryInfo di)
-        {
-            Directory.CreateDirectory(di.FullName);
-        }
     }
 
     public class TypeCache

--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -41,7 +41,7 @@ namespace Server
             {
                 var path = Path.Combine(savePath, name);
 
-                AssemblyHandler.EnsureDirectory(path);
+                PathUtility.EnsureDirectory(path);
 
                 string binPath = Path.Combine(path, $"{name}.bin");
                 using var bin = new BinaryFileWriter(binPath, true);
@@ -54,7 +54,7 @@ namespace Server
             {
                 var path = Path.Combine(savePath, name);
 
-                AssemblyHandler.EnsureDirectory(path);
+                PathUtility.EnsureDirectory(path);
 
                 string binPath = Path.Combine(path, $"{name}.bin");
 

--- a/Projects/Server/Text/StringHelpers.cs
+++ b/Projects/Server/Text/StringHelpers.cs
@@ -169,6 +169,28 @@ namespace Server
             return str;
         }
 
+        public static string TrimMultiline(this string str, string lineSeparator = "\n")
+        {
+            var parts = str.Split(lineSeparator);
+            for (var i = 0; i < parts.Length; i++)
+            {
+                parts[i] = parts[i].Trim();
+            }
+
+            return string.Join(lineSeparator, parts);
+        }
+
+        public static string IndentMultiline(this string str, string indent = "\t", string lineSeparator = "\n")
+        {
+            var parts = str.Split(lineSeparator);
+            for (var i = 0; i < parts.Length; i++)
+            {
+                parts[i] = $"{indent}{parts[i]}";
+            }
+
+            return string.Join(lineSeparator, parts);
+        }
+
         public static List<string> Wrap(this string value, int perLine, int maxLines)
         {
             if ((value = value?.Trim() ?? "").Length <= 0)

--- a/Projects/Server/Timer/Timer.TimerWheel.cs
+++ b/Projects/Server/Timer/Timer.TimerWheel.cs
@@ -242,7 +242,7 @@ namespace Server
             }
 
 #if DEBUG_TIMERS
-            tw.WriteLine("\nStack Traces:");
+            tw.WriteLine($"{Environment.NewLine}Stack Traces:");
             foreach (var kvp in DelayCallTimer._stackTraces)
             {
                 tw.WriteLine(kvp.Value);

--- a/Projects/Server/Utilities/PathUtility.cs
+++ b/Projects/Server/Utilities/PathUtility.cs
@@ -1,0 +1,67 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2021 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: PathUtility.cs                                                  *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.IO;
+using Server.Text;
+
+namespace Server
+{
+    public static class PathUtility
+    {
+        public static string EnsureDirectory(string dir)
+        {
+            var path = GetFullPath(dir, Core.BaseDirectory);
+            Directory.CreateDirectory(path);
+
+            return path;
+        }
+
+        public static void EnsureDirectory(this FileInfo fi)
+        {
+            var dir = GetFullPath(fi.DirectoryName, Core.BaseDirectory);
+            if (dir != null)
+            {
+                Directory.CreateDirectory(dir);
+            }
+        }
+
+        public static void EnsureDirectory(this DirectoryInfo di)
+        {
+            var file = GetFullPath(di.FullName, Core.BaseDirectory);
+            Directory.CreateDirectory(file);
+        }
+
+        public static string GetFullPath(string relativeOrAbsolutePath) =>
+            GetFullPath(relativeOrAbsolutePath, Core.BaseDirectory);
+
+        public static string GetFullPath(string relativeOrAbsolutePath, string basePath) =>
+            relativeOrAbsolutePath switch
+            {
+                null => null,
+                ""   => basePath,
+                _ => Path.IsPathRooted(relativeOrAbsolutePath)
+                    ? relativeOrAbsolutePath
+                    : Path.GetFullPath(relativeOrAbsolutePath, basePath)
+            };
+
+        public static string EnsureRandomPath(string basePath)
+        {
+            Span<byte> bytes = stackalloc byte[8];
+            Utility.RandomBytes(bytes);
+            return EnsureDirectory(Path.Combine(basePath, bytes.ToHexString()));
+        }
+    }
+}

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1331,28 +1331,6 @@ namespace Server
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Max<T>(T val, T max) where T : IComparable<T> => val.CompareTo(max) > 0 ? val : max;
 
-        public static string TrimMultiline(this string str, string lineSeparator = "\n")
-        {
-            var parts = str.Split(lineSeparator);
-            for (var i = 0; i < parts.Length; i++)
-            {
-                parts[i] = parts[i].Trim();
-            }
-
-            return string.Join(lineSeparator, parts);
-        }
-
-        public static string IndentMultiline(this string str, string indent = "\t", string lineSeparator = "\n")
-        {
-            var parts = str.Split(lineSeparator);
-            for (var i = 0; i < parts.Length; i++)
-            {
-                parts[i] = $"{indent}{parts[i]}";
-            }
-
-            return string.Join(lineSeparator, parts);
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Tidy<T>(this List<T> list) where T : ISerializable
         {

--- a/Projects/Server/World/EntityPersistence.cs
+++ b/Projects/Server/World/EntityPersistence.cs
@@ -40,7 +40,7 @@ namespace Server
 
             var path = Path.Combine(savePath, typeName);
 
-            AssemblyHandler.EnsureDirectory(path);
+            PathUtility.EnsureDirectory(path);
 
             string idxPath = Path.Combine(path, $"{typeName}.idx");
             string tdbPath = Path.Combine(path, $"{typeName}.tdb");

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -142,7 +142,7 @@ namespace Server
 
         public static void Configure()
         {
-            var tempSavePath = ServerConfiguration.GetSetting("world.tempSavePath", Path.GetTempPath());
+            var tempSavePath = ServerConfiguration.GetSetting("world.tempSavePath", "temp");
             _tempSavePath = PathUtility.GetFullPath(tempSavePath);
 
             var savePath = ServerConfiguration.GetOrUpdateSetting("world.savePath", "Saves");

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -46,7 +46,6 @@ namespace Server
         private static readonly ConcurrentQueue<Item> _decayQueue = new();
 
         private static string _tempSavePath; // Path to the temporary folder for the save
-        private static string _savePath; // Path to "Saves" folder
         private static bool _enableSaveStats;
 
         public const bool DirtyTrackingEnabled = false;
@@ -130,6 +129,8 @@ namespace Server
         internal static List<Type> MobileTypes { get; } = new();
         internal static List<Type> GuildTypes { get; } = new();
 
+        public static string SavePath { get; private set; }
+
         public static WorldState WorldState { get; private set; }
         public static bool Saving => WorldState == WorldState.Saving;
         public static bool Running => WorldState is not WorldState.Loading and not WorldState.Initial;
@@ -141,10 +142,12 @@ namespace Server
 
         public static void Configure()
         {
-            var tempSavePath = ServerConfiguration.GetOrUpdateSetting("world.tempSavePath", "temp");
-            _tempSavePath = Path.Combine(Core.BaseDirectory, tempSavePath);
+            var tempSavePath = ServerConfiguration.GetSetting("world.tempSavePath", Path.GetTempPath());
+            _tempSavePath = PathUtility.GetFullPath(tempSavePath);
+
             var savePath = ServerConfiguration.GetOrUpdateSetting("world.savePath", "Saves");
-            _savePath = Path.Combine(Core.BaseDirectory, savePath);
+            SavePath = PathUtility.GetFullPath(savePath);
+
             _enableSaveStats = ServerConfiguration.GetOrUpdateSetting("world.enableSaveStats", false);
 
             // Mobiles & Items
@@ -256,7 +259,7 @@ namespace Server
             logger.Information("Loading world");
             var watch = Stopwatch.StartNew();
 
-            Persistence.Load(_savePath);
+            Persistence.Load(SavePath);
             EventSink.InvokeWorldLoad();
 
             ProcessSafetyQueues();
@@ -344,7 +347,7 @@ namespace Server
 
                 var timestamp = Utility.GetTimeStamp();
                 var saveStatsPath = Path.Combine(Core.BaseDirectory, $"Logs/Saves/Save-Stats-{timestamp}.log");
-                AssemblyHandler.EnsureDirectory(saveStatsPath);
+                PathUtility.EnsureDirectory(saveStatsPath);
 
                 using var op = new StreamWriter(saveStatsPath, true);
 
@@ -388,7 +391,7 @@ namespace Server
         {
             Exception exception = null;
 
-            var tempPath = Path.Combine(_tempSavePath, Utility.GetTimeStamp());
+            var tempPath = PathUtility.EnsureRandomPath(_tempSavePath);
 
             try
             {
@@ -417,8 +420,8 @@ namespace Server
             {
                 try
                 {
-                    EventSink.InvokeWorldSavePostSnapshot(_savePath, tempPath);
-                    Directory.Move(tempPath, _savePath);
+                    EventSink.InvokeWorldSavePostSnapshot(SavePath, tempPath);
+                    Directory.Move(tempPath, SavePath);
                 }
                 catch (Exception ex)
                 {

--- a/Projects/UOContent.Tests/Fixtures/ServerFixture.cs
+++ b/Projects/UOContent.Tests/Fixtures/ServerFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Server.Misc;
 
 namespace Server.Tests
@@ -8,8 +9,8 @@ namespace Server.Tests
         // Global setup
         static ServerFixture()
         {
+            Core.Assembly = Assembly.GetExecutingAssembly();
             Core.LoopContext = new EventLoopContext();
-
             Core.Expansion = Expansion.EJ;
 
             // Load Configurations

--- a/Projects/UOContent/Accounting/Account.Migrations.cs
+++ b/Projects/UOContent/Accounting/Account.Migrations.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using Server.Accounting.Security;
+
+namespace Server.Accounting
+{
+    public partial class Account
+    {
+        private void MigrateFrom(V3Content content)
+        {
+            _username = content.Username;
+            _passwordAlgorithm = content.PasswordAlgorithm;
+            _password = content.Password;
+            _accessLevel = content.AccessLevel;
+            _flags = content.Flags;
+            Created = content.Created;
+            _lastLogin = content.LastLogin;
+            _totalGold = content.TotalGold;
+            _totalPlat = content.TotalPlat;
+            _mobiles = content.Mobiles;
+            _comments = content.Comments;
+            _tags = content.Tags;
+            _loginIPs = content.LoginIPs;
+            _ipRestrictions = content.IpRestrictions;
+            _totalGameTime = content.TotalGameTime;
+            _email = content.Email;
+        }
+
+        private void Deserialize(IGenericReader reader, int version)
+        {
+            if (version != 2)
+            {
+                // Due to a bug where we were not versioning at all, reset so we don't have an issue deserializing
+                reader.Seek(0, SeekOrigin.Begin);
+            }
+
+            _username = reader.ReadString();
+            _passwordAlgorithm = version < 2 ? (PasswordProtectionAlgorithm)reader.ReadInt() : reader.ReadEnum<PasswordProtectionAlgorithm>();
+            _password = reader.ReadString();
+            _accessLevel = version < 2 ? (AccessLevel)reader.ReadInt() : reader.ReadEnum<AccessLevel>();
+            _flags = reader.ReadInt();
+            Created = reader.ReadDateTime();
+            _lastLogin = reader.ReadDateTime();
+
+            _totalGold = reader.ReadInt();
+            _totalPlat = reader.ReadInt();
+
+            var length = reader.ReadInt();
+            _mobiles = new Mobile[length];
+            for (int i = 0; i < length; i++)
+            {
+                _mobiles[i] = reader.ReadEntity<Mobile>();
+            }
+
+            length = reader.ReadInt();
+            _comments = length > 0 ? new List<AccountComment>(length) : null;
+            for (int i = 0; i < length; i++)
+            {
+                _comments!.Add(new AccountComment(reader));
+            }
+
+            length = reader.ReadInt();
+            _tags = length > 0 ? new List<AccountTag>(length) : null;
+            for (int i = 0; i < length; i++)
+            {
+                _tags!.Add(new AccountTag(reader));
+            }
+
+            length = reader.ReadInt();
+            _loginIPs = new IPAddress[length];
+            for (int i = 0; i < length; i++)
+            {
+                if (version < 2)
+                {
+                    if (IPAddress.TryParse(reader.ReadString(), out var address))
+                    {
+                        _loginIPs[i] = Utility.Intern(address);
+                    }
+                }
+                else
+                {
+                    _loginIPs[i] = reader.ReadIPAddress();
+                }
+            }
+
+            length = reader.ReadInt();
+            _ipRestrictions = new string[length];
+            for (int i = 0; i < length; i++)
+            {
+                _ipRestrictions[i] = reader.ReadString();
+            }
+
+            _totalGameTime = reader.ReadTimeSpan();
+
+            _email = reader.ReadString();
+
+            Timer.StartTimer(AfterDeserialization);
+        }
+    }
+}

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net;
 using System.Xml;
 using Server.Accounting.Security;
@@ -355,97 +354,6 @@ namespace Server.Accounting
             {
                 CheckYoung();
             }
-        }
-
-        private void MigrateFrom(V3Content content)
-        {
-            _username = content.Username;
-            _passwordAlgorithm = content.PasswordAlgorithm;
-            _password = content.Password;
-            _accessLevel = content.AccessLevel;
-            _flags = content.Flags;
-            Created = content.Created;
-            _lastLogin = content.LastLogin;
-            _totalGold = content.TotalGold;
-            _totalPlat = content.TotalPlat;
-            _mobiles = content.Mobiles;
-            _comments = content.Comments;
-            _tags = content.Tags;
-            _loginIPs = content.LoginIPs;
-            _ipRestrictions = content.IpRestrictions;
-            _totalGameTime = content.TotalGameTime;
-            _email = content.Email;
-        }
-
-        private void Deserialize(IGenericReader reader, int version)
-        {
-            if (version != 2)
-            {
-                // Due to a bug where we were not versioning at all, reset so we don't have an issue deserializing
-                reader.Seek(0, SeekOrigin.Begin);
-            }
-
-            _username = reader.ReadString();
-            _passwordAlgorithm = version < 2 ? (PasswordProtectionAlgorithm)reader.ReadInt() : reader.ReadEnum<PasswordProtectionAlgorithm>();
-            _password = reader.ReadString();
-            _accessLevel = version < 2 ? (AccessLevel)reader.ReadInt() : reader.ReadEnum<AccessLevel>();
-            _flags = reader.ReadInt();
-            Created = reader.ReadDateTime();
-            _lastLogin = reader.ReadDateTime();
-
-            _totalGold = reader.ReadInt();
-            _totalPlat = reader.ReadInt();
-
-            var length = reader.ReadInt();
-            _mobiles = new Mobile[length];
-            for (int i = 0; i < length; i++)
-            {
-                _mobiles[i] = reader.ReadEntity<Mobile>();
-            }
-
-            length = reader.ReadInt();
-            _comments = length > 0 ? new List<AccountComment>(length) : null;
-            for (int i = 0; i < length; i++)
-            {
-                _comments!.Add(new AccountComment(reader));
-            }
-
-            length = reader.ReadInt();
-            _tags = length > 0 ? new List<AccountTag>(length) : null;
-            for (int i = 0; i < length; i++)
-            {
-                _tags!.Add(new AccountTag(reader));
-            }
-
-            length = reader.ReadInt();
-            _loginIPs = new IPAddress[length];
-            for (int i = 0; i < length; i++)
-            {
-                if (version < 2)
-                {
-                    if (IPAddress.TryParse(reader.ReadString(), out var address))
-                    {
-                        _loginIPs[i] = Utility.Intern(address);
-                    }
-                }
-                else
-                {
-                    _loginIPs[i] = reader.ReadIPAddress();
-                }
-            }
-
-            length = reader.ReadInt();
-            _ipRestrictions = new string[length];
-            for (int i = 0; i < length; i++)
-            {
-                _ipRestrictions[i] = reader.ReadString();
-            }
-
-            _totalGameTime = reader.ReadTimeSpan();
-
-            _email = reader.ReadString();
-
-            Timer.StartTimer(AfterDeserialization);
         }
 
         /// <summary>

--- a/Projects/UOContent/Compression/TarArchive.cs
+++ b/Projects/UOContent/Compression/TarArchive.cs
@@ -75,7 +75,7 @@ namespace Server.Compression
             _pathToTar ??= GetPathToTar();
 
             var useExternalCompression = compressCommand != null ? $"--use-compress-program \"{compressCommand}\" " : "";
-            var arguments = $"{useExternalCompression} -xqf \"{fileNamePath}\" -C \"{outputDirectory}\"";
+            var arguments = $"{useExternalCompression} -xf \"{fileNamePath}\" -C \"{outputDirectory}\"";
 
             return RunTar(arguments, compressionProgramPath) == 0;
         }
@@ -100,7 +100,7 @@ namespace Server.Compression
             }
             var pathsToCompress = builder.ToString();
 
-            var tarFlags = compressCommand == null ? "-acqf" : "-cqf";
+            var tarFlags = compressCommand == null ? "-acf" : "-cf";
             var useExternalCompression = compressCommand != null ? $"--use-compress-program \"{compressCommand}\" " : "";
             var arguments = $"{useExternalCompression}{tarFlags} \"{destinationArchiveFileName}\" -C \"{relativeTo}\" {pathsToCompress}";
 

--- a/Projects/UOContent/Compression/TarArchive.cs
+++ b/Projects/UOContent/Compression/TarArchive.cs
@@ -50,8 +50,7 @@ namespace Server.Compression
 
         private static string DownloadTarForWindows()
         {
-            var tempDir = Path.Combine(Core.BaseDirectory, "temp");
-            AssemblyHandler.EnsureDirectory("temp");
+            var tempDir = PathUtility.EnsureRandomPath(Path.GetTempPath());
 
             var libarchiveFile = Path.Combine(tempDir, "libarchive.zip");
             using WebClient wc = new WebClient();
@@ -90,7 +89,7 @@ namespace Server.Compression
         {
             _pathToTar ??= GetPathToTar();
 
-            AssemblyHandler.EnsureDirectory(new FileInfo(destinationArchiveFileName));
+            new FileInfo(destinationArchiveFileName).EnsureDirectory();
             var di = new DirectoryInfo(paths[0]);
             var directory = di.Parent!.FullName;
 

--- a/Projects/UOContent/Compression/ZstdArchive.cs
+++ b/Projects/UOContent/Compression/ZstdArchive.cs
@@ -46,13 +46,11 @@ namespace Server.Compression
         }
 
         public static bool CreateFromPaths(
-            List<string> paths,
+            IEnumerable<string> paths,
             string destinationArchiveFileName,
-            int compressionLevel = 10
+            string relativeTo
         )
         {
-            Debug.Assert(compressionLevel is >= 1 and <= 22, $"{nameof(compressionLevel)} must be between 1 and 22");
-
             // bsdtar has a bug and hangs, so we are doing it in two steps.
             if (Core.IsWindows)
             {
@@ -60,7 +58,7 @@ namespace Server.Compression
 
                 try
                 {
-                    if (!TarArchive.CreateFromPaths(paths, tempTarArchive))
+                    if (!TarArchive.CreateFromPaths(paths, relativeTo, tempTarArchive))
                     {
                         return false;
                     }
@@ -70,7 +68,7 @@ namespace Server.Compression
                         StartInfo = new ProcessStartInfo
                         {
                             FileName = Path.Combine(_pathToZstd, "zstd.exe"),
-                            Arguments = $"-q -10 \"{tempTarArchive}\" -o \"{destinationArchiveFileName}\""
+                            Arguments = $"-q \"{tempTarArchive}\" -o \"{destinationArchiveFileName}\""
                         }
                     };
 
@@ -89,7 +87,7 @@ namespace Server.Compression
                 }
             }
 
-            return TarArchive.CreateFromPaths(paths, destinationArchiveFileName, "zstd -10", _pathToZstd);
+            return TarArchive.CreateFromPaths(paths, destinationArchiveFileName, relativeTo, "zstd", _pathToZstd);
         }
     }
 }

--- a/Projects/UOContent/Compression/ZstdArchive.cs
+++ b/Projects/UOContent/Compression/ZstdArchive.cs
@@ -42,7 +42,7 @@ namespace Server.Compression
                 }
             }
 
-            return TarArchive.ExtractToDirectory(fileNamePath, outputDirectory, "zstd -d", _pathToZstd);
+            return TarArchive.ExtractToDirectory(fileNamePath, outputDirectory, "zstd -q -d", _pathToZstd);
         }
 
         public static bool CreateFromPaths(
@@ -87,7 +87,7 @@ namespace Server.Compression
                 }
             }
 
-            return TarArchive.CreateFromPaths(paths, destinationArchiveFileName, relativeTo, "zstd", _pathToZstd);
+            return TarArchive.CreateFromPaths(paths, destinationArchiveFileName, relativeTo, "zstd -q", _pathToZstd);
         }
     }
 }

--- a/Projects/UOContent/Engines/Spawners/Commands/ConvertPremiumSpawners.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/ConvertPremiumSpawners.cs
@@ -77,7 +77,7 @@ namespace Server.Engines.Spawners
                 {
                     var stemDir = stem[..^file.Name.Length];
                     var fullOutputDir = Path.Combine(outputDir, stemDir);
-                    AssemblyHandler.EnsureDirectory(fullOutputDir);
+                    PathUtility.EnsureDirectory(fullOutputDir);
 
                     var outputFileName = $"{file.Name[..^file.Extension.Length]}.json";
                     ParsePremiumSpawnerFile(file.FullName, Path.Combine(fullOutputDir, outputFileName), options);

--- a/Projects/UOContent/Engines/Spawners/Commands/ExportSpawnersCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/ExportSpawnersCommand.cs
@@ -53,7 +53,7 @@ namespace Server.Engines.Spawners
                 if (!Path.IsPathRooted(path))
                 {
                     path = Path.Combine(Core.BaseDirectory, path);
-                    AssemblyHandler.EnsureDirectory(directory);
+                    PathUtility.EnsureDirectory(directory);
                 }
                 else if (!Directory.Exists(directory))
                 {

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.Toolkit.HighPerformance;
 using Server.Compression;
 using Server.Logging;
 
@@ -55,10 +55,10 @@ namespace Server.Saves
             var archivePath = ServerConfiguration.GetOrUpdateSetting("autoArchive.archivePath", "Archives");
             ArchivePath = PathUtility.GetFullPath(archivePath);
 
-            _compressionFormat = ServerConfiguration.GetOrUpdateSetting("autoArchive.compressionFormat", CompressionFormat.Zstd);
-
             var useLocalArchives = ServerConfiguration.GetOrUpdateSetting("autoArchive.archiveLocally", true);
             _enablePruning = ServerConfiguration.GetOrUpdateSetting("autoArchive.enableArchivePruning", true);
+
+            _compressionFormat = ServerConfiguration.GetOrUpdateSetting("autoArchive.compressionFormat", CompressionFormat.Zstd);
 
             if (useLocalArchives)
             {
@@ -106,19 +106,14 @@ namespace Server.Saves
         private static void RestoreFromArchive()
         {
             var savePath = Path.Combine(Core.BaseDirectory, ServerConfiguration.GetSetting("world.savePath", "Saves"));
-            var files = Directory.Exists(savePath) ? Directory.GetFiles(savePath, "????-??-??-??-??-??.*") : null;
-
-            if (files == null || files.Length == 0)
-            {
-                return;
-            }
-
-            var latestFiles = GetInRange(files, DateTime.MinValue, DateTime.MaxValue, true);
+            var allFiles = Directory.Exists(savePath) ? Directory.EnumerateFiles(savePath) : null;
+            var latestFiles = LatestByDatedName(allFiles, DateTime.MinValue, DateTime.MaxValue, true);
 
             foreach (var file in latestFiles)
             {
                 if (RestoreFromFile(file, savePath))
                 {
+                    File.Delete(file);
                     break;
                 }
             }
@@ -137,17 +132,9 @@ namespace Server.Saves
             logger.Information($"Restoring latest world save from archive {fileName}");
 
             var tempPath = PathUtility.EnsureRandomPath(_tempArchivePath);
-            bool successful;
-
-            if (fileName.EndsWithOrdinal(".tar.zst"))
-            {
-                successful = ZstdArchive.ExtractToDirectory(fi.FullName, tempPath);
-            }
-            else
-            {
-                TarArchive.ExtractToDirectory(fi.FullName, tempPath);
-                successful = true;
-            }
+            var successful = fileName.EndsWithOrdinal(".tar.zst")
+                ? ZstdArchive.ExtractToDirectory(fi.FullName, tempPath)
+                : TarArchive.ExtractToDirectory(fi.FullName, tempPath);
 
             if (!successful)
             {
@@ -155,24 +142,18 @@ namespace Server.Saves
                 return false;
             }
 
-            var allFolders = Directory.EnumerateDirectories(tempPath, "????-??-??-??-??-??");
-            var worldSaveFolders = GetInRange(allFolders, DateTime.MinValue, DateTime.MaxValue);
-            var first = true;
+            var allFolders = Directory.EnumerateDirectories(tempPath);
+            var worldSaveFolders = LatestByDatedName(allFolders, DateTime.MinValue, DateTime.MaxValue);
             foreach (var folder in worldSaveFolders)
             {
-                if (first)
-                {
-                    first = false;
-                    Directory.Delete(savePath, true);
-                    var dirInfo = new DirectoryInfo(folder);
-                    logger.Information($"Restoring backup {dirInfo.Name}");
-                    Directory.Move(folder, savePath);
-                }
-                else
-                {
-                    Directory.Delete(folder, true);
-                }
+                Directory.Delete(savePath, true);
+                var dirInfo = new DirectoryInfo(folder);
+                logger.Information($"Restoring backup {dirInfo.Name}");
+                Directory.Move(folder, savePath);
+                break;
             }
+
+            Directory.Delete(tempPath, true);
 
             return true;
         }
@@ -187,16 +168,18 @@ namespace Server.Saves
                 PruneLocalArchives(ArchivePeriod.Monthly, 12);
             }
 
-            if (Directory.Exists(AutomaticBackupPath))
+            if (!Directory.Exists(AutomaticBackupPath))
             {
-                var allFolders = Directory.EnumerateDirectories(AutomaticBackupPath, "????-??-??-??-??-??", SearchOption.AllDirectories);
-                var latestBackupFolders = GetInRange(allFolders, DateTime.MinValue, Core.Now.AddMonths(-1));
+                return;
+            }
 
-                foreach (var folder in latestBackupFolders)
-                {
-                    logger.Information($"Pruning backup {folder}");
-                    Directory.Delete(folder, true);
-                }
+            var allFolders = Directory.EnumerateDirectories(AutomaticBackupPath);
+            var latestBackupFolders = LatestByDatedName(allFolders, DateTime.MinValue, Core.Now.AddMonths(-1));
+
+            foreach (var folder in latestBackupFolders)
+            {
+                logger.Information($"Pruning backup {folder}");
+                Directory.Delete(folder, true);
             }
         }
 
@@ -209,8 +192,8 @@ namespace Server.Saves
                 return;
             }
 
-            var allFiles = Directory.EnumerateFiles(archivePath, "????-??-??-??-??-??.*");
-            var archives = GetInRange(allFiles, DateTime.MinValue, DateTime.MaxValue, true);
+            var allFiles = Directory.EnumerateFiles(archivePath);
+            var archives = LatestByDatedName(allFiles, DateTime.MinValue, DateTime.MaxValue, true);
 
             var periodLowerStr = periodStr.ToLowerInvariant();
             foreach (var archive in archives)
@@ -246,91 +229,141 @@ namespace Server.Saves
                 {
                     if (date >= _nextHourlyArchive)
                     {
-                        var lastHour = date.Date.AddHours(date.Hour);
-                        Rollup(ArchivePeriod.Hourly, lastHour.AddHours(-1), lastHour.ToTimeStamp());
-                        _nextHourlyArchive = _nextHourlyArchive.AddHours(2);
+                        Rollup(ArchivePeriod.Hourly);
+                        _nextHourlyArchive = _nextHourlyArchive.AddHours(1);
                     }
 
                     if (date >= _nextDailyArchive)
                     {
-                        var yesterday = date.Date.AddDays(-1);
-                        Rollup(ArchivePeriod.Daily, yesterday, yesterday.ToTimeStamp());
-                        _nextDailyArchive = _nextDailyArchive.AddDays(2);
+                        Rollup(ArchivePeriod.Daily);
+                        _nextDailyArchive = _nextDailyArchive.AddDays(1);
                     }
 
                     if (date >= _nextMonthlyArchive)
                     {
-                        var lastMonth = new DateTime(date.Year, date.Month, 1).AddMonths(-1);
-                        Rollup(ArchivePeriod.Monthly, lastMonth, lastMonth.ToTimeStamp());
-                        _nextMonthlyArchive = _nextMonthlyArchive.AddMonths(2);
+                        Rollup(ArchivePeriod.Monthly);
+                        _nextMonthlyArchive = _nextMonthlyArchive.AddMonths(1);
                     }
 
                     Prune?.Invoke();
-
                     _isArchiving = 0;
                 },
                 null
             );
         }
 
-        private static void Rollup(ArchivePeriod archivePeriod, DateTime rangeStart, string archiveNameNoExtension)
+        private static void Rollup(ArchivePeriod archivePeriod)
         {
             if (!Directory.Exists(AutomaticBackupPath))
             {
                 return;
             }
 
-            var archivePeriodStr = archivePeriod.ToString();
-            var archivePeriodStrLower = archivePeriodStr.ToLowerInvariant();
+            var allFolders = Directory.EnumerateDirectories(AutomaticBackupPath);
 
-            var stopWatch = new Stopwatch();
-            stopWatch.Start();
-            var allFolders = Directory.EnumerateDirectories(AutomaticBackupPath, "????-??-??-??-??-??");
-
-            var rangeEnd = archivePeriod switch
+            var items = new Dictionary<DateTime, SortedDictionary<DateTime, string>>();
+            foreach (var path in allFolders)
             {
-                ArchivePeriod.Monthly => rangeStart.AddMonths(1),
-                ArchivePeriod.Daily   => rangeStart.AddDays(1),
-                _  => rangeStart.AddHours(1),
-            };
+                var dirName = new DirectoryInfo(path).Name;
 
-            var latestFolders = GetInRange(allFolders, rangeStart, rangeEnd).ToList();
-
-            // We don't want to re-archive a single save. This usually means we rebooted and found the one we purposefully left behind
-            if (latestFolders.Count <= 1)
-            {
-                return;
-            }
-
-            var archivePath = PathUtility.EnsureDirectory(Path.Combine(ArchivePath, archivePeriodStr));
-
-            var extension = _compressionFormat.GetFileExtension();
-            var archiveFilePath = Path.Combine(archivePath, $"{archiveNameNoExtension}{extension}");
-
-            logger.Information($"Creating {archivePeriodStrLower} archive");
-            var archiveCreated = _compressionFormat == CompressionFormat.Zstd
-                ? ZstdArchive.CreateFromPaths(latestFolders, archiveFilePath)
-                : TarArchive.CreateFromPaths(latestFolders, archiveFilePath);
-
-            if (archiveCreated)
-            {
-                stopWatch.Stop();
-                var elapsed = stopWatch.Elapsed.TotalSeconds;
-                logger.Information($"Created {archivePeriodStrLower} archive at {archiveFilePath} ({elapsed:F2} seconds)");
-
-                // Keep the latest one, but delete the rest.
-                for (var i = 1; i < latestFolders.Count; i++)
+                if (!TryGetDate(dirName, out var date))
                 {
-                    Directory.Delete(latestFolders[i], true);
+                    continue;
+                }
+
+                var rangeStart = date.ArchivePeriodStart(archivePeriod);
+
+                if (items.TryGetValue(rangeStart, out var value))
+                {
+                    value.Add(date, path);
+                }
+                else
+                {
+                    value = new SortedDictionary<DateTime, string>(new DescendingComparer<DateTime>())
+                    {
+                        { date, path }
+                    };
+
+                    items.Add(rangeStart, value);
                 }
             }
-            else
+
+            var archivePeriodStr = archivePeriod.ToString();
+            var archivePath = PathUtility.EnsureDirectory(Path.Combine(ArchivePath, archivePeriodStr));
+            var archivePeriodStrLower = archivePeriodStr.ToLowerInvariant();
+            var extension = _compressionFormat.GetFileExtension();
+
+            // Leave behind 1 hourly for daily, 1 daily for monthly.
+            var minimum = archivePeriod != ArchivePeriod.Monthly ? 1 : 0;
+
+            foreach (var (rangeStart, sortedBackups) in items)
             {
-                logger.Warning($"Failed to create {archivePeriodStrLower} archive");
+                var backups = sortedBackups.Values;
+                if (backups.Count <= minimum)
+                {
+                    continue;
+                }
+
+                var stopWatch = new Stopwatch();
+                stopWatch.Start();
+
+                var fileName = $"{rangeStart.ToTimeStamp(archivePeriod)}{extension}";
+                var archiveFilePath = Path.Combine(archivePath, fileName);
+
+                var archiveCreated = CreateArchive(archiveFilePath, AutomaticBackupPath, backups);
+
+                if (archiveCreated)
+                {
+                    var elapsed = stopWatch.Elapsed.TotalSeconds;
+                    logger.Information($"Created {archivePeriodStrLower} archive at {archiveFilePath} ({elapsed:F2} seconds)");
+
+                    var i = 0;
+                    foreach (var backup in backups)
+                    {
+                        // Keep the latest one, but delete the rest.
+                        if (i++ == 0)
+                        {
+                            continue;
+                        }
+
+                        Directory.Delete(backup, true);
+                    }
+                }
+                else
+                {
+                    logger.Warning($"Failed to create {archivePeriodStrLower} archive");
+                }
+
+                stopWatch.Stop();
             }
         }
 
-        private static IEnumerable<string> GetInRange(
+        private static bool CreateArchive(string archiveFilePath, string relativeTo, IEnumerable<string> backups) =>
+            _compressionFormat == CompressionFormat.Zstd
+                ? ZstdArchive.CreateFromPaths(backups, relativeTo, archiveFilePath)
+                : TarArchive.CreateFromPaths(backups, relativeTo, archiveFilePath);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string ToTimeStamp(this DateTime date, ArchivePeriod archivePeriod) =>
+            archivePeriod switch
+            {
+                ArchivePeriod.Monthly => date.ToString("YYYY-MM"),
+                ArchivePeriod.Daily   => date.ToString("YYYY-MM-dd"),
+                ArchivePeriod.Hourly  => date.ToString("YYYY-MM-dd-HH"),
+                _                     => date.ToTimeStamp()
+            };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static DateTime ArchivePeriodStart(this DateTime date, ArchivePeriod archivePeriod) =>
+            archivePeriod switch
+            {
+                ArchivePeriod.Monthly => date.Date.AddDays(-(date.Day - 1)),
+                ArchivePeriod.Daily   => date.Date,
+                ArchivePeriod.Hourly  => date.Date.AddHours(date.Hour),
+                _                     => date
+            };
+
+        private static IEnumerable<string> LatestByDatedName(
             IEnumerable<string> allItems,
             DateTime rangeStart,
             DateTime rangeEnd,
@@ -340,16 +373,7 @@ namespace Server.Saves
             var items = new SortedDictionary<DateTime, string>(new DescendingComparer<DateTime>());
             foreach (var item in allItems)
             {
-                string name;
-                if (files)
-                {
-                    var fileName = new FileInfo(item).Name;
-                    name = fileName[..fileName.IndexOfOrdinal(".")];
-                }
-                else
-                {
-                    name = new DirectoryInfo(item).Name;
-                }
+                var name = files ? Path.GetFileNameWithoutExtension(item) : new DirectoryInfo(item).Name;
 
                 if (IsInRange(name, rangeStart, rangeEnd, out var date))
                 {
@@ -360,15 +384,21 @@ namespace Server.Saves
             return items.Values;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsInRange(string name, DateTime start, DateTime end, out DateTime date) =>
             TryGetDate(name, out date) && start <= date && end >= date;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryGetDate(string value, out DateTime date)
         {
-            // Expecting YYYY-MM-DD-HH-mm-ss
-            var split = value.Split("-");
-            if (split.Length != 6)
+            Span<int> parts = stackalloc int[] { 0, 0, 1, 0, 0, 0 };
+
+            var i = 0;
+            foreach (var part in value.Tokenize('-'))
+            {
+                parts[i++] = int.Parse(part);
+            }
+
+            if (i == 0)
             {
                 date = DateTime.MinValue;
                 return false;
@@ -377,21 +407,21 @@ namespace Server.Saves
             try
             {
                 date = new DateTime(
-                    int.Parse(split[0]),
-                    int.Parse(split[1]),
-                    int.Parse(split[2]),
-                    int.Parse(split[3]),
-                    int.Parse(split[4]),
-                    int.Parse(split[5])
+                    parts[0],
+                    parts[1],
+                    parts[2],
+                    parts[3],
+                    parts[4],
+                    parts[5],
+                    DateTimeKind.Utc
                 );
+                return true;
             }
             catch
             {
                 date = DateTime.MinValue;
                 return false;
             }
-
-            return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -50,7 +50,7 @@ namespace Server.Saves
 
             var backupPath = ServerConfiguration.GetOrUpdateSetting("autoArchive.backupPath", "Backups");
             BackupPath = PathUtility.GetFullPath(backupPath);
-            AutomaticBackupPath = Path.Combine(backupPath, "Automatic");
+            AutomaticBackupPath = Path.Combine(BackupPath, "Automatic");
 
             var archivePath = ServerConfiguration.GetOrUpdateSetting("autoArchive.archivePath", "Archives");
             ArchivePath = PathUtility.GetFullPath(archivePath);
@@ -95,7 +95,8 @@ namespace Server.Saves
                 return;
             }
 
-            var backupPath = PathUtility.GetFullPath(Utility.GetTimeStamp(), AutomaticBackupPath);
+            Directory.CreateDirectory(AutomaticBackupPath);
+            var backupPath = Path.Combine(AutomaticBackupPath, Utility.GetTimeStamp());
             Directory.Move(args.OldSavePath, backupPath);
 
             logger.Information($"Created backup at {backupPath}");

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -317,7 +317,7 @@ namespace Server.Saves
             foreach (var (rangeStart, sortedBackups) in items)
             {
                 var backups = sortedBackups.Values;
-                if (backups.Count <= minimum)
+                if (backups.Count == 0)
                 {
                     continue;
                 }

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -95,7 +95,7 @@ namespace Server.Saves
                 return;
             }
 
-            var backupPath = PathUtility.GetFullPath(AutomaticBackupPath, Utility.GetTimeStamp());
+            var backupPath = PathUtility.GetFullPath(Utility.GetTimeStamp(), AutomaticBackupPath);
             Directory.Move(args.OldSavePath, backupPath);
 
             logger.Information($"Created backup at {backupPath}");

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -390,7 +390,7 @@ namespace Server.Saves
 
         private static bool TryGetDate(string value, out DateTime date)
         {
-            Span<int> parts = stackalloc int[] { 0, 0, 1, 0, 0, 0 };
+            Span<int> parts = stackalloc int[] { 0, 1, 1, 0, 0, 0 };
 
             var i = 0;
             foreach (var part in value.Tokenize('-'))

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -107,10 +107,12 @@ namespace Server.Saves
         private static void RestoreFromArchive()
         {
             var savePath = Path.Combine(Core.BaseDirectory, ServerConfiguration.GetSetting("world.savePath", "Saves"));
-            var allFiles = Directory.Exists(savePath) ? Directory.EnumerateFiles(savePath) : null;
-            var latestFiles = PathsByTimestampName(allFiles, true);
+            if (!Directory.Exists(savePath))
+            {
+                return;
+            }
 
-            foreach (var file in latestFiles)
+            foreach (var file in PathsByTimestampName(savePath, true))
             {
                 if (RestoreFromFile(file, savePath))
                 {
@@ -143,9 +145,7 @@ namespace Server.Saves
                 return false;
             }
 
-            var allFolders = Directory.EnumerateDirectories(tempPath);
-            var worldSaveFolders = PathsByTimestampName(allFolders);
-            foreach (var folder in worldSaveFolders)
+            foreach (var folder in PathsByTimestampName(tempPath))
             {
                 Directory.Delete(savePath, true);
                 var dirInfo = new DirectoryInfo(folder);
@@ -203,11 +203,8 @@ namespace Server.Saves
                 return;
             }
 
-            var allFiles = Directory.EnumerateFiles(archivePath);
-            var archives = PathsByTimestampName(allFiles, true);
-
             var periodLowerStr = periodStr.ToLowerInvariant();
-            foreach (var archive in archives)
+            foreach (var archive in PathsByTimestampName(archivePath, true))
             {
                 if (minRetained > 0)
                 {
@@ -381,8 +378,9 @@ namespace Server.Saves
                 _                     => date
             };
 
-        private static IEnumerable<string> PathsByTimestampName(IEnumerable<string> allItems, bool files = false)
+        private static IEnumerable<string> PathsByTimestampName(string path, bool files = false)
         {
+            var allItems = files ? Directory.GetFiles(path) : Directory.GetDirectories(path);
             var items = new SortedDictionary<DateTime, string>(new DescendingComparer<DateTime>());
             foreach (var item in allItems)
             {

--- a/Projects/UOContent/World Saves/AutoArchive.cs
+++ b/Projects/UOContent/World Saves/AutoArchive.cs
@@ -45,7 +45,7 @@ namespace Server.Saves
 
         public static void Configure()
         {
-            var tempArchivePath = ServerConfiguration.GetSetting("autoArchive.tempArchivePath", Path.GetTempPath());
+            var tempArchivePath = ServerConfiguration.GetSetting("autoArchive.tempArchivePath", "temp");
             _tempArchivePath = PathUtility.GetFullPath(tempArchivePath);
 
             var backupPath = ServerConfiguration.GetOrUpdateSetting("autoArchive.backupPath", "Backups");


### PR DESCRIPTION
* Makes EnsureDirectory properly work for relative and absolute paths
* Adds a `PathUtility.GetFullPath` which returns full paths for relative paths to `Core.BaseDirectory`. If the path is absolute, it will return as-is.
* Moves EnsureDirectory to `PathUtility`. So `ScriptsHandler.EnsureDirectory` and `AssemblyHandler.EnsureDirectory` are now `PathUtility.EnsureDirectory`
* Fixes crash guard so that it copies accounts properly.
* Changes world save and auto archive to use a random folder name inside of the temp folder.

### **Note**:
If the system volume is slow (not SSD), it is highly recommended that the following settings are _added_ to modernuo.json:
```json
{
  ...
  "settings": {
    ...
    "world.tempSavePath": "path to temporary folder on fast hard drive",
    "autoArchive.tempArchivePath": "path to temporary folder on fast hard drive"
  }
}
```