### PR TITLE
fix: Adds ISpanFormattable support to Serial

### DIFF
--- a/Projects/Server.Tests/Tests/SerialTests.cs
+++ b/Projects/Server.Tests/Tests/SerialTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Xunit;
+
+namespace Server.Tests;
+
+public class SerialTests
+{
+    [Fact]
+    public void TestSerialTryFormatDefault()
+    {
+        var serial = (Serial)0xABCD1234u;
+        const string serialStr = "0xABCD1234";
+        Span<char> buffer = stackalloc char[serialStr.Length];
+        var result = serial.TryFormat(buffer, out var charsWritten, null, null);
+        Assert.True(result);
+        Assert.Equal(serialStr.Length, charsWritten);
+        Assert.Equal(serialStr, buffer.ToString());
+
+        var interpolated = $"{serial}";
+        Assert.Equal(serialStr, interpolated);
+    }
+
+    [Fact]
+    public void TestSerialTryFormatCustom()
+    {
+        var serial = (Serial)0xABCD1234u;
+        const string serialStr = "2882343476";
+        Span<char> buffer = stackalloc char[serialStr.Length];
+        var result = serial.TryFormat(buffer, out var charsWritten, "##", null);
+        Assert.True(result);
+        Assert.Equal(serialStr.Length, charsWritten);
+        Assert.Equal(serialStr, buffer.ToString());
+
+        var interpolated = $"{serial:##}";
+        Assert.Equal(serialStr, interpolated);
+    }
+}

--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -135,6 +135,6 @@ namespace Server.Guilds
             return results;
         }
 
-        public override string ToString() => $"0x{Serial.Value:X} \"{Name} [{Abbreviation}]\"";
+        public override string ToString() => $"{Serial} \"{Name} [{Abbreviation}]\"";
     }
 }

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -3165,10 +3165,10 @@ namespace Server
             if (item == this)
             {
                 Console.WriteLine(
-                    "Warning: Adding item to itself: [0x{0:X} {1}].AddItem( [0x{2:X} {3}] )",
-                    Serial.Value,
+                    "Warning: Adding item to itself: [0x{0} {1}].AddItem( [0x{2} {3}] )",
+                    Serial,
                     GetType().Name,
-                    item.Serial.Value,
+                    item.Serial,
                     item.GetType().Name
                 );
                 Console.WriteLine(new StackTrace());
@@ -3178,10 +3178,10 @@ namespace Server
             if (IsChildOf(item))
             {
                 Console.WriteLine(
-                    "Warning: Adding parent item to child: [0x{0:X} {1}].AddItem( [0x{2:X} {3}] )",
-                    Serial.Value,
+                    "Warning: Adding parent item to child: [0x{0} {1}].AddItem( [0x{2} {3}] )",
+                    Serial,
                     GetType().Name,
-                    item.Serial.Value,
+                    item.Serial,
                     item.GetType().Name
                 );
                 Console.WriteLine(new StackTrace());
@@ -4245,7 +4245,7 @@ namespace Server
         public virtual bool IsStandardLoot() =>
             (!Mobile.InsuranceEnabled || !Insured) && BlessedFor == null && m_LootType == LootType.Regular;
 
-        public override string ToString() => $"0x{Serial.Value:X} \"{GetType().Name}\"";
+        public override string ToString() => $"{Serial} \"{GetType().Name}\"";
 
         public virtual void OnSectorActivate()
         {

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -3790,7 +3790,7 @@ namespace Server
             }
         }
 
-        public override string ToString() => $"0x{Serial.Value:X} \"{Name}\"";
+        public override string ToString() => $"{Serial} \"{Name}\"";
 
         public virtual void SendSkillMessage()
         {
@@ -5311,8 +5311,8 @@ namespace Server
             catch
             {
                 Console.WriteLine(
-                    "Warning: 0x{0:X}: Item must have a zero parameter constructor to be separated from a stack. '{1}'.",
-                    oldItem.Serial.Value,
+                    "Warning: {0}: Item must have a zero parameter constructor to be separated from a stack. '{1}'.",
+                    oldItem.Serial,
                     oldItem.GetType().Name
                 );
                 return null;

--- a/Projects/Server/Serial.cs
+++ b/Projects/Server/Serial.cs
@@ -16,120 +16,148 @@
 using System;
 using System.Runtime.CompilerServices;
 
-namespace Server
+namespace Server;
+
+public readonly struct Serial : IComparable<Serial>, IComparable<uint>, IEquatable<Serial>, ISpanFormattable
 {
-    public readonly struct Serial : IComparable<Serial>, IComparable<uint>, IEquatable<Serial>
+    public static readonly Serial MinusOne = new(0xFFFFFFFF);
+    public static readonly Serial Zero = new(0);
+
+    private Serial(uint serial) => Value = serial;
+
+    public uint Value { get; }
+
+    public bool IsMobile
     {
-        public static readonly Serial MinusOne = new(0xFFFFFFFF);
-        public static readonly Serial Zero = new(0);
-
-        private Serial(uint serial) => Value = serial;
-
-        public uint Value { get; }
-
-        public bool IsMobile
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Value > 0 && Value < World.ItemOffset;
-        }
-
-        public bool IsItem
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Value >= World.ItemOffset && Value < World.MaxItemSerial;
-        }
-
-        public bool IsValid
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => Value > 0;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override int GetHashCode() => Value.GetHashCode();
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int CompareTo(Serial other) => Value.CompareTo(other.Value);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int CompareTo(uint other) => Value.CompareTo(other);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override bool Equals(object obj) =>
-            obj switch
-            {
-                Serial serial => this == serial,
-                uint u        => Value == u,
-                _             => false
-            };
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator ==(Serial l, Serial r) => l.Value == r.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator ==(Serial l, uint r) => l.Value == r;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator !=(Serial l, Serial r) => l.Value != r.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator !=(Serial l, uint r) => l.Value != r;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(Serial l, Serial r) => l.Value > r.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >(Serial l, uint r) => l.Value > r;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(Serial l, Serial r) => l.Value < r.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <(Serial l, uint r) => l.Value < r;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(Serial l, Serial r) => l.Value >= r.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator >=(Serial l, uint r) => l.Value >= r;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(Serial l, Serial r) => l.Value <= r.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator <=(Serial l, uint r) => l.Value <= r;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Serial operator +(Serial l, Serial r) => (Serial)(l.Value + r.Value);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Serial operator +(Serial l, uint r) => (Serial)(l.Value + r);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Serial operator ++(Serial l) => (Serial)(l.Value + 1);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Serial operator -(Serial l, Serial r) => (Serial)(l.Value - r.Value);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Serial operator -(Serial l, uint r) => (Serial)(l.Value - r);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Serial operator --(Serial l) => (Serial)(l.Value - 1);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public override string ToString() => $"0x{Value:X8}";
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator uint(Serial a) => a.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static explicit operator Serial(uint a) => new(a);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(Serial other) => Value == other.Value;
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int ToInt32() => (int)Value;
+        get => Value > 0 && Value < World.ItemOffset;
     }
+
+    public bool IsItem
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Value >= World.ItemOffset && Value < World.MaxItemSerial;
+    }
+
+    public bool IsValid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Value > 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override int GetHashCode() => Value.GetHashCode();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CompareTo(Serial other) => Value.CompareTo(other.Value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CompareTo(uint other) => Value.CompareTo(other);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override bool Equals(object obj) =>
+        obj switch
+        {
+            Serial serial => this == serial,
+            uint u        => Value == u,
+            _             => false
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(Serial l, Serial r) => l.Value == r.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator ==(Serial l, uint r) => l.Value == r;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(Serial l, Serial r) => l.Value != r.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator !=(Serial l, uint r) => l.Value != r;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >(Serial l, Serial r) => l.Value > r.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >(Serial l, uint r) => l.Value > r;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <(Serial l, Serial r) => l.Value < r.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <(Serial l, uint r) => l.Value < r;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >=(Serial l, Serial r) => l.Value >= r.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator >=(Serial l, uint r) => l.Value >= r;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <=(Serial l, Serial r) => l.Value <= r.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool operator <=(Serial l, uint r) => l.Value <= r;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Serial operator +(Serial l, Serial r) => (Serial)(l.Value + r.Value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Serial operator +(Serial l, uint r) => (Serial)(l.Value + r);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Serial operator ++(Serial l) => (Serial)(l.Value + 1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Serial operator -(Serial l, Serial r) => (Serial)(l.Value - r.Value);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Serial operator -(Serial l, uint r) => (Serial)(l.Value - r);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Serial operator --(Serial l) => (Serial)(l.Value - 1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public override string ToString() => $"0x{Value:X8}";
+
+    public string ToString(string format, IFormatProvider formatProvider) => ToString();
+
+    public bool TryFormat(
+        Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider provider
+    )
+    {
+        if (format != null)
+        {
+            return Value.TryFormat(destination, out charsWritten, format, provider);
+        }
+
+        if (destination.Length < 10)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        destination[0] = '0';
+        destination[1] = 'x';
+
+        var result = Value.TryFormat(destination[2..], out charsWritten, "X8", provider);
+        if (result)
+        {
+            charsWritten += 2;
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(Serial a) => a.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Serial(uint a) => new(a);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(Serial other) => Value == other.Value;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ToInt32() => (int)Value;
 }

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -255,7 +255,7 @@ namespace Server.Misc
                 }
                 else
                 {
-                    state.LogInfo($"Deleting character {index} (0x{m.Serial.Value:X})");
+                    state.LogInfo($"Deleting character {index} ({m.Serial})");
 
                     acct.Comments.Add(new AccountComment("System", $"Character #{index + 1} {m} deleted by {state}"));
 

--- a/Projects/UOContent/Commands/Generic/Commands/Interface.cs
+++ b/Projects/UOContent/Commands/Generic/Commands/Interface.cs
@@ -394,7 +394,7 @@ namespace Server.Commands.Generic
                 case 4: // Go there
                     {
                         m_From.SendGump(new InterfaceItemGump(m_From, m_Columns, m_List, m_Page, m_Item));
-                        InvokeCommand($"Go {m_Item.Serial.Value}");
+                        InvokeCommand($"Go {m_Item.Serial}");
                         break;
                     }
                 case 5: // Move to target
@@ -567,7 +567,7 @@ namespace Server.Commands.Generic
                 case 4: // Go there
                     {
                         m_From.SendGump(new InterfaceMobileGump(m_From, m_Columns, m_List, m_Page, m_Mobile));
-                        InvokeCommand($"Go {m_Mobile.Serial.Value}");
+                        InvokeCommand($"Go {m_Mobile.Serial}");
                         break;
                     }
                 case 5: // Bring them here

--- a/Projects/UOContent/Commands/Logging.cs
+++ b/Projects/UOContent/Commands/Logging.cs
@@ -46,7 +46,7 @@ namespace Server.Commands
             o switch
             {
                 Mobile m  => m.Account == null ? $"{m} (no account)" : $"{m} ('{m.Account.Username}')",
-                Item item => $"0x{item.Serial.Value:X} ({item.GetType().Name})",
+                Item item => $"{item.Serial} ({item.GetType().Name})",
                 _         => o
             };
 

--- a/Projects/UOContent/Commands/Object Creation/Add.cs
+++ b/Projects/UOContent/Commands/Object Creation/Add.cs
@@ -35,22 +35,22 @@ namespace Server.Commands
         {
             var sb = new StringBuilder();
 
-            sb.AppendFormat("{0} {1} building ", from.AccessLevel, CommandLogging.Format(from));
+            sb.Append($"{from.AccessLevel} {CommandLogging.Format(from)} building ");
 
             if (start == end)
             {
-                sb.AppendFormat("at {0} in {1}", start, from.Map);
+                sb.Append($"at {start} in {from.Map}");
             }
             else
             {
-                sb.AppendFormat("from {0} to {1} in {2}", start, end, from.Map);
+                sb.Append($"from {start} to {end} in {from.Map}");
             }
 
             sb.Append(':');
 
             for (var i = 0; i < args.Length; ++i)
             {
-                sb.AppendFormat(" \"{0}\"", args[i]);
+                sb.Append($" \"{args[i]}\"");
             }
 
             CommandLogging.WriteLine(from, sb.ToString());
@@ -321,7 +321,7 @@ namespace Server.Commands
                     {
                         var built = Build(from, ctor, values, props, realProps, ref sendError);
 
-                        sb.AppendFormat("0x{0:X}; ", built.Serial.Value);
+                        sb.Append($"{built.Serial}; ");
 
                         if (built is Item item)
                         {
@@ -353,7 +353,7 @@ namespace Server.Commands
 
                             var built = Build(from, ctor, values, props, realProps, ref sendError);
 
-                            sb.AppendFormat("0x{0:X}; ", built.Serial.Value);
+                            sb.Append($"{built.Serial}; ");
 
                             if (built is Item item)
                             {

--- a/Projects/UOContent/Gumps/ClientGump.cs
+++ b/Projects/UOContent/Gumps/ClientGump.cs
@@ -66,7 +66,7 @@ namespace Server.Gumps
             if (m != null)
             {
                 AddHtml(14, 36 + line * 20, 200, 20, Color("Mobile:", LabelColor32));
-                AddHtml(70, 36 + line++ * 20, 200, 20, Color($"{m.Name} (0x{m.Serial.Value:X})", LabelColor32));
+                AddHtml(70, 36 + line++ * 20, 200, 20, Color($"{m.Name} ({m.Serial})", LabelColor32));
 
                 AddHtml(14, 36 + line * 20, 200, 20, Color("Location:", LabelColor32));
                 AddHtml(70, 36 + line++ * 20, 200, 20, Color($"{m.Location} [{m.Map}]", LabelColor32));

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -511,16 +511,16 @@ namespace Server.Gumps
                 {
                     if (serial.IsItem)
                     {
-                        return $"(I) 0x{serial.Value:X}";
+                        return $"(I) {serial}";
                     }
 
                     if (serial.IsMobile)
                     {
-                        return $"(M) 0x{serial.Value:X}";
+                        return $"(M) {serial}";
                     }
                 }
 
-                return $"(?) 0x{serial.Value:X}";
+                return $"(?) {serial}";
             }
 
             if (o is byte or sbyte or short or ushort or int or uint or long or ulong)
@@ -530,12 +530,12 @@ namespace Server.Gumps
 
             if (o is Mobile mobile)
             {
-                return $"(M) 0x{mobile.Serial.Value:X} \"{mobile.Name}\"";
+                return $"(M) {mobile.Serial} \"{mobile.Name}\"";
             }
 
             if (o is Item item)
             {
-                return $"(I) 0x{item.Serial.Value:X}";
+                return $"(I) {item.Serial}";
             }
 
             if (o is Type type)

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -1056,21 +1056,21 @@ namespace Server.Items
 
             if (m != null && (strBonus != 0 || dexBonus != 0 || intBonus != 0))
             {
-                var modName = Serial.ToString();
+                var serial = Serial;
 
                 if (strBonus != 0)
                 {
-                    m.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                    m.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                 }
 
                 if (dexBonus != 0)
                 {
-                    m.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                    m.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                 }
 
                 if (intBonus != 0)
                 {
-                    m.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                    m.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                 }
             }
 
@@ -1180,21 +1180,21 @@ namespace Server.Items
 
             if (strBonus != 0 || dexBonus != 0 || intBonus != 0)
             {
-                var modName = Serial.ToString();
+                var serial = Serial;
 
                 if (strBonus != 0)
                 {
-                    from.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                    from.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                 }
 
                 if (dexBonus != 0)
                 {
-                    from.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                    from.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                 }
 
                 if (intBonus != 0)
                 {
-                    from.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                    from.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                 }
             }
 
@@ -1205,11 +1205,11 @@ namespace Server.Items
         {
             if (parent is Mobile m)
             {
-                var modName = Serial.ToString();
+                var serial = Serial;
 
-                m.RemoveStatMod($"{modName}Str");
-                m.RemoveStatMod($"{modName}Dex");
-                m.RemoveStatMod($"{modName}Int");
+                m.RemoveStatMod($"{serial}Str");
+                m.RemoveStatMod($"{serial}Dex");
+                m.RemoveStatMod($"{serial}Int");
 
                 if (Core.AOS)
                 {

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -518,21 +518,21 @@ namespace Server.Items
                 return;
             }
 
-            var modName = Serial.ToString();
+            var serial = Serial;
 
             if (strBonus != 0)
             {
-                parent.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                parent.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
             }
 
             if (dexBonus != 0)
             {
-                parent.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                parent.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
             }
 
             if (intBonus != 0)
             {
-                parent.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                parent.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
             }
         }
 
@@ -619,11 +619,11 @@ namespace Server.Items
                     SkillBonuses.Remove();
                 }
 
-                var modName = Serial.ToString();
+                var serial = Serial;
 
-                mob.RemoveStatMod($"{modName}Str");
-                mob.RemoveStatMod($"{modName}Dex");
-                mob.RemoveStatMod($"{modName}Int");
+                mob.RemoveStatMod($"{serial}Str");
+                mob.RemoveStatMod($"{serial}Dex");
+                mob.RemoveStatMod($"{serial}Int");
 
                 mob.CheckStatTimers();
             }

--- a/Projects/UOContent/Items/Jewels/BaseJewel.cs
+++ b/Projects/UOContent/Items/Jewels/BaseJewel.cs
@@ -212,21 +212,21 @@ public abstract partial class BaseJewel : Item, ICraftable
 
             if (strBonus != 0 || dexBonus != 0 || intBonus != 0)
             {
-                var modName = Serial.ToString();
+                var serial = Serial;
 
                 if (strBonus != 0)
                 {
-                    from.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                    from.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                 }
 
                 if (dexBonus != 0)
                 {
-                    from.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                    from.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                 }
 
                 if (intBonus != 0)
                 {
-                    from.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                    from.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                 }
             }
 
@@ -240,11 +240,11 @@ public abstract partial class BaseJewel : Item, ICraftable
         {
             SkillBonuses.Remove();
 
-            var modName = Serial.ToString();
+            var serial = Serial;
 
-            from.RemoveStatMod($"{modName}Str");
-            from.RemoveStatMod($"{modName}Dex");
-            from.RemoveStatMod($"{modName}Int");
+            from.RemoveStatMod($"{serial}Str");
+            from.RemoveStatMod($"{serial}Dex");
+            from.RemoveStatMod($"{serial}Int");
 
             from.CheckStatTimers();
         }
@@ -421,21 +421,21 @@ public abstract partial class BaseJewel : Item, ICraftable
 
         if (m != null && (strBonus != 0 || dexBonus != 0 || intBonus != 0))
         {
-            var modName = Serial.ToString();
+            var serial = Serial;
 
             if (strBonus != 0)
             {
-                m.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                m.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
             }
 
             if (dexBonus != 0)
             {
-                m.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                m.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
             }
 
             if (intBonus != 0)
             {
-                m.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                m.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
             }
         }
 

--- a/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
@@ -623,21 +623,21 @@ namespace Server.Items
 
                 if (strBonus != 0 || dexBonus != 0 || intBonus != 0)
                 {
-                    var modName = Serial.ToString();
+                    var serial = Serial;
 
                     if (strBonus != 0)
                     {
-                        from.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                        from.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                     }
 
                     if (dexBonus != 0)
                     {
-                        from.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                        from.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                     }
 
                     if (intBonus != 0)
                     {
-                        from.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                        from.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                     }
                 }
 
@@ -651,11 +651,11 @@ namespace Server.Items
             {
                 SkillBonuses.Remove();
 
-                var modName = Serial.ToString();
+                var serial = Serial;
 
-                from.RemoveStatMod($"{modName}Str");
-                from.RemoveStatMod($"{modName}Dex");
-                from.RemoveStatMod($"{modName}Int");
+                from.RemoveStatMod($"{serial}Str");
+                from.RemoveStatMod($"{serial}Dex");
+                from.RemoveStatMod($"{serial}Int");
 
                 from.CheckStatTimers();
             }
@@ -974,21 +974,21 @@ namespace Server.Items
             {
                 if (strBonus != 0 || dexBonus != 0 || intBonus != 0)
                 {
-                    var modName = Serial.ToString();
+                    var serial = Serial;
 
                     if (strBonus != 0)
                     {
-                        m.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                        m.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                     }
 
                     if (dexBonus != 0)
                     {
-                        m.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                        m.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                     }
 
                     if (intBonus != 0)
                     {
-                        m.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                        m.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                     }
                 }
 

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -939,21 +939,21 @@ namespace Server.Items
             {
                 var m = from;
 
-                var modName = Serial.ToString();
+                var serial = Serial;
 
                 if (strBonus != 0)
                 {
-                    m.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                    m.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                 }
 
                 if (dexBonus != 0)
                 {
-                    m.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                    m.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                 }
 
                 if (intBonus != 0)
                 {
-                    m.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                    m.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                 }
             }
 
@@ -1004,11 +1004,11 @@ namespace Server.Items
                 return;
             }
 
-            var modName = Serial.ToString();
+            var serial = Serial;
 
-            m.RemoveStatMod($"{modName}Str");
-            m.RemoveStatMod($"{modName}Dex");
-            m.RemoveStatMod($"{modName}Int");
+            m.RemoveStatMod($"{serial}Str");
+            m.RemoveStatMod($"{serial}Dex");
+            m.RemoveStatMod($"{serial}Int");
 
             if (!_enableInstaHit && m.Weapon is BaseWeapon weapon)
             {
@@ -4148,21 +4148,21 @@ namespace Server.Items
 
             if (parentMobile != null && (strBonus != 0 || dexBonus != 0 || intBonus != 0))
             {
-                var modName = Serial.ToString();
+                var serial = Serial;
 
                 if (strBonus != 0)
                 {
-                    parentMobile.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                    parentMobile.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                 }
 
                 if (dexBonus != 0)
                 {
-                    parentMobile.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                    parentMobile.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                 }
 
                 if (intBonus != 0)
                 {
-                    parentMobile.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                    parentMobile.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                 }
             }
 

--- a/Projects/UOContent/Misc/AOS.cs
+++ b/Projects/UOContent/Misc/AOS.cs
@@ -566,21 +566,21 @@ namespace Server
 
             if (strBonus != 0 || dexBonus != 0 || intBonus != 0)
             {
-                var modName = Owner.Serial.ToString();
+                var serial = Owner.Serial;
 
                 if (strBonus != 0)
                 {
-                    to.AddStatMod(new StatMod(StatType.Str, $"{modName}Str", strBonus, TimeSpan.Zero));
+                    to.AddStatMod(new StatMod(StatType.Str, $"{serial}Str", strBonus, TimeSpan.Zero));
                 }
 
                 if (dexBonus != 0)
                 {
-                    to.AddStatMod(new StatMod(StatType.Dex, $"{modName}Dex", dexBonus, TimeSpan.Zero));
+                    to.AddStatMod(new StatMod(StatType.Dex, $"{serial}Dex", dexBonus, TimeSpan.Zero));
                 }
 
                 if (intBonus != 0)
                 {
-                    to.AddStatMod(new StatMod(StatType.Int, $"{modName}Int", intBonus, TimeSpan.Zero));
+                    to.AddStatMod(new StatMod(StatType.Int, $"{serial}Int", intBonus, TimeSpan.Zero));
                 }
             }
 
@@ -589,11 +589,11 @@ namespace Server
 
         public void RemoveStatBonuses(Mobile from)
         {
-            var modName = Owner.Serial.ToString();
+            var serial = Owner.Serial;
 
-            from.RemoveStatMod($"{modName}Str");
-            from.RemoveStatMod($"{modName}Dex");
-            from.RemoveStatMod($"{modName}Int");
+            from.RemoveStatMod($"{serial}Str");
+            from.RemoveStatMod($"{serial}Dex");
+            from.RemoveStatMod($"{serial}Int");
 
             from.CheckStatTimers();
         }

--- a/Projects/UOContent/Misc/CrashGuard.cs
+++ b/Projects/UOContent/Misc/CrashGuard.cs
@@ -195,7 +195,7 @@ namespace Server.Misc
 
                             if (m != null)
                             {
-                                op.Write($" (mobile = 0x{m.Serial.Value:X} '{m.Name}')");
+                                op.Write($" (mobile = {m.Serial} '{m.Name}')");
                             }
 
                             op.WriteLine();


### PR DESCRIPTION
Updates `Serial` so string interpolation is automatic and optimized (no allocation):
```cs
$"{serial}" // 0x12345678
```

This means you don't have to do the following:
```cs
$"{serial.Value:X}"
```

Also Serial will respect custom formatters. For example if you want a normal integer representation:
```cs
$"{serial:##}"
```