### PR TITLE
fix: Add optional conditional on exportspawners

### DIFF
--- a/Projects/UOContent/Engines/Spawners/Commands/ExportSpawnersCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/ExportSpawnersCommand.cs
@@ -13,6 +13,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Server.Commands.Generic;
@@ -35,13 +36,14 @@ namespace Server.Engines.Spawners
             Commands = new[] { "ExportSpawners" };
             ObjectTypes = ObjectTypes.Items;
             Usage = "ExportSpawners";
-            Description = "Exports the given the spawners to the a file";
+            Description = "Exports the given spawners to the a file";
             ListOptimized = true;
         }
 
         public override void ExecuteList(CommandEventArgs e, List<object> list)
         {
-            var path = e.Arguments.Length == 0 ? null : e.Arguments[0].Trim();
+            string path = e.Arguments.Length == 0 ? string.Empty : e.Arguments[0].Trim();
+            string condition = e.Arguments.Length == 2 ? e.Arguments[1].Trim() : string.Empty;
 
             if (string.IsNullOrEmpty(path))
             {
@@ -71,9 +73,15 @@ namespace Server.Engines.Spawners
             {
                 if (list[i] is BaseSpawner spawner)
                 {
-                    var dynamicJson = DynamicJson.Create(spawner.GetType());
-                    spawner.ToJson(dynamicJson, options);
-                    spawnRecords.Add(dynamicJson);
+                    if (!string.IsNullOrEmpty(spawner.Name) && spawner.Name.StartsWith(
+                            condition,
+                            StringComparison.OrdinalIgnoreCase
+                        ))
+                    {
+                        var dynamicJson = DynamicJson.Create(spawner.GetType());
+                        spawner.ToJson(dynamicJson, options);
+                        spawnRecords.Add(dynamicJson);
+                    }
                 }
             }
 

--- a/Projects/UOContent/Engines/Spawners/Commands/ExportSpawnersCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/ExportSpawnersCommand.cs
@@ -36,7 +36,7 @@ namespace Server.Engines.Spawners
             Commands = new[] { "ExportSpawners" };
             ObjectTypes = ObjectTypes.Items;
             Usage = "ExportSpawners";
-            Description = "Exports the given spawners to the a file";
+            Description = "Exports the given spawners to a file";
             ListOptimized = true;
         }
 

--- a/Projects/UOContent/Engines/Spawners/Commands/RespawnCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/RespawnCommand.cs
@@ -33,7 +33,7 @@ namespace Server.Engines.Spawners
             Commands = new[] { "Respawn" };
             ObjectTypes = ObjectTypes.Items;
             Usage = "Respawn";
-            Description = "Respawns the given the spawners.";
+            Description = "Respawns the given spawners.";
             ListOptimized = true;
         }
 

--- a/Projects/UOContent/Engines/Spawners/SpawnerGump.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnerGump.cs
@@ -20,7 +20,7 @@ namespace Server.Engines.Spawners
 
             AddBackground(0, 0, 343, 371 + (m_Entry != null ? 44 : 0), 5054);
 
-            AddHtml(95, 1, 250, 20, "<BASEFONT COLOR=#F4F4F4>Creatures List</BASEFONT>");
+            AddHtml(71, 1, 161, 20, $"<BASEFONT COLOR=#F4F4F4><CENTER>{spawner.Name}</CENTER></BASEFONT>");
             AddHtml(245, 1, 250, 20, "<BASEFONT COLOR=#F4F4F4>#</BASEFONT>");
             AddHtml(282, 1, 250, 20, "<BASEFONT COLOR=#F4F4F4>Prb</BASEFONT>");
 


### PR DESCRIPTION
Updated command to allow an optional conditional when exporting.

If I have 3 spawners, named: `Spawner_1`, `Yew_1`, and `Yew_2`, I could export just the spawners starting with `yew` via:

`[facet exportspawners Spawns\yew.json yew`

Ref: https://github.com/modernuo/ModernUO/issues/1091