### PR TITLE
fix: Adds packet logging

### DIFF
--- a/Projects/Server/Buffers/CircularBuffer.cs
+++ b/Projects/Server/Buffers/CircularBuffer.cs
@@ -129,7 +129,7 @@ namespace System.Buffers
 
         public Span<T> GetSpan(int index)
         {
-            if (index < 0 || index > 1)
+            if (index is < 0 or > 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }

--- a/Projects/Server/Buffers/CircularBufferReader.cs
+++ b/Projects/Server/Buffers/CircularBufferReader.cs
@@ -62,12 +62,9 @@ namespace Server.Network
 
             try
             {
-                using var sw = new StreamWriter("Packets.log", true);
-
+                using var sw = new StreamWriter("unhandled-packets.log", true);
                 sw.WriteLine("Client: {0}: Unhandled packet 0x{1:X2}", state, _first[0]);
-
-                Utility.FormatBuffer(sw, _first.ToArray(), _second.ToArray());
-
+                sw.FormatBuffer(_first, _second, Length);
                 sw.WriteLine();
                 sw.WriteLine();
             }

--- a/Projects/Server/Buffers/CircularBufferReader.cs
+++ b/Projects/Server/Buffers/CircularBufferReader.cs
@@ -32,6 +32,10 @@ namespace Server.Network
         public int Position { get; private set; }
         public int Remaining => Length - Position;
 
+        // Only used for debugging!
+        public ReadOnlySpan<byte> First => _first;
+        public ReadOnlySpan<byte> Second => _second;
+
         public CircularBufferReader(ref CircularBuffer<byte> buffer) : this(buffer.GetSpan(0), buffer.GetSpan(1))
         {
         }
@@ -62,7 +66,7 @@ namespace Server.Network
 
                 sw.WriteLine("Client: {0}: Unhandled packet 0x{1:X2}", state, _first[0]);
 
-                Utility.FormatBuffer(sw, _first.ToArray(), new Memory<byte>(_second.ToArray()));
+                Utility.FormatBuffer(sw, _first.ToArray(), _second.ToArray());
 
                 sw.WriteLine();
                 sw.WriteLine();

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -589,7 +589,6 @@ namespace Server.Network
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
                 // ignored
             }
         }

--- a/Projects/Server/Text/HexStringConverter.cs
+++ b/Projects/Server/Text/HexStringConverter.cs
@@ -59,25 +59,25 @@ namespace Server.Text
             return result;
         }
 
-        public static unsafe string ToSpacedHexString(this ReadOnlySpan<byte> bytes)
+        public static unsafe int ToSpacedHexString(this ReadOnlySpan<byte> bytes, Span<char> result)
         {
-            var result = new string((char)0, bytes.Length * 3 - 1);
+            var charsWritten = 0;
             fixed (char* resultP = result)
             {
-                for (int i = 0, j = 0; i < bytes.Length; i++)
+                for (int i = 0; i < bytes.Length; i++)
                 {
-                    var resultP2 = (uint*)(resultP + j);
+                    var resultP2 = (uint*)(resultP + charsWritten);
                     *resultP2 = m_Lookup32Chars[bytes[i]];
-                    j += 2;
+                    charsWritten += 2;
 
                     if (i < bytes.Length - 1)
                     {
-                        *(resultP + j++) = ' ';
+                        *(resultP + charsWritten++) = ' ';
                     }
                 }
             }
 
-            return result;
+            return charsWritten;
         }
 
         public static string ToDelimitedHexString(this byte[] bytes) => ((ReadOnlySpan<byte>)bytes).ToDelimitedHexString();

--- a/Projects/Server/Text/HexStringConverter.cs
+++ b/Projects/Server/Text/HexStringConverter.cs
@@ -59,6 +59,27 @@ namespace Server.Text
             return result;
         }
 
+        public static unsafe string ToSpacedHexString(this ReadOnlySpan<byte> bytes)
+        {
+            var result = new string((char)0, bytes.Length * 3 - 1);
+            fixed (char* resultP = result)
+            {
+                for (int i = 0, j = 0; i < bytes.Length; i++)
+                {
+                    var resultP2 = (uint*)(resultP + j);
+                    *resultP2 = m_Lookup32Chars[bytes[i]];
+                    j += 2;
+
+                    if (i < bytes.Length - 1)
+                    {
+                        *(resultP + j++) = ' ';
+                    }
+                }
+            }
+
+            return result;
+        }
+
         public static string ToDelimitedHexString(this byte[] bytes) => ((ReadOnlySpan<byte>)bytes).ToDelimitedHexString();
 
         public static unsafe string ToDelimitedHexString(this ReadOnlySpan<byte> bytes)

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -638,6 +638,12 @@ namespace Server
             op.WriteLine("        0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F");
             op.WriteLine("       -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --");
 
+            if (totalLength == 0)
+            {
+                op.WriteLine("0000   ");
+                return;
+            }
+
             Span<byte> lineBytes = stackalloc byte[16];
             Span<char> lineChars = stackalloc char[47];
             for (var i = 0; i < totalLength; i += 16)

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -638,7 +638,7 @@ namespace Server
             op.WriteLine("        0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F");
             op.WriteLine("       -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --");
 
-            if (totalLength == 0)
+            if (totalLength <= 0)
             {
                 op.WriteLine("0000   ");
                 return;

--- a/Projects/UOContent/Network/NetworkCommands.cs
+++ b/Projects/UOContent/Network/NetworkCommands.cs
@@ -1,0 +1,58 @@
+using Server.Commands;
+using Server.Commands.Generic;
+using Server.Mobiles;
+
+namespace Server.Network
+{
+    public class PacketLoggingCommand : BaseCommand
+    {
+        public static void Initialize()
+        {
+            TargetCommands.Register(new PacketLoggingCommand());
+        }
+
+        public PacketLoggingCommand()
+        {
+            AccessLevel = AccessLevel.Developer;
+            Commands = new[] { "PacketLogging" };
+            ObjectTypes = ObjectTypes.Mobiles;
+            Supports = CommandSupport.AllMobiles;
+            Usage = "PacketLogging <on|off>";
+            Description = "Enables or disables packet logging for a particular user until they disconnect.";
+        }
+
+        public override void Execute(CommandEventArgs e, object targeted)
+        {
+            if (e.Arguments.Length == 0)
+            {
+                LogFailure("Format: PacketLogging <on|off>");
+                return;
+            }
+
+            var from = e.Mobile;
+            var enable = Utility.ToBoolean(e.Arguments[0]);
+
+            if (targeted is not PlayerMobile pm)
+            {
+                LogFailure("That is not a player.");
+            }
+            else if (pm.NetState == null)
+            {
+                LogFailure("The player is not connected.");
+            }
+            else if (from != pm && from.AccessLevel < pm.AccessLevel)
+            {
+                LogFailure("You do not have permission to enable packet logging for this staff member.");
+            }
+            else
+            {
+                pm.NetState.PacketLogging = enable;
+                var enabled = enable ? "enabled" : "disabled";
+                CommandLogging.WriteLine(
+                    from,
+                    $"{from.AccessLevel} {CommandLogging.Format(from)} {enabled} packet logging for {pm.Account.Username} ({pm.NetState})"
+                );
+            }
+        }
+    }
+}

--- a/Projects/UOContent/Network/NetworkCommands.cs
+++ b/Projects/UOContent/Network/NetworkCommands.cs
@@ -42,7 +42,7 @@ namespace Server.Network
             }
             else if (from != pm && from.AccessLevel < pm.AccessLevel)
             {
-                LogFailure("You do not have permission to enable packet logging for this staff member.");
+                LogFailure("You do not have the required access level to do this.");
             }
             else
             {
@@ -52,6 +52,8 @@ namespace Server.Network
                     from,
                     $"{from.AccessLevel} {CommandLogging.Format(from)} {enabled} packet logging for {pm.Account.Username} ({pm.NetState})"
                 );
+
+                AddResponse($"Packet logging has been {enabled} for {pm.Account.Username} ({pm.NetState})");
             }
         }
     }


### PR DESCRIPTION
### Enabling Packet Logging
`[packetlogging on` and target the user.
Supports command modifiers such as:
`[online packetlogging on where accesslevel = player`

Logs are saved in `path/<ip address>/packets.log`. It is a simple append-format log with no date splitting.