### PR TITLE
Fix missing EJ houses in catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 .DS_Store
 
 /packages/*
+/Distribution/Configuration/server-access.json

--- a/Projects/UOContent/Multis/Houses/HousePlacementTool.cs
+++ b/Projects/UOContent/Multis/Houses/HousePlacementTool.cs
@@ -103,8 +103,11 @@ namespace Server.Items
             {
                 case 1: // Classic Houses
                     {
-                        // TODO: Add flag to use ClassicHouses or EJ
-                        m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.HousesEJ));
+                        if (Core.EJ)
+                            m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.ClassicHouses));
+                        else
+                            m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.HousesEJ));
+
                         break;
                     }
                 case 2: // 2-Story Customizable Houses
@@ -318,7 +321,7 @@ namespace Server.Items
         {
             m_Table = new Dictionary<Type, object>();
 
-            FillTable(ClassicHouses);
+            FillTable(Core.EJ ? HousesEJ : ClassicHouses);
             FillTable(TwoStoryFoundations);
             FillTable(ThreeStoryFoundations);
         }

--- a/Projects/UOContent/Multis/Houses/HousePlacementTool.cs
+++ b/Projects/UOContent/Multis/Houses/HousePlacementTool.cs
@@ -103,10 +103,8 @@ namespace Server.Items
             {
                 case 1: // Classic Houses
                     {
-                        if (Core.EJ)
-                            m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.ClassicHouses));
-                        else
-                            m_From.SendGump(new HousePlacementListGump(m_From, HousePlacementEntry.HousesEJ));
+                        var entry = Core.EJ ? HousePlacementEntry.HousesEJ : HousePlacementEntry.ClassicHouses;
+                        m_From.SendGump(new HousePlacementListGump(m_From, entry));
 
                         break;
                     }


### PR DESCRIPTION
Fix missing EJ houses in AOS catalog: this causes max locked down and securable to zero and prevent users to lock or secure items and containers in owned houses.

resolve #923 