### PR TITLE
fix: Fixes en-us forced pricing culture throwing when bulding in VS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,13 +28,13 @@
         <DefineConstants Condition="'$(SkipLocalsInitAttribute)'=='true'">NO_LOCAL_INIT</DefineConstants>
         <DefineConstants>MUO</DefineConstants>
         <GitVersionBaseDirectory>$(SolutionDir)</GitVersionBaseDirectory>
+        <PredefinedCulturesOnly>false</PredefinedCulturesOnly>
     </PropertyGroup>
     <PropertyGroup Condition="'$(RuntimeIdentifier)'==''">
         <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
         <SelfContained>false</SelfContained>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <InvariantGlobalization>true</InvariantGlobalization>
-        <PredefinedCulturesOnly>true</PredefinedCulturesOnly>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsWindows)'=='true' AND '$(RuntimeIdentifier)'==''">
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,6 +34,7 @@
         <SelfContained>false</SelfContained>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <InvariantGlobalization>true</InvariantGlobalization>
+        <PredefinedCulturesOnly>true</PredefinedCulturesOnly>
     </PropertyGroup>
     <PropertyGroup Condition="'$(IsWindows)'=='true' AND '$(RuntimeIdentifier)'==''">
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>


### PR DESCRIPTION
Fixes culture not found exception with global invariance set through builds in VS.

Closes #920 as a more proper fix.