### PR TITLE
fix: Fixes localization corner cases with OPL

### DIFF
--- a/Projects/Server/Client/ClientVersion.cs
+++ b/Projects/Server/Client/ClientVersion.cs
@@ -39,6 +39,7 @@ public class ClientVersion : IComparable<ClientVersion>, IComparer<ClientVersion
     public static readonly ClientVersion Version60142 = new("6.0.14.2");
     public static readonly ClientVersion Version7000 = new("7.0.0.0");
     public static readonly ClientVersion Version7090 = new("7.0.9.0");
+    public static readonly ClientVersion Version70120 = new("7.0.12.0"); // Plant localization change
     public static readonly ClientVersion Version70130 = new("7.0.13.0");
     public static readonly ClientVersion Version70160 = new("7.0.16.0");
     public static readonly ClientVersion Version70300 = new("7.0.30.0");

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1471,8 +1471,7 @@ namespace Server
             World.RemoveEntity(this);
 
             OnAfterDelete();
-
-            m_PropertyList = null;
+            ClearProperties();
         }
 
         public ISpawner Spawner
@@ -1808,9 +1807,9 @@ namespace Server
         /// <summary>
         ///     Overridable. Sends the <see cref="PropertyList">object property list</see> to <paramref name="from" />.
         /// </summary>
-        public virtual void SendPropertiesTo(Mobile from)
+        public virtual void SendPropertiesTo(NetState ns)
         {
-            from.NetState?.Send(PropertyList.Buffer);
+            ns?.Send(PropertyList.Buffer);
         }
 
         /// <summary>
@@ -2401,7 +2400,7 @@ namespace Server
             return list;
         }
 
-        public void ClearProperties()
+        public virtual void ClearProperties()
         {
             m_PropertyList = null;
         }
@@ -3080,7 +3079,7 @@ namespace Server
             SendOPLPacketTo(ns, opl);
         }
 
-        public void SendOPLPacketTo(NetState ns, Span<byte> opl = default)
+        public virtual void SendOPLPacketTo(NetState ns, Span<byte> opl = default)
         {
             if (!ObjectPropertyList.Enabled)
             {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1987,7 +1987,7 @@ namespace Server
         /// </summary>
         public virtual void AddBlessedForProperty(IPropertyList list, Mobile m)
         {
-            list.Add(1062203, m.Name); // Blessed for ~1_NAME~
+            list.Add(1062203, $"{m.Name}"); // Blessed for ~1_NAME~
         }
 
         /// <summary>

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1874,35 +1874,35 @@ namespace Server
 
             if (v != 0)
             {
-                list.Add(1060448, $"{v}"); // physical resist ~1_val~%
+                list.Add(1060448, v); // physical resist ~1_val~%
             }
 
             v = FireResistance;
 
             if (v != 0)
             {
-                list.Add(1060447, $"{v}"); // fire resist ~1_val~%
+                list.Add(1060447, v); // fire resist ~1_val~%
             }
 
             v = ColdResistance;
 
             if (v != 0)
             {
-                list.Add(1060445, $"{v}"); // cold resist ~1_val~%
+                list.Add(1060445, v); // cold resist ~1_val~%
             }
 
             v = PoisonResistance;
 
             if (v != 0)
             {
-                list.Add(1060449, $"{v}"); // poison resist ~1_val~%
+                list.Add(1060449, v); // poison resist ~1_val~%
             }
 
             v = EnergyResistance;
 
             if (v != 0)
             {
-                list.Add(1060446, $"{v}"); // energy resist ~1_val~%
+                list.Add(1060446, v); // energy resist ~1_val~%
             }
         }
 
@@ -1987,7 +1987,7 @@ namespace Server
         /// </summary>
         public virtual void AddBlessedForProperty(IPropertyList list, Mobile m)
         {
-            list.Add(1062203, $"{m.Name}"); // Blessed for ~1_NAME~
+            list.Add(1062203, m.Name); // Blessed for ~1_NAME~
         }
 
         /// <summary>

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1829,7 +1829,7 @@ namespace Server
                 }
                 else
                 {
-                    list.Add(1050039, $"{m_Amount}\t#{LabelNumber}"); // ~1_NUMBER~ ~2_ITEMNAME~
+                    list.Add(1050039, $"{m_Amount}\t{LabelNumber:#}"); // ~1_NUMBER~ ~2_ITEMNAME~
                 }
             }
             else

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -3413,9 +3413,9 @@ namespace Server
 
         public int GetAOSStatus(int index) => AOSStatusHandler?.Invoke(this, index) ?? 0;
 
-        public virtual void SendPropertiesTo(Mobile from)
+        public virtual void SendPropertiesTo(NetState ns)
         {
-            from.NetState?.Send(PropertyList.Buffer);
+            ns?.Send(PropertyList.Buffer);
         }
 
         public virtual void OnAosSingleClick(Mobile from)

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -3485,11 +3485,14 @@ namespace Server
 
                 if (guildTitle.Length > 0)
                 {
-                    list.Add(
-                        NewGuildDisplay
-                            ? $"{Utility.FixHtml(guildTitle)}, {Utility.FixHtml(guild.Name)}"
-                            : $"{Utility.FixHtml(guildTitle)}, {Utility.FixHtml(guild.Name)} Guild{type}"
-                    );
+                    if (NewGuildDisplay)
+                    {
+                        list.Add($"{Utility.FixHtml(guildTitle)}, {Utility.FixHtml(guild.Name)}");
+                    }
+                    else
+                    {
+                        list.Add($"{Utility.FixHtml(guildTitle)}, {Utility.FixHtml(guild.Name)} Guild{type}");
+                    }
                 }
                 else
                 {

--- a/Projects/Server/Network/Packets/IncomingEntityPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingEntityPackets.cs
@@ -175,7 +175,7 @@ public static class IncomingEntityPackets
 
                 if (m != null && from.CanSee(m) && Utility.InUpdateRange(from.Location, m.Location))
                 {
-                    m.SendPropertiesTo(from);
+                    m.SendPropertiesTo(state);
                 }
             }
             else if (s.IsItem)
@@ -185,7 +185,7 @@ public static class IncomingEntityPackets
                 if (item?.Deleted == false && from.CanSee(item) &&
                     Utility.InUpdateRange(from.Location, item.GetWorldLocation()))
                 {
-                    item.SendPropertiesTo(from);
+                    item.SendPropertiesTo(state);
                 }
             }
         }

--- a/Projects/Server/Network/Packets/IncomingExtendedCommandPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingExtendedCommandPackets.cs
@@ -330,7 +330,7 @@ public static class IncomingExtendedCommandPackets
 
             if (m != null && from.CanSee(m) && Utility.InUpdateRange(from.Location, m.Location))
             {
-                m.SendPropertiesTo(from);
+                m.SendPropertiesTo(state);
             }
         }
         else if (s.IsItem)
@@ -340,7 +340,7 @@ public static class IncomingExtendedCommandPackets
             if (item?.Deleted == false && from.CanSee(item) &&
                 Utility.InUpdateRange(from.Location, item.GetWorldLocation()))
             {
-                item.SendPropertiesTo(from);
+                item.SendPropertiesTo(state);
             }
         }
     }

--- a/Projects/Server/PropertyList/IPropertyList.cs
+++ b/Projects/Server/PropertyList/IPropertyList.cs
@@ -22,8 +22,21 @@ public interface IPropertyList : ISelfInterpolatedStringHandler
 {
     public void Reset();
     public void Terminate();
+
+    /** Convenience method for $"{argument}". */
     public void Add(int number, string argument = null);
+
+    /** Convenience method for $"{text}". */
     public void Add(string text);
+
+    /** Convenience method for $"{value}". */
+    public void Add(int number, int value);
+
+    /** Convenience method for $"{value:#}". */
+    public void AddLocalized(int value);
+
+    /** Convenience method for $"{value:#}". */
+    public void AddLocalized(int number, int value);
 
     // String Interpolation
     public void Add([InterpolatedStringHandlerArgument("")] ref InterpolatedStringHandler handler);

--- a/Projects/Server/PropertyList/IPropertyList.cs
+++ b/Projects/Server/PropertyList/IPropertyList.cs
@@ -23,8 +23,10 @@ public interface IPropertyList : ISelfInterpolatedStringHandler
     public void Reset();
     public void Terminate();
 
+    public void Add(int number);
+
     /** Convenience method for $"{argument}". */
-    public void Add(int number, string argument = null);
+    public void Add(int number, string argument);
 
     /** Convenience method for $"{text}". */
     public void Add(string text);

--- a/Projects/Server/PropertyList/IPropertyList.cs
+++ b/Projects/Server/PropertyList/IPropertyList.cs
@@ -26,5 +26,6 @@ public interface IPropertyList : ISelfInterpolatedStringHandler
     public void Add(string text);
 
     // String Interpolation
+    public void Add([InterpolatedStringHandlerArgument("")] ref InterpolatedStringHandler handler);
     public void Add(int number, [InterpolatedStringHandlerArgument("")] ref InterpolatedStringHandler handler);
 }

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -119,46 +119,10 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
         _hash ^= (val >> 26) & 0x3F;
     }
 
-    public void Add(int number, string? arguments = null)
-    {
-        if (number == 0)
-        {
-            return;
-        }
-
-        arguments ??= "";
-
-        if (Header == 0)
-        {
-            Header = number;
-            HeaderArgs = arguments;
-        }
-
-        AddHash(number);
-        if (arguments.Length > 0)
-        {
-            AddHash(arguments.GetHashCode(StringComparison.Ordinal));
-        }
-
-        int strLength = arguments.Length * 2;
-        int length = _bufferPos + 6 + strLength;
-        while (length > _buffer.Length)
-        {
-            Flush();
-        }
-
-        var writer = new SpanWriter(_buffer.AsSpan(_bufferPos));
-        writer.Write(number);
-        writer.Write((ushort)strLength);
-        writer.WriteLittleUni(arguments);
-
-        _bufferPos += writer.BytesWritten;
-        _pos = 0;
-    }
+    public void Add(int number, string? arguments = null) => InternalAdd(number, $"{arguments ?? ""}");
+    public void Add(string argument) => Add(GetStringNumber(), $"{argument}");
 
     private int GetStringNumber() => _stringNumbers[_stringNumbersIndex++ % _stringNumbers.Length];
-
-    public void Add(string argument) => Add(GetStringNumber(), argument);
 
     // String Interpolation
     public void Add(

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -160,13 +160,19 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void Add(string argument) => Add(GetStringNumber(), argument);
 
+    // String Interpolation
     public void Add(
         [InterpolatedStringHandlerArgument("")]
         ref IPropertyList.InterpolatedStringHandler handler
-    ) => Add(GetStringNumber(), ref handler);
+    ) => InternalAdd(GetStringNumber(), ref handler);
 
-    // String Interpolation
     public void Add(
+        int number,
+        [InterpolatedStringHandlerArgument("")]
+        ref IPropertyList.InterpolatedStringHandler handler
+    ) => InternalAdd(number, ref handler);
+
+    private void InternalAdd(
         int number,
         [InterpolatedStringHandlerArgument("")]
         ref IPropertyList.InterpolatedStringHandler handler)

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -120,7 +120,10 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
     }
 
     public void Add(int number, string? arguments = null) => InternalAdd(number, $"{arguments ?? ""}");
-    public void Add(string argument) => Add(GetStringNumber(), $"{argument}");
+    public void Add(string argument) => InternalAdd(GetStringNumber(), $"{argument}");
+    public void Add(int number, int value) => InternalAdd(number, $"{value}");
+    public void AddLocalized(int value) => InternalAdd(GetStringNumber(), $"{value:#}");
+    public void AddLocalized(int number, int value) => InternalAdd(number, $"{value:#}");
 
     private int GetStringNumber() => _stringNumbers[_stringNumbersIndex++ % _stringNumbers.Length];
 

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -41,7 +41,6 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
     private int _stringNumbersIndex;
     private byte[] _buffer;
     private int _bufferPos;
-    private int _formattedCount;
 
     // For string interpolation
     private int _pos;
@@ -82,7 +81,6 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
         HeaderArgs = null;
         STArrayPool<char>.Shared.Return(_arrayToReturnToPool);
         _pos = 0;
-        _formattedCount = 0;
     }
 
     private void Flush()
@@ -187,12 +185,7 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
         }
 
         AddHash(number);
-
-        // Sometimes we might have an empty argument, but it is still an argument.
-        if (chars.Length > 0 || _formattedCount > 0)
-        {
-            AddHash(string.GetHashCode(chars, StringComparison.Ordinal));
-        }
+        AddHash(string.GetHashCode(chars, StringComparison.Ordinal));
 
         int strLength = chars.Length * 2;
         int length = _bufferPos + 6 + strLength;
@@ -211,7 +204,6 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void InitializeInterpolation(int literalLength, int formattedCount)
     {
-        _formattedCount = formattedCount;
         _arrayToReturnToPool ??= STArrayPool<char>.Shared.Rent(GetDefaultLength(literalLength, formattedCount));
         _pos = 0;
     }

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -253,7 +253,6 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted<T>(T value)
     {
-
         string? s;
         if (value is IFormattable)
         {
@@ -284,6 +283,14 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted<T>(T value, string? format)
     {
+        // We support localization '#' cliloc formatter for custom property lists
+        // This allows someone to build an IPropertyList that creates HTML using the same syntax as LocalizationInterpolationHandler
+        if (format == "#")
+        {
+            AppendLiteral("#");
+            format = null;
+        }
+
         string? s;
         if (value is IFormattable)
         {

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BulkOrderBook.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BulkOrderBook.cs
@@ -262,7 +262,7 @@ namespace Server.Engines.BulkOrders
         {
             base.GetProperties(list);
 
-            list.Add(1062344, $"{Entries.Count}"); // Deeds in book: ~1_val~
+            list.Add(1062344, Entries.Count); // Deeds in book: ~1_val~
 
             if (!string.IsNullOrEmpty(m_BookName))
             {

--- a/Projects/UOContent/Engines/Bulk Orders/LargeBOD.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/LargeBOD.cs
@@ -54,7 +54,7 @@ namespace Server.Engines.BulkOrders
                 list.Add(LargeBODGump.GetMaterialNumberFor(Material)); // All items must be made with x material.
             }
 
-            list.Add(1060656, $"{AmountMax}"); // amount to make: ~1_val~
+            list.Add(1060656, AmountMax); // amount to make: ~1_val~
 
             for (var i = 0; i < _entries.Length; ++i)
             {

--- a/Projects/UOContent/Engines/Bulk Orders/LargeBOD.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/LargeBOD.cs
@@ -59,7 +59,7 @@ namespace Server.Engines.BulkOrders
             for (var i = 0; i < _entries.Length; ++i)
             {
                 var entry = _entries[i];
-                list.Add(1060658 + i, $"#{entry.Details.Number}\t{entry.Amount}"); // ~1_val~: ~2_val~
+                list.Add(1060658 + i, $"{entry.Details.Number:#}\t{entry.Amount}"); // ~1_val~: ~2_val~
             }
         }
 

--- a/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
@@ -78,7 +78,7 @@ namespace Server.Engines.BulkOrders
             }
 
             list.Add(1060656, $"{AmountMax}");                // amount to make: ~1_val~
-            list.Add(1060658, $"#{m_Number}\t{m_AmountCur}"); // ~1_val~: ~2_val~
+            list.Add(1060658, $"{m_Number:#}\t{m_AmountCur}"); // ~1_val~: ~2_val~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
@@ -77,7 +77,7 @@ namespace Server.Engines.BulkOrders
                 list.Add(SmallBODGump.GetMaterialNumberFor(Material)); // All items must be made with x material.
             }
 
-            list.Add(1060656, $"{AmountMax}");                // amount to make: ~1_val~
+            list.Add(1060656, AmountMax);                // amount to make: ~1_val~
             list.Add(1060658, $"{m_Number:#}\t{m_AmountCur}"); // ~1_val~: ~2_val~
         }
 

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
@@ -945,11 +945,11 @@ namespace Server.Engines.CannedEvil
 
             if (m_Active)
             {
-                list.Add(1060742); // active
-                list.Add(1060658, $"Type\t{m_Type}"); // ~1_val~: ~2_val~
-                list.Add(1060659, $"Level\t{Level}"); // ~1_val~: ~2_val~
+                list.Add(1060742);                         // active
+                list.Add(1060658, $"{"Type"}\t{m_Type}"); // ~1_val~: ~2_val~
+                list.Add(1060659, $"{"Level"}\t{Level}"); // ~1_val~: ~2_val~
                 var killRatio = 100.0 * ((double)m_Kills / MaxKills);
-                list.Add(1060660, $"Kills\t{m_Kills} of {MaxKills} ({killRatio:F1}%)"); // ~1_val~: ~2_val~
+                list.Add(1060660, $"{"Kills"}\t{m_Kills} of {MaxKills} ({killRatio:F1}%)"); // ~1_val~: ~2_val~
                 //list.Add(1060661, "Spawn Range\t{0}", m_SpawnRange); // ~1_val~: ~2_val~
             }
             else

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
@@ -950,7 +950,6 @@ namespace Server.Engines.CannedEvil
                 list.Add(1060659, $"{"Level"}\t{Level}"); // ~1_val~: ~2_val~
                 var killRatio = 100.0 * ((double)m_Kills / MaxKills);
                 list.Add(1060660, $"{"Kills"}\t{m_Kills} of {MaxKills} ({killRatio:F1}%)"); // ~1_val~: ~2_val~
-                //list.Add(1060661, "Spawn Range\t{0}", m_SpawnRange); // ~1_val~: ~2_val~
             }
             else
             {

--- a/Projects/UOContent/Engines/Factions/Items/Traps/FactionTrapRemovalKit.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Traps/FactionTrapRemovalKit.cs
@@ -35,7 +35,7 @@ namespace Server.Factions
             base.GetProperties(list);
 
             // NOTE: OSI does not list uses remaining; intentional difference
-            list.Add(1060584, $"{Charges}"); // uses remaining: ~1_val~
+            list.Add(1060584, Charges); // uses remaining: ~1_val~
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
@@ -314,7 +314,7 @@ namespace Server.Factions
 
             if (m_Faction != null && Map == Faction.Facet)
             {
-                list.Add(1060846, m_Faction.Definition.PropName); // Guard: ~1_val~
+                list.Add(1060846, $"{m_Faction.Definition.PropName}"); // Guard: ~1_val~
             }
         }
 

--- a/Projects/UOContent/Engines/Plants/PlantItem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantItem.cs
@@ -263,10 +263,17 @@ namespace Server.Engines.Plants
 
             if (m_PlantStatus < PlantStatus.Seed)
             {
-                list.Add(
-                    1060830, // a ~1_val~ of ~2_val~ dirt
-                    ShowContainerType ? $"{container:#}\t{dirt:#}" : $"{dirt:#}"
-                );
+                if (ShowContainerType)
+                {
+                    // a ~1_val~ of ~2_val~ dirt
+                    list.Add(1060830, $"{container:#}\t{dirt:#}");
+                }
+                else
+                {
+                    // a ~1_val~ of ~2_val~ dirt
+                    list.Add(1060830, $"{dirt:#}");
+                }
+
                 return;
             }
 
@@ -290,24 +297,37 @@ namespace Server.Engines.Plants
 
             if (m_ShowType)
             {
-                list.Add(
-                    m_PlantStatus == PlantStatus.Plant
-                        ? typeInfo.GetPlantLabelPlant(hueInfo)
-                        : typeInfo.GetPlantLabelSeed(hueInfo),
-                    ShowContainerType
-                        ? $"{container:#}\t{dirt:#}\t{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}\t{plantStatus:#}"
-                        : $"{dirt:#}\t{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}\t{plantStatus:#}"
-                );
+                var plantNumber = m_PlantStatus == PlantStatus.Plant
+                    ? typeInfo.GetPlantLabelPlant(hueInfo)
+                    : typeInfo.GetPlantLabelSeed(hueInfo);
+
+                if (ShowContainerType)
+                {
+                    list.Add(
+                        plantNumber,
+                        $"{container:#}\t{dirt:#}\t{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}\t{plantStatus:#}"
+                    );
+                }
+                else
+                {
+                    list.Add(
+                        plantNumber,
+                        $"{dirt:#}\t{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}\t{plantStatus:#}"
+                    );
+                }
             }
             else
             {
                 var category = typeInfo.PlantCategory == PlantCategory.Default ? hueInfo.Name : (int)typeInfo.PlantCategory;
-                list.Add(
-                    hueInfo.IsBright() ? 1060832 : 1060831,
-                    ShowContainerType
-                        ? $"{container:#}\t{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}"
-                        : $"{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}"
-                );
+                var plantNumber = hueInfo.IsBright() ? 1060832 : 1060831;
+                if (ShowContainerType)
+                {
+                    list.Add(plantNumber, $"{container:#}\t{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}");
+                }
+                else
+                {
+                    list.Add(plantNumber,$"{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}");
+                }
             }
         }
 

--- a/Projects/UOContent/Engines/Plants/PlantItem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantItem.cs
@@ -368,7 +368,7 @@ namespace Server.Engines.Plants
             if (m_PlantStatus < PlantStatus.Seed)
             {
                 // Clients above 7.0.12.0 use the regular PropertyList
-                if (list == PropertyList)
+                if (list != _oldClientPropertyList)
                 {
                     // a ~1_val~ of ~2_val~ dirt
                     list.Add(1060830, $"{container:#}\t{dirt:#}");
@@ -406,7 +406,7 @@ namespace Server.Engines.Plants
                     ? typeInfo.GetPlantLabelPlant(hueInfo)
                     : typeInfo.GetPlantLabelSeed(hueInfo);
 
-                if (list == PropertyList)
+                if (list != _oldClientPropertyList)
                 {
                     list.Add(
                         plantNumber,
@@ -425,7 +425,7 @@ namespace Server.Engines.Plants
             {
                 var category = typeInfo.PlantCategory == PlantCategory.Default ? hueInfo.Name : (int)typeInfo.PlantCategory;
                 var plantNumber = hueInfo.IsBright() ? 1060832 : 1060831;
-                if (list == PropertyList)
+                if (list != _oldClientPropertyList)
                 {
                     list.Add(plantNumber, $"{container:#}\t{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}");
                 }

--- a/Projects/UOContent/Engines/Plants/PlantItem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantItem.cs
@@ -253,76 +253,61 @@ namespace Server.Engines.Plants
             if (m_PlantStatus >= PlantStatus.DeadTwigs)
             {
                 base.AddNameProperty(list);
+                return;
             }
-            else if (m_PlantStatus < PlantStatus.Seed)
+
+            var container = GetLocalizedContainerType();
+            var dirt = PlantSystem.GetLocalizedDirtStatus();
+            var health = PlantSystem.GetLocalizedHealth();
+            var plantStatus = GetLocalizedPlantStatus();
+
+            if (m_PlantStatus < PlantStatus.Seed)
             {
-                string args;
+                list.Add(
+                    1060830, // a ~1_val~ of ~2_val~ dirt
+                    ShowContainerType ? $"{container:#}\t{dirt:#}" : $"{dirt:#}"
+                );
+                return;
+            }
 
-                if (ShowContainerType)
-                {
-                    args = $"#{GetLocalizedContainerType()}\t#{PlantSystem.GetLocalizedDirtStatus()}";
-                }
-                else
-                {
-                    args = $"#{PlantSystem.GetLocalizedDirtStatus()}";
-                }
+            var typeInfo = PlantTypeInfo.GetInfo(m_PlantType);
+            var hueInfo = PlantHueInfo.GetInfo(m_PlantHue);
 
-                list.Add(1060830, args); // a ~1_val~ of ~2_val~ dirt
+            if (m_PlantStatus >= PlantStatus.DecorativePlant)
+            {
+                list.Add(typeInfo.GetPlantLabelDecorative(hueInfo), $"{hueInfo.Name:#}\t{typeInfo.Name:#}");
+                return;
+            }
+
+            if (m_PlantStatus >= PlantStatus.FullGrownPlant)
+            {
+                list.Add(
+                    typeInfo.GetPlantLabelFullGrown(hueInfo),
+                    $"{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}"
+                );
+                return;
+            }
+
+            if (m_ShowType)
+            {
+                list.Add(
+                    m_PlantStatus == PlantStatus.Plant
+                        ? typeInfo.GetPlantLabelPlant(hueInfo)
+                        : typeInfo.GetPlantLabelSeed(hueInfo),
+                    ShowContainerType
+                        ? $"{container:#}\t{dirt:#}\t{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}\t{plantStatus:#}"
+                        : $"{dirt:#}\t{health:#}\t{hueInfo.Name:#}\t{typeInfo.Name:#}\t{plantStatus:#}"
+                );
             }
             else
             {
-                var typeInfo = PlantTypeInfo.GetInfo(m_PlantType);
-                var hueInfo = PlantHueInfo.GetInfo(m_PlantHue);
-
-                if (m_PlantStatus >= PlantStatus.DecorativePlant)
-                {
-                    list.Add(typeInfo.GetPlantLabelDecorative(hueInfo), $"#{hueInfo.Name}\t#{typeInfo.Name}");
-                }
-                else if (m_PlantStatus >= PlantStatus.FullGrownPlant)
-                {
-                    list.Add(
-                        typeInfo.GetPlantLabelFullGrown(hueInfo),
-                        $"#{PlantSystem.GetLocalizedHealth()}\t#{hueInfo.Name}\t#{typeInfo.Name}"
-                    );
-                }
-                else
-                {
-                    string args;
-
-                    if (ShowContainerType)
-                    {
-                        args =
-                            $"#{GetLocalizedContainerType()}\t#{PlantSystem.GetLocalizedDirtStatus()}\t#{PlantSystem.GetLocalizedHealth()}";
-                    }
-                    else
-                    {
-                        args = $"#{PlantSystem.GetLocalizedDirtStatus()}\t#{PlantSystem.GetLocalizedHealth()}";
-                    }
-
-                    if (m_ShowType)
-                    {
-                        args += $"\t#{hueInfo.Name}\t#{typeInfo.Name}\t#{GetLocalizedPlantStatus()}";
-
-                        if (m_PlantStatus == PlantStatus.Plant)
-                        {
-                            list.Add(typeInfo.GetPlantLabelPlant(hueInfo), args);
-                        }
-                        else
-                        {
-                            list.Add(typeInfo.GetPlantLabelSeed(hueInfo), args);
-                        }
-                    }
-                    else
-                    {
-                        args +=
-                            $"\t#{(typeInfo.PlantCategory == PlantCategory.Default ? hueInfo.Name : (int)typeInfo.PlantCategory)}\t#{GetLocalizedPlantStatus()}";
-
-                        list.Add(
-                            hueInfo.IsBright() ? 1060832 : 1060831,
-                            args
-                        ); // a ~1_val~ of ~2_val~ dirt with a ~3_val~ [bright] ~4_val~ ~5_val~
-                    }
-                }
+                var category = typeInfo.PlantCategory == PlantCategory.Default ? hueInfo.Name : (int)typeInfo.PlantCategory;
+                list.Add(
+                    hueInfo.IsBright() ? 1060832 : 1060831,
+                    ShowContainerType
+                        ? $"{container:#}\t{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}"
+                        : $"{dirt:#}\t{health:#}\t{category:#}\t{plantStatus:#}"
+                );
             }
         }
 

--- a/Projects/UOContent/Engines/Plants/Seed.cs
+++ b/Projects/UOContent/Engines/Plants/Seed.cs
@@ -126,7 +126,39 @@ namespace Server.Engines.Plants
 
         public override void AddNameProperty(IPropertyList list)
         {
-            list.Add(GetLabel(out var args), args);
+            var typeInfo = PlantTypeInfo.GetInfo(m_PlantType);
+            var hueInfo = PlantHueInfo.GetInfo(m_PlantHue);
+
+            int title;
+
+            if (m_ShowType || typeInfo.PlantCategory == PlantCategory.Default)
+            {
+                title = hueInfo.Name;
+            }
+            else
+            {
+                title = (int)typeInfo.PlantCategory;
+            }
+
+            if (Amount == 1)
+            {
+                if (m_ShowType)
+                {
+                    list.Add(typeInfo.GetSeedLabel(hueInfo), $"{title:#}\t{typeInfo.Name:#}");
+                    return;
+                }
+
+                list.Add(hueInfo.IsBright() ? 1060839 : 1060838, $"{title:#}");
+                return;
+            }
+
+            if (m_ShowType)
+            {
+                list.Add(typeInfo.GetSeedLabelPlural(hueInfo), $"{Amount}\t{title:#}\t{typeInfo.Name:#}");
+                return;
+            }
+
+            list.Add(hueInfo.IsBright() ? 1113491 : 1113490, $"{Amount}\t{title:#}");
         }
 
         public override void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Engines/Quests/Collector/Items/PaintedImage.cs
+++ b/Projects/UOContent/Engines/Quests/Collector/Items/PaintedImage.cs
@@ -34,7 +34,7 @@ namespace Server.Engines.Quests.Collector
         public override void AddNameProperty(IPropertyList list)
         {
             var info = ImageTypeInfo.Get(m_Image);
-            list.Add(1060847, $"#1055126\t#{info.Name}"); // a painted image of:
+            list.Add(1060847, $"{1055126:#}\t{info.Name:#}"); // a painted image of:
         }
 
         public override void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Engines/Quests/Core/Items/HornOfRetreat.cs
+++ b/Projects/UOContent/Engines/Quests/Core/Items/HornOfRetreat.cs
@@ -47,7 +47,7 @@ namespace Server.Engines.Quests
         {
             base.GetProperties(list);
 
-            list.Add(1060741, $"{m_Charges}"); // charges: ~1_val~
+            list.Add(1060741, m_Charges); // charges: ~1_val~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
@@ -391,13 +391,10 @@ namespace Server.Engines.Quests.Hag
 
                 if (creature.GetType() == type)
                 {
-                    System.From.SendLocalizedMessage(
-                        1055043,
-                        $"#{info.Name}"
-                    ); // You gather a ~1_INGREDIENT_NAME~ from the corpse.
+                    // You gather a ~1_INGREDIENT_NAME~ from the corpse.
+                    System.From.SendLocalizedMessage(1055043, $"#{info.Name}");
 
                     CurProgress++;
-
                     break;
                 }
             }

--- a/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
@@ -365,12 +365,12 @@ namespace Server.Engines.Spawners
             {
                 list.Add(1060742); // active
 
-                list.Add(1060656, $"{m_Count}");                            // amount to make: ~1_val~
-                list.Add(1061169, $"{m_HomeRange}");                        // range ~1_val~
-                list.Add(1050039, $"walking range:\t{m_WalkingRange}");     // ~1_NUMBER~ ~2_ITEMNAME~
-                list.Add(1053099, $"group:\t{m_Group}");                    // ~1_oretype~: ~2_armortype~
-                list.Add(1060847, $"team:\t{m_Team}");                      // ~1_val~ ~2_val~
-                list.Add(1063483, $"delay:\t{m_MinDelay} to {m_MaxDelay}"); // ~1_MATERIAL~: ~2_ITEMNAME~
+                list.Add(1060656, $"{m_Count}");                                // amount to make: ~1_val~
+                list.Add(1061169, $"{m_HomeRange}");                            // range ~1_val~
+                list.Add(1050039, $"{"walking range:"}\t{m_WalkingRange}");     // ~1_NUMBER~ ~2_ITEMNAME~
+                list.Add(1053099, $"{"group:"}\t{m_Group}");                    // ~1_oretype~: ~2_armortype~
+                list.Add(1060847, $"{"team:"}\t{m_Team}");                      // ~1_val~ ~2_val~
+                list.Add(1063483, $"{"delay:"}\t{m_MinDelay} to {m_MaxDelay}"); // ~1_MATERIAL~: ~2_ITEMNAME~
 
                 GetSpawnerProperties(list);
 

--- a/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
@@ -365,8 +365,8 @@ namespace Server.Engines.Spawners
             {
                 list.Add(1060742); // active
 
-                list.Add(1060656, $"{m_Count}");                                // amount to make: ~1_val~
-                list.Add(1061169, $"{m_HomeRange}");                            // range ~1_val~
+                list.Add(1060656, m_Count);                                // amount to make: ~1_val~
+                list.Add(1061169, m_HomeRange);                            // range ~1_val~
                 list.Add(1050039, $"{"walking range:"}\t{m_WalkingRange}");     // ~1_NUMBER~ ~2_ITEMNAME~
                 list.Add(1053099, $"{"group:"}\t{m_Group}");                    // ~1_oretype~: ~2_armortype~
                 list.Add(1060847, $"{"team:"}\t{m_Team}");                      // ~1_val~ ~2_val~

--- a/Projects/UOContent/Engines/Spawners/RegionSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/RegionSpawner.cs
@@ -94,7 +94,7 @@ namespace Server.Engines.Spawners
 
             if (Running && m_SpawnRegion != null)
             {
-                list.Add(1076228, $"region:\t{m_SpawnRegion.Name}"); // ~1_DUMMY~ ~2_DUMMY~
+                list.Add(1076228, $"{"region:"}\t{m_SpawnRegion.Name}"); // ~1_DUMMY~ ~2_DUMMY~
             }
         }
 

--- a/Projects/UOContent/Engines/Treasures of Tokuno/BasePigmentsOfTokuno.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/BasePigmentsOfTokuno.cs
@@ -122,7 +122,7 @@ namespace Server.Items
                 TextDefinition.AddTo(list, m_Label);
             }
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Items/Aquarium/Aquarium.cs
+++ b/Projects/UOContent/Items/Aquarium/Aquarium.cs
@@ -399,8 +399,8 @@ namespace Server.Items
                 list.Add(1074249, $"{decorations}"); // Decorations: ~1_NUM~
             }
 
-            list.Add(1074250, $"#{FoodNumber()}");  // Food state: ~1_STATE~
-            list.Add(1074251, $"#{WaterNumber()}"); // Water state: ~1_STATE~
+            list.Add(1074250, $"{FoodNumber():#}");  // Food state: ~1_STATE~
+            list.Add(1074251, $"{WaterNumber():#}"); // Water state: ~1_STATE~
 
             if (_food.State == (int)FoodState.Dead)
             {

--- a/Projects/UOContent/Items/Aquarium/Aquarium.cs
+++ b/Projects/UOContent/Items/Aquarium/Aquarium.cs
@@ -389,18 +389,18 @@ namespace Server.Items
 
             if (dead > 0)
             {
-                list.Add(1074248, $"{dead}"); // Dead Creatures: ~1_NUM~
+                list.Add(1074248, dead); // Dead Creatures: ~1_NUM~
             }
 
             var decorations = Items.Count - LiveCreatures - dead;
 
             if (decorations > 0)
             {
-                list.Add(1074249, $"{decorations}"); // Decorations: ~1_NUM~
+                list.Add(1074249, decorations); // Decorations: ~1_NUM~
             }
 
-            list.Add(1074250, $"{FoodNumber():#}");  // Food state: ~1_STATE~
-            list.Add(1074251, $"{WaterNumber():#}"); // Water state: ~1_STATE~
+            list.AddLocalized(1074250, FoodNumber());  // Food state: ~1_STATE~
+            list.AddLocalized(1074251, WaterNumber()); // Water state: ~1_STATE~
 
             if (_food.State == (int)FoodState.Dead)
             {

--- a/Projects/UOContent/Items/Aquarium/Aquarium.cs
+++ b/Projects/UOContent/Items/Aquarium/Aquarium.cs
@@ -912,12 +912,8 @@ namespace Server.Items
 
             AddItem(item);
 
-            from?.SendLocalizedMessage(
-                1073635,
-                item.LabelNumber != 0
-                    ? $"#{item.LabelNumber}"
-                    : item.Name
-            ); // You add the following decoration to your aquarium: ~1_NAME~
+            // You add the following decoration to your aquarium: ~1_NAME~
+            from?.SendLocalizedMessage(1073635, item.LabelNumber != 0 ? $"#{item.LabelNumber}" : item.Name);
 
             InvalidateProperties();
             return true;

--- a/Projects/UOContent/Items/Aquarium/FishBowl.cs
+++ b/Projects/UOContent/Items/Aquarium/FishBowl.cs
@@ -88,7 +88,7 @@ namespace Server.Items
 
                 if (fish != null)
                 {
-                    list.Add(1074494, $"#{fish.LabelNumber}"); // Contains: ~1_CREATURE~
+                    list.Add(1074494, $"{fish.LabelNumber:#}"); // Contains: ~1_CREATURE~
                 }
             }
         }

--- a/Projects/UOContent/Items/Aquarium/FishBowl.cs
+++ b/Projects/UOContent/Items/Aquarium/FishBowl.cs
@@ -88,7 +88,7 @@ namespace Server.Items
 
                 if (fish != null)
                 {
-                    list.Add(1074494, $"{fish.LabelNumber:#}"); // Contains: ~1_CREATURE~
+                    list.AddLocalized();(1074494, fish.LabelNumber); // Contains: ~1_CREATURE~
                 }
             }
         }

--- a/Projects/UOContent/Items/Aquarium/FishBowl.cs
+++ b/Projects/UOContent/Items/Aquarium/FishBowl.cs
@@ -88,7 +88,7 @@ namespace Server.Items
 
                 if (fish != null)
                 {
-                    list.AddLocalized();(1074494, fish.LabelNumber); // Contains: ~1_CREATURE~
+                    list.AddLocalized(1074494, fish.LabelNumber); // Contains: ~1_CREATURE~
                 }
             }
         }

--- a/Projects/UOContent/Items/Aquarium/VacationWafer.cs
+++ b/Projects/UOContent/Items/Aquarium/VacationWafer.cs
@@ -18,7 +18,7 @@ namespace Server.Items
         {
             base.AddNameProperties(list);
 
-            list.Add(1074432, $"{VacationDays}"); // Vacation days: ~1_DAYS~
+            list.AddLocalized(1074432, VacationDays); // Vacation days: ~1_DAYS~
         }
     }
 }

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -1253,12 +1253,12 @@ namespace Server.Items
             {
                 list.Add(
                     _quality == ArmorQuality.Exceptional ? 1053100 : 1053099,
-                    name != null ? $"#{oreType}\t{Name}" : $"#{oreType}\t#{LabelNumber}"
+                    name != null ? $"{oreType:#}\t{Name}" : $"{oreType:#}\t{LabelNumber:#}"
                 );
             }
             else if (_quality == ArmorQuality.Exceptional)
             {
-                list.Add(1050040, name ?? $"#{LabelNumber}"); // exceptional ~1_ITEMNAME~
+                list.Add(1050040, name ?? $"{LabelNumber:#}"); // exceptional ~1_ITEMNAME~
             }
             else if (name == null)
             {

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -1251,14 +1251,27 @@ namespace Server.Items
 
             if (oreType != 0)
             {
-                list.Add(
-                    _quality == ArmorQuality.Exceptional ? 1053100 : 1053099,
-                    name != null ? $"{oreType:#}\t{Name}" : $"{oreType:#}\t{LabelNumber:#}"
-                );
+                var qualityNumber = _quality == ArmorQuality.Exceptional ? 1053100 : 1053099;
+
+                if (name != null)
+                {
+                    list.Add(qualityNumber, $"{oreType:#}\t{Name}");
+                }
+                else
+                {
+                    list.Add(qualityNumber, $"{oreType:#}\t{LabelNumber:#}");
+                }
             }
             else if (_quality == ArmorQuality.Exceptional)
             {
-                list.Add(1050040, name ?? $"{LabelNumber:#}"); // exceptional ~1_ITEMNAME~
+                if (name != null)
+                {
+                    list.Add(1050040, name); // exceptional ~1_ITEMNAME~
+                }
+                else
+                {
+                    list.Add(1050040, $"{LabelNumber:#}"); // exceptional ~1_ITEMNAME~
+                }
             }
             else if (name == null)
             {

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -1270,7 +1270,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    list.Add(1050040, $"{LabelNumber:#}"); // exceptional ~1_ITEMNAME~
+                    list.AddLocalized(1050040, LabelNumber); // exceptional ~1_ITEMNAME~
                 }
             }
             else if (name == null)
@@ -1325,72 +1325,72 @@ namespace Server.Items
 
             if ((prop = ArtifactRarity) > 0)
             {
-                list.Add(1061078, $"{prop}"); // artifact rarity ~1_val~
+                list.Add(1061078, prop); // artifact rarity ~1_val~
             }
 
             if ((prop = Attributes.WeaponDamage) != 0)
             {
-                list.Add(1060401, $"{prop}"); // damage increase ~1_val~%
+                list.Add(1060401, prop); // damage increase ~1_val~%
             }
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = GetLowerStatReq()) != 0)
             {
-                list.Add(1060435, $"{prop}"); // lower requirements ~1_val~%
+                list.Add(1060435, prop); // lower requirements ~1_val~%
             }
 
             if ((prop = GetLuckBonus() + Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if (ArmorAttributes.MageArmor != 0)
@@ -1400,12 +1400,12 @@ namespace Server.Items
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -1415,22 +1415,22 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if ((prop = ArmorAttributes.SelfRepair) != 0)
             {
-                list.Add(1060450, $"{prop}"); // self repair ~1_val~
+                list.Add(1060450, prop); // self repair ~1_val~
             }
 
             if (Attributes.SpellChanneling != 0)
@@ -1440,39 +1440,39 @@ namespace Server.Items
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if (Core.ML && (prop = Attributes.IncreasedKarmaLoss) != 0)
             {
-                list.Add(1075210, $"{prop}"); // Increased Karma Loss ~1val~%
+                list.Add(1075210, prop); // Increased Karma Loss ~1val~%
             }
 
             AddResistanceProperties(list);
 
             if ((prop = GetDurabilityBonus()) > 0)
             {
-                list.Add(1060410, $"{prop}"); // durability ~1_val~%
+                list.Add(1060410, prop); // durability ~1_val~%
             }
 
             if ((prop = ComputeStatReq(StatType.Str)) > 0)
             {
-                list.Add(1061170, $"{prop}"); // strength requirement ~1_val~
+                list.Add(1061170, prop); // strength requirement ~1_val~
             }
 
             if (_hitPoints >= 0 && _maxHitPoints > 0)

--- a/Projects/UOContent/Items/Armor/Glasses/ElvenGlasses.cs
+++ b/Projects/UOContent/Items/Armor/Glasses/ElvenGlasses.cs
@@ -50,77 +50,77 @@ namespace Server.Items
 
             if ((prop = _weaponAttributes.HitColdArea) != 0)
             {
-                list.Add(1060416, $"{prop}"); // hit cold area ~1_val~%
+                list.Add(1060416, prop); // hit cold area ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitDispel) != 0)
             {
-                list.Add(1060417, $"{prop}"); // hit dispel ~1_val~%
+                list.Add(1060417, prop); // hit dispel ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitEnergyArea) != 0)
             {
-                list.Add(1060418, $"{prop}"); // hit energy area ~1_val~%
+                list.Add(1060418, prop); // hit energy area ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitFireArea) != 0)
             {
-                list.Add(1060419, $"{prop}"); // hit fire area ~1_val~%
+                list.Add(1060419, prop); // hit fire area ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitFireball) != 0)
             {
-                list.Add(1060420, $"{prop}"); // hit fireball ~1_val~%
+                list.Add(1060420, prop); // hit fireball ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitHarm) != 0)
             {
-                list.Add(1060421, $"{prop}"); // hit harm ~1_val~%
+                list.Add(1060421, prop); // hit harm ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitLeechHits) != 0)
             {
-                list.Add(1060422, $"{prop}"); // hit life leech ~1_val~%
+                list.Add(1060422, prop); // hit life leech ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitLightning) != 0)
             {
-                list.Add(1060423, $"{prop}"); // hit lightning ~1_val~%
+                list.Add(1060423, prop); // hit lightning ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitLowerAttack) != 0)
             {
-                list.Add(1060424, $"{prop}"); // hit lower attack ~1_val~%
+                list.Add(1060424, prop); // hit lower attack ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitLowerDefend) != 0)
             {
-                list.Add(1060425, $"{prop}"); // hit lower defense ~1_val~%
+                list.Add(1060425, prop); // hit lower defense ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitMagicArrow) != 0)
             {
-                list.Add(1060426, $"{prop}"); // hit magic arrow ~1_val~%
+                list.Add(1060426, prop); // hit magic arrow ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitLeechMana) != 0)
             {
-                list.Add(1060427, $"{prop}"); // hit mana leech ~1_val~%
+                list.Add(1060427, prop); // hit mana leech ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitPhysicalArea) != 0)
             {
-                list.Add(1060428, $"{prop}"); // hit physical area ~1_val~%
+                list.Add(1060428, prop); // hit physical area ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitPoisonArea) != 0)
             {
-                list.Add(1060429, $"{prop}"); // hit poison area ~1_val~%
+                list.Add(1060429, prop); // hit poison area ~1_val~%
             }
 
             if ((prop = _weaponAttributes.HitLeechStam) != 0)
             {
-                list.Add(1060430, $"{prop}"); // hit stamina leech ~1_val~%
+                list.Add(1060430, prop); // hit stamina leech ~1_val~%
             }
         }
     }

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -690,12 +690,14 @@ namespace Server.Items
 
             if (oreType != 0)
             {
-                list.Add(
-                    1053099, // ~1_oretype~ ~2_armortype~
-                    name != null
-                        ? $"{oreType:#}\t{name}"
-                        : $"{oreType:#}\t{LabelNumber:#}"
-                );
+                if (name != null)
+                {
+                    list.Add(1053099, $"{oreType:#}\t{name}"); // ~1_oretype~ ~2_armortype~
+                }
+                else
+                {
+                    list.Add(1053099, $"{oreType:#}\t{LabelNumber:#}"); // ~1_oretype~ ~2_armortype~
+                }
             }
             else if (name == null)
             {

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -690,7 +690,12 @@ namespace Server.Items
 
             if (oreType != 0)
             {
-                list.Add(1053099, name != null ? $"#{oreType}\t{name}" : $"#{oreType}\t#{LabelNumber}"); // ~1_oretype~ ~2_armortype~
+                list.Add(
+                    1053099, // ~1_oretype~ ~2_armortype~
+                    name != null
+                        ? $"{oreType:#}\t{name}"
+                        : $"{oreType:#}\t{LabelNumber:#}"
+                );
             }
             else if (name == null)
             {

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -744,72 +744,72 @@ namespace Server.Items
 
             if ((prop = ArtifactRarity) > 0)
             {
-                list.Add(1061078, $"{prop}"); // artifact rarity ~1_val~
+                list.Add(1061078, prop); // artifact rarity ~1_val~
             }
 
             if ((prop = Attributes.WeaponDamage) != 0)
             {
-                list.Add(1060401, $"{prop}"); // damage increase ~1_val~%
+                list.Add(1060401, prop); // damage increase ~1_val~%
             }
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = ClothingAttributes.LowerStatReq) != 0)
             {
-                list.Add(1060435, $"{prop}"); // lower requirements ~1_val~%
+                list.Add(1060435, prop); // lower requirements ~1_val~%
             }
 
             if ((prop = Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if (ClothingAttributes.MageArmor != 0)
@@ -819,12 +819,12 @@ namespace Server.Items
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -834,22 +834,22 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if ((prop = ClothingAttributes.SelfRepair) != 0)
             {
-                list.Add(1060450, $"{prop}"); // self repair ~1_val~
+                list.Add(1060450, prop); // self repair ~1_val~
             }
 
             if (Attributes.SpellChanneling != 0)
@@ -859,39 +859,39 @@ namespace Server.Items
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if (Core.ML && (prop = Attributes.IncreasedKarmaLoss) != 0)
             {
-                list.Add(1075210, $"{prop}"); // Increased Karma Loss ~1val~%
+                list.Add(1075210, prop); // Increased Karma Loss ~1val~%
             }
 
             AddResistanceProperties(list);
 
             if ((prop = ClothingAttributes.DurabilityBonus) > 0)
             {
-                list.Add(1060410, $"{prop}"); // durability ~1_val~%
+                list.Add(1060410, prop); // durability ~1_val~%
             }
 
             if ((prop = ComputeStatReq(StatType.Str)) > 0)
             {
-                list.Add(1061170, $"{prop}"); // strength requirement ~1_val~
+                list.Add(1061170, prop); // strength requirement ~1_val~
             }
 
             if (_hitPoints >= 0 && _maxHitPoints > 0)

--- a/Projects/UOContent/Items/Decoration Artifacts/BaseDecorationArtifact.cs
+++ b/Projects/UOContent/Items/Decoration Artifacts/BaseDecorationArtifact.cs
@@ -15,7 +15,7 @@ public abstract partial class BaseDecorationArtifact : Item
     {
         base.GetProperties(list);
 
-        list.Add(1061078, $"{ArtifactRarity}"); // artifact rarity ~1_val~
+        list.Add(1061078, ArtifactRarity); // artifact rarity ~1_val~
     }
 }
 
@@ -32,6 +32,6 @@ public abstract partial class BaseDecorationContainerArtifact : BaseContainer
     {
         base.AddNameProperties(list);
 
-        list.Add(1061078, $"{ArtifactRarity}"); // artifact rarity ~1_val~
+        list.Add(1061078, ArtifactRarity); // artifact rarity ~1_val~
     }
 }

--- a/Projects/UOContent/Items/Deeds/CommodityDeed.cs
+++ b/Projects/UOContent/Items/Deeds/CommodityDeed.cs
@@ -68,11 +68,12 @@ public partial class CommodityDeed : Item
 
         if (Commodity != null)
         {
-            var args = Commodity.Name == null
-                ? $"#{(Commodity as ICommodity)?.DescriptionNumber ?? Commodity.LabelNumber}\t{Commodity.Amount}"
-                : $"{Commodity.Name}\t{Commodity.Amount}";
-
-            list.Add(1060658, args); // ~1_val~: ~2_val~
+            list.Add(
+                1060658, // ~1_val~: ~2_val~
+                Commodity.Name == null
+                    ? $"{(Commodity as ICommodity)?.DescriptionNumber ?? Commodity.LabelNumber:#}\t{Commodity.Amount}"
+                    : $"{Commodity.Name}\t{Commodity.Amount}"
+            );
         }
         else
         {
@@ -86,11 +87,13 @@ public partial class CommodityDeed : Item
 
         if (Commodity != null)
         {
-            var args = Commodity.Name == null
-                ? $"#{(Commodity as ICommodity)?.DescriptionNumber ?? Commodity.LabelNumber}\t{Commodity.Amount}"
-                : $"{Commodity.Name}\t{Commodity.Amount}";
-
-            LabelTo(from, 1060658, args); // ~1_val~: ~2_val~
+            LabelTo(
+                from,
+                1060658, // ~1_val~: ~2_val~
+                Commodity.Name == null
+                    ? $"#{(Commodity as ICommodity)?.DescriptionNumber ?? Commodity.LabelNumber}\t{Commodity.Amount}"
+                    : $"{Commodity.Name}\t{Commodity.Amount}"
+            );
         }
     }
 

--- a/Projects/UOContent/Items/Deeds/CommodityDeed.cs
+++ b/Projects/UOContent/Items/Deeds/CommodityDeed.cs
@@ -1,5 +1,6 @@
 using ModernUO.Serialization;
 using Server.Targeting;
+using Server.Text;
 
 namespace Server.Items;
 
@@ -66,14 +67,20 @@ public partial class CommodityDeed : Item
     {
         base.GetProperties(list);
 
-        if (Commodity != null)
+        if (Commodity is ICommodity ic)
         {
-            list.Add(
-                1060658, // ~1_val~: ~2_val~
-                Commodity.Name == null
-                    ? $"{(Commodity as ICommodity)?.DescriptionNumber ?? Commodity.LabelNumber:#}\t{Commodity.Amount}"
-                    : $"{Commodity.Name}\t{Commodity.Amount}"
-            );
+            list.Add(1060658, $"{ic.DescriptionNumber:#}\t{Commodity.Amount}"); // ~1_val~: ~2_val~
+        }
+        else if (Commodity != null)
+        {
+            if (Commodity.Name == null)
+            {
+                list.Add(1060658, $"{Commodity.LabelNumber:#}\t{Commodity.Amount}"); // ~1_val~: ~2_val~
+            }
+            else
+            {
+                list.Add(1060658, $"{Commodity.Name}\t{Commodity.Amount}"); // ~1_val~: ~2_val~
+            }
         }
         else
         {

--- a/Projects/UOContent/Items/Jewels/BaseJewel.cs
+++ b/Projects/UOContent/Items/Jewels/BaseJewel.cs
@@ -265,77 +265,77 @@ namespace Server.Items
 
             if ((prop = ArtifactRarity) > 0)
             {
-                list.Add(1061078, $"{prop}"); // artifact rarity ~1_val~
+                list.Add(1061078, prop); // artifact rarity ~1_val~
             }
 
             if ((prop = Attributes.WeaponDamage) != 0)
             {
-                list.Add(1060401, $"{prop}"); // damage increase ~1_val~%
+                list.Add(1060401, prop); // damage increase ~1_val~%
             }
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -345,17 +345,17 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if (Attributes.SpellChanneling != 0)
@@ -365,27 +365,27 @@ namespace Server.Items
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if (Core.ML && (prop = Attributes.IncreasedKarmaLoss) != 0)
             {
-                list.Add(1075210, $"{prop}"); // Increased Karma Loss ~1val~%
+                list.Add(1075210, prop); // Increased Karma Loss ~1val~%
             }
 
             AddResistanceProperties(list);

--- a/Projects/UOContent/Items/Misc/BankCheck.cs
+++ b/Projects/UOContent/Items/Misc/BankCheck.cs
@@ -77,7 +77,7 @@ namespace Server.Items
             }
             else
             {
-                list.Add(1060738, $"{m_Worth}"); // value: ~1_val~
+                list.Add(1060738, m_Worth); // value: ~1_val~
             }
         }
 

--- a/Projects/UOContent/Items/Misc/BankCheck.cs
+++ b/Projects/UOContent/Items/Misc/BankCheck.cs
@@ -71,7 +71,14 @@ namespace Server.Items
         public override void GetProperties(IPropertyList list)
         {
             base.GetProperties(list);
-            list.Add(1060738, Core.ML ? $"{m_Worth:N0}" : m_Worth.ToString()); // value: ~1_val~)
+            if (Core.ML)
+            {
+                list.Add(1060738, $"{m_Worth:N0}"); // value: ~1_val~
+            }
+            else
+            {
+                list.Add(1060738, $"{m_Worth}"); // value: ~1_val~
+            }
         }
 
         public override void OnAdded(IEntity parent)

--- a/Projects/UOContent/Items/Misc/CommunicationCrystals.cs
+++ b/Projects/UOContent/Items/Misc/CommunicationCrystals.cs
@@ -97,11 +97,11 @@ namespace Server.Items
 
             list.Add(Active ? 1060742 : 1060743);  // active / inactive
             list.Add(1060745);                     // broadcast
-            list.Add(1060741, $"{Charges}"); // charges: ~1_val~
+            list.Add(1060741, Charges); // charges: ~1_val~
 
             if (Receivers.Count > 0)
             {
-                list.Add(1060746, $"{Receivers.Count}"); // links: ~1_val~
+                list.Add(1060746, Receivers.Count); // links: ~1_val~
             }
         }
 

--- a/Projects/UOContent/Items/Misc/PromotionalToken.cs
+++ b/Projects/UOContent/Items/Misc/PromotionalToken.cs
@@ -27,7 +27,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1070998, $"{ItemName}"); // Use this to redeem<br>your ~1_PROMO~
+            list.Add(1070998, ItemName); // Use this to redeem<br>your ~1_PROMO~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Items/Misc/PromotionalToken.cs
+++ b/Projects/UOContent/Items/Misc/PromotionalToken.cs
@@ -27,7 +27,17 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1070998, ItemName); // Use this to redeem<br>your ~1_PROMO~
+            if (ItemName != null)
+            {
+                if (ItemName.Number > 0)
+                {
+                    list.Add(1070998, ItemName.Number); // Use this to redeem<br>your ~1_PROMO~
+                }
+                else
+                {
+                    list.Add(1070998, ItemName.String); // Use this to redeem<br>your ~1_PROMO~
+                }
+            }
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Items/Misc/Teleporter.cs
+++ b/Projects/UOContent/Items/Misc/Teleporter.cs
@@ -168,15 +168,15 @@ namespace Server.Items
 
             if (m_MapDest != null)
             {
-                list.Add(1060658, $"Map\t{m_MapDest}");
+                list.Add(1060658, $"{"Map"}\t{m_MapDest}");
             }
 
             if (m_PointDest != Point3D.Zero)
             {
-                list.Add(1060659, $"Coords\t{m_PointDest}");
+                list.Add(1060659, $"{"Coords"}\t{m_PointDest}");
             }
 
-            list.Add(1060660, $"Creatures\t{(m_Creatures ? "Yes" : "No")}");
+            list.Add(1060660, $"{"Creatures"}\t{(m_Creatures ? "Yes" : "No")}");
         }
 
         public override void OnSingleClick(Mobile from)
@@ -483,11 +483,11 @@ namespace Server.Items
 
             if (m_MessageString != null)
             {
-                list.Add(1060662, $"Message\t{m_MessageString}");
+                list.Add(1060662, $"{"Message"}\t{m_MessageString}");
             }
             else if (m_MessageNumber != 0)
             {
-                list.Add(1060662, $"Message\t#{m_MessageNumber}");
+                list.Add(1060662, $"{"Message"}\t{m_MessageNumber:#}");
             }
         }
 
@@ -625,16 +625,16 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060661, $"Range\t{m_Range}");
+            list.Add(1060661, $"{"Range"}\t{m_Range}");
 
             if (m_Keyword >= 0)
             {
-                list.Add(1060662, $"Keyword\t{m_Keyword}");
+                list.Add(1060662, $"{"Keyword"}\t{m_Keyword}");
             }
 
             if (m_Substring != null)
             {
-                list.Add(1060663, $"Substring\t{m_Substring}");
+                list.Add(1060663, $"{"Substring"}\t{m_Substring}");
             }
         }
 

--- a/Projects/UOContent/Items/Quivers/BaseQuiver.cs
+++ b/Projects/UOContent/Items/Quivers/BaseQuiver.cs
@@ -272,7 +272,7 @@ namespace Server.Items
 
             if ((prop = m_DamageIncrease) != 0)
             {
-                list.Add(1074762, $"{prop}"); // Damage modifier: ~1_PERCENT~%
+                list.Add(1074762, prop); // Damage modifier: ~1_PERCENT~%
             }
 
             int phys = 0, fire = 0, cold = 0, pois = 0, nrgy = 0, chaos = 0, direct = 0;
@@ -281,104 +281,104 @@ namespace Server.Items
 
             if (phys != 0)
             {
-                list.Add(1060403, $"{phys}"); // physical damage ~1_val~%
+                list.Add(1060403, phys); // physical damage ~1_val~%
             }
 
             if (fire != 0)
             {
-                list.Add(1060405, $"{fire}"); // fire damage ~1_val~%
+                list.Add(1060405, fire); // fire damage ~1_val~%
             }
 
             if (cold != 0)
             {
-                list.Add(1060404, $"{cold}"); // cold damage ~1_val~%
+                list.Add(1060404, cold); // cold damage ~1_val~%
             }
 
             if (pois != 0)
             {
-                list.Add(1060406, $"{pois}"); // poison damage ~1_val~%
+                list.Add(1060406, pois); // poison damage ~1_val~%
             }
 
             if (nrgy != 0)
             {
-                list.Add(1060407, $"{nrgy}"); // energy damage ~1_val
+                list.Add(1060407, nrgy); // energy damage ~1_val
             }
 
             if (chaos != 0)
             {
-                list.Add(1072846, $"{chaos}"); // chaos damage ~1_val~%
+                list.Add(1072846, chaos); // chaos damage ~1_val~%
             }
 
             if (direct != 0)
             {
-                list.Add(1079978, $"{direct}"); // Direct Damage: ~1_PERCENT~%
+                list.Add(1079978, direct); // Direct Damage: ~1_PERCENT~%
             }
 
             list.Add(1075085); // Requirement: Mondain's Legacy
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -388,42 +388,42 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if ((prop = m_LowerAmmoCost) > 0)
             {
-                list.Add(1075208, $"{prop}"); // Lower Ammo Cost ~1_Percentage~%
+                list.Add(1075208, prop); // Lower Ammo Cost ~1_Percentage~%
             }
 
             var weight = ammo != null ? ammo.Weight + ammo.Amount : 0;
@@ -435,7 +435,7 @@ namespace Server.Items
 
             if ((prop = m_WeightReduction) != 0)
             {
-                list.Add(1072210, $"{prop}"); // Weight reduction: ~1_PERCENTAGE~%
+                list.Add(1072210, prop); // Weight reduction: ~1_PERCENTAGE~%
             }
         }
 

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
@@ -72,7 +72,7 @@ namespace Server.Items
         {
             if (Amount > 1)
             {
-                list.Add(1050039, $"{Amount}\t#{1027154}"); // ~1_NUMBER~ ~2_ITEMNAME~
+                list.Add(1050039, $"{Amount}\t{1027154:#}"); // ~1_NUMBER~ ~2_ITEMNAME~
             }
             else
             {

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
@@ -87,7 +87,7 @@ namespace Server.Items
         {
             if (Amount > 1)
             {
-                list.Add(1050039, $"{Amount}\t#{1026583}"); // ~1_NUMBER~ ~2_ITEMNAME~
+                list.Add(1050039, $"{Amount}\t{1026583:#}"); // ~1_NUMBER~ ~2_ITEMNAME~
             }
             else
             {

--- a/Projects/UOContent/Items/Resources/Tailor/Hides.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Hides.cs
@@ -59,7 +59,7 @@ namespace Server.Items
         {
             if (Amount > 1)
             {
-                list.Add(1050039, $"{Amount}\t#1024216"); // ~1_NUMBER~ ~2_ITEMNAME~
+                list.Add(1050039, $"{Amount}\t{1024216:#}"); // ~1_NUMBER~ ~2_ITEMNAME~
             }
             else
             {

--- a/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
@@ -59,7 +59,7 @@ namespace Server.Items
         {
             if (Amount > 1)
             {
-                list.Add(1050039, $"{Amount}\t#1024199"); // ~1_NUMBER~ ~2_ITEMNAME~
+                list.Add(1050039, $"{Amount}\t{1024199:#}"); // ~1_NUMBER~ ~2_ITEMNAME~
             }
             else
             {

--- a/Projects/UOContent/Items/Skill Items/Carpenter Items/TaxidermyKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Carpenter Items/TaxidermyKit.cs
@@ -264,7 +264,7 @@ namespace Server.Items
                     list.Add(1070857, m_Hunter.Name); // Caught by ~1_fisherman~
                 }
 
-                list.Add(1070858, $"{m_AnimalWeight}"); // ~1_weight~ stones
+                list.Add(1070858, m_AnimalWeight); // ~1_weight~ stones
             }
         }
 
@@ -439,7 +439,7 @@ namespace Server.Items
                     list.Add(1070857, m_Hunter.Name); // Caught by ~1_fisherman~
                 }
 
-                list.Add(1070858, $"{m_AnimalWeight}"); // ~1_weight~ stones
+                list.Add(1070858, m_AnimalWeight); // ~1_weight~ stones
             }
         }
 

--- a/Projects/UOContent/Items/Skill Items/Fishing/Misc/ShipwreckedItem.cs
+++ b/Projects/UOContent/Items/Skill Items/Fishing/Misc/ShipwreckedItem.cs
@@ -48,7 +48,7 @@ namespace Server.Items
 
         public override void OnSingleClick(Mobile from)
         {
-            LabelTo(from, 1050039, $"#{LabelNumber}\t#1041645");
+            LabelTo(from, 1050039, $"{LabelNumber:#}\t{1041645:#}");
         }
 
         public override void AddNameProperties(IPropertyList list)

--- a/Projects/UOContent/Items/Skill Items/Harvest Tools/BaseHarvestTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Harvest Tools/BaseHarvestTool.cs
@@ -122,7 +122,7 @@ namespace Server.Items
                 list.Add(1060636); // exceptional
             }
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
         }
 
         public virtual void DisplayDurabilityTo(Mobile m)

--- a/Projects/UOContent/Items/Skill Items/Magical/Misc/RecallRune.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Misc/RecallRune.cs
@@ -246,9 +246,13 @@ namespace Server.Items
                 {
                     list.Add(House != null ? 1062453 : 1060806, $"a recall rune for {desc}"); // ~1_val~ (Trammel)[(House)]
                 }
+                else if (House != null)
+                {
+                    list.Add($"a recall rune for {desc} ({m_TargetMap})(House)");
+                }
                 else
                 {
-                    list.Add(House != null ? $"a recall rune for {desc} ({m_TargetMap})(House)" : $"a recall rune for {desc} ({m_TargetMap})");
+                    list.Add($"a recall rune for {desc} ({m_TargetMap})");
                 }
             }
         }

--- a/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
@@ -738,72 +738,72 @@ namespace Server.Items
 
             if ((prop = Attributes.WeaponDamage) != 0)
             {
-                list.Add(1060401, $"{prop}"); // damage increase ~1_val~%
+                list.Add(1060401, prop); // damage increase ~1_val~%
             }
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -813,17 +813,17 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if (Attributes.SpellChanneling != 0)
@@ -833,30 +833,30 @@ namespace Server.Items
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if (Core.ML && (prop = Attributes.IncreasedKarmaLoss) != 0)
             {
-                list.Add(1075210, $"{prop}"); // Increased Karma Loss ~1val~%
+                list.Add(1075210, prop); // Increased Karma Loss ~1val~%
             }
 
-            list.Add(1042886, $"{SpellCount}"); // ~1_NUMBERS_OF_SPELLS~ Spells
+            list.Add(1042886, SpellCount); // ~1_NUMBERS_OF_SPELLS~ Spells
         }
 
         public override void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Items/Skill Items/Misc/RecipeScroll.cs
+++ b/Projects/UOContent/Items/Skill Items/Misc/RecipeScroll.cs
@@ -50,7 +50,14 @@ namespace Server.Items
 
             if (r != null)
             {
-                list.Add(1049644, $"{r.TextDefinition}"); // [~1_stuff~]
+                if (r.TextDefinition.Number > 0)
+                {
+                    list.Add(1049644, r.TextDefinition.Number); // [~1_stuff~]
+                }
+                else
+                {
+                    list.Add(1049644, r.TextDefinition.String); // [~1_stuff~]
+                }
             }
         }
 

--- a/Projects/UOContent/Items/Skill Items/Musical Instruments/BaseInstrument.cs
+++ b/Projects/UOContent/Items/Skill Items/Musical Instruments/BaseInstrument.cs
@@ -376,7 +376,7 @@ namespace Server.Items
                 list.Add(1060636); // exceptional
             }
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
 
             if (m_ReplenishesCharges)
             {

--- a/Projects/UOContent/Items/Skill Items/Ninjitsu/Fukiya.cs
+++ b/Projects/UOContent/Items/Skill Items/Ninjitsu/Fukiya.cs
@@ -91,7 +91,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
 
             if (m_Poison != null && m_PoisonCharges > 0)
             {

--- a/Projects/UOContent/Items/Skill Items/Ninjitsu/FukiyaDarts.cs
+++ b/Projects/UOContent/Items/Skill Items/Ninjitsu/FukiyaDarts.cs
@@ -77,7 +77,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
 
             if (m_Poison != null && m_PoisonCharges > 0)
             {

--- a/Projects/UOContent/Items/Skill Items/Ninjitsu/LeatherNinjaBelt.cs
+++ b/Projects/UOContent/Items/Skill Items/Ninjitsu/LeatherNinjaBelt.cs
@@ -93,7 +93,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
 
             if (m_Poison != null && m_PoisonCharges > 0)
             {

--- a/Projects/UOContent/Items/Skill Items/Ninjitsu/Shuriken.cs
+++ b/Projects/UOContent/Items/Skill Items/Ninjitsu/Shuriken.cs
@@ -78,7 +78,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
 
             if (m_Poison != null && m_PoisonCharges > 0)
             {

--- a/Projects/UOContent/Items/Skill Items/Tools/BaseTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/BaseTool.cs
@@ -127,7 +127,7 @@ namespace Server.Items
                 list.Add(1060636); // exceptional
             }
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
         }
 
         public virtual void DisplayDurabilityTo(Mobile m)

--- a/Projects/UOContent/Items/Skill Items/Tools/RunicSewingKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/RunicSewingKit.cs
@@ -28,7 +28,7 @@ namespace Server.Items
         {
             if (CraftResources.IsStandard(Resource))
             {
-                list.Add(1061119, $"{" "}"); // ~1_LEATHER_TYPE~ runic sewing kit
+                list.Add(1061119, " "); // ~1_LEATHER_TYPE~ runic sewing kit
                 return;
             }
 

--- a/Projects/UOContent/Items/Skill Items/Tools/RunicSewingKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/RunicSewingKit.cs
@@ -26,23 +26,15 @@ namespace Server.Items
 
         public override void AddNameProperty(IPropertyList list)
         {
-            var v = " ";
-
-            if (!CraftResources.IsStandard(Resource))
+            if (CraftResources.IsStandard(Resource))
             {
-                var num = CraftResources.GetLocalizationNumber(Resource);
-
-                if (num > 0)
-                {
-                    v = $"#{num}";
-                }
-                else
-                {
-                    v = CraftResources.GetName(Resource);
-                }
+                list.Add(1061119, $"{" "}"); // ~1_LEATHER_TYPE~ runic sewing kit
+                return;
             }
 
-            list.Add(1061119, v); // ~1_LEATHER_TYPE~ runic sewing kit
+            var num = CraftResources.GetLocalizationNumber(Resource);
+            // ~1_LEATHER_TYPE~ runic sewing kit
+            list.Add(1061119, num > 0 ? $"#{num}" : CraftResources.GetName(Resource));
         }
 
         public override void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Items/Skill Items/Tools/RunicSewingKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/RunicSewingKit.cs
@@ -33,8 +33,17 @@ namespace Server.Items
             }
 
             var num = CraftResources.GetLocalizationNumber(Resource);
-            // ~1_LEATHER_TYPE~ runic sewing kit
-            list.Add(1061119, num > 0 ? $"#{num}" : CraftResources.GetName(Resource));
+
+            if (num > 0)
+            {
+                // ~1_LEATHER_TYPE~ runic sewing kit
+                list.Add(1061119, $"#{num}");
+            }
+            else
+            {
+                // ~1_LEATHER_TYPE~ runic sewing kit
+                list.Add(1061119, CraftResources.GetName(Resource));
+            }
         }
 
         public override void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBox.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBox.cs
@@ -169,17 +169,17 @@ namespace Server.Items
 
             if (commonSongs > 0)
             {
-                list.Add(1075234, $"{commonSongs}"); // ~1_NUMBER~ Common Tracks
+                list.Add(1075234, commonSongs); // ~1_NUMBER~ Common Tracks
             }
 
             if (uncommonSongs > 0)
             {
-                list.Add(1075235, $"{uncommonSongs}"); // ~1_NUMBER~ Uncommon Tracks
+                list.Add(1075235, uncommonSongs); // ~1_NUMBER~ Uncommon Tracks
             }
 
             if (rareSongs > 0)
             {
-                list.Add(1075236, $"{rareSongs}"); // ~1_NUMBER~ Rare Tracks
+                list.Add(1075236, rareSongs); // ~1_NUMBER~ Rare Tracks
             }
         }
 

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/FountainOfLife.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/FountainOfLife.cs
@@ -125,7 +125,7 @@ namespace Server.Items
         {
             base.AddNameProperties(list);
 
-            list.Add(1075217, $"{m_Charges}"); // ~1_val~ charges remaining
+            list.Add(1075217, m_Charges); // ~1_val~ charges remaining
         }
 
         public override void OnDelete()

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/Talismans.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/Talismans.cs
@@ -29,7 +29,7 @@ namespace Server.Items
 
         public override void AddNameProperty(IPropertyList list)
         {
-            list.Add(1075200, $"#{(int)Form}");
+            list.Add(1075200, $"{(int)Form:#}");
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/AncientSmithyHammer.cs
+++ b/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/AncientSmithyHammer.cs
@@ -79,7 +79,7 @@ namespace Server.Items
 
             if (m_Bonus != 0)
             {
-                list.Add(1060451, $"#1042354\t{m_Bonus}"); // ~1_skillname~ +~2_val~
+                list.Add(1060451, $"{1042354:#}\t{m_Bonus}"); // ~1_skillname~ +~2_val~
             }
         }
 

--- a/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/GlovesOfMining.cs
+++ b/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/GlovesOfMining.cs
@@ -202,7 +202,7 @@ namespace Server.Items
 
             if (m_Bonus != 0)
             {
-                list.Add(1062005, $"{m_Bonus}"); // mining bonus +~1_val~
+                list.Add(1062005, m_Bonus); // mining bonus +~1_val~
             }
         }
 

--- a/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/PowderOfTemperament.cs
+++ b/Projects/UOContent/Items/Special/Bulk Order Rewards/Blacksmithy/PowderOfTemperament.cs
@@ -66,7 +66,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
         }
 
         public virtual void DisplayDurabilityTo(Mobile m)

--- a/Projects/UOContent/Items/Special/Gifts/RoseOfTrinsic.cs
+++ b/Projects/UOContent/Items/Special/Gifts/RoseOfTrinsic.cs
@@ -69,7 +69,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1062925, $"{Petals}"); // Petals:  ~1_COUNT~
+            list.Add(1062925, Petals); // Petals:  ~1_COUNT~
         }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Projects/UOContent/Items/Special/HeritageToken.cs
+++ b/Projects/UOContent/Items/Special/HeritageToken.cs
@@ -34,7 +34,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1070998, $"#{1076595}"); // Use this to redeem<br>Your Heritage Items
+            list.Add(1070998, $"{1076595:#}"); // Use this to redeem<br>Your Heritage Items
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Items/Special/HeritageToken.cs
+++ b/Projects/UOContent/Items/Special/HeritageToken.cs
@@ -34,7 +34,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1070998, $"{1076595:#}"); // Use this to redeem<br>Your Heritage Items
+            list.AddLocalized(1070998, 1076595); // Use this to redeem<br>Your Heritage Items
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleDeed.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleDeed.cs
@@ -93,9 +93,9 @@ namespace Server.Items
             {
                 list.Add(
                     1060658, // ~1_val~: ~2_val~
-                    $"location\t{HouseRaffleStone.FormatLocation(m_PlotLocation, m_Facet, false)}"
+                    $"{"location"}\t{HouseRaffleStone.FormatLocation(m_PlotLocation, m_Facet, false)}"
                 );
-                list.Add(1060659, $"facet\t{m_Facet}"); // ~1_val~: ~2_val~
+                list.Add(1060659, $"{"facet"}\t{m_Facet}"); // ~1_val~: ~2_val~
                 list.Add(1150486);                      // [Marked Item]
             }
 

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -411,8 +411,8 @@ namespace Server.Items
             {
                 case HouseRaffleState.Active:
                     {
-                        list.Add(1060658, $"ticket price\t{FormatPrice()}");  // ~1_val~: ~2_val~
-                        list.Add(1060659, $"ends\t{m_Started + m_Duration}"); // ~1_val~: ~2_val~
+                        list.Add(1060658, $"{"ticket price"}\t{FormatPrice()}");  // ~1_val~: ~2_val~
+                        list.Add(1060659, $"{"ends"}\t{m_Started + m_Duration}"); // ~1_val~: ~2_val~
                         break;
                     }
                 case HouseRaffleState.Completed:

--- a/Projects/UOContent/Items/Special/Solen Items/BagOfSending.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BagOfSending.cs
@@ -106,7 +106,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060741, $"{m_Charges}"); // charges: ~1_val~
+            list.Add(1060741, m_Charges); // charges: ~1_val~
         }
 
         public override void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Items/Special/Solen Items/BraceletOfBinding.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BraceletOfBinding.cs
@@ -91,19 +91,17 @@ namespace Server.Items
 
         public override void AddNameProperty(IPropertyList list)
         {
-            list.Add(
-                1054000,
-                $"{m_Charges}\t{m_Inscription.DefaultIfNullOrEmpty(" ")}"
-            ); // a bracelet of binding : ~1_val~ ~2_val~
+            // a bracelet of binding : ~1_val~ ~2_val~
+            list.Add(1054000, $"{m_Charges}\t{m_Inscription.DefaultIfNullOrEmpty(" ")}");
         }
 
         public override void OnSingleClick(Mobile from)
         {
             LabelTo(
                 from,
-                1054000,
+                1054000, // a bracelet of binding : ~1_val~ ~2_val~
                 $"{m_Charges}\t{m_Inscription.DefaultIfNullOrEmpty(" ")}"
-            ); // a bracelet of binding : ~1_val~ ~2_val~
+            );
         }
 
         public override void GetContextMenuEntries(Mobile from, List<ContextMenuEntry> list)

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -129,11 +129,11 @@ namespace Server.Items
             {
                 list.Add(
                     1070721, // Skill stored: ~1_skillname~ ~2_skillamount~
-                    $"#{AosSkillBonuses.GetLabel(Skill)}\t{SkillValue:F1}"
+                    $"{AosSkillBonuses.GetLabel(Skill):#}\t{SkillValue:F1}"
                 );
             }
 
-            list.Add(1041602, LastUserName ?? $"#{1074235}"); // Owner: ~1_val~
+            list.Add(1041602, LastUserName ?? $"{1074235:#}"); // Owner: ~1_val~
         }
 
         private static bool CheckCombat(Mobile m, TimeSpan time)

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -139,7 +139,7 @@ namespace Server.Items
             }
             else
             {
-                list.Add(1041602, $"{1074235:#}"); // Owner: ~1_val~
+                list.AddLocalized(1041602, 1074235); // Owner: ~1_val~
             }
         }
 
@@ -975,7 +975,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+            list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -133,7 +133,14 @@ namespace Server.Items
                 );
             }
 
-            list.Add(1041602, LastUserName ?? $"{1074235:#}"); // Owner: ~1_val~
+            if (LastUserName != null)
+            {
+                list.Add(1041602, LastUserName); // Owner: ~1_val~
+            }
+            else
+            {
+                list.Add(1041602, $"{1074235:#}"); // Owner: ~1_val~
+            }
         }
 
         private static bool CheckCombat(Mobile m, TimeSpan time)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/Cannon.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/Cannon.cs
@@ -27,7 +27,7 @@ namespace Server.Items
                     list.Add(1076223); // 7th Year Veteran Reward
                 }
 
-                list.Add(1076207, $"{addon.Charges}"); // Remaining Charges: ~1_val~
+                list.Add(1076207, addon.Charges); // Remaining Charges: ~1_val~
             }
         }
 
@@ -471,7 +471,7 @@ namespace Server.Items
                 list.Add(1076223); // 7th Year Veteran Reward
             }
 
-            list.Add(1076207, $"{m_Charges}"); // Remaining Charges: ~1_val~
+            list.Add(1076207, m_Charges); // Remaining Charges: ~1_val~
         }
 
         public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/WeaponEngravingTool.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/WeaponEngravingTool.cs
@@ -110,7 +110,7 @@ namespace Server.Items
 
             if (ShowUsesRemaining)
             {
-                list.Add(1060584, $"{m_UsesRemaining}"); // uses remaining: ~1_val~
+                list.Add(1060584, m_UsesRemaining); // uses remaining: ~1_val~
             }
         }
 

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -587,7 +587,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    list.Add(1072304, "Nobody"); // Owned by ~1_name~
+                    list.Add(1072304, $"{"Nobody"}"); // Owned by ~1_name~
                 }
             }
 

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -564,7 +564,7 @@ namespace Server.Items
             }
             else if (m_Removal != TalismanRemoval.None)
             {
-                list.Add(1072389, $"{1072000 + (int)m_Removal:#}"); // Talisman of ~1_name~
+                list.AddLocalized(1072389, 1072000 + (int)m_Removal); // Talisman of ~1_name~
             }
             else
             {
@@ -587,7 +587,7 @@ namespace Server.Items
                 }
                 else
                 {
-                    list.Add(1072304, $"{"Nobody"}"); // Owned by ~1_name~
+                    list.Add(1072304, "Nobody"); // Owned by ~1_name~
                 }
             }
 
@@ -595,7 +595,7 @@ namespace Server.Items
             {
                 if (m_ChargeTime > 0)
                 {
-                    list.Add(1074884, $"{m_ChargeTime}"); // Charge time left: ~1_val~
+                    list.Add(1074884, m_ChargeTime); // Charge time left: ~1_val~
                 }
                 else
                 {
@@ -643,72 +643,72 @@ namespace Server.Items
 
             if ((prop = Attributes.WeaponDamage) != 0)
             {
-                list.Add(1060401, $"{prop}"); // damage increase ~1_val~%
+                list.Add(1060401, prop); // damage increase ~1_val~%
             }
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -718,17 +718,17 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if (Attributes.SpellChanneling != 0)
@@ -738,32 +738,32 @@ namespace Server.Items
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if (Core.ML && (prop = Attributes.IncreasedKarmaLoss) != 0)
             {
-                list.Add(1075210, $"{prop}"); // Increased Karma Loss ~1val~%
+                list.Add(1075210, prop); // Increased Karma Loss ~1val~%
             }
 
             if (m_MaxCharges > 0)
             {
-                list.Add(1060741, $"{m_Charges}"); // charges: ~1_val~
+                list.Add(1060741, m_Charges); // charges: ~1_val~
             }
 
             if (m_Slayer != TalismanSlayerName.None)

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -564,7 +564,7 @@ namespace Server.Items
             }
             else if (m_Removal != TalismanRemoval.None)
             {
-                list.Add(1072389, $"#{1072000 + (int)m_Removal}"); // Talisman of ~1_name~
+                list.Add(1072389, $"{1072000 + (int)m_Removal:#}"); // Talisman of ~1_name~
             }
             else
             {
@@ -625,7 +625,7 @@ namespace Server.Items
             {
                 list.Add(
                     1072395, // ~1_NAME~ Exceptional Bonus: ~2_val~%
-                    $"#{AosSkillBonuses.GetLabel(m_Skill)}\t{m_ExceptionalBonus}"
+                    $"{AosSkillBonuses.GetLabel(m_Skill):#}\t{m_ExceptionalBonus}"
                 );
             }
 
@@ -633,7 +633,7 @@ namespace Server.Items
             {
                 list.Add(
                     1072394, // ~1_NAME~ Bonus: ~2_val~%
-                    $"#{AosSkillBonuses.GetLabel(m_Skill)}\t{m_SuccessBonus}"
+                    $"{AosSkillBonuses.GetLabel(m_Skill):#}\t{m_SuccessBonus}"
                 );
             }
 

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -557,10 +557,15 @@ namespace Server.Items
             }
             else if (m_Summoner?.IsEmpty == false)
             {
-                list.Add(
-                    1072400,
-                    m_Summoner?.Name ?? "Unknown"
-                ); // Talisman of ~1_name~ Summoning
+                var name = m_Summoner?.Name;
+                if (name?.Number > 0)
+                {
+                    list.Add(1072400, name.Number); // Talisman of ~1_name~ Summoning
+                }
+                else
+                {
+                    list.Add(1072400, name?.String ?? "Unknown"); // Talisman of ~1_name~ Summoning
+                }
             }
             else if (m_Removal != TalismanRemoval.None)
             {

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -2855,12 +2855,12 @@ namespace Server.Items
 
             if (ArtifactRarity > 0)
             {
-                list.Add(1061078, $"{ArtifactRarity}"); // artifact rarity ~1_val~
+                list.Add(1061078, ArtifactRarity); // artifact rarity ~1_val~
             }
 
             if (this is IUsesRemaining usesRemaining && usesRemaining.ShowUsesRemaining)
             {
-                list.Add(1060584, $"{usesRemaining.UsesRemaining}"); // uses remaining: ~1_val~
+                list.Add(1060584, usesRemaining.UsesRemaining); // uses remaining: ~1_val~
             }
 
             if (m_Poison != null && m_PoisonCharges > 0)
@@ -2904,107 +2904,107 @@ namespace Server.Items
 
             if ((prop = GetDamageBonus() + Attributes.WeaponDamage) != 0)
             {
-                list.Add(1060401, $"{prop}"); // damage increase ~1_val~%
+                list.Add(1060401, prop); // damage increase ~1_val~%
             }
 
             if ((prop = Attributes.DefendChance) != 0)
             {
-                list.Add(1060408, $"{prop}"); // defense chance increase ~1_val~%
+                list.Add(1060408, prop); // defense chance increase ~1_val~%
             }
 
             if ((prop = Attributes.EnhancePotions) != 0)
             {
-                list.Add(1060411, $"{prop}"); // enhance potions ~1_val~%
+                list.Add(1060411, prop); // enhance potions ~1_val~%
             }
 
             if ((prop = Attributes.CastRecovery) != 0)
             {
-                list.Add(1060412, $"{prop}"); // faster cast recovery ~1_val~
+                list.Add(1060412, prop); // faster cast recovery ~1_val~
             }
 
             if ((prop = Attributes.CastSpeed) != 0)
             {
-                list.Add(1060413, $"{prop}"); // faster casting ~1_val~
+                list.Add(1060413, prop); // faster casting ~1_val~
             }
 
             if ((prop = GetHitChanceBonus() + Attributes.AttackChance) != 0)
             {
-                list.Add(1060415, $"{prop}"); // hit chance increase ~1_val~%
+                list.Add(1060415, prop); // hit chance increase ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitColdArea) != 0)
             {
-                list.Add(1060416, $"{prop}"); // hit cold area ~1_val~%
+                list.Add(1060416, prop); // hit cold area ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitDispel) != 0)
             {
-                list.Add(1060417, $"{prop}"); // hit dispel ~1_val~%
+                list.Add(1060417, prop); // hit dispel ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitEnergyArea) != 0)
             {
-                list.Add(1060418, $"{prop}"); // hit energy area ~1_val~%
+                list.Add(1060418, prop); // hit energy area ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitFireArea) != 0)
             {
-                list.Add(1060419, $"{prop}"); // hit fire area ~1_val~%
+                list.Add(1060419, prop); // hit fire area ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitFireball) != 0)
             {
-                list.Add(1060420, $"{prop}"); // hit fireball ~1_val~%
+                list.Add(1060420, prop); // hit fireball ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitHarm) != 0)
             {
-                list.Add(1060421, $"{prop}"); // hit harm ~1_val~%
+                list.Add(1060421, prop); // hit harm ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitLeechHits) != 0)
             {
-                list.Add(1060422, $"{prop}"); // hit life leech ~1_val~%
+                list.Add(1060422, prop); // hit life leech ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitLightning) != 0)
             {
-                list.Add(1060423, $"{prop}"); // hit lightning ~1_val~%
+                list.Add(1060423, prop); // hit lightning ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitLowerAttack) != 0)
             {
-                list.Add(1060424, $"{prop}"); // hit lower attack ~1_val~%
+                list.Add(1060424, prop); // hit lower attack ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitLowerDefend) != 0)
             {
-                list.Add(1060425, $"{prop}"); // hit lower defense ~1_val~%
+                list.Add(1060425, prop); // hit lower defense ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitMagicArrow) != 0)
             {
-                list.Add(1060426, $"{prop}"); // hit magic arrow ~1_val~%
+                list.Add(1060426, prop); // hit magic arrow ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitLeechMana) != 0)
             {
-                list.Add(1060427, $"{prop}"); // hit mana leech ~1_val~%
+                list.Add(1060427, prop); // hit mana leech ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitPhysicalArea) != 0)
             {
-                list.Add(1060428, $"{prop}"); // hit physical area ~1_val~%
+                list.Add(1060428, prop); // hit physical area ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitPoisonArea) != 0)
             {
-                list.Add(1060429, $"{prop}"); // hit poison area ~1_val~%
+                list.Add(1060429, prop); // hit poison area ~1_val~%
             }
 
             if ((prop = WeaponAttributes.HitLeechStam) != 0)
             {
-                list.Add(1060430, $"{prop}"); // hit stamina leech ~1_val~%
+                list.Add(1060430, prop); // hit stamina leech ~1_val~%
             }
 
             if (ImmolatingWeaponSpell.IsImmolating(this))
@@ -3014,42 +3014,42 @@ namespace Server.Items
 
             if (Core.ML && (ranged?.Velocity ?? 0) != 0)
             {
-                list.Add(1072793, $"{prop}"); // Velocity ~1_val~%
+                list.Add(1072793, prop); // Velocity ~1_val~%
             }
 
             if ((prop = Attributes.BonusDex) != 0)
             {
-                list.Add(1060409, $"{prop}"); // dexterity bonus ~1_val~
+                list.Add(1060409, prop); // dexterity bonus ~1_val~
             }
 
             if ((prop = Attributes.BonusHits) != 0)
             {
-                list.Add(1060431, $"{prop}"); // hit point increase ~1_val~
+                list.Add(1060431, prop); // hit point increase ~1_val~
             }
 
             if ((prop = Attributes.BonusInt) != 0)
             {
-                list.Add(1060432, $"{prop}"); // intelligence bonus ~1_val~
+                list.Add(1060432, prop); // intelligence bonus ~1_val~
             }
 
             if ((prop = Attributes.LowerManaCost) != 0)
             {
-                list.Add(1060433, $"{prop}"); // lower mana cost ~1_val~%
+                list.Add(1060433, prop); // lower mana cost ~1_val~%
             }
 
             if ((prop = Attributes.LowerRegCost) != 0)
             {
-                list.Add(1060434, $"{prop}"); // lower reagent cost ~1_val~%
+                list.Add(1060434, prop); // lower reagent cost ~1_val~%
             }
 
             if ((prop = GetLowerStatReq()) != 0)
             {
-                list.Add(1060435, $"{prop}"); // lower requirements ~1_val~%
+                list.Add(1060435, prop); // lower requirements ~1_val~%
             }
 
             if ((prop = GetLuckBonus() + Attributes.Luck) != 0)
             {
-                list.Add(1060436, $"{prop}"); // luck ~1_val~
+                list.Add(1060436, prop); // luck ~1_val~
             }
 
             if ((prop = WeaponAttributes.MageWeapon) != 0)
@@ -3059,12 +3059,12 @@ namespace Server.Items
 
             if ((prop = Attributes.BonusMana) != 0)
             {
-                list.Add(1060439, $"{prop}"); // mana increase ~1_val~
+                list.Add(1060439, prop); // mana increase ~1_val~
             }
 
             if ((prop = Attributes.RegenMana) != 0)
             {
-                list.Add(1060440, $"{prop}"); // mana regeneration ~1_val~
+                list.Add(1060440, prop); // mana regeneration ~1_val~
             }
 
             if (Attributes.NightSight != 0)
@@ -3074,22 +3074,22 @@ namespace Server.Items
 
             if ((prop = Attributes.ReflectPhysical) != 0)
             {
-                list.Add(1060442, $"{prop}"); // reflect physical damage ~1_val~%
+                list.Add(1060442, prop); // reflect physical damage ~1_val~%
             }
 
             if ((prop = Attributes.RegenStam) != 0)
             {
-                list.Add(1060443, $"{prop}"); // stamina regeneration ~1_val~
+                list.Add(1060443, prop); // stamina regeneration ~1_val~
             }
 
             if ((prop = Attributes.RegenHits) != 0)
             {
-                list.Add(1060444, $"{prop}"); // hit point regeneration ~1_val~
+                list.Add(1060444, prop); // hit point regeneration ~1_val~
             }
 
             if ((prop = WeaponAttributes.SelfRepair) != 0)
             {
-                list.Add(1060450, $"{prop}"); // self repair ~1_val~
+                list.Add(1060450, prop); // self repair ~1_val~
             }
 
             if (Attributes.SpellChanneling != 0)
@@ -3099,27 +3099,27 @@ namespace Server.Items
 
             if ((prop = Attributes.SpellDamage) != 0)
             {
-                list.Add(1060483, $"{prop}"); // spell damage increase ~1_val~%
+                list.Add(1060483, prop); // spell damage increase ~1_val~%
             }
 
             if ((prop = Attributes.BonusStam) != 0)
             {
-                list.Add(1060484, $"{prop}"); // stamina increase ~1_val~
+                list.Add(1060484, prop); // stamina increase ~1_val~
             }
 
             if ((prop = Attributes.BonusStr) != 0)
             {
-                list.Add(1060485, $"{prop}"); // strength bonus ~1_val~
+                list.Add(1060485, prop); // strength bonus ~1_val~
             }
 
             if ((prop = Attributes.WeaponSpeed) != 0)
             {
-                list.Add(1060486, $"{prop}"); // swing speed increase ~1_val~%
+                list.Add(1060486, prop); // swing speed increase ~1_val~%
             }
 
             if (Core.ML && (prop = Attributes.IncreasedKarmaLoss) != 0)
             {
-                list.Add(1075210, $"{prop}"); // Increased Karma Loss ~1val~%
+                list.Add(1075210, prop); // Increased Karma Loss ~1val~%
             }
 
             GetDamageTypes(
@@ -3135,37 +3135,37 @@ namespace Server.Items
 
             if (phys != 0)
             {
-                list.Add(1060403, $"{phys}"); // physical damage ~1_val~%
+                list.Add(1060403, phys); // physical damage ~1_val~%
             }
 
             if (fire != 0)
             {
-                list.Add(1060405, $"{fire}"); // fire damage ~1_val~%
+                list.Add(1060405, fire); // fire damage ~1_val~%
             }
 
             if (cold != 0)
             {
-                list.Add(1060404, $"{cold}"); // cold damage ~1_val~%
+                list.Add(1060404, cold); // cold damage ~1_val~%
             }
 
             if (pois != 0)
             {
-                list.Add(1060406, $"{pois}"); // poison damage ~1_val~%
+                list.Add(1060406, pois); // poison damage ~1_val~%
             }
 
             if (nrgy != 0)
             {
-                list.Add(1060407, $"{nrgy}"); // energy damage ~1_val
+                list.Add(1060407, nrgy); // energy damage ~1_val
             }
 
             if (Core.ML && chaos != 0)
             {
-                list.Add(1072846, $"{chaos}"); // chaos damage ~1_val~%
+                list.Add(1072846, chaos); // chaos damage ~1_val~%
             }
 
             if (Core.ML && direct != 0)
             {
-                list.Add(1079978, $"{direct}"); // Direct Damage: ~1_PERCENT~%
+                list.Add(1079978, direct); // Direct Damage: ~1_PERCENT~%
             }
 
             list.Add(1061168, $"{MinDamage}\t{MaxDamage}"); // weapon damage ~1_val~ - ~2_val~
@@ -3181,14 +3181,14 @@ namespace Server.Items
 
             if (MaxRange > 1)
             {
-                list.Add(1061169, $"{MaxRange}"); // range ~1_val~
+                list.Add(1061169, MaxRange); // range ~1_val~
             }
 
             var strReq = AOS.Scale(StrRequirement, 100 - GetLowerStatReq());
 
             if (strReq > 0)
             {
-                list.Add(1061170, $"{strReq}"); // strength requirement ~1_val~
+                list.Add(1061170, strReq); // strength requirement ~1_val~
             }
 
             if (Layer == Layer.TwoHanded)

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -2778,7 +2778,12 @@ namespace Server.Items
 
             if (oreType != 0)
             {
-                list.Add(1053099, name != null ? $"#{oreType}\t{name}" : $"#{oreType}\t#{LabelNumber}"); // ~1_oretype~ ~2_armortype~
+                list.Add(
+                    1053099, // ~1_oretype~ ~2_armortype~
+                    name != null
+                        ? $"{oreType:#}\t{name}"
+                        : $"{oreType:#}\t{LabelNumber:#}"
+                );
             }
             else if (name == null)
             {

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -2778,12 +2778,14 @@ namespace Server.Items
 
             if (oreType != 0)
             {
-                list.Add(
-                    1053099, // ~1_oretype~ ~2_armortype~
-                    name != null
-                        ? $"{oreType:#}\t{name}"
-                        : $"{oreType:#}\t{LabelNumber:#}"
-                );
+                if (name != null)
+                {
+                    list.Add(1053099, $"{oreType:#}\t{name}"); // ~1_oretype~ ~2_armortype~
+                }
+                else
+                {
+                    list.Add(1053099, $"{oreType:#}\t{LabelNumber:#}"); // ~1_oretype~ ~2_armortype~
+                }
             }
             else if (name == null)
             {

--- a/Projects/UOContent/Misc/AOS.cs
+++ b/Projects/UOContent/Misc/AOS.cs
@@ -1041,7 +1041,7 @@ namespace Server
             {
                 if (GetValues(i, out var skill, out var bonus))
                 {
-                    list.Add(1060451 + i, $"#{GetLabel(skill)}\t{bonus}");
+                    list.Add(1060451 + i, $"{GetLabel(skill):#}\t{bonus}");
                 }
             }
         }

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -3525,14 +3525,15 @@ namespace Server.Mobiles
 
                     if (faction.Commander == this)
                     {
-                        list.Add(1042733, faction.Definition.PropName); // Commanding Lord of the ~1_FACTION_NAME~
+                        // Commanding Lord of the ~1_FACTION_NAME~
+                        list.Add(1042733, $"{faction.Definition.PropName}");
                     }
                     else if (pl.Sheriff != null)
                     {
                         list.Add(
-                            1042734,
+                            1042734, // The Sheriff of  ~1_CITY~, ~2_FACTION_NAME~
                             $"{pl.Sheriff.Definition.FriendlyName}\t{faction.Definition.PropName}"
-                        ); // The Sheriff of  ~1_CITY~, ~2_FACTION_NAME~
+                        );
                     }
                     else if (pl.Finance != null)
                     {

--- a/Projects/UOContent/Multis/Houses/BaseHouse.cs
+++ b/Projects/UOContent/Multis/Houses/BaseHouse.cs
@@ -3730,7 +3730,7 @@ namespace Server.Multis
                 }
                 else
                 {
-                    list.Add(1061114, $"{"unknown"}"); // Location: ~1_val~
+                    list.Add(1061114, "unknown"); // Location: ~1_val~
                 }
             }
 

--- a/Projects/UOContent/Multis/Houses/BaseHouse.cs
+++ b/Projects/UOContent/Multis/Houses/BaseHouse.cs
@@ -3721,12 +3721,17 @@ namespace Server.Multis
                     ref ySouth
                 );
 
-                var location =
-                    valid ? $"{yLat}° {yMins}'{(ySouth ? "S" : "N")}, {xLong}° {xMins}'{(xEast ? "E" : "W")}" : "unknown";
-
                 list.Add(1061112, Utility.FixHtml(houseName)); // House Name: ~1_val~
                 list.Add(1061113, owner);                      // Owner: ~1_val~
-                list.Add(1061114, location);                   // Location: ~1_val~
+                if (valid)
+                {
+                    // Location: ~1_val~
+                    list.Add(1061114, $"{yLat}° {yMins}'{(ySouth ? "S" : "N")}, {xLong}° {xMins}'{(xEast ? "E" : "W")}");
+                }
+                else
+                {
+                    list.Add(1061114, $"{"unknown"}"); // Location: ~1_val~
+                }
             }
 
             public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Multis/Houses/HouseSign.cs
+++ b/Projects/UOContent/Multis/Houses/HouseSign.cs
@@ -83,7 +83,7 @@ namespace Server.Multis
                         level = DecayLevel.IDOC;
                     }
 
-                    list.Add(1062028, $"#{1043009 + (int)level}"); // Condition: This structure is ...
+                    list.Add(1062028, $"{1043009 + (int)level:#}"); // Condition: This structure is ...
                 }
             }
         }

--- a/Projects/UOContent/Multis/Houses/HouseSign.cs
+++ b/Projects/UOContent/Multis/Houses/HouseSign.cs
@@ -83,7 +83,7 @@ namespace Server.Multis
                         level = DecayLevel.IDOC;
                     }
 
-                    list.Add(1062028, $"{1043009 + (int)level:#}"); // Condition: This structure is ...
+                    list.AddLocalized(1062028, 1043009 + (int)level); // Condition: This structure is ...
                 }
             }
         }

--- a/Projects/UOContent/Spells/Spellweaving/Items/ArcaneFocus.cs
+++ b/Projects/UOContent/Spells/Spellweaving/Items/ArcaneFocus.cs
@@ -38,7 +38,7 @@ namespace Server.Items
         {
             base.GetProperties(list);
 
-            list.Add(1060485, $"{StrengthBonus}"); // strength bonus ~1_val~
+            list.Add(1060485, StrengthBonus); // strength bonus ~1_val~
         }
 
         public override void Serialize(IGenericWriter writer)

--- a/Projects/UOContent/Spells/Spellweaving/Items/TransientItem.cs
+++ b/Projects/UOContent/Spells/Spellweaving/Items/TransientItem.cs
@@ -53,9 +53,9 @@ namespace Server.Items
         public virtual void SendTimeRemainingMessage(Mobile to)
         {
             to.SendLocalizedMessage(
-                1072516,
+                1072516, // ~1_name~ will expire in ~2_val~ seconds!
                 $"{Name ?? $"#{LabelNumber}"}\t{(int)LifeSpan.TotalSeconds}"
-            ); // ~1_name~ will expire in ~2_val~ seconds!
+            );
         }
 
         public override void OnDelete()


### PR DESCRIPTION
## Changes
- [X] Adds OPL convenience methods
    - `opl.Add(cliloc, value)` and `opl.Add(value)` - value as an integer or string works just like `opl.Add(cliloc, $"{value}")`
    - `opl.AddLocalized(cliloc, clilocValue)` - works the same as `opl.Add(cliloc, $"#{clilocValue}");`
- [X] Simplifies basic `list.Add()` situations
- [X] Changes cliloc as an argument so it works with custom IPropertyList implementations (HTML)
- [X] Fixes plants so they support the old localization and new (changed in 7.0.12.0+)
- [X] Exposes more methods to override for Item to make creating custom OPL possible.

## Important Notes
* Using a ternary as an argument, like this `opl.Add(number, showType ? $"{type}\t{value}" : $"{value}");` _will not use the correct string interpolation_. This means if you use a custom PropertyList (for HTML or some other purpose), the property list won't be localized properly.
* All localization values must be interpolated, even if they are literal strings, or integers. Example: `opl.Add(number, $"{"Charges"}\t{m_Charges}");` is correct. Using the following: `$"Charges\t{m_Charges}"` will not work for custom PropertyList implementations!