### PR TITLE
Epoll: set struct pack and size

### DIFF
--- a/Projects/Server/Network/PollGroup/EPollGroup.cs
+++ b/Projects/Server/Network/PollGroup/EPollGroup.cs
@@ -95,16 +95,16 @@ namespace Server.Network
 
         private static class Linux
         {
-            [DllImport("libc.so.6", SetLastError = true)]
+            [DllImport("libc", SetLastError = true)]
             public static extern int epoll_create1(epoll_flags flags);
 
-            [DllImport("libc.so.6", SetLastError = true)]
+            [DllImport("libc", SetLastError = true)]
             public static extern int epoll_close(int epfd);
 
-            [DllImport("libc.so.6", SetLastError = true)]
+            [DllImport("libc", SetLastError = true)]
             public static extern int epoll_ctl(int epfd, epoll_op op, int fd, ref epoll_event ee);
 
-            [DllImport("libc.so.6", SetLastError = true)]
+            [DllImport("libc", SetLastError = true)]
             public static extern int epoll_wait(int epfd, [In, Out] epoll_event[] ee, int maxevents, int timeout);
         }
 


### PR DESCRIPTION
This seems to fix the memory corruption in `EPollgroup.cs` when there's more than one event in the queue. Tested with 3 clients on Linux x64 5.13.0, libc 2.33. 

I can't test on Windows so you please check before merging.

### Before
![image](https://user-images.githubusercontent.com/1094679/136544110-b3eb631e-e2fb-4485-99f7-63018d7eb841.png)

### After
![image](https://user-images.githubusercontent.com/1094679/136544262-3300d285-b9ff-4b47-8aae-ec698bb7df65.png)
