### PR TITLE
feat: Adds a single threaded array pool

### DIFF
--- a/Projects/Benchmarks/Benchmarks/Collections/BenchmarkPooledRefQueue.cs
+++ b/Projects/Benchmarks/Benchmarks/Collections/BenchmarkPooledRefQueue.cs
@@ -1,0 +1,80 @@
+using System.Buffers;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server.Buffers;
+using Server.Collections;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    public class BenchmarkPooledRefQueue
+    {
+        private static long[][] arrays = new long[16][];
+        private static long[][] stArrays = new long[16][];
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Allocate
+            arrays = new long[16][];
+            for (var i = 0; i < 16; i++)
+            {
+                arrays[i] = ArrayPool<long>.Shared.Rent(64);
+            }
+
+            stArrays = new long[16][];
+            for (var i = 0; i < 16; i++)
+            {
+                stArrays[i] = STArrayPool<long>.Shared.Rent(64);
+            }
+
+            for (var i = 0; i < 16; i++)
+            {
+                ArrayPool<long>.Shared.Return(arrays[i]);
+            }
+
+            for (var i = 0; i < 16; i++)
+            {
+                STArrayPool<long>.Shared.Return(stArrays[i]);
+            }
+        }
+
+        [Benchmark]
+        public void UseQueue()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                var queue = new Queue<long>();
+                for (var j = 0; j < 32; j++)
+                {
+                    queue.Enqueue(j);
+                }
+
+                for (var j = 0; j < 32; j++)
+                {
+                    var num = queue.Dequeue();
+                }
+            }
+        }
+
+        [Benchmark]
+        public void UsePooledRefQueue()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                using var queue = PooledRefQueue<long>.Create();
+                for (var j = 0; j < 32; j++)
+                {
+                    queue.Enqueue(j);
+                }
+
+                for (var j = 0; j < 32; j++)
+                {
+                    var num = queue.Dequeue();
+                }
+            }
+        }
+    }
+}

--- a/Projects/Benchmarks/Benchmarks/Collections/BenchmarkPooledRefQueue.cs
+++ b/Projects/Benchmarks/Benchmarks/Collections/BenchmarkPooledRefQueue.cs
@@ -11,20 +11,17 @@ namespace Benchmarks
     [SimpleJob(RuntimeMoniker.Net60)]
     public class BenchmarkPooledRefQueue
     {
-        private static long[][] arrays = new long[16][];
-        private static long[][] stArrays = new long[16][];
-
         [GlobalSetup]
         public void Setup()
         {
             // Allocate
-            arrays = new long[16][];
+            var arrays = new long[16][];
             for (var i = 0; i < 16; i++)
             {
                 arrays[i] = ArrayPool<long>.Shared.Rent(64);
             }
 
-            stArrays = new long[16][];
+            var stArrays = new long[16][];
             for (var i = 0; i < 16; i++)
             {
                 stArrays[i] = STArrayPool<long>.Shared.Rent(64);
@@ -65,6 +62,24 @@ namespace Benchmarks
             for (var i = 0; i < 8; i++)
             {
                 using var queue = PooledRefQueue<long>.Create();
+                for (var j = 0; j < 32; j++)
+                {
+                    queue.Enqueue(j);
+                }
+
+                for (var j = 0; j < 32; j++)
+                {
+                    var num = queue.Dequeue();
+                }
+            }
+        }
+
+        [Benchmark]
+        public void UsePooledRefQueueMT()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                using var queue = PooledRefQueue<long>.CreateMT();
                 for (var j = 0; j < 32; j++)
                 {
                     queue.Enqueue(j);

--- a/Projects/Benchmarks/Benchmarks/Collections/BenchmarkSTArray.cs
+++ b/Projects/Benchmarks/Benchmarks/Collections/BenchmarkSTArray.cs
@@ -1,0 +1,92 @@
+using System.Buffers;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Server.Buffers;
+
+namespace Benchmarks
+{
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    public class BenchmarkSTArray
+    {
+        private static long[][] arrays = new long[16][];
+        private static long[][] stArrays = new long[16][];
+        private static long[][] newArrays = new long[16][];
+        private static Queue<long>[] newQueue = new Queue<long>[16];
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Allocate
+            arrays = new long[16][];
+            for (var i = 0; i < 16; i++)
+            {
+                arrays[i] = ArrayPool<long>.Shared.Rent(64);
+            }
+
+            stArrays = new long[16][];
+            for (var i = 0; i < 16; i++)
+            {
+                stArrays[i] = STArrayPool<long>.Shared.Rent(64);
+            }
+
+            for (var i = 0; i < 16; i++)
+            {
+                ArrayPool<long>.Shared.Return(arrays[i]);
+            }
+
+            for (var i = 0; i < 16; i++)
+            {
+                STArrayPool<long>.Shared.Return(stArrays[i]);
+            }
+        }
+
+        [Benchmark]
+        public void ArrayPool()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                arrays[i] = ArrayPool<long>.Shared.Rent(64);
+            }
+
+            for (var i = 0; i < 8; i++)
+            {
+                ArrayPool<long>.Shared.Return(arrays[i], true);
+            }
+        }
+
+        [Benchmark]
+        public void STArrayPool()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                arrays[i] = STArrayPool<long>.Shared.Rent(64);
+            }
+
+            for (var i = 0; i < 8; i++)
+            {
+                STArrayPool<long>.Shared.Return(arrays[i], true);
+            }
+        }
+
+        [Benchmark]
+        public void NewArray()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                newArrays[i] = new long[64];
+            }
+        }
+
+        [Benchmark]
+        public void NewQueue()
+        {
+            for (var i = 0; i < 8; i++)
+            {
+                newQueue[i] = new Queue<long>();
+                newQueue[i].EnsureCapacity(64);
+            }
+        }
+    }
+}

--- a/Projects/Benchmarks/Program.cs
+++ b/Projects/Benchmarks/Program.cs
@@ -26,7 +26,9 @@ namespace Benchmarks
             //var mapMobilesSelectors = BenchmarkRunner.Run<MapMobileSelectors>();
             //var mapMultiTilesSelectors = BenchmarkRunner.Run<MapMultiTilesSelectors>();
             //var mapMultiSelectors = BenchmarkRunner.Run<MapMultiSelectors>();
-            var mapItemsSelectors = BenchmarkRunner.Run<MapItemSelectors>();
+            // var mapItemsSelectors = BenchmarkRunner.Run<MapItemSelectors>();
+            // var stArray = BenchmarkRunner.Run<BenchmarkSTArray>();
+            var pooledRefQueue = BenchmarkRunner.Run<BenchmarkPooledRefQueue>();
         }
     }
 }

--- a/Projects/Server.Tests/Tests/Buffers/STArrayPoolTests.cs
+++ b/Projects/Server.Tests/Tests/Buffers/STArrayPoolTests.cs
@@ -1,0 +1,71 @@
+using System;
+using Server.Buffers;
+using Xunit;
+
+namespace Server.Tests.Tests.Buffers;
+
+public class STArrayPoolTests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(2, 16)]
+    [InlineData(56, 64)]
+    [InlineData(120, 128)]
+    [InlineData(65535, 65536)]
+    [InlineData(1024 * 1024 * 15, 1024 * 1024 * 16)]
+    public void ValidMinimumLengths(int requestedLength, int expectedLength)
+    {
+        var arr = STArrayPool<byte>.Shared.Rent(requestedLength);
+        Assert.Equal(expectedLength, arr.Length);
+    }
+
+    [Fact]
+    public void NegativeLengthThrows()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () =>
+            {
+                var arr = STArrayPool<byte>.Shared.Rent(-1);
+            }
+        );
+    }
+
+    [Fact]
+    public void CachesOnlyUpToCPUCountPerBucket()
+    {
+        STArrayPool<byte>.Shared.ResetForTesting();
+
+        var cores = Environment.ProcessorCount;
+        var arrays1 = new byte[cores * 8 + 2][]; // 1 for the cache, and 8 * CPU for the stacks
+        var weakReferences1 = new WeakReference[cores * 8 + 2];
+
+        var arrays2 = new byte[cores * 8 + 2][]; // 1 for the cache, and 8 * CPU for the stacks
+        var weakReferences2 = new WeakReference[cores * 8 + 2];
+
+        for (var i = 0; i < arrays1.Length; i++)
+        {
+            arrays1[i] = STArrayPool<byte>.Shared.Rent(32);
+            weakReferences1[i] = new WeakReference(arrays1[i]);
+
+            arrays2[i] = STArrayPool<byte>.Shared.Rent(64);
+            weakReferences2[i] = new WeakReference(arrays1[i]);
+        }
+
+        for (var i = 0; i < arrays1.Length; i++)
+        {
+            STArrayPool<byte>.Shared.Return(arrays1[i]);
+            arrays1[i] = null;
+
+            STArrayPool<byte>.Shared.Return(arrays2[i]);
+            arrays2[i] = null;
+        }
+
+        GC.Collect();
+        for (var i = 0; i < weakReferences1.Length; i++)
+        {
+            // When the last one is returned, the one right before it is dropped.
+            Assert.Equal(i != weakReferences1.Length - 2, weakReferences1[i].IsAlive);
+            Assert.Equal(i != weakReferences2.Length - 2, weakReferences2[i].IsAlive);
+        }
+    }
+}

--- a/Projects/Server/Collections/PooledRefQueue.cs
+++ b/Projects/Server/Collections/PooledRefQueue.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Server.Buffers;
 
 namespace Server.Collections
 {
@@ -32,7 +32,7 @@ namespace Server.Collections
             {
                 < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
                 0   => Array.Empty<T>(),
-                _   => ArrayPool<T>.Shared.Rent(capacity)
+                _   => STArrayPool<T>.Shared.Rent(capacity)
             };
 
             _head = 0;
@@ -261,7 +261,7 @@ namespace Server.Collections
                 return Array.Empty<T>();
             }
 
-            T[] arr = ArrayPool<T>.Shared.Rent(_size);
+            T[] arr = STArrayPool<T>.Shared.Rent(_size);
 
             if (_head < _tail)
             {
@@ -280,7 +280,7 @@ namespace Server.Collections
         // must be >= _size.
         private void SetCapacity(int capacity)
         {
-            T[] newarray = ArrayPool<T>.Shared.Rent(capacity);
+            T[] newarray = STArrayPool<T>.Shared.Rent(capacity);
             if (_size > 0)
             {
                 if (_head < _tail)
@@ -296,7 +296,8 @@ namespace Server.Collections
 
             if (_array.Length > 0)
             {
-                ArrayPool<T>.Shared.Return(_array, true);
+                Clear();
+                STArrayPool<T>.Shared.Return(_array);
             }
 
             _array = newarray;
@@ -377,7 +378,8 @@ namespace Server.Collections
             var array = _array;
             if (array.Length > 0)
             {
-                ArrayPool<T>.Shared.Return(array, true);
+                Clear();
+                STArrayPool<T>.Shared.Return(array);
             }
 
             this = default;

--- a/Projects/Server/Collections/PooledRefQueue.cs
+++ b/Projects/Server/Collections/PooledRefQueue.cs
@@ -260,14 +260,14 @@ namespace Server.Collections
             return arr;
         }
 
-        public T[] ToPooledArray()
+        public T[] ToPooledArray(bool mt = false)
         {
             if (_size == 0)
             {
                 return Array.Empty<T>();
             }
 
-            T[] arr = (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(_size);
+            T[] arr = (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(_size);
 
             if (_head < _tail)
             {

--- a/Projects/Server/Collections/STArrayPool.cs
+++ b/Projects/Server/Collections/STArrayPool.cs
@@ -207,7 +207,7 @@ public class STArrayPool<T> : ArrayPool<T>
     private sealed class STArrayStack
     {
         // Maximum buffers we will store in our stack
-        private readonly T[][] _arrays = new T[StackArraySize][];
+        private readonly T[][] _arrays = new T[StackArraySize * Environment.ProcessorCount][];
         private int _count;
         private long _ticks;
 

--- a/Projects/Server/Collections/STArrayPool.cs
+++ b/Projects/Server/Collections/STArrayPool.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Server.Buffers;
+
+/**
+ * Adaptation of the TlsOverPerCoreLockedStacksArrayPool for single threaded *unsafe* usage.
+ */
+public class STArrayPool<T> : ArrayPool<T>
+{
+    private const int StackArraySize = 8;
+    private const int BucketCount = 27; // SelectBucketIndex(1024 * 1024 * 1024 + 1)
+    private static readonly STArrayPool<T> _shared = new();
+
+    public static STArrayPool<T> Shared => _shared;
+
+    private static STArray[] _cacheBuckets;
+    private readonly STArrayStack[] _buckets = new STArrayStack[BucketCount];
+
+    private STArrayPool() {}
+
+    public override T[] Rent(int minimumLength)
+    {
+        T[] buffer;
+
+        var bucketIndex = SelectBucketIndex(minimumLength);
+        var cachedBuckets = _cacheBuckets;
+        if (cachedBuckets is not null && (uint)bucketIndex < (uint)cachedBuckets.Length)
+        {
+            buffer = cachedBuckets[bucketIndex].Array;
+            if (buffer is not null)
+            {
+                cachedBuckets[bucketIndex].Array = null;
+                return buffer;
+            }
+        }
+
+        var buckets = _buckets;
+        if ((uint)bucketIndex < (uint)buckets.Length)
+        {
+            var b = buckets[bucketIndex];
+            if (b is not null)
+            {
+                buffer = b.TryPop();
+                if (buffer is not null)
+                {
+                    return buffer;
+                }
+            }
+        }
+
+        if (minimumLength == 0)
+        {
+            // We aren't renting.
+            return Array.Empty<T>();
+        }
+
+        if (minimumLength < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumLength));
+        }
+
+        buffer = GC.AllocateUninitializedArray<T>(minimumLength);
+        return buffer;
+    }
+
+    public override void Return(T[] array, bool clearArray = false)
+    {
+        if (array is null)
+        {
+            throw new ArgumentNullException(nameof(array));
+        }
+
+        var bucketIndex = SelectBucketIndex(array.Length);
+        var cacheBuckets = _cacheBuckets ?? InitializeBuckets();
+
+        if ((uint)bucketIndex < (uint)_cacheBuckets!.Length)
+        {
+            if (clearArray)
+            {
+                Array.Clear(array);
+            }
+
+            if (array.Length != GetMaxSizeForBucket(bucketIndex))
+            {
+                throw new ArgumentException("Buffer is not from the pool", nameof(array));
+            }
+
+            ref var bucketArray = ref cacheBuckets[bucketIndex];
+            var prev = bucketArray.Array;
+            bucketArray = new STArray(array);
+            if (prev is not null)
+            {
+                var bucket = _buckets[bucketIndex] ?? CreateBucketStack(bucketIndex);
+                bucket.TryPush(prev);
+            }
+        }
+    }
+
+    public bool Trim()
+    {
+        var ticks = Core.TickCount;
+        var pressure = GetMemoryPressure();
+
+        var buckets = _buckets;
+        for (var i = 0; i < buckets.Length; i++)
+        {
+            buckets[i]?.Trim(ticks, pressure, GetMaxSizeForBucket(i));
+        }
+
+        // Under high pressure, release all cached buckets
+        if (pressure == MemoryPressure.High)
+        {
+            Array.Clear(_cacheBuckets);
+        }
+        else
+        {
+            uint threshold = pressure switch
+            {
+                MemoryPressure.Medium => 10000,
+                _                     => 30000,
+            };
+
+            var cacheBuckets = _cacheBuckets;
+            for (var i = 0; i < cacheBuckets.Length; i++)
+            {
+                ref var b = ref cacheBuckets[i];
+
+                if (b.Array is null)
+                {
+                    continue;
+                }
+
+                var lastSeen = b.Ticks;
+                if (lastSeen == 0)
+                {
+                    b.Ticks = ticks;
+                }
+                else if (ticks - lastSeen >= threshold)
+                {
+                    b.Array = null;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private STArrayStack CreateBucketStack(int bucketIndex)
+    {
+        return _buckets[bucketIndex] = new STArrayStack();
+    }
+
+    private STArray[] InitializeBuckets()
+    {
+        Debug.Assert(_cacheBuckets is null, $"Non-null {nameof(_cacheBuckets)}");
+        var buckets = new STArray[BucketCount];
+        return _cacheBuckets = buckets;
+    }
+
+    // Buffers are bucketed so that a request between 2^(n-1) + 1 and 2^n is given a buffer of 2^n
+    // Bucket index is log2(bufferSize - 1) with the exception that buffers between 1 and 16 bytes
+    // are combined, and the index is slid down by 3 to compensate.
+    // Zero is a valid bufferSize, and it is assigned the highest bucket index so that zero-length
+    // buffers are not retained by the pool. The pool will return the Array.Empty singleton for these.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int SelectBucketIndex(int bufferSize) => BitOperations.Log2((uint)bufferSize - 1 | 15) - 3;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int GetMaxSizeForBucket(int binIndex)
+    {
+        int maxSize = 16 << binIndex;
+        Debug.Assert(maxSize >= 0);
+        return maxSize;
+    }
+
+    internal enum MemoryPressure
+    {
+        Low,
+        Medium,
+        High
+    }
+
+    internal static MemoryPressure GetMemoryPressure()
+    {
+        GCMemoryInfo memoryInfo = GC.GetGCMemoryInfo();
+
+        if (memoryInfo.MemoryLoadBytes >= memoryInfo.HighMemoryLoadThresholdBytes * 0.90)
+        {
+            return MemoryPressure.High;
+        }
+
+        if (memoryInfo.MemoryLoadBytes >= memoryInfo.HighMemoryLoadThresholdBytes * 0.70)
+        {
+            return MemoryPressure.Medium;
+        }
+
+        return MemoryPressure.Low;
+    }
+
+    private sealed class STArrayStack
+    {
+        // Maximum buffers we will store in our stack
+        private readonly T[][] _arrays = new T[StackArraySize][];
+        private int _count;
+        private long _ticks;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPush(T[] array)
+        {
+            var arrays = _arrays;
+            var count = _count;
+            if ((uint)count < (uint)_arrays.Length)
+            {
+                arrays[count] = array;
+                _count = count + 1;
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T[] TryPop()
+        {
+            var arrays = _arrays;
+            var count = _count - 1;
+            if ((uint)count < (uint)arrays.Length)
+            {
+                var arr = arrays[count];
+                arrays[count] = null;
+                _count = count;
+                return arr;
+            }
+
+            return null;
+        }
+
+        public void Trim(long now, MemoryPressure pressure, int bucketSize)
+        {
+            if (_count == 0)
+            {
+                return;
+            }
+
+            // 10 seconds under high pressure, otherwise 60 seconds
+            var threshold = pressure == MemoryPressure.High ? 10000 : 60000;
+
+            if (_ticks == 0)
+            {
+                _ticks = now;
+                return;
+            }
+
+            if (now - _ticks <= threshold)
+            {
+                return;
+            }
+
+            int trimCount = 1;
+            switch (pressure)
+            {
+                case MemoryPressure.Medium:
+                    {
+                        trimCount = 2;
+                        break;
+                    }
+                case MemoryPressure.High:
+                    {
+                        if (bucketSize > 16384)
+                        {
+                            trimCount++;
+                        }
+
+                        var size = Unsafe.SizeOf<T>();
+                        if (size > 32)
+                        {
+                            trimCount += 2;
+                        }
+                        else if (size > 16)
+                        {
+                            trimCount++;
+                        }
+
+                        break;
+                    }
+            }
+
+            while (_count > 0 && trimCount-- > 0)
+            {
+                _arrays[--_count] = null;
+            }
+        }
+    }
+
+    private struct STArray
+    {
+        public T[] Array;
+        public long Ticks;
+
+        public STArray(T[] array)
+        {
+            Array = array;
+            Ticks = 0;
+        }
+    }
+}

--- a/Projects/Server/Collections/STArrayPool.cs
+++ b/Projects/Server/Collections/STArrayPool.cs
@@ -53,6 +53,8 @@ public class STArrayPool<T> : ArrayPool<T>
                     return buffer;
                 }
             }
+
+            minimumLength = GetMaxSizeForBucket(bucketIndex);
         }
 
         if (minimumLength == 0)

--- a/Projects/Server/Collections/STArrayPool.cs
+++ b/Projects/Server/Collections/STArrayPool.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using System.Buffers;
 using System.Diagnostics;
@@ -7,7 +10,7 @@ using System.Runtime.CompilerServices;
 namespace Server.Buffers;
 
 /**
- * Adaptation of the TlsOverPerCoreLockedStacksArrayPool for single threaded *unsafe* usage.
+ * Adaptation of the ArrayPool<T>.Shared (TlsOverPerCoreLockedStacksArrayPool) for single threaded *unsafe* usage.
  */
 public class STArrayPool<T> : ArrayPool<T>
 {

--- a/Projects/Server/Collections/STArrayPool.cs
+++ b/Projects/Server/Collections/STArrayPool.cs
@@ -21,7 +21,7 @@ public class STArrayPool<T> : ArrayPool<T>
     public static STArrayPool<T> Shared => _shared;
 
     private static STArray[] _cacheBuckets;
-    private readonly STArrayStack[] _buckets = new STArrayStack[BucketCount];
+    private STArrayStack[] _buckets = new STArrayStack[BucketCount];
 
     private STArrayPool() {}
 
@@ -102,6 +102,15 @@ public class STArrayPool<T> : ArrayPool<T>
                 var bucket = _buckets[bucketIndex] ?? CreateBucketStack(bucketIndex);
                 bucket.TryPush(prev);
             }
+        }
+    }
+
+    public void ResetForTesting()
+    {
+        if (Core.IsRunningFromXUnit)
+        {
+            _cacheBuckets = null;
+            _buckets = new STArrayStack[BucketCount];
         }
     }
 

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -691,7 +691,7 @@ namespace Server
                 }
             }
 
-            ArrayPool<Item>.Shared.Return(items);
+            ArrayPool<Item>.Shared.Return(items, true);
         }
 
         /* This could probably be re-implemented if necessary (perhaps via an ITile interface?).

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/BladeSpirits.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/BladeSpirits.cs
@@ -94,7 +94,7 @@ namespace Server.Mobiles
                         Dispel(mobs[amount--]);
                     }
 
-                    ArrayPool<Mobile>.Shared.Return(mobs);
+                    ArrayPool<Mobile>.Shared.Return(mobs, true);
                 }
             }
 

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/EnergyVortex.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/EnergyVortex.cs
@@ -100,7 +100,7 @@ namespace Server.Mobiles
                         Dispel(mobs[amount--]);
                     }
 
-                    ArrayPool<Mobile>.Shared.Return(mobs);
+                    ArrayPool<Mobile>.Shared.Return(mobs, true);
                 }
             }
 


### PR DESCRIPTION
## Added Feature
Adds a single threaded array pool that works exactly the same as `ArrayPool<T>.Shared`.
The `STArrayPool<T>.Shared` can only be used on a single thread, the main game thread of the server.

Note: Unlike the built-in array pool, there is no hook into the _GC Gen 2_. This means to relieve potentially high memory pressure, `ArrayPool<T>.Shared.Trim()` must be called. The pool will only release arrays _after two successive calls within 10 seconds or longer_. If the server is at less than 70% total memory usage, or the server is not going to use this pool for something egregious, then don't bother ever calling Trim().


## Changes
- [X] Fixes ArrayPool calls that should be cleared due to references.
- [X] Benchmarks against ArrayPool with 4+ rented arrays deep of the same length.
- [x] Unit tests

Closes #683 