### PR TITLE
fix: Properly count timers for DumpInfo

### DIFF
--- a/Projects/Server/Timer/Timer.TimerWheel.cs
+++ b/Projects/Server/Timer/Timer.TimerWheel.cs
@@ -221,12 +221,17 @@ namespace Server
                         continue;
                     }
 
-                    var name = t.ToString();
-
-                    hash.TryGetValue(name, out var count);
-                    hash[name] = count + 1;
-
-                    total++;
+                    while (t != null)
+                    {
+                        var name = t.ToString();
+                        
+                        hash.TryGetValue(name, out var count);
+                        hash[name] = count + 1;
+                        
+                        total++;
+                        
+                        t = t?._nextTimer;
+                    }
                 }
             }
 


### PR DESCRIPTION
Resolves an issue where only the root timer was counted in the ring slot.