### PR TITLE
Remove random blood moss spawn from _hythloth.cfg

### DIFF
--- a/Distribution/Data/Decoration/Britannia/_hythloth.cfg
+++ b/Distribution/Data/Decoration/Britannia/_hythloth.cfg
@@ -701,10 +701,6 @@ MetalDoor2 0x06C7 (Facing=EastCCW)
 5988 159 0
 6060 167 0
 
-# Blood Moss
-Static 0x0F7B
-2678 712 0
-
 # garbage
 Static 0x10F0
 5988 46 22


### PR DESCRIPTION
Blood moss is randomly placed near minoc moongate! Unnecessary and causes confusion to players who walk around picking up reagents. Simple removal.

Also note: This is tied to issue #640 where an individual reported a reagent being static.