### PR TITLE
fix - mageryspell circle out of bounds

### DIFF
--- a/Projects/UOContent/Spells/Base/MagerySpell.cs
+++ b/Projects/UOContent/Spells/Base/MagerySpell.cs
@@ -30,6 +30,8 @@ namespace Server.Spells
                 circle -= 2;
             }
 
+            circle = Math.Max(0, circle);
+
             // Original RunUO algorithm for required skill
             // const double chanceOffset = 20.0
             // const double chanceLength = 100.0 / 7.0


### PR DESCRIPTION
When spell from first circle is casted from scroll, it crashed. Spell circle cant be below 0.