### PR TITLE
fix: Removes side effect of setting skill mod when changing Owner

### DIFF
--- a/Projects/Server/Mobiles/Mods/MobileMod.cs
+++ b/Projects/Server/Mobiles/Mods/MobileMod.cs
@@ -21,7 +21,7 @@ namespace Server;
 public partial class MobileMod
 {
     [DirtyTrackingEntity]
-    public virtual Mobile Owner { get; set; }
+    public Mobile Owner { get; set; }
 
     public MobileMod(Mobile owner) => Owner = owner;
 }

--- a/Projects/Server/Mobiles/Mods/SkillMod.cs
+++ b/Projects/Server/Mobiles/Mods/SkillMod.cs
@@ -21,7 +21,6 @@ namespace Server;
 public abstract partial class SkillMod : MobileMod
 {
     private bool _obeyCap;
-
     private bool _relative;
     private SkillName _skill;
     private double _value;
@@ -60,7 +59,7 @@ public abstract partial class SkillMod : MobileMod
             if (owner != value)
             {
                 owner?.RemoveSkillMod(this);
-                owner = value;
+                base.Owner = owner = value;
                 owner?.AddSkillMod(this);
             }
         }

--- a/Projects/Server/Mobiles/Mods/SkillMod.cs
+++ b/Projects/Server/Mobiles/Mods/SkillMod.cs
@@ -50,21 +50,6 @@ public abstract partial class SkillMod : MobileMod
         }
     }
 
-    public override Mobile Owner
-    {
-        get => base.Owner;
-        set
-        {
-            var owner = base.Owner;
-            if (owner != value)
-            {
-                owner?.RemoveSkillMod(this);
-                base.Owner = owner = value;
-                owner?.AddSkillMod(this);
-            }
-        }
-    }
-
     [SerializableField(1)]
     public SkillName Skill
     {

--- a/Projects/Server/Skills.cs
+++ b/Projects/Server/Skills.cs
@@ -276,29 +276,29 @@ namespace Server
 
                 double bonusObey = 0.0, bonusNotObey = 0.0;
 
-                for (var i = 0; i < mods.Count; ++i)
+                foreach (var mod in mods)
                 {
-                    var mod = mods[i];
-
-                    if (mod.Skill == (SkillName)Info.SkillID)
+                    if (mod.Skill != (SkillName)Info.SkillID)
                     {
-                        if (mod.Relative)
+                        continue;
+                    }
+
+                    if (mod.Relative)
+                    {
+                        if (mod.ObeyCap)
                         {
-                            if (mod.ObeyCap)
-                            {
-                                bonusObey += mod.Value;
-                            }
-                            else
-                            {
-                                bonusNotObey += mod.Value;
-                            }
+                            bonusObey += mod.Value;
                         }
                         else
                         {
-                            bonusObey = 0.0;
-                            bonusNotObey = 0.0;
-                            value = mod.Value;
+                            bonusNotObey += mod.Value;
                         }
+                    }
+                    else
+                    {
+                        bonusObey = 0.0;
+                        bonusNotObey = 0.0;
+                        value = mod.Value;
                     }
                 }
 


### PR DESCRIPTION
## Breaking Change!
Setting `mod.Owner` will no longer update a skill mod.
**Please stick to the API and use `mobile.AddSkillMod(mod)` for all situations, including equipping.**