### PR TITLE
Fix globalization invariant mode 

### DIFF
--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -10,6 +10,7 @@
         <PublishDir>..\..\Distribution</PublishDir>
         <OutDir>..\..\Distribution</OutDir>
         <Version>0.0.0</Version>
+        <InvariantGlobalization>false</InvariantGlobalization>
     </PropertyGroup>
     <Target Name="CleanPub" AfterTargets="Clean">
         <Message Text="Removing distribution files..." />

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -10,7 +10,7 @@
         <PublishDir>..\..\Distribution</PublishDir>
         <OutDir>..\..\Distribution</OutDir>
         <Version>0.0.0</Version>
-        <InvariantGlobalization>false</InvariantGlobalization>
+        <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
     <Target Name="CleanPub" AfterTargets="Clean">
         <Message Text="Removing distribution files..." />

--- a/Projects/UOContent/Items/Misc/BankCheck.cs
+++ b/Projects/UOContent/Items/Misc/BankCheck.cs
@@ -77,7 +77,7 @@ namespace Server.Items
 
             if (Core.ML)
             {
-                worth = m_Worth.ToString("N0", CultureInfo.GetCultureInfo("en-US"));
+                worth = m_Worth.ToString("N0", CultureInfo.InvariantCulture);
             }
             else
             {

--- a/Projects/UOContent/Mobiles/Vendors/PlayerVendor.cs
+++ b/Projects/UOContent/Mobiles/Vendors/PlayerVendor.cs
@@ -37,7 +37,7 @@ namespace Server.Mobiles
         public int Price { get; }
 
         public string FormattedPrice =>
-            Core.ML ? Price.ToString("N0", CultureInfo.GetCultureInfo("en-US")) : Price.ToString();
+            Core.ML ? Price.ToString("N0", CultureInfo.InvariantCulture) : Price.ToString();
 
         public string Description
         {


### PR DESCRIPTION
In some cases the Globalization Invariant mode is enabled by default even if not specified.

Starting from .NET 6 there are some breaking changes that causes exceptions when this mode is active and the code try to get a specific CultureInfo.

I made the configuration explicit for server project and remove two hard coded culture info found in the UOContent project.