### PR TITLE
fix: Fixes LearnAllRecipes

### DIFF
--- a/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Server.Commands;
 using Server.Factions;
 using Server.Items;
+using Server.Logging;
 using Server.Mobiles;
 using Server.Utilities;
 
@@ -25,6 +26,8 @@ namespace Server.Engines.Craft
 
     public class CraftItem
     {
+        private static readonly ILogger logger = LogFactory.GetLogger(typeof(CraftItem));
+
         private static readonly Dictionary<Type, int> _itemIds = new();
 
         private static readonly int[] m_HeatSources =
@@ -174,8 +177,8 @@ namespace Server.Engines.Craft
         {
             if (Recipe != null)
             {
-                Console.WriteLine(
-                    "Warning: Attempted add of recipe #{0} to the crafting of {1} in CraftSystem {2}.",
+                logger.Warning(
+                    "Attempted add of recipe #{Id} to the crafting of {ItemTypeName} in CraftSystem {CraftSystem}.",
                     id,
                     ItemType.Name,
                     system
@@ -190,16 +193,7 @@ namespace Server.Engines.Craft
         {
             var number = ItemIDOf(type);
 
-            if (number >= 0x4000)
-            {
-                number += 1078872;
-            }
-            else
-            {
-                number += 1020000;
-            }
-
-            return number;
+            return number + (number >= 0x4000 ? 1078872 : 1020000);
         }
 
         public static int ItemIDOf(Type type)

--- a/Projects/UOContent/Engines/Craft/Core/Recipes.cs
+++ b/Projects/UOContent/Engines/Craft/Core/Recipes.cs
@@ -3,99 +3,96 @@ using System.Collections.Generic;
 using Server.Mobiles;
 using Server.Targeting;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class Recipe
 {
-    public class Recipe
+    private TextDefinition _td;
+
+    public Recipe(int id, CraftSystem system, CraftItem item)
     {
-        private TextDefinition m_TD;
+        ID = id;
+        CraftSystem = system;
+        CraftItem = item;
 
-        public Recipe(int id, CraftSystem system, CraftItem item)
+        if (!Recipes.TryAdd(id, this))
         {
-            ID = id;
-            CraftSystem = system;
-            CraftItem = item;
+            throw new Exception("Attempting to create recipe with preexisting ID.");
+        }
 
-            if (Recipes.ContainsKey(id))
+        LargestRecipeID = Math.Max(id, LargestRecipeID);
+    }
+
+    public static Dictionary<int, Recipe> Recipes { get; } = new();
+
+    public static int LargestRecipeID { get; private set; }
+
+    public CraftSystem CraftSystem { get; set; }
+
+    public CraftItem CraftItem { get; set; }
+
+    public int ID { get; }
+
+    public TextDefinition TextDefinition => _td ??= new TextDefinition(CraftItem.NameNumber, CraftItem.NameString);
+
+    public static void Initialize()
+    {
+        CommandSystem.Register("LearnAllRecipes", AccessLevel.GameMaster, LearnAllRecipes_OnCommand);
+        CommandSystem.Register("ForgetAllRecipes", AccessLevel.GameMaster, ForgetAllRecipes_OnCommand);
+    }
+
+    [Usage("LearnAllRecipes"), Description("Teaches a player all available recipes.")]
+    private static void LearnAllRecipes_OnCommand(CommandEventArgs e)
+    {
+        var m = e.Mobile;
+        m.SendMessage("Target a player to teach them all of the recipes.");
+
+        m.BeginTarget(
+            -1,
+            false,
+            TargetFlags.None,
+            (from, targeted) =>
             {
-                throw new Exception("Attempting to create recipe with preexisting ID.");
+                if (targeted is PlayerMobile mobile)
+                {
+                    foreach (var kvp in Recipes)
+                    {
+                        mobile.AcquireRecipe(kvp.Key);
+                    }
+
+                    from.SendMessage("You teach them all of the recipes.");
+                }
+                else
+                {
+                    from.SendMessage("That is not a player!");
+                }
             }
+        );
+    }
 
-            Recipes.Add(id, this);
-            LargestRecipeID = Math.Max(id, LargestRecipeID);
-        }
+    [Usage("ForgetAllRecipes"), Description("Makes a player forget all the recipes they've learned.")]
+    private static void ForgetAllRecipes_OnCommand(CommandEventArgs e)
+    {
+        var m = e.Mobile;
+        m.SendMessage("Target a player to have them forget all of the recipes they've learned.");
 
-        public static Dictionary<int, Recipe> Recipes { get; } = new();
-
-        public static int LargestRecipeID { get; private set; }
-
-        public CraftSystem CraftSystem { get; set; }
-
-        public CraftItem CraftItem { get; set; }
-
-        public int ID { get; }
-
-        public TextDefinition TextDefinition =>
-            m_TD ?? (m_TD = new TextDefinition(CraftItem.NameNumber, CraftItem.NameString));
-
-        public static void Initialize()
-        {
-            CommandSystem.Register("LearnAllRecipes", AccessLevel.GameMaster, LearnAllRecipes_OnCommand);
-            CommandSystem.Register("ForgetAllRecipes", AccessLevel.GameMaster, ForgetAllRecipes_OnCommand);
-        }
-
-        [Usage("LearnAllRecipes"), Description("Teaches a player all available recipes.")]
-        private static void LearnAllRecipes_OnCommand(CommandEventArgs e)
-        {
-            var m = e.Mobile;
-            m.SendMessage("Target a player to teach them all of the recipes.");
-
-            m.BeginTarget(
-                -1,
-                false,
-                TargetFlags.None,
-                (from, targeted) =>
+        m.BeginTarget(
+            -1,
+            false,
+            TargetFlags.None,
+            (from, targeted) =>
+            {
+                if (targeted is PlayerMobile mobile)
                 {
-                    if (targeted is PlayerMobile mobile)
-                    {
-                        foreach (var kvp in Recipes)
-                        {
-                            mobile.AcquireRecipe(kvp.Key);
-                        }
+                    mobile.ResetRecipes();
 
-                        from.SendMessage("You teach them all of the recipes.");
-                    }
-                    else
-                    {
-                        from.SendMessage("That is not a player!");
-                    }
+                    from.SendMessage("They forget all their recipes.");
                 }
-            );
-        }
-
-        [Usage("ForgetAllRecipes"), Description("Makes a player forget all the recipes they've learned.")]
-        private static void ForgetAllRecipes_OnCommand(CommandEventArgs e)
-        {
-            var m = e.Mobile;
-            m.SendMessage("Target a player to have them forget all of the recipes they've learned.");
-
-            m.BeginTarget(
-                -1,
-                false,
-                TargetFlags.None,
-                (from, targeted) =>
+                else
                 {
-                    if (targeted is PlayerMobile mobile)
-                    {
-                        mobile.ResetRecipes();
-
-                        from.SendMessage("They forget all their recipes.");
-                    }
-                    else
-                    {
-                        from.SendMessage("That is not a player!");
-                    }
+                    from.SendMessage("That is not a player!");
                 }
-            );
-        }
+            }
+        );
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefAlchemy.cs
+++ b/Projects/UOContent/Engines/Craft/DefAlchemy.cs
@@ -1,315 +1,317 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefAlchemy : CraftSystem
 {
-    public class DefAlchemy : CraftSystem
+    private static readonly Type typeofPotion = typeof(BasePotion);
+
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefAlchemy();
+    }
 
-        private static readonly Type typeofPotion = typeof(BasePotion);
+    private DefAlchemy() : base(1, 1, 1.25)
+    {
+    }
 
-        private DefAlchemy() : base(1, 1, 1.25) // base( 1, 1, 3.1 )
+    public override SkillName MainSkill => SkillName.Alchemy;
+
+    public override TextDefinition GumpTitle => 1044001;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item) => 0.0;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Alchemy;
-
-        public override TextDefinition GumpTitle => 1044001;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefAlchemy();
-
-        public override double GetChanceAtMin(CraftItem item) => 0.0;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        return 0;
+    }
+
+    public override void PlayCraftEffect(Mobile from)
+    {
+        from.PlaySound(0x242);
+    }
+
+    public static bool IsPotion(Type type) => typeofPotion.IsAssignableFrom(type);
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            from.PlaySound(0x242);
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public static bool IsPotion(Type type) => typeofPotion.IsAssignableFrom(type);
-
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (failed)
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (IsPotion(item.ItemType))
-                {
-                    from.AddToBackpack(new Bottle());
-                    return 500287; // You fail to create a useful potion.
-                }
-
-                return 1044043; // You failed to create the item, and some of your materials are lost.
-            }
-
-            from.PlaySound(0x240); // Sound of a filling bottle
-
             if (IsPotion(item.ItemType))
             {
-                if (quality == -1)
-                {
-                    return 1048136; // You create the potion and pour it into a keg.
-                }
-
-                return 500279;      // You pour the potion into a bottle...
+                from.AddToBackpack(new Bottle());
+                return 500287; // You fail to create a useful potion.
             }
 
-            return 1044154; // You create the item.
+            return 1044043; // You failed to create the item, and some of your materials are lost.
         }
 
-        public override void InitCraftList()
+        from.PlaySound(0x240); // Sound of a filling bottle
+
+        if (IsPotion(item.ItemType))
         {
-            int index;
+            if (quality == -1)
+            {
+                return 1048136; // You create the potion and pour it into a keg.
+            }
 
-            // Refresh Potion
-            index = AddCraft(typeof(RefreshPotion), 1044530, 1044538, -25, 25.0, typeof(BlackPearl), 1044353, 1, 1044361);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(
-                typeof(TotalRefreshPotion),
-                1044530,
-                1044539,
-                25.0,
-                75.0,
-                typeof(BlackPearl),
-                1044353,
-                5,
-                1044361
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+            return 500279; // You pour the potion into a bottle...
+        }
 
-            // Agility Potion
-            index = AddCraft(typeof(AgilityPotion), 1044531, 1044540, 15.0, 65.0, typeof(Bloodmoss), 1044354, 1, 1044362);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(
-                typeof(GreaterAgilityPotion),
-                1044531,
-                1044541,
-                35.0,
-                85.0,
-                typeof(Bloodmoss),
-                1044354,
-                3,
-                1044362
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        return 1044154; // You create the item.
+    }
 
-            // Nightsight Potion
-            index = AddCraft(
-                typeof(NightSightPotion),
-                1044532,
-                1044542,
-                -25.0,
-                25.0,
-                typeof(SpidersSilk),
-                1044360,
-                1,
-                1044368
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+    public override void InitCraftList()
+    {
+        int index;
 
-            // Heal Potion
-            index = AddCraft(typeof(LesserHealPotion), 1044533, 1044543, -25.0, 25.0, typeof(Ginseng), 1044356, 1, 1044364);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(typeof(HealPotion), 1044533, 1044544, 15.0, 65.0, typeof(Ginseng), 1044356, 3, 1044364);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(typeof(GreaterHealPotion), 1044533, 1044545, 55.0, 105.0, typeof(Ginseng), 1044356, 7, 1044364);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        // Refresh Potion
+        index = AddCraft(typeof(RefreshPotion), 1044530, 1044538, -25, 25.0, typeof(BlackPearl), 1044353, 1, 1044361);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(TotalRefreshPotion),
+            1044530,
+            1044539,
+            25.0,
+            75.0,
+            typeof(BlackPearl),
+            1044353,
+            5,
+            1044361
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
 
-            // Strength Potion
-            index = AddCraft(
-                typeof(StrengthPotion),
-                1044534,
-                1044546,
-                25.0,
-                75.0,
-                typeof(MandrakeRoot),
-                1044357,
-                2,
-                1044365
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(
-                typeof(GreaterStrengthPotion),
-                1044534,
-                1044547,
-                45.0,
-                95.0,
-                typeof(MandrakeRoot),
-                1044357,
-                5,
-                1044365
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        // Agility Potion
+        index = AddCraft(typeof(AgilityPotion), 1044531, 1044540, 15.0, 65.0, typeof(Bloodmoss), 1044354, 1, 1044362);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(GreaterAgilityPotion),
+            1044531,
+            1044541,
+            35.0,
+            85.0,
+            typeof(Bloodmoss),
+            1044354,
+            3,
+            1044362
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
 
-            // Poison Potion
+        // Nightsight Potion
+        index = AddCraft(
+            typeof(NightSightPotion),
+            1044532,
+            1044542,
+            -25.0,
+            25.0,
+            typeof(SpidersSilk),
+            1044360,
+            1,
+            1044368
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+
+        // Heal Potion
+        index = AddCraft(typeof(LesserHealPotion), 1044533, 1044543, -25.0, 25.0, typeof(Ginseng), 1044356, 1, 1044364);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(typeof(HealPotion), 1044533, 1044544, 15.0, 65.0, typeof(Ginseng), 1044356, 3, 1044364);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(typeof(GreaterHealPotion), 1044533, 1044545, 55.0, 105.0, typeof(Ginseng), 1044356, 7, 1044364);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+
+        // Strength Potion
+        index = AddCraft(
+            typeof(StrengthPotion),
+            1044534,
+            1044546,
+            25.0,
+            75.0,
+            typeof(MandrakeRoot),
+            1044357,
+            2,
+            1044365
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(GreaterStrengthPotion),
+            1044534,
+            1044547,
+            45.0,
+            95.0,
+            typeof(MandrakeRoot),
+            1044357,
+            5,
+            1044365
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+
+        // Poison Potion
+        index = AddCraft(
+            typeof(LesserPoisonPotion),
+            1044535,
+            1044548,
+            -5.0,
+            45.0,
+            typeof(Nightshade),
+            1044358,
+            1,
+            1044366
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(typeof(PoisonPotion), 1044535, 1044549, 15.0, 65.0, typeof(Nightshade), 1044358, 2, 1044366);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(GreaterPoisonPotion),
+            1044535,
+            1044550,
+            55.0,
+            105.0,
+            typeof(Nightshade),
+            1044358,
+            4,
+            1044366
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(DeadlyPoisonPotion),
+            1044535,
+            1044551,
+            90.0,
+            140.0,
+            typeof(Nightshade),
+            1044358,
+            8,
+            1044366
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+
+        // Cure Potion
+        index = AddCraft(typeof(LesserCurePotion), 1044536, 1044552, -10.0, 40.0, typeof(Garlic), 1044355, 1, 1044363);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(typeof(CurePotion), 1044536, 1044553, 25.0, 75.0, typeof(Garlic), 1044355, 3, 1044363);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(typeof(GreaterCurePotion), 1044536, 1044554, 65.0, 115.0, typeof(Garlic), 1044355, 6, 1044363);
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+
+        // Explosion Potion
+        index = AddCraft(
+            typeof(LesserExplosionPotion),
+            1044537,
+            1044555,
+            5.0,
+            55.0,
+            typeof(SulfurousAsh),
+            1044359,
+            3,
+            1044367
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(ExplosionPotion),
+            1044537,
+            1044556,
+            35.0,
+            85.0,
+            typeof(SulfurousAsh),
+            1044359,
+            5,
+            1044367
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+        index = AddCraft(
+            typeof(GreaterExplosionPotion),
+            1044537,
+            1044557,
+            65.0,
+            115.0,
+            typeof(SulfurousAsh),
+            1044359,
+            10,
+            1044367
+        );
+        AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(SmokeBomb), 1044537, 1030248, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
+            AddRes(index, typeof(Ginseng), 1044356, 3, 1044364);
+            SetNeededExpansion(index, Expansion.SE);
+
+            // Conflagration Potions
             index = AddCraft(
-                typeof(LesserPoisonPotion),
-                1044535,
-                1044548,
-                -5.0,
-                45.0,
-                typeof(Nightshade),
-                1044358,
-                1,
-                1044366
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(typeof(PoisonPotion), 1044535, 1044549, 15.0, 65.0, typeof(Nightshade), 1044358, 2, 1044366);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(
-                typeof(GreaterPoisonPotion),
-                1044535,
-                1044550,
+                typeof(ConflagrationPotion),
+                1044109,
+                1072096,
                 55.0,
                 105.0,
-                typeof(Nightshade),
-                1044358,
-                4,
-                1044366
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(
-                typeof(DeadlyPoisonPotion),
-                1044535,
-                1044551,
-                90.0,
-                140.0,
-                typeof(Nightshade),
-                1044358,
-                8,
-                1044366
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-
-            // Cure Potion
-            index = AddCraft(typeof(LesserCurePotion), 1044536, 1044552, -10.0, 40.0, typeof(Garlic), 1044355, 1, 1044363);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(typeof(CurePotion), 1044536, 1044553, 25.0, 75.0, typeof(Garlic), 1044355, 3, 1044363);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(typeof(GreaterCurePotion), 1044536, 1044554, 65.0, 115.0, typeof(Garlic), 1044355, 6, 1044363);
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-
-            // Explosion Potion
-            index = AddCraft(
-                typeof(LesserExplosionPotion),
-                1044537,
-                1044555,
-                5.0,
-                55.0,
-                typeof(SulfurousAsh),
-                1044359,
-                3,
-                1044367
-            );
-            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-            index = AddCraft(
-                typeof(ExplosionPotion),
-                1044537,
-                1044556,
-                35.0,
-                85.0,
-                typeof(SulfurousAsh),
-                1044359,
+                typeof(GraveDust),
+                1023983,
                 5,
-                1044367
+                1044253
             );
             AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+            SetNeededExpansion(index, Expansion.SE);
             index = AddCraft(
-                typeof(GreaterExplosionPotion),
-                1044537,
-                1044557,
+                typeof(GreaterConflagrationPotion),
+                1044109,
+                1072099,
                 65.0,
                 115.0,
-                typeof(SulfurousAsh),
-                1044359,
+                typeof(GraveDust),
+                1023983,
                 10,
-                1044367
+                1044253
             );
             AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(SmokeBomb), 1044537, 1030248, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
-                AddRes(index, typeof(Ginseng), 1044356, 3, 1044364);
-                SetNeededExpansion(index, Expansion.SE);
-
-                // Conflagration Potions
-                index = AddCraft(
-                    typeof(ConflagrationPotion),
-                    1044109,
-                    1072096,
-                    55.0,
-                    105.0,
-                    typeof(GraveDust),
-                    1023983,
-                    5,
-                    1044253
-                );
-                AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(GreaterConflagrationPotion),
-                    1044109,
-                    1072099,
-                    65.0,
-                    115.0,
-                    typeof(GraveDust),
-                    1023983,
-                    10,
-                    1044253
-                );
-                AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-                SetNeededExpansion(index, Expansion.SE);
-                // Confusion Blast Potions
-                index = AddCraft(
-                    typeof(ConfusionBlastPotion),
-                    1044109,
-                    1072106,
-                    55.0,
-                    105.0,
-                    typeof(PigIron),
-                    1023978,
-                    5,
-                    1044253
-                );
-                AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(GreaterConfusionBlastPotion),
-                    1044109,
-                    1072109,
-                    65.0,
-                    115.0,
-                    typeof(PigIron),
-                    1023978,
-                    10,
-                    1044253
-                );
-                AddRes(index, typeof(Bottle), 1044529, 1, 500315);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+            SetNeededExpansion(index, Expansion.SE);
+            // Confusion Blast Potions
+            index = AddCraft(
+                typeof(ConfusionBlastPotion),
+                1044109,
+                1072106,
+                55.0,
+                105.0,
+                typeof(PigIron),
+                1023978,
+                5,
+                1044253
+            );
+            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(GreaterConfusionBlastPotion),
+                1044109,
+                1072109,
+                65.0,
+                115.0,
+                typeof(PigIron),
+                1023978,
+                10,
+                1044253
+            );
+            AddRes(index, typeof(Bottle), 1044529, 1, 500315);
+            SetNeededExpansion(index, Expansion.SE);
         }
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
+++ b/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
@@ -1,725 +1,715 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefBlacksmithy : CraftSystem
 {
-    public class DefBlacksmithy : CraftSystem
+    private static readonly Type typeofAnvil = typeof(AnvilAttribute);
+    private static readonly Type typeofForge = typeof(ForgeAttribute);
+
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefBlacksmithy();
+    }
 
-        private static readonly Type typeofAnvil = typeof(AnvilAttribute);
-        private static readonly Type typeofForge = typeof(ForgeAttribute);
+    private DefBlacksmithy() : base(1, 1, 1.25)
+    {
+    }
 
-        private DefBlacksmithy() : base(1, 1, 1.25) // base( 1, 2, 1.7 )
+    public override SkillName MainSkill => SkillName.Blacksmith;
+
+    public override TextDefinition GumpTitle => 1044002;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
+
+    public override double GetChanceAtMin(CraftItem item) => 0.0;
+
+    public static void CheckAnvilAndForge(Mobile from, int range, out bool anvil, out bool forge)
+    {
+        anvil = false;
+        forge = false;
+
+        var map = from.Map;
+
+        if (map == null)
         {
-            /*
-
-            base( MinCraftEffect, MaxCraftEffect, Delay )
-
-            MinCraftEffect : The minimum number of time the mobile will play the craft effect
-            MaxCraftEffect : The maximum number of time the mobile will play the craft effect
-            Delay : The delay between each craft effect
-
-            Example: (3, 6, 1.7) would make the mobile do the PlayCraftEffect override
-            function between 3 and 6 time, with a 1.7 second delay each time.
-
-            */
+            return;
         }
 
-        public override SkillName MainSkill => SkillName.Blacksmith;
+        var eable = map.GetItemsInRange(from.Location, range);
 
-        public override TextDefinition GumpTitle => 1044002;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefBlacksmithy();
-
-        public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
-
-        public override double GetChanceAtMin(CraftItem item) => 0.0;
-
-        public static void CheckAnvilAndForge(Mobile from, int range, out bool anvil, out bool forge)
+        foreach (var item in eable)
         {
-            anvil = false;
-            forge = false;
+            var type = item.GetType();
 
-            var map = from.Map;
+            var isAnvil = type.IsDefined(typeofAnvil, false) || item.ItemID is 4015 or 4016 or 11733 or 11734;
+            var isForge = type.IsDefined(typeofForge, false) || item.ItemID is 4017 or >= 6522 and <= 6569 or 11736;
 
-            if (map == null)
+            if (isAnvil || isForge)
             {
-                return;
-            }
-
-            var eable = map.GetItemsInRange(from.Location, range);
-
-            foreach (var item in eable)
-            {
-                var type = item.GetType();
-
-                var isAnvil = type.IsDefined(typeofAnvil, false) || item.ItemID is 4015 or 4016 or 11733 or 11734;
-                var isForge = type.IsDefined(typeofForge, false) || item.ItemID is 4017 or >= 6522 and <= 6569 or 11736;
-
-                if (isAnvil || isForge)
+                if (from.Z + 16 < item.Z || item.Z + 16 < from.Z || !from.InLOS(item))
                 {
-                    if (from.Z + 16 < item.Z || item.Z + 16 < from.Z || !from.InLOS(item))
-                    {
-                        continue;
-                    }
+                    continue;
+                }
 
-                    anvil = anvil || isAnvil;
-                    forge = forge || isForge;
+                anvil = anvil || isAnvil;
+                forge = forge || isForge;
 
-                    if (anvil && forge)
-                    {
-                        break;
-                    }
+                if (anvil && forge)
+                {
+                    break;
                 }
             }
+        }
 
-            eable.Free();
+        eable.Free();
 
-            for (var x = -range; (!anvil || !forge) && x <= range; ++x)
+        for (var x = -range; (!anvil || !forge) && x <= range; ++x)
+        {
+            for (var y = -range; (!anvil || !forge) && y <= range; ++y)
             {
-                for (var y = -range; (!anvil || !forge) && y <= range; ++y)
+                var tiles = map.Tiles.GetStaticTiles(from.X + x, from.Y + y, true);
+
+                for (var i = 0; (!anvil || !forge) && i < tiles.Length; ++i)
                 {
-                    var tiles = map.Tiles.GetStaticTiles(from.X + x, from.Y + y, true);
+                    var id = tiles[i].ID;
 
-                    for (var i = 0; (!anvil || !forge) && i < tiles.Length; ++i)
+                    var isAnvil = id is 4015 or 4016 or 11733 or 11734;
+                    var isForge = id is 4017 or >= 6522 and <= 6569 or 11736;
+
+                    if (isAnvil || isForge)
                     {
-                        var id = tiles[i].ID;
-
-                        var isAnvil = id is 4015 or 4016 or 11733 or 11734;
-                        var isForge = id is 4017 or >= 6522 and <= 6569 or 11736;
-
-                        if (isAnvil || isForge)
+                        if (from.Z + 16 < tiles[i].Z || tiles[i].Z + 16 < from.Z ||
+                            !from.InLOS(new Point3D(from.X + x, from.Y + y, tiles[i].Z + tiles[i].Height / 2 + 1)))
                         {
-                            if (from.Z + 16 < tiles[i].Z || tiles[i].Z + 16 < from.Z ||
-                                !from.InLOS(new Point3D(from.X + x, from.Y + y, tiles[i].Z + tiles[i].Height / 2 + 1)))
-                            {
-                                continue;
-                            }
-
-                            anvil = anvil || isAnvil;
-                            forge = forge || isForge;
+                            continue;
                         }
+
+                        anvil = anvil || isAnvil;
+                        forge = forge || isForge;
                     }
                 }
             }
         }
+    }
 
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckTool(tool, from))
-            {
-                return 1048146; // If you have a tool equipped, you must use that tool.
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            CheckAnvilAndForge(from, 2, out var anvil, out var forge);
-
-            if (anvil && forge)
-            {
-                return 0;
-            }
-
-            return 1044267; // You must be near an anvil and a forge to smith items.
+            return 1044038; // You have worn out your tool!
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        if (!BaseTool.CheckTool(tool, from))
         {
-            // To animate and synchronize with sound
-            // if (from.Body.Type == BodyType.Human && !from.Mounted)
-            // from.Animate( 9, 5, 1, true, false, 0 );
-            // 0.7 second delay
-            from.PlaySound(0x2A);
+            return 1048146; // If you have a tool equipped, you must use that tool.
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void InitCraftList()
+        CheckAnvilAndForge(from, 2, out var anvil, out var forge);
+
+        if (anvil && forge)
         {
-            /*
-            Syntax for a SIMPLE craft item
-            AddCraft( ObjectType, Group, MinSkill, MaxSkill, ResourceType, Amount, Message )
+            return 0;
+        }
 
-            ObjectType : The type of the object you want to add to the build list.
-            Group : The group in which the object will be showed in the craft menu.
-            MinSkill : The minimum of skill value
-            MaxSkill : The maximum of skill value
-            ResourceType : The type of the resource the mobile need to create the item
-            Amount : The amount of the ResourceType it need to create the item
-            Message : String or Int for Localized.  The message that will be sent to the mobile, if the specified resource is missing.
+        return 1044267; // You must be near an anvil and a forge to smith items.
+    }
 
-            Syntax for a COMPLEX craft item.  A complex item is an item that need either more than
-            only one skill, or more than only one resource.
+    public override void PlayCraftEffect(Mobile from)
+    {
+        // To animate and synchronize with sound
+        // if (from.Body.Type == BodyType.Human && !from.Mounted)
+        // from.Animate( 9, 5, 1, true, false, 0 );
+        // 0.7 second delay
+        from.PlaySound(0x2A);
+    }
 
-            Coming soon....
-            */
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
+        {
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
+        }
 
-            AddCraft(typeof(RingmailGloves), 1011076, 1025099, 12.0, 62.0, typeof(IronIngot), 1044036, 10, 1044037);
-            AddCraft(typeof(RingmailLegs), 1011076, 1025104, 19.4, 69.4, typeof(IronIngot), 1044036, 16, 1044037);
-            AddCraft(typeof(RingmailArms), 1011076, 1025103, 16.9, 66.9, typeof(IronIngot), 1044036, 14, 1044037);
-            AddCraft(typeof(RingmailChest), 1011076, 1025100, 21.9, 71.9, typeof(IronIngot), 1044036, 18, 1044037);
-
-            AddCraft(typeof(ChainCoif), 1011077, 1025051, 14.5, 64.5, typeof(IronIngot), 1044036, 10, 1044037);
-            AddCraft(typeof(ChainLegs), 1011077, 1025054, 36.7, 86.7, typeof(IronIngot), 1044036, 18, 1044037);
-            AddCraft(typeof(ChainChest), 1011077, 1025055, 39.1, 89.1, typeof(IronIngot), 1044036, 20, 1044037);
-
-            int index;
-
-            AddCraft(typeof(PlateArms), 1011078, 1025136, 66.3, 116.3, typeof(IronIngot), 1044036, 18, 1044037);
-            AddCraft(typeof(PlateGloves), 1011078, 1025140, 58.9, 108.9, typeof(IronIngot), 1044036, 12, 1044037);
-            AddCraft(typeof(PlateGorget), 1011078, 1025139, 56.4, 106.4, typeof(IronIngot), 1044036, 10, 1044037);
-            AddCraft(typeof(PlateLegs), 1011078, 1025137, 68.8, 118.8, typeof(IronIngot), 1044036, 20, 1044037);
-            AddCraft(typeof(PlateChest), 1011078, 1046431, 75.0, 125.0, typeof(IronIngot), 1044036, 25, 1044037);
-            AddCraft(typeof(FemalePlateChest), 1011078, 1046430, 44.1, 94.1, typeof(IronIngot), 1044036, 20, 1044037);
-
-            if (Core.AOS) // exact pre-aos functionality unknown
+        if (failed)
+        {
+            if (lostMaterial)
             {
-                AddCraft(typeof(DragonBardingDeed), 1011078, 1053012, 72.5, 122.5, typeof(IronIngot), 1044036, 750, 1044037);
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(PlateMempo), 1011078, 1030180, 80.0, 130.0, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(PlateDo), 1011078, 1030184, 87.0, 137.0, typeof(IronIngot), 1044036, 28, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(PlateHiroSode), 1011078, 1030187, 80.0, 130.0, typeof(IronIngot), 1044036, 16, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(PlateSuneate), 1011078, 1030195, 65.0, 115.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(PlateHaidate), 1011078, 1030200, 65.0, 115.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddCraft(typeof(Bascinet), 1011079, 1025132, 8.3, 58.3, typeof(IronIngot), 1044036, 15, 1044037);
-            AddCraft(typeof(CloseHelm), 1011079, 1025128, 37.9, 87.9, typeof(IronIngot), 1044036, 15, 1044037);
-            AddCraft(typeof(Helmet), 1011079, 1025130, 37.9, 87.9, typeof(IronIngot), 1044036, 15, 1044037);
-            AddCraft(typeof(NorseHelm), 1011079, 1025134, 37.9, 87.9, typeof(IronIngot), 1044036, 15, 1044037);
-            AddCraft(typeof(PlateHelm), 1011079, 1025138, 62.6, 112.6, typeof(IronIngot), 1044036, 15, 1044037);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(ChainHatsuburi), 1011079, 1030175, 30.0, 80.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(PlateHatsuburi), 1011079, 1030176, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(HeavyPlateJingasa), 1011079, 1030178, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(LightPlateJingasa), 1011079, 1030188, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(SmallPlateJingasa), 1011079, 1030191, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(DecorativePlateKabuto), 1011079, 1030179, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(PlateBattleKabuto), 1011079, 1030192, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(StandardPlateKabuto), 1011079, 1030196, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                if (Core.ML)
-                {
-                    index = AddCraft(typeof(Circlet), 1011079, 1032645, 62.1, 112.1, typeof(IronIngot), 1044036, 6, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(RoyalCirclet), 1011079, 1032646, 70.0, 120.0, typeof(IronIngot), 1044036, 6, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(GemmedCirclet), 1011079, 1032647, 75.0, 125.0, typeof(IronIngot), 1044036, 6, 1044037);
-                    AddRes(index, typeof(Tourmaline), 1044237, 1, 1044240);
-                    AddRes(index, typeof(Amethyst), 1044236, 1, 1044240);
-                    AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                    SetNeededExpansion(index, Expansion.ML);
-                }
-            }
-
-            AddCraft(typeof(Buckler), 1011080, 1027027, -25.0, 25.0, typeof(IronIngot), 1044036, 10, 1044037);
-            AddCraft(typeof(BronzeShield), 1011080, 1027026, -15.2, 34.8, typeof(IronIngot), 1044036, 12, 1044037);
-            AddCraft(typeof(HeaterShield), 1011080, 1027030, 24.3, 74.3, typeof(IronIngot), 1044036, 18, 1044037);
-            AddCraft(typeof(MetalShield), 1011080, 1027035, -10.2, 39.8, typeof(IronIngot), 1044036, 14, 1044037);
-            AddCraft(typeof(MetalKiteShield), 1011080, 1027028, 4.6, 54.6, typeof(IronIngot), 1044036, 16, 1044037);
-            AddCraft(typeof(WoodenKiteShield), 1011080, 1027032, -15.2, 34.8, typeof(IronIngot), 1044036, 8, 1044037);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(ChaosShield), 1011080, 1027107, 85.0, 135.0, typeof(IronIngot), 1044036, 25, 1044037);
-                AddCraft(typeof(OrderShield), 1011080, 1027108, 85.0, 135.0, typeof(IronIngot), 1044036, 25, 1044037);
-            }
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(BoneHarvester), 1011081, 1029915, 33.0, 83.0, typeof(IronIngot), 1044036, 10, 1044037);
-            }
-
-            AddCraft(typeof(Broadsword), 1011081, 1023934, 35.4, 85.4, typeof(IronIngot), 1044036, 10, 1044037);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(CrescentBlade), 1011081, 1029921, 45.0, 95.0, typeof(IronIngot), 1044036, 14, 1044037);
-            }
-
-            AddCraft(typeof(Cutlass), 1011081, 1025185, 24.3, 74.3, typeof(IronIngot), 1044036, 8, 1044037);
-            AddCraft(typeof(Dagger), 1011081, 1023921, -0.4, 49.6, typeof(IronIngot), 1044036, 3, 1044037);
-            AddCraft(typeof(Katana), 1011081, 1025119, 44.1, 94.1, typeof(IronIngot), 1044036, 8, 1044037);
-            AddCraft(typeof(Kryss), 1011081, 1025121, 36.7, 86.7, typeof(IronIngot), 1044036, 8, 1044037);
-            AddCraft(typeof(Longsword), 1011081, 1023937, 28.0, 78.0, typeof(IronIngot), 1044036, 12, 1044037);
-            AddCraft(typeof(Scimitar), 1011081, 1025046, 31.7, 81.7, typeof(IronIngot), 1044036, 10, 1044037);
-            AddCraft(typeof(VikingSword), 1011081, 1025049, 24.3, 74.3, typeof(IronIngot), 1044036, 14, 1044037);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(NoDachi), 1011081, 1030221, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Wakizashi), 1011081, 1030223, 50.0, 100.0, typeof(IronIngot), 1044036, 8, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Lajatang), 1011081, 1030226, 80.0, 130.0, typeof(IronIngot), 1044036, 25, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Daisho), 1011081, 1030228, 60.0, 110.0, typeof(IronIngot), 1044036, 15, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Tekagi), 1011081, 1030230, 55.0, 105.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Shuriken), 1011081, 1030231, 45.0, 95.0, typeof(IronIngot), 1044036, 5, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Kama), 1011081, 1030232, 40.0, 90.0, typeof(IronIngot), 1044036, 14, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Sai), 1011081, 1030234, 50.0, 100.0, typeof(IronIngot), 1044036, 12, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                if (Core.ML)
-                {
-                    index = AddCraft(typeof(RadiantScimitar), 1011081, 1031571, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(WarCleaver), 1011081, 1031567, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(ElvenSpellblade), 1011081, 1031564, 70.0, 120.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(AssassinSpike), 1011081, 1031565, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(Leafblade), 1011081, 1031566, 70.0, 120.0, typeof(IronIngot), 1044036, 12, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(RuneBlade), 1011081, 1031570, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(ElvenMachete), 1011081, 1031573, 70.0, 120.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(RuneCarvingKnife), 1011081, 1072915, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
-                    AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
-                    AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
-                    AddRareRecipe(index, 0);
-                    ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(ColdForgedBlade), 1011081, 1072916, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
-                    AddRes(index, typeof(Taint), 1032684, 10, 1053098);
-                    AddRes(index, typeof(Blight), 1032675, 10, 1053098);
-                    AddRareRecipe(index, 1);
-                    ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(OverseerSunderedBlade), 1011081, 1072920, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
-                    AddRes(index, typeof(Blight), 1032675, 10, 1053098);
-                    AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
-                    AddRareRecipe(index, 2);
-                    ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(LuminousRuneBlade), 1011081, 1072922, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
-                    AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                    AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
-                    AddRareRecipe(index, 3);
-                    ForceNonExceptional(index);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(TrueSpellblade), 1011081, 1073513, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                    AddRecipe(index, 4);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(IcySpellblade), 1011081, 1073514, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
-                    AddRecipe(index, 5);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(FierySpellblade), 1011081, 1073515, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
-                    AddRecipe(index, 6);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(SpellbladeOfDefense), 1011081, 1073516, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
-                    AddRecipe(index, 7);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(TrueAssassinSpike), 1011081, 1073517, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
-                    AddRecipe(index, 8);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(ChargedAssassinSpike), 1011081, 1073518, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
-                    AddRecipe(index, 9);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(MagekillerAssassinSpike), 1011081, 1073519, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
-                    AddRecipe(index, 10);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(WoundingAssassinSpike), 1011081, 1073520, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
-                    AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
-                    AddRecipe(index, 11);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(TrueLeafblade), 1011081, 1073521, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
-                    AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                    AddRecipe(index, 12);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(Luckblade), 1011081, 1073522, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
-                    AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
-                    AddRecipe(index, 13);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(MagekillerLeafblade), 1011081, 1073523, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
-                    AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
-                    AddRecipe(index, 14);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(LeafbladeOfEase), 1011081, 1073524, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
-                    AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
-                    AddRecipe(index, 15);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(KnightsWarCleaver), 1011081, 1073525, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
-                    AddRecipe(index, 16);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(ButchersWarCleaver), 1011081, 1073526, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
-                    AddRecipe(index, 17);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(SerratedWarCleaver), 1011081, 1073527, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
-                    AddRecipe(index, 18);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(TrueWarCleaver), 1011081, 1073528, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
-                    AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
-                    AddRecipe(index, 19);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(AdventurersMachete), 1011081, 1073533, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
-                    AddRecipe(index, 20);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(OrcishMachete), 1011081, 1073534, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(Scourge), 1072136, 1, 1042081);
-                    AddRecipe(index, 21);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(MacheteOfDefense), 1011081, 1073535, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
-                    AddRecipe(index, 22);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(DiseasedMachete), 1011081, 1073536, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
-                    AddRes(index, typeof(Blight), 1072134, 1, 1042081);
-                    AddRecipe(index, 23);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(Runesabre), 1011081, 1073537, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
-                    AddRecipe(index, 24);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(MagesRuneBlade), 1011081, 1073538, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                    AddRecipe(index, 25);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(RuneBladeOfKnowledge), 1011081, 1073539, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
-                    AddRecipe(index, 26);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(CorruptedRuneBlade), 1011081, 1073540, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(Corruption), 1072135, 1, 1042081);
-                    AddRecipe(index, 27);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(TrueRadiantScimitar), 1011081, 1073541, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
-                    AddRecipe(index, 28);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(DarkglowScimitar), 1011081, 1073542, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
-                    AddRecipe(index, 29);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(IcyScimitar), 1011081, 1073543, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
-                    AddRecipe(index, 30);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(TwinklingScimitar), 1011081, 1073544, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                    AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
-                    AddRecipe(index, 31);
-                    SetNeededExpansion(index, Expansion.ML);
-
-                    index = AddCraft(typeof(BoneMachete), 1011081, 1020526, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
-                    AddRes(index, typeof(Bone), 1049064, 6, 1049063);
-                    AddQuestRecipe(index, 32);
-                    SetNeededExpansion(index, Expansion.ML);
-                }
-            }
-
-            AddCraft(typeof(Axe), 1011082, 1023913, 34.2, 84.2, typeof(IronIngot), 1044036, 14, 1044037);
-            AddCraft(typeof(BattleAxe), 1011082, 1023911, 30.5, 80.5, typeof(IronIngot), 1044036, 14, 1044037);
-            AddCraft(typeof(DoubleAxe), 1011082, 1023915, 29.3, 79.3, typeof(IronIngot), 1044036, 12, 1044037);
-            AddCraft(typeof(ExecutionersAxe), 1011082, 1023909, 34.2, 84.2, typeof(IronIngot), 1044036, 14, 1044037);
-            AddCraft(typeof(LargeBattleAxe), 1011082, 1025115, 28.0, 78.0, typeof(IronIngot), 1044036, 12, 1044037);
-            AddCraft(typeof(TwoHandedAxe), 1011082, 1025187, 33.0, 83.0, typeof(IronIngot), 1044036, 16, 1044037);
-            AddCraft(typeof(WarAxe), 1011082, 1025040, 39.1, 89.1, typeof(IronIngot), 1044036, 16, 1044037);
+            return 1044157; // You failed to create the item, but no materials were lost.
+        }
+
+        if (quality == 0)
+        {
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
+
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
+
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override void InitCraftList()
+    {
+        /*
+        Syntax for a SIMPLE craft item
+        AddCraft( ObjectType, Group, MinSkill, MaxSkill, ResourceType, Amount, Message )
+
+        ObjectType : The type of the object you want to add to the build list.
+        Group : The group in which the object will be showed in the craft menu.
+        MinSkill : The minimum of skill value
+        MaxSkill : The maximum of skill value
+        ResourceType : The type of the resource the mobile need to create the item
+        Amount : The amount of the ResourceType it need to create the item
+        Message : String or Int for Localized.  The message that will be sent to the mobile, if the specified resource is missing.
+
+        Syntax for a COMPLEX craft item.  A complex item is an item that need either more than
+        only one skill, or more than only one resource.
+
+        Coming soon....
+        */
+
+        AddCraft(typeof(RingmailGloves), 1011076, 1025099, 12.0, 62.0, typeof(IronIngot), 1044036, 10, 1044037);
+        AddCraft(typeof(RingmailLegs), 1011076, 1025104, 19.4, 69.4, typeof(IronIngot), 1044036, 16, 1044037);
+        AddCraft(typeof(RingmailArms), 1011076, 1025103, 16.9, 66.9, typeof(IronIngot), 1044036, 14, 1044037);
+        AddCraft(typeof(RingmailChest), 1011076, 1025100, 21.9, 71.9, typeof(IronIngot), 1044036, 18, 1044037);
+
+        AddCraft(typeof(ChainCoif), 1011077, 1025051, 14.5, 64.5, typeof(IronIngot), 1044036, 10, 1044037);
+        AddCraft(typeof(ChainLegs), 1011077, 1025054, 36.7, 86.7, typeof(IronIngot), 1044036, 18, 1044037);
+        AddCraft(typeof(ChainChest), 1011077, 1025055, 39.1, 89.1, typeof(IronIngot), 1044036, 20, 1044037);
+
+        int index;
+
+        AddCraft(typeof(PlateArms), 1011078, 1025136, 66.3, 116.3, typeof(IronIngot), 1044036, 18, 1044037);
+        AddCraft(typeof(PlateGloves), 1011078, 1025140, 58.9, 108.9, typeof(IronIngot), 1044036, 12, 1044037);
+        AddCraft(typeof(PlateGorget), 1011078, 1025139, 56.4, 106.4, typeof(IronIngot), 1044036, 10, 1044037);
+        AddCraft(typeof(PlateLegs), 1011078, 1025137, 68.8, 118.8, typeof(IronIngot), 1044036, 20, 1044037);
+        AddCraft(typeof(PlateChest), 1011078, 1046431, 75.0, 125.0, typeof(IronIngot), 1044036, 25, 1044037);
+        AddCraft(typeof(FemalePlateChest), 1011078, 1046430, 44.1, 94.1, typeof(IronIngot), 1044036, 20, 1044037);
+
+        if (Core.AOS) // exact pre-aos functionality unknown
+        {
+            AddCraft(typeof(DragonBardingDeed), 1011078, 1053012, 72.5, 122.5, typeof(IronIngot), 1044036, 750, 1044037);
+        }
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(PlateMempo), 1011078, 1030180, 80.0, 130.0, typeof(IronIngot), 1044036, 18, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(PlateDo), 1011078, 1030184, 87.0, 137.0, typeof(IronIngot), 1044036, 28, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(PlateHiroSode), 1011078, 1030187, 80.0, 130.0, typeof(IronIngot), 1044036, 16, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(PlateSuneate), 1011078, 1030195, 65.0, 115.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(PlateHaidate), 1011078, 1030200, 65.0, 115.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        AddCraft(typeof(Bascinet), 1011079, 1025132, 8.3, 58.3, typeof(IronIngot), 1044036, 15, 1044037);
+        AddCraft(typeof(CloseHelm), 1011079, 1025128, 37.9, 87.9, typeof(IronIngot), 1044036, 15, 1044037);
+        AddCraft(typeof(Helmet), 1011079, 1025130, 37.9, 87.9, typeof(IronIngot), 1044036, 15, 1044037);
+        AddCraft(typeof(NorseHelm), 1011079, 1025134, 37.9, 87.9, typeof(IronIngot), 1044036, 15, 1044037);
+        AddCraft(typeof(PlateHelm), 1011079, 1025138, 62.6, 112.6, typeof(IronIngot), 1044036, 15, 1044037);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(ChainHatsuburi), 1011079, 1030175, 30.0, 80.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(PlateHatsuburi), 1011079, 1030176, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(HeavyPlateJingasa), 1011079, 1030178, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(LightPlateJingasa), 1011079, 1030188, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(SmallPlateJingasa), 1011079, 1030191, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(DecorativePlateKabuto), 1011079, 1030179, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(PlateBattleKabuto), 1011079, 1030192, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(StandardPlateKabuto), 1011079, 1030196, 90.0, 140.0, typeof(IronIngot), 1044036, 25, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
 
             if (Core.ML)
             {
-                index = AddCraft(typeof(OrnateAxe), 1011082, 1031572, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
+                index = AddCraft(typeof(Circlet), 1011079, 1032645, 62.1, 112.1, typeof(IronIngot), 1044036, 6, 1044037);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(GuardianAxe), 1011082, 1073545, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                index = AddCraft(typeof(RoyalCirclet), 1011079, 1032646, 70.0, 120.0, typeof(IronIngot), 1044036, 6, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(GemmedCirclet), 1011079, 1032647, 75.0, 125.0, typeof(IronIngot), 1044036, 6, 1044037);
+                AddRes(index, typeof(Tourmaline), 1044237, 1, 1044240);
+                AddRes(index, typeof(Amethyst), 1044236, 1, 1044240);
                 AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                AddRecipe(index, 33);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(SingingAxe), 1011082, 1073546, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
-                AddRecipe(index, 34);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(ThunderingAxe), 1011082, 1073547, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
-                AddRecipe(index, 35);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(HeavyOrnateAxe), 1011082, 1073548, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
-                AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
-                AddRecipe(index, 36);
                 SetNeededExpansion(index, Expansion.ML);
             }
+        }
 
-            AddCraft(typeof(Bardiche), 1011083, 1023917, 31.7, 81.7, typeof(IronIngot), 1044036, 18, 1044037);
+        AddCraft(typeof(Buckler), 1011080, 1027027, -25.0, 25.0, typeof(IronIngot), 1044036, 10, 1044037);
+        AddCraft(typeof(BronzeShield), 1011080, 1027026, -15.2, 34.8, typeof(IronIngot), 1044036, 12, 1044037);
+        AddCraft(typeof(HeaterShield), 1011080, 1027030, 24.3, 74.3, typeof(IronIngot), 1044036, 18, 1044037);
+        AddCraft(typeof(MetalShield), 1011080, 1027035, -10.2, 39.8, typeof(IronIngot), 1044036, 14, 1044037);
+        AddCraft(typeof(MetalKiteShield), 1011080, 1027028, 4.6, 54.6, typeof(IronIngot), 1044036, 16, 1044037);
+        AddCraft(typeof(WoodenKiteShield), 1011080, 1027032, -15.2, 34.8, typeof(IronIngot), 1044036, 8, 1044037);
 
-            if (Core.AOS)
-            {
-                AddCraft(typeof(BladedStaff), 1011083, 1029917, 40.0, 90.0, typeof(IronIngot), 1044036, 12, 1044037);
-            }
+        if (Core.AOS)
+        {
+            AddCraft(typeof(ChaosShield), 1011080, 1027107, 85.0, 135.0, typeof(IronIngot), 1044036, 25, 1044037);
+            AddCraft(typeof(OrderShield), 1011080, 1027108, 85.0, 135.0, typeof(IronIngot), 1044036, 25, 1044037);
+        }
 
-            if (Core.AOS)
-            {
-                AddCraft(typeof(DoubleBladedStaff), 1011083, 1029919, 45.0, 95.0, typeof(IronIngot), 1044036, 16, 1044037);
-            }
+        if (Core.AOS)
+        {
+            AddCraft(typeof(BoneHarvester), 1011081, 1029915, 33.0, 83.0, typeof(IronIngot), 1044036, 10, 1044037);
+        }
 
-            AddCraft(typeof(Halberd), 1011083, 1025183, 39.1, 89.1, typeof(IronIngot), 1044036, 20, 1044037);
+        AddCraft(typeof(Broadsword), 1011081, 1023934, 35.4, 85.4, typeof(IronIngot), 1044036, 10, 1044037);
 
-            if (Core.AOS)
-            {
-                AddCraft(typeof(Lance), 1011083, 1029920, 48.0, 98.0, typeof(IronIngot), 1044036, 20, 1044037);
-            }
+        if (Core.AOS)
+        {
+            AddCraft(typeof(CrescentBlade), 1011081, 1029921, 45.0, 95.0, typeof(IronIngot), 1044036, 14, 1044037);
+        }
 
-            if (Core.AOS)
-            {
-                AddCraft(typeof(Pike), 1011083, 1029918, 47.0, 97.0, typeof(IronIngot), 1044036, 12, 1044037);
-            }
+        AddCraft(typeof(Cutlass), 1011081, 1025185, 24.3, 74.3, typeof(IronIngot), 1044036, 8, 1044037);
+        AddCraft(typeof(Dagger), 1011081, 1023921, -0.4, 49.6, typeof(IronIngot), 1044036, 3, 1044037);
+        AddCraft(typeof(Katana), 1011081, 1025119, 44.1, 94.1, typeof(IronIngot), 1044036, 8, 1044037);
+        AddCraft(typeof(Kryss), 1011081, 1025121, 36.7, 86.7, typeof(IronIngot), 1044036, 8, 1044037);
+        AddCraft(typeof(Longsword), 1011081, 1023937, 28.0, 78.0, typeof(IronIngot), 1044036, 12, 1044037);
+        AddCraft(typeof(Scimitar), 1011081, 1025046, 31.7, 81.7, typeof(IronIngot), 1044036, 10, 1044037);
+        AddCraft(typeof(VikingSword), 1011081, 1025049, 24.3, 74.3, typeof(IronIngot), 1044036, 14, 1044037);
 
-            AddCraft(typeof(ShortSpear), 1011083, 1025123, 45.3, 95.3, typeof(IronIngot), 1044036, 6, 1044037);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(Scythe), 1011083, 1029914, 39.0, 89.0, typeof(IronIngot), 1044036, 14, 1044037);
-            }
-
-            AddCraft(typeof(Spear), 1011083, 1023938, 49.0, 99.0, typeof(IronIngot), 1044036, 12, 1044037);
-            AddCraft(typeof(WarFork), 1011083, 1025125, 42.9, 92.9, typeof(IronIngot), 1044036, 12, 1044037);
-
-            // Not craftable (is this an AOS change ??)
-            // AddCraft( typeof( Pitchfork ), 1011083, 1023720, 36.1, 86.1, typeof( IronIngot ), 1044036, 12, 1044037 );
-
-            AddCraft(typeof(HammerPick), 1011084, 1025181, 34.2, 84.2, typeof(IronIngot), 1044036, 16, 1044037);
-            AddCraft(typeof(Mace), 1011084, 1023932, 14.5, 64.5, typeof(IronIngot), 1044036, 6, 1044037);
-            AddCraft(typeof(Maul), 1011084, 1025179, 19.4, 69.4, typeof(IronIngot), 1044036, 10, 1044037);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(Scepter), 1011084, 1029916, 21.4, 71.4, typeof(IronIngot), 1044036, 10, 1044037);
-            }
-
-            AddCraft(typeof(WarMace), 1011084, 1025127, 28.0, 78.0, typeof(IronIngot), 1044036, 14, 1044037);
-            AddCraft(typeof(WarHammer), 1011084, 1025177, 34.2, 84.2, typeof(IronIngot), 1044036, 16, 1044037);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(Tessen), 1011084, 1030222, 85.0, 135.0, typeof(IronIngot), 1044036, 16, 1044037);
-                AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-                AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(NoDachi), 1011081, 1030221, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Wakizashi), 1011081, 1030223, 50.0, 100.0, typeof(IronIngot), 1044036, 8, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Lajatang), 1011081, 1030226, 80.0, 130.0, typeof(IronIngot), 1044036, 25, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Daisho), 1011081, 1030228, 60.0, 110.0, typeof(IronIngot), 1044036, 15, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Tekagi), 1011081, 1030230, 55.0, 105.0, typeof(IronIngot), 1044036, 12, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Shuriken), 1011081, 1030231, 45.0, 95.0, typeof(IronIngot), 1044036, 5, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Kama), 1011081, 1030232, 40.0, 90.0, typeof(IronIngot), 1044036, 14, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Sai), 1011081, 1030234, 50.0, 100.0, typeof(IronIngot), 1044036, 12, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
 
             if (Core.ML)
             {
-                index = AddCraft(typeof(DiamondMace), 1011084, 1031556, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
+                index = AddCraft(typeof(RadiantScimitar), 1011081, 1031571, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(ShardThrasher), 1011084, 1072918, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
-                AddRes(index, typeof(EyeOfTheTravesty), 1073126, 1, 1042081);
-                AddRes(index, typeof(Muculent), 1072139, 10, 1042081);
-                AddRes(index, typeof(Corruption), 1072135, 10, 1042081);
-                AddRareRecipe(index, 37);
+                index = AddCraft(typeof(WarCleaver), 1011081, 1031567, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(ElvenSpellblade), 1011081, 1031564, 70.0, 120.0, typeof(IronIngot), 1044036, 14, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(AssassinSpike), 1011081, 1031565, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(Leafblade), 1011081, 1031566, 70.0, 120.0, typeof(IronIngot), 1044036, 12, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(RuneBlade), 1011081, 1031570, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(ElvenMachete), 1011081, 1031573, 70.0, 120.0, typeof(IronIngot), 1044036, 14, 1044037);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(RuneCarvingKnife), 1011081, 1072915, 70.0, 120.0, typeof(IronIngot), 1044036, 9, 1044037);
+                AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
+                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
+                AddRareRecipe(index, 0);
                 ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(RubyMace), 1011084, 1073529, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
-                AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
-                AddRecipe(index, 38);
+                index = AddCraft(typeof(ColdForgedBlade), 1011081, 1072916, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
+                AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
+                AddRes(index, typeof(Taint), 1032684, 10, 1053098);
+                AddRes(index, typeof(Blight), 1032675, 10, 1053098);
+                AddRareRecipe(index, 1);
+                ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(EmeraldMace), 1011084, 1073530, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
-                AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
-                AddRecipe(index, 39);
+                index = AddCraft(typeof(OverseerSunderedBlade), 1011081, 1072920, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
+                AddRes(index, typeof(Blight), 1032675, 10, 1053098);
+                AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
+                AddRareRecipe(index, 2);
+                ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(SapphireMace), 1011084, 1073531, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
-                AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
-                AddRecipe(index, 40);
+                index = AddCraft(typeof(LuminousRuneBlade), 1011081, 1072922, 70.0, 120.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(GrizzledBones), 1032684, 1, 1053098);
+                AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
+                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+                AddRareRecipe(index, 3);
+                ForceNonExceptional(index);
                 SetNeededExpansion(index, Expansion.ML);
 
-                index = AddCraft(typeof(SilverEtchedMace), 1011084, 1073532, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
+                index = AddCraft(typeof(TrueSpellblade), 1011081, 1073513, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
                 AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
-                AddRecipe(index, 41);
+                AddRecipe(index, 4);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(IcySpellblade), 1011081, 1073514, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
+                AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
+                AddRecipe(index, 5);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(FierySpellblade), 1011081, 1073515, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
+                AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
+                AddRecipe(index, 6);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(SpellbladeOfDefense), 1011081, 1073516, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
+                AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
+                AddRecipe(index, 7);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(TrueAssassinSpike), 1011081, 1073517, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
+                AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
+                AddRecipe(index, 8);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(ChargedAssassinSpike), 1011081, 1073518, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
+                AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
+                AddRecipe(index, 9);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(MagekillerAssassinSpike), 1011081, 1073519, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
+                AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
+                AddRecipe(index, 10);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(WoundingAssassinSpike), 1011081, 1073520, 75.0, 125.0, typeof(IronIngot), 1044036, 9, 1044037);
+                AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
+                AddRecipe(index, 11);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(TrueLeafblade), 1011081, 1073521, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
+                AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
+                AddRecipe(index, 12);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(Luckblade), 1011081, 1073522, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
+                AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
+                AddRecipe(index, 13);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(MagekillerLeafblade), 1011081, 1073523, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
+                AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
+                AddRecipe(index, 14);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(LeafbladeOfEase), 1011081, 1073524, 75.0, 125.0, typeof(IronIngot), 1044036, 12, 1044037);
+                AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
+                AddRecipe(index, 15);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(KnightsWarCleaver), 1011081, 1073525, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
+                AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
+                AddRecipe(index, 16);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(ButchersWarCleaver), 1011081, 1073526, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
+                AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
+                AddRecipe(index, 17);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(SerratedWarCleaver), 1011081, 1073527, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
+                AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
+                AddRecipe(index, 18);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(TrueWarCleaver), 1011081, 1073528, 75.0, 125.0, typeof(IronIngot), 1044036, 18, 1044037);
+                AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
+                AddRecipe(index, 19);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(AdventurersMachete), 1011081, 1073533, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
+                AddRes(index, typeof(WhitePearl), 1032694, 1, 1044240);
+                AddRecipe(index, 20);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(OrcishMachete), 1011081, 1073534, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
+                AddRes(index, typeof(Scourge), 1072136, 1, 1042081);
+                AddRecipe(index, 21);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(MacheteOfDefense), 1011081, 1073535, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
+                AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
+                AddRecipe(index, 22);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(DiseasedMachete), 1011081, 1073536, 75.0, 125.0, typeof(IronIngot), 1044036, 14, 1044037);
+                AddRes(index, typeof(Blight), 1072134, 1, 1042081);
+                AddRecipe(index, 23);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(Runesabre), 1011081, 1073537, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
+                AddRecipe(index, 24);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(MagesRuneBlade), 1011081, 1073538, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
+                AddRecipe(index, 25);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(RuneBladeOfKnowledge), 1011081, 1073539, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
+                AddRecipe(index, 26);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(CorruptedRuneBlade), 1011081, 1073540, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(Corruption), 1072135, 1, 1042081);
+                AddRecipe(index, 27);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(TrueRadiantScimitar), 1011081, 1073541, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
+                AddRecipe(index, 28);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(DarkglowScimitar), 1011081, 1073542, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
+                AddRecipe(index, 29);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(IcyScimitar), 1011081, 1073543, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
+                AddRecipe(index, 30);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(TwinklingScimitar), 1011081, 1073544, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+                AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
+                AddRecipe(index, 31);
+                SetNeededExpansion(index, Expansion.ML);
+
+                index = AddCraft(typeof(BoneMachete), 1011081, 1020526, 45.0, 95.0, typeof(IronIngot), 1044036, 20, 1044037);
+                AddRes(index, typeof(Bone), 1049064, 6, 1049063);
+                AddQuestRecipe(index, 32);
                 SetNeededExpansion(index, Expansion.ML);
             }
-
-            index = AddCraft(typeof(DragonGloves), 1053114, 1029795, 68.9, 118.9, typeof(RedScales), 1060883, 16, 1060884);
-            SetUseSubRes2(index, true);
-
-            index = AddCraft(typeof(DragonHelm), 1053114, 1029797, 72.6, 122.6, typeof(RedScales), 1060883, 20, 1060884);
-            SetUseSubRes2(index, true);
-
-            index = AddCraft(typeof(DragonLegs), 1053114, 1029799, 78.8, 128.8, typeof(RedScales), 1060883, 28, 1060884);
-            SetUseSubRes2(index, true);
-
-            index = AddCraft(typeof(DragonArms), 1053114, 1029815, 76.3, 126.3, typeof(RedScales), 1060883, 24, 1060884);
-            SetUseSubRes2(index, true);
-
-            index = AddCraft(typeof(DragonChest), 1053114, 1029793, 85.0, 135.0, typeof(RedScales), 1060883, 36, 1060884);
-            SetUseSubRes2(index, true);
-
-            // Set the overridable material
-            SetSubRes(typeof(IronIngot), 1044022);
-
-            // Add every material you want the player to be able to choose from
-            // This will override the overridable material
-            AddSubRes(typeof(IronIngot), 1044022, 00.0, 1044036, 1044267);
-            AddSubRes(typeof(DullCopperIngot), 1044023, 65.0, 1044036, 1044268);
-            AddSubRes(typeof(ShadowIronIngot), 1044024, 70.0, 1044036, 1044268);
-            AddSubRes(typeof(CopperIngot), 1044025, 75.0, 1044036, 1044268);
-            AddSubRes(typeof(BronzeIngot), 1044026, 80.0, 1044036, 1044268);
-            AddSubRes(typeof(GoldIngot), 1044027, 85.0, 1044036, 1044268);
-            AddSubRes(typeof(AgapiteIngot), 1044028, 90.0, 1044036, 1044268);
-            AddSubRes(typeof(VeriteIngot), 1044029, 95.0, 1044036, 1044268);
-            AddSubRes(typeof(ValoriteIngot), 1044030, 99.0, 1044036, 1044268);
-
-            SetSubRes2(typeof(RedScales), 1060875);
-
-            AddSubRes2(typeof(RedScales), 1060875, 0.0, 1053137, 1044268);
-            AddSubRes2(typeof(YellowScales), 1060876, 0.0, 1053137, 1044268);
-            AddSubRes2(typeof(BlackScales), 1060877, 0.0, 1053137, 1044268);
-            AddSubRes2(typeof(GreenScales), 1060878, 0.0, 1053137, 1044268);
-            AddSubRes2(typeof(WhiteScales), 1060879, 0.0, 1053137, 1044268);
-            AddSubRes2(typeof(BlueScales), 1060880, 0.0, 1053137, 1044268);
-
-            Resmelt = true;
-            Repair = true;
-            MarkOption = true;
-            CanEnhance = Core.AOS;
         }
-    }
 
-    [AttributeUsage(AttributeTargets.Class)]
-    public class ForgeAttribute : Attribute
-    {
-    }
+        AddCraft(typeof(Axe), 1011082, 1023913, 34.2, 84.2, typeof(IronIngot), 1044036, 14, 1044037);
+        AddCraft(typeof(BattleAxe), 1011082, 1023911, 30.5, 80.5, typeof(IronIngot), 1044036, 14, 1044037);
+        AddCraft(typeof(DoubleAxe), 1011082, 1023915, 29.3, 79.3, typeof(IronIngot), 1044036, 12, 1044037);
+        AddCraft(typeof(ExecutionersAxe), 1011082, 1023909, 34.2, 84.2, typeof(IronIngot), 1044036, 14, 1044037);
+        AddCraft(typeof(LargeBattleAxe), 1011082, 1025115, 28.0, 78.0, typeof(IronIngot), 1044036, 12, 1044037);
+        AddCraft(typeof(TwoHandedAxe), 1011082, 1025187, 33.0, 83.0, typeof(IronIngot), 1044036, 16, 1044037);
+        AddCraft(typeof(WarAxe), 1011082, 1025040, 39.1, 89.1, typeof(IronIngot), 1044036, 16, 1044037);
 
-    [AttributeUsage(AttributeTargets.Class)]
-    public class AnvilAttribute : Attribute
-    {
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(OrnateAxe), 1011082, 1031572, 70.0, 120.0, typeof(IronIngot), 1044036, 18, 1044037);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(GuardianAxe), 1011082, 1073545, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+            AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
+            AddRecipe(index, 33);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(SingingAxe), 1011082, 1073546, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+            AddRes(index, typeof(BrilliantAmber), 1032697, 1, 1044240);
+            AddRecipe(index, 34);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(ThunderingAxe), 1011082, 1073547, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+            AddRes(index, typeof(EcruCitrine), 1032693, 1, 1044240);
+            AddRecipe(index, 35);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(HeavyOrnateAxe), 1011082, 1073548, 75.0, 125.0, typeof(IronIngot), 1044036, 15, 1044037);
+            AddRes(index, typeof(Turquoise), 1032691, 1, 1044240);
+            AddRecipe(index, 36);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        AddCraft(typeof(Bardiche), 1011083, 1023917, 31.7, 81.7, typeof(IronIngot), 1044036, 18, 1044037);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(BladedStaff), 1011083, 1029917, 40.0, 90.0, typeof(IronIngot), 1044036, 12, 1044037);
+        }
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(DoubleBladedStaff), 1011083, 1029919, 45.0, 95.0, typeof(IronIngot), 1044036, 16, 1044037);
+        }
+
+        AddCraft(typeof(Halberd), 1011083, 1025183, 39.1, 89.1, typeof(IronIngot), 1044036, 20, 1044037);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(Lance), 1011083, 1029920, 48.0, 98.0, typeof(IronIngot), 1044036, 20, 1044037);
+        }
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(Pike), 1011083, 1029918, 47.0, 97.0, typeof(IronIngot), 1044036, 12, 1044037);
+        }
+
+        AddCraft(typeof(ShortSpear), 1011083, 1025123, 45.3, 95.3, typeof(IronIngot), 1044036, 6, 1044037);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(Scythe), 1011083, 1029914, 39.0, 89.0, typeof(IronIngot), 1044036, 14, 1044037);
+        }
+
+        AddCraft(typeof(Spear), 1011083, 1023938, 49.0, 99.0, typeof(IronIngot), 1044036, 12, 1044037);
+        AddCraft(typeof(WarFork), 1011083, 1025125, 42.9, 92.9, typeof(IronIngot), 1044036, 12, 1044037);
+
+        // Not craftable (is this an AOS change ??)
+        // AddCraft( typeof( Pitchfork ), 1011083, 1023720, 36.1, 86.1, typeof( IronIngot ), 1044036, 12, 1044037 );
+
+        AddCraft(typeof(HammerPick), 1011084, 1025181, 34.2, 84.2, typeof(IronIngot), 1044036, 16, 1044037);
+        AddCraft(typeof(Mace), 1011084, 1023932, 14.5, 64.5, typeof(IronIngot), 1044036, 6, 1044037);
+        AddCraft(typeof(Maul), 1011084, 1025179, 19.4, 69.4, typeof(IronIngot), 1044036, 10, 1044037);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(Scepter), 1011084, 1029916, 21.4, 71.4, typeof(IronIngot), 1044036, 10, 1044037);
+        }
+
+        AddCraft(typeof(WarMace), 1011084, 1025127, 28.0, 78.0, typeof(IronIngot), 1044036, 14, 1044037);
+        AddCraft(typeof(WarHammer), 1011084, 1025177, 34.2, 84.2, typeof(IronIngot), 1044036, 16, 1044037);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(Tessen), 1011084, 1030222, 85.0, 135.0, typeof(IronIngot), 1044036, 16, 1044037);
+            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+            AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(DiamondMace), 1011084, 1031556, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(ShardThrasher), 1011084, 1072918, 70.0, 120.0, typeof(IronIngot), 1044036, 20, 1044037);
+            AddRes(index, typeof(EyeOfTheTravesty), 1073126, 1, 1042081);
+            AddRes(index, typeof(Muculent), 1072139, 10, 1042081);
+            AddRes(index, typeof(Corruption), 1072135, 10, 1042081);
+            AddRareRecipe(index, 37);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(RubyMace), 1011084, 1073529, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
+            AddRes(index, typeof(FireRuby), 1032695, 1, 1044240);
+            AddRecipe(index, 38);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(EmeraldMace), 1011084, 1073530, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
+            AddRes(index, typeof(PerfectEmerald), 1032692, 1, 1044240);
+            AddRecipe(index, 39);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(SapphireMace), 1011084, 1073531, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
+            AddRes(index, typeof(DarkSapphire), 1032690, 1, 1044240);
+            AddRecipe(index, 40);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(SilverEtchedMace), 1011084, 1073532, 75.0, 125.0, typeof(IronIngot), 1044036, 20, 1044037);
+            AddRes(index, typeof(BlueDiamond), 1032696, 1, 1044240);
+            AddRecipe(index, 41);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        index = AddCraft(typeof(DragonGloves), 1053114, 1029795, 68.9, 118.9, typeof(RedScales), 1060883, 16, 1060884);
+        SetUseSubRes2(index, true);
+
+        index = AddCraft(typeof(DragonHelm), 1053114, 1029797, 72.6, 122.6, typeof(RedScales), 1060883, 20, 1060884);
+        SetUseSubRes2(index, true);
+
+        index = AddCraft(typeof(DragonLegs), 1053114, 1029799, 78.8, 128.8, typeof(RedScales), 1060883, 28, 1060884);
+        SetUseSubRes2(index, true);
+
+        index = AddCraft(typeof(DragonArms), 1053114, 1029815, 76.3, 126.3, typeof(RedScales), 1060883, 24, 1060884);
+        SetUseSubRes2(index, true);
+
+        index = AddCraft(typeof(DragonChest), 1053114, 1029793, 85.0, 135.0, typeof(RedScales), 1060883, 36, 1060884);
+        SetUseSubRes2(index, true);
+
+        // Set the overridable material
+        SetSubRes(typeof(IronIngot), 1044022);
+
+        // Add every material you want the player to be able to choose from
+        // This will override the overridable material
+        AddSubRes(typeof(IronIngot), 1044022, 00.0, 1044036, 1044267);
+        AddSubRes(typeof(DullCopperIngot), 1044023, 65.0, 1044036, 1044268);
+        AddSubRes(typeof(ShadowIronIngot), 1044024, 70.0, 1044036, 1044268);
+        AddSubRes(typeof(CopperIngot), 1044025, 75.0, 1044036, 1044268);
+        AddSubRes(typeof(BronzeIngot), 1044026, 80.0, 1044036, 1044268);
+        AddSubRes(typeof(GoldIngot), 1044027, 85.0, 1044036, 1044268);
+        AddSubRes(typeof(AgapiteIngot), 1044028, 90.0, 1044036, 1044268);
+        AddSubRes(typeof(VeriteIngot), 1044029, 95.0, 1044036, 1044268);
+        AddSubRes(typeof(ValoriteIngot), 1044030, 99.0, 1044036, 1044268);
+
+        SetSubRes2(typeof(RedScales), 1060875);
+
+        AddSubRes2(typeof(RedScales), 1060875, 0.0, 1053137, 1044268);
+        AddSubRes2(typeof(YellowScales), 1060876, 0.0, 1053137, 1044268);
+        AddSubRes2(typeof(BlackScales), 1060877, 0.0, 1053137, 1044268);
+        AddSubRes2(typeof(GreenScales), 1060878, 0.0, 1053137, 1044268);
+        AddSubRes2(typeof(WhiteScales), 1060879, 0.0, 1053137, 1044268);
+        AddSubRes2(typeof(BlueScales), 1060880, 0.0, 1053137, 1044268);
+
+        Resmelt = true;
+        Repair = true;
+        MarkOption = true;
+        CanEnhance = Core.AOS;
     }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class ForgeAttribute : Attribute
+{
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public class AnvilAttribute : Attribute
+{
 }

--- a/Projects/UOContent/Engines/Craft/DefBowFletching.cs
+++ b/Projects/UOContent/Engines/Craft/DefBowFletching.cs
@@ -1,260 +1,262 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefBowFletching : CraftSystem
 {
-    public class DefBowFletching : CraftSystem
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefBowFletching();
+    }
 
-        private DefBowFletching() : base(1, 1, 1.25) // base( 1, 2, 1.7 )
+    private DefBowFletching() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Fletching;
+
+    public override TextDefinition GumpTitle => 1044006;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override CraftECA ECA => CraftECA.FiftyPercentChanceMinusTenPercent;
+
+    public override double GetChanceAtMin(CraftItem item) => 0.5;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Fletching;
-
-        public override TextDefinition GumpTitle => 1044006;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefBowFletching();
-
-        public override CraftECA ECA => CraftECA.FiftyPercentChanceMinusTenPercent;
-
-        public override double GetChanceAtMin(CraftItem item) => 0.5;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void PlayCraftEffect(Mobile from)
-        {
-            // no animation
-            // if (from.Body.Type == BodyType.Human && !from.Mounted)
-            // from.Animate( 33, 5, 1, true, false, 0 );
+        return 0;
+    }
 
-            from.PlaySound(0x55);
+    public override void PlayCraftEffect(Mobile from)
+    {
+        // no animation
+        // if (from.Body.Type == BodyType.Human && !from.Mounted)
+        // from.Animate( 33, 5, 1, true, false, 0 );
+
+        from.PlaySound(0x55);
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
+        {
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (failed)
         {
-            if (toolBroken)
+            if (lostMaterial)
             {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
 
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 1044157; // You failed to create the item, but no materials were lost.
         }
 
-        public override void InitCraftList()
+        if (quality == 0)
         {
-            int index;
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
 
-            // Materials
-            AddCraft(typeof(Kindling), 1044457, 1023553, 0.0, 00.0, typeof(Log), 1044041, 1, 1044351);
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
 
-            index = AddCraft(typeof(Shaft), 1044457, 1027124, 0.0, 40.0, typeof(Log), 1044041, 1, 1044351);
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override void InitCraftList()
+    {
+        int index;
+
+        // Materials
+        AddCraft(typeof(Kindling), 1044457, 1023553, 0.0, 00.0, typeof(Log), 1044041, 1, 1044351);
+
+        index = AddCraft(typeof(Shaft), 1044457, 1027124, 0.0, 40.0, typeof(Log), 1044041, 1, 1044351);
+        SetUseAllRes(index, true);
+
+        // Ammunition
+        index = AddCraft(typeof(Arrow), 1044565, 1023903, 0.0, 40.0, typeof(Shaft), 1044560, 1, 1044561);
+        AddRes(index, typeof(Feather), 1044562, 1, 1044563);
+        SetUseAllRes(index, true);
+
+        index = AddCraft(typeof(Bolt), 1044565, 1027163, 0.0, 40.0, typeof(Shaft), 1044560, 1, 1044561);
+        AddRes(index, typeof(Feather), 1044562, 1, 1044563);
+        SetUseAllRes(index, true);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(FukiyaDarts), 1044565, 1030246, 50.0, 90.0, typeof(Log), 1044041, 1, 1044351);
             SetUseAllRes(index, true);
-
-            // Ammunition
-            index = AddCraft(typeof(Arrow), 1044565, 1023903, 0.0, 40.0, typeof(Shaft), 1044560, 1, 1044561);
-            AddRes(index, typeof(Feather), 1044562, 1, 1044563);
-            SetUseAllRes(index, true);
-
-            index = AddCraft(typeof(Bolt), 1044565, 1027163, 0.0, 40.0, typeof(Shaft), 1044560, 1, 1044561);
-            AddRes(index, typeof(Feather), 1044562, 1, 1044563);
-            SetUseAllRes(index, true);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(FukiyaDarts), 1044565, 1030246, 50.0, 90.0, typeof(Log), 1044041, 1, 1044351);
-                SetUseAllRes(index, true);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            // Weapons
-            AddCraft(typeof(Bow), 1044566, 1025042, 30.0, 70.0, typeof(Log), 1044041, 7, 1044351);
-            AddCraft(typeof(Crossbow), 1044566, 1023919, 60.0, 100.0, typeof(Log), 1044041, 7, 1044351);
-            AddCraft(typeof(HeavyCrossbow), 1044566, 1025117, 80.0, 120.0, typeof(Log), 1044041, 10, 1044351);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(CompositeBow), 1044566, 1029922, 70.0, 110.0, typeof(Log), 1044041, 7, 1044351);
-                AddCraft(typeof(RepeatingCrossbow), 1044566, 1029923, 90.0, 130.0, typeof(Log), 1044041, 10, 1044351);
-            }
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(Yumi), 1044566, 1030224, 90.0, 130.0, typeof(Log), 1044041, 10, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            if (Core.ML)
-            {
-                index = AddCraft(
-                    typeof(BlightGrippedLongbow),
-                    1044566,
-                    1072907,
-                    75.0,
-                    125.0,
-                    typeof(Log),
-                    1044041,
-                    20,
-                    1044351
-                );
-                AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
-                AddRes(index, typeof(Blight), 1032675, 10, 1053098);
-                AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                AddRareRecipe(index, 200);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                /* TODO
-                index = AddCraft( typeof( FaerieFire ), 1044566, 1072908, 75.0, 125.0, typeof( Log ), 1044041, 20, 1044351 );
-                AddRes( index, typeof( LardOfParoxysmus ), 1032681, 1, 1053098 );
-                AddRes( index, typeof( Putrefication ), 1032678, 10, 1053098 );
-                AddRes( index, typeof( Taint ), 1032679, 10, 1053098 );
-                AddRareRecipe( index, 201 );
-                ForceNonExceptional( index );
-                SetNeededExpansion( index, Expansion.ML );
-                */
-
-                index = AddCraft(
-                    typeof(SilvanisFeywoodBow),
-                    1044566,
-                    1072955,
-                    75.0,
-                    125.0,
-                    typeof(Log),
-                    1044041,
-                    20,
-                    1044351
-                );
-                AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
-                AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
-                AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
-                AddRareRecipe(index, 202);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                /* TODO
-                index = AddCraft( typeof( MischiefMaker ), 1044566, 1072910, 75.0, 125.0, typeof( Log ), 1044041, 15, 1044351 );
-                AddRes( index, typeof( DreadHornMane ), 1032682, 1, 1053098 );
-                AddRes( index, typeof( Corruption ), 1032676, 10, 1053098 );
-                AddRes( index, typeof( Putrefication ), 1032678, 10, 1053098 );
-                AddRareRecipe( index, 203 );
-                ForceNonExceptional( index );
-                SetNeededExpansion( index, Expansion.ML );
-                */
-
-                index = AddCraft(typeof(TheNightReaper), 1044566, 1072912, 75.0, 125.0, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
-                AddRes(index, typeof(Blight), 1032675, 10, 1053098);
-                AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
-                AddRareRecipe(index, 204);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(BarbedLongbow), 1044566, 1073505, 75.0, 125.0, typeof(Log), 1044041, 20, 1044351);
-                AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
-                AddRecipe(index, 205);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(SlayerLongbow), 1044566, 1073506, 75.0, 125.0, typeof(Log), 1044041, 20, 1044351);
-                AddRes(index, typeof(BrilliantAmber), 1026256, 1, 1053098);
-                AddRecipe(index, 206);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(FrozenLongbow), 1044566, 1073507, 75.0, 125.0, typeof(Log), 1044041, 20, 1044351);
-                AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
-                AddRecipe(index, 207);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(LongbowOfMight), 1044566, 1073508, 75.0, 125.0, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(BlueDiamond), 1026255, 1, 1053098);
-                AddRecipe(index, 208);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(RangersShortbow), 1044566, 1073509, 75.0, 125.0, typeof(Log), 1044041, 15, 1044351);
-                AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
-                AddRecipe(index, 209);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(LightweightShortbow),
-                    1044566,
-                    1073510,
-                    75.0,
-                    125.0,
-                    typeof(Log),
-                    1044041,
-                    15,
-                    1044351
-                );
-                AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
-                AddRecipe(index, 210);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(MysticalShortbow), 1044566, 1073511, 75.0, 125.0, typeof(Log), 1044041, 15, 1044351);
-                AddRes(index, typeof(EcruCitrine), 1026252, 1, 1053098);
-                AddRecipe(index, 211);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(AssassinsShortbow),
-                    1044566,
-                    1073512,
-                    75.0,
-                    125.0,
-                    typeof(Log),
-                    1044041,
-                    15,
-                    1044351
-                );
-                AddRes(index, typeof(DarkSapphire), 1026249, 1, 1053098);
-                AddRecipe(index, 212);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            MarkOption = true;
-            Repair = Core.AOS;
+            SetNeededExpansion(index, Expansion.SE);
         }
+
+        // Weapons
+        AddCraft(typeof(Bow), 1044566, 1025042, 30.0, 70.0, typeof(Log), 1044041, 7, 1044351);
+        AddCraft(typeof(Crossbow), 1044566, 1023919, 60.0, 100.0, typeof(Log), 1044041, 7, 1044351);
+        AddCraft(typeof(HeavyCrossbow), 1044566, 1025117, 80.0, 120.0, typeof(Log), 1044041, 10, 1044351);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(CompositeBow), 1044566, 1029922, 70.0, 110.0, typeof(Log), 1044041, 7, 1044351);
+            AddCraft(typeof(RepeatingCrossbow), 1044566, 1029923, 90.0, 130.0, typeof(Log), 1044041, 10, 1044351);
+        }
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(Yumi), 1044566, 1030224, 90.0, 130.0, typeof(Log), 1044041, 10, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        if (Core.ML)
+        {
+            index = AddCraft(
+                typeof(BlightGrippedLongbow),
+                1044566,
+                1072907,
+                75.0,
+                125.0,
+                typeof(Log),
+                1044041,
+                20,
+                1044351
+            );
+            AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
+            AddRes(index, typeof(Blight), 1032675, 10, 1053098);
+            AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
+            AddRareRecipe(index, 200);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            /* TODO
+            index = AddCraft( typeof( FaerieFire ), 1044566, 1072908, 75.0, 125.0, typeof( Log ), 1044041, 20, 1044351 );
+            AddRes( index, typeof( LardOfParoxysmus ), 1032681, 1, 1053098 );
+            AddRes( index, typeof( Putrefication ), 1032678, 10, 1053098 );
+            AddRes( index, typeof( Taint ), 1032679, 10, 1053098 );
+            AddRareRecipe( index, 201 );
+            ForceNonExceptional( index );
+            SetNeededExpansion( index, Expansion.ML );
+            */
+
+            index = AddCraft(
+                typeof(SilvanisFeywoodBow),
+                1044566,
+                1072955,
+                75.0,
+                125.0,
+                typeof(Log),
+                1044041,
+                20,
+                1044351
+            );
+            AddRes(index, typeof(LardOfParoxysmus), 1032681, 1, 1053098);
+            AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
+            AddRes(index, typeof(Muculent), 1032680, 10, 1053098);
+            AddRareRecipe(index, 202);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            /* TODO
+            index = AddCraft( typeof( MischiefMaker ), 1044566, 1072910, 75.0, 125.0, typeof( Log ), 1044041, 15, 1044351 );
+            AddRes( index, typeof( DreadHornMane ), 1032682, 1, 1053098 );
+            AddRes( index, typeof( Corruption ), 1032676, 10, 1053098 );
+            AddRes( index, typeof( Putrefication ), 1032678, 10, 1053098 );
+            AddRareRecipe( index, 203 );
+            ForceNonExceptional( index );
+            SetNeededExpansion( index, Expansion.ML );
+            */
+
+            index = AddCraft(typeof(TheNightReaper), 1044566, 1072912, 75.0, 125.0, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(DreadHornMane), 1032682, 1, 1053098);
+            AddRes(index, typeof(Blight), 1032675, 10, 1053098);
+            AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
+            AddRareRecipe(index, 204);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(BarbedLongbow), 1044566, 1073505, 75.0, 125.0, typeof(Log), 1044041, 20, 1044351);
+            AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
+            AddRecipe(index, 205);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(SlayerLongbow), 1044566, 1073506, 75.0, 125.0, typeof(Log), 1044041, 20, 1044351);
+            AddRes(index, typeof(BrilliantAmber), 1026256, 1, 1053098);
+            AddRecipe(index, 206);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(FrozenLongbow), 1044566, 1073507, 75.0, 125.0, typeof(Log), 1044041, 20, 1044351);
+            AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
+            AddRecipe(index, 207);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(LongbowOfMight), 1044566, 1073508, 75.0, 125.0, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(BlueDiamond), 1026255, 1, 1053098);
+            AddRecipe(index, 208);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(RangersShortbow), 1044566, 1073509, 75.0, 125.0, typeof(Log), 1044041, 15, 1044351);
+            AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
+            AddRecipe(index, 209);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(LightweightShortbow),
+                1044566,
+                1073510,
+                75.0,
+                125.0,
+                typeof(Log),
+                1044041,
+                15,
+                1044351
+            );
+            AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
+            AddRecipe(index, 210);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(MysticalShortbow), 1044566, 1073511, 75.0, 125.0, typeof(Log), 1044041, 15, 1044351);
+            AddRes(index, typeof(EcruCitrine), 1026252, 1, 1053098);
+            AddRecipe(index, 211);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(AssassinsShortbow),
+                1044566,
+                1073512,
+                75.0,
+                125.0,
+                typeof(Log),
+                1044041,
+                15,
+                1044351
+            );
+            AddRes(index, typeof(DarkSapphire), 1026249, 1, 1053098);
+            AddRecipe(index, 212);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        MarkOption = true;
+        Repair = Core.AOS;
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefCarpentry.cs
+++ b/Projects/UOContent/Engines/Craft/DefCarpentry.cs
@@ -1,607 +1,609 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefCarpentry : CraftSystem
 {
-    public class DefCarpentry : CraftSystem
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefCarpentry();
+    }
 
-        private DefCarpentry() : base(1, 1, 1.25) // base( 1, 1, 3.0 )
+    private DefCarpentry() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Carpentry;
+
+    public override TextDefinition GumpTitle => 1044004;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item) => 0.5;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Carpentry;
-
-        public override TextDefinition GumpTitle => 1044004;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefCarpentry();
-
-        public override double GetChanceAtMin(CraftItem item) => 0.5;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void PlayCraftEffect(Mobile from)
-        {
-            // no animation
-            // if (from.Body.Type == BodyType.Human && !from.Mounted)
-            // from.Animate( 9, 5, 1, true, false, 0 );
-            // 0.7 second delay
+        return 0;
+    }
 
-            from.PlaySound(0x23D);
+    public override void PlayCraftEffect(Mobile from)
+    {
+        // no animation
+        // if (from.Body.Type == BodyType.Human && !from.Mounted)
+        // from.Animate( 9, 5, 1, true, false, 0 );
+        // 0.7 second delay
+
+        from.PlaySound(0x23D);
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
+        {
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (failed)
         {
-            if (toolBroken)
+            if (lostMaterial)
             {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
 
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 1044157; // You failed to create the item, but no materials were lost.
         }
 
-        public override void InitCraftList()
+        if (quality == 0)
         {
-            int index;
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
 
-            // Other Items
-            if (Core.Expansion is Expansion.AOS or Expansion.SE)
-            {
-                index = AddCraft(typeof(Board), 1044294, 1027127, 0.0, 0.0, typeof(Log), 1044466, 1, 1044465);
-                SetUseAllRes(index, true);
-            }
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
 
-            AddCraft(typeof(BarrelStaves), 1044294, 1027857, 00.0, 25.0, typeof(Log), 1044041, 5, 1044351);
-            AddCraft(typeof(BarrelLid), 1044294, 1027608, 11.0, 36.0, typeof(Log), 1044041, 4, 1044351);
-            AddCraft(typeof(ShortMusicStand), 1044294, 1044313, 78.9, 103.9, typeof(Log), 1044041, 15, 1044351);
-            AddCraft(typeof(TallMusicStand), 1044294, 1044315, 81.5, 106.5, typeof(Log), 1044041, 20, 1044351);
-            AddCraft(typeof(Easel), 1044294, 1044317, 86.8, 111.8, typeof(Log), 1044041, 20, 1044351);
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(RedHangingLantern), 1044294, 1029412, 65.0, 90.0, typeof(Log), 1044041, 5, 1044351);
-                AddRes(index, typeof(BlankScroll), 1044377, 10, 1044378);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(WhiteHangingLantern), 1044294, 1029416, 65.0, 90.0, typeof(Log), 1044041, 5, 1044351);
-                AddRes(index, typeof(BlankScroll), 1044377, 10, 1044378);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(ShojiScreen), 1044294, 1029423, 80.0, 105.0, typeof(Log), 1044041, 75, 1044351);
-                AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-                AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(BambooScreen), 1044294, 1029428, 80.0, 105.0, typeof(Log), 1044041, 75, 1044351);
-                AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-                AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+        return 1044154; // You create the item.
+    }
 
-            if (Core.AOS) // Duplicate Entries to preserve ordering depending on era
-            {
-                index = AddCraft(typeof(FishingPole), 1044294, 1023519, 68.4, 93.4, typeof(Log), 1044041, 5, 1044351 );
-                AddSkill(index, SkillName.Tailoring, 40.0, 45.0);
-                AddRes(index, typeof(Cloth), 1044286, 5, 1044287);
-            }
+    public override void InitCraftList()
+    {
+        int index;
 
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(RunedSwitch), 1044294, 1072896, 70.0, 120.0, typeof(Log), 1044041, 2, 1044351);
-                AddRes(index, typeof(EnchantedSwitch), 1072893, 1, 1053098);
-                AddRes(index, typeof(RunedPrism), 1073465, 1, 1053098);
-                AddRes(index, typeof(JeweledFiligree), 1072894, 1, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ArcanistStatueSouthDeed), 1044294, 1072885, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ArcanistStatueEastDeed), 1044294, 1072886, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WarriorStatueSouthDeed), 1044294, 1072887, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
-                AddRecipe(index, 300);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WarriorStatueEastDeed), 1044294, 1072888, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
-                AddRecipe(index, 301);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(SquirrelStatueSouthDeed), 1044294, 1072884, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
-                AddRecipe(index, 302);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(SquirrelStatueEastDeed), 1044294, 1073398, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
-                AddRecipe(index, 303);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(GiantReplicaAcorn), 1044294, 1072889, 80.0, 105.0, typeof(Log), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(MountedDreadHorn), 1044294, 1032632, 90.0, 115.0, typeof(Log), 1044041, 50, 1044351);
-                AddRes(index, typeof(PristineDreadHorn), 1032634, 1, 1053098);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(AcidProofRope), 1044294, 1074886, 80, 130.0, typeof(GreaterStrengthPotion), 1073466, 2, 1044253);
-                AddRes(index, typeof(ProtectionScroll), 1044395, 1, 1053098);
-                AddRes(index, typeof(SwitchItem), 1032127, 1, 1053098);
-                AddRareRecipe(index, 304);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
+        // Other Items
+        if (Core.Expansion is Expansion.AOS or Expansion.SE)
+        {
+            index = AddCraft(typeof(Board), 1044294, 1027127, 0.0, 0.0, typeof(Log), 1044466, 1, 1044465);
+            SetUseAllRes(index, true);
+        }
 
-            // Furniture
-            AddCraft(typeof(FootStool), 1044291, 1022910, 11.0, 36.0, typeof(Log), 1044041, 9, 1044351);
-            AddCraft(typeof(Stool), 1044291, 1022602, 11.0, 36.0, typeof(Log), 1044041, 9, 1044351);
-            AddCraft(typeof(BambooChair), 1044291, 1044300, 21.0, 46.0, typeof(Log), 1044041, 13, 1044351);
-            AddCraft(typeof(WoodenChair), 1044291, 1044301, 21.0, 46.0, typeof(Log), 1044041, 13, 1044351);
-            AddCraft(typeof(FancyWoodenChairCushion), 1044291, 1044302, 42.1, 67.1, typeof(Log), 1044041, 15, 1044351);
-            AddCraft(typeof(WoodenChairCushion), 1044291, 1044303, 42.1, 67.1, typeof(Log), 1044041, 13, 1044351);
-            AddCraft(typeof(WoodenBench), 1044291, 1022860, 52.6, 77.6, typeof(Log), 1044041, 17, 1044351);
-            AddCraft(typeof(WoodenThrone), 1044291, 1044304, 52.6, 77.6, typeof(Log), 1044041, 17, 1044351);
-            AddCraft(typeof(Throne), 1044291, 1044305, 73.6, 98.6, typeof(Log), 1044041, 19, 1044351);
-            AddCraft(typeof(Nightstand), 1044291, 1044306, 42.1, 67.1, typeof(Log), 1044041, 17, 1044351);
-            AddCraft(typeof(WritingTable), 1044291, 1022890, 63.1, 88.1, typeof(Log), 1044041, 17, 1044351);
-            AddCraft(typeof(YewWoodTable), 1044291, 1044307, 63.1, 88.1, typeof(Log), 1044041, 23, 1044351);
-            AddCraft(typeof(LargeTable), 1044291, 1044308, 84.2, 109.2, typeof(Log), 1044041, 27, 1044351);
+        AddCraft(typeof(BarrelStaves), 1044294, 1027857, 00.0, 25.0, typeof(Log), 1044041, 5, 1044351);
+        AddCraft(typeof(BarrelLid), 1044294, 1027608, 11.0, 36.0, typeof(Log), 1044041, 4, 1044351);
+        AddCraft(typeof(ShortMusicStand), 1044294, 1044313, 78.9, 103.9, typeof(Log), 1044041, 15, 1044351);
+        AddCraft(typeof(TallMusicStand), 1044294, 1044315, 81.5, 106.5, typeof(Log), 1044041, 20, 1044351);
+        AddCraft(typeof(Easel), 1044294, 1044317, 86.8, 111.8, typeof(Log), 1044041, 20, 1044351);
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(ElegantLowTable), 1044291, 1030265, 80.0, 105.0, typeof(Log), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(PlainLowTable), 1044291, 1030266, 80.0, 105.0, typeof(Log), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(RedHangingLantern), 1044294, 1029412, 65.0, 90.0, typeof(Log), 1044041, 5, 1044351);
+            AddRes(index, typeof(BlankScroll), 1044377, 10, 1044378);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(WhiteHangingLantern), 1044294, 1029416, 65.0, 90.0, typeof(Log), 1044041, 5, 1044351);
+            AddRes(index, typeof(BlankScroll), 1044377, 10, 1044378);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(ShojiScreen), 1044294, 1029423, 80.0, 105.0, typeof(Log), 1044041, 75, 1044351);
+            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+            AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(BambooScreen), 1044294, 1029428, 80.0, 105.0, typeof(Log), 1044041, 75, 1044351);
+            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+            AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
 
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(OrnateElvenTableSouthDeed), 1044291, 1072869, 85.0, 110.0, typeof(Log), 1044041, 60, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(OrnateElvenTableEastDeed), 1044291, 1073384, 85.0, 110.0, typeof(Log), 1044041, 60, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(FancyElvenTableSouthDeed), 1044291, 1073385, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(FancyElvenTableEastDeed), 1044291, 1073386, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenPodium), 1044291, 1073399, 80.0, 105.0, typeof(Log), 1044041, 20, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(OrnateElvenChair), 1044291, 1072870, 80.0, 105.0, typeof(Log), 1044041, 30, 1044351);
-                AddRecipe(index, 305);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(BigElvenChair), 1044291, 1072872, 85.0, 110.0, typeof(Log), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenReadingChair), 1044291, 1072873, 80.0, 105.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-            }
+        if (Core.AOS) // Duplicate Entries to preserve ordering depending on era
+        {
+            index = AddCraft(typeof(FishingPole), 1044294, 1023519, 68.4, 93.4, typeof(Log), 1044041, 5, 1044351 );
+            AddSkill(index, SkillName.Tailoring, 40.0, 45.0);
+            AddRes(index, typeof(Cloth), 1044286, 5, 1044287);
+        }
 
-            // Containers
-            AddCraft(typeof(WoodenBox), 1044292, 1023709, 21.0, 46.0, typeof(Log), 1044041, 10, 1044351);
-            AddCraft(typeof(SmallCrate), 1044292, 1044309, 10.0, 35.0, typeof(Log), 1044041, 8, 1044351);
-            AddCraft(typeof(MediumCrate), 1044292, 1044310, 31.0, 56.0, typeof(Log), 1044041, 15, 1044351);
-            AddCraft(typeof(LargeCrate), 1044292, 1044311, 47.3, 72.3, typeof(Log), 1044041, 18, 1044351);
-            AddCraft(typeof(WoodenChest), 1044292, 1023650, 73.6, 98.6, typeof(Log), 1044041, 20, 1044351);
-            AddCraft(typeof(EmptyBookcase), 1044292, 1022718, 31.5, 56.5, typeof(Log), 1044041, 25, 1044351);
-            AddCraft(typeof(FancyArmoire), 1044292, 1044312, 84.2, 109.2, typeof(Log), 1044041, 35, 1044351);
-            AddCraft(typeof(Armoire), 1044292, 1022643, 84.2, 109.2, typeof(Log), 1044041, 35, 1044351);
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(RunedSwitch), 1044294, 1072896, 70.0, 120.0, typeof(Log), 1044041, 2, 1044351);
+            AddRes(index, typeof(EnchantedSwitch), 1072893, 1, 1053098);
+            AddRes(index, typeof(RunedPrism), 1073465, 1, 1053098);
+            AddRes(index, typeof(JeweledFiligree), 1072894, 1, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ArcanistStatueSouthDeed), 1044294, 1072885, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ArcanistStatueEastDeed), 1044294, 1072886, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WarriorStatueSouthDeed), 1044294, 1072887, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
+            AddRecipe(index, 300);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WarriorStatueEastDeed), 1044294, 1072888, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
+            AddRecipe(index, 301);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(SquirrelStatueSouthDeed), 1044294, 1072884, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
+            AddRecipe(index, 302);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(SquirrelStatueEastDeed), 1044294, 1073398, 0.0, 35.0, typeof(Log), 1044041, 250, 1044351);
+            AddRecipe(index, 303);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(GiantReplicaAcorn), 1044294, 1072889, 80.0, 105.0, typeof(Log), 1044041, 35, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(MountedDreadHorn), 1044294, 1032632, 90.0, 115.0, typeof(Log), 1044041, 50, 1044351);
+            AddRes(index, typeof(PristineDreadHorn), 1032634, 1, 1053098);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(AcidProofRope), 1044294, 1074886, 80, 130.0, typeof(GreaterStrengthPotion), 1073466, 2, 1044253);
+            AddRes(index, typeof(ProtectionScroll), 1044395, 1, 1053098);
+            AddRes(index, typeof(SwitchItem), 1032127, 1, 1053098);
+            AddRareRecipe(index, 304);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+        }
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(PlainWoodenChest), 1044292, 1030251, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(OrnateWoodenChest), 1044292, 1030253, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(GildedWoodenChest), 1044292, 1030255, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(WoodenFootLocker), 1044292, 1030257, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(FinishedWoodenChest), 1044292, 1030259, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(TallCabinet), 1044292, 1030261, 90.0, 115.0, typeof(Log), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(ShortCabinet), 1044292, 1030263, 90.0, 115.0, typeof(Log), 1044041, 35, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(RedArmoire), 1044292, 1030328, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(ElegantArmoire), 1044292, 1030330, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(MapleArmoire), 1044292, 1030332, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(CherryArmoire), 1044292, 1030334, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+        // Furniture
+        AddCraft(typeof(FootStool), 1044291, 1022910, 11.0, 36.0, typeof(Log), 1044041, 9, 1044351);
+        AddCraft(typeof(Stool), 1044291, 1022602, 11.0, 36.0, typeof(Log), 1044041, 9, 1044351);
+        AddCraft(typeof(BambooChair), 1044291, 1044300, 21.0, 46.0, typeof(Log), 1044041, 13, 1044351);
+        AddCraft(typeof(WoodenChair), 1044291, 1044301, 21.0, 46.0, typeof(Log), 1044041, 13, 1044351);
+        AddCraft(typeof(FancyWoodenChairCushion), 1044291, 1044302, 42.1, 67.1, typeof(Log), 1044041, 15, 1044351);
+        AddCraft(typeof(WoodenChairCushion), 1044291, 1044303, 42.1, 67.1, typeof(Log), 1044041, 13, 1044351);
+        AddCraft(typeof(WoodenBench), 1044291, 1022860, 52.6, 77.6, typeof(Log), 1044041, 17, 1044351);
+        AddCraft(typeof(WoodenThrone), 1044291, 1044304, 52.6, 77.6, typeof(Log), 1044041, 17, 1044351);
+        AddCraft(typeof(Throne), 1044291, 1044305, 73.6, 98.6, typeof(Log), 1044041, 19, 1044351);
+        AddCraft(typeof(Nightstand), 1044291, 1044306, 42.1, 67.1, typeof(Log), 1044041, 17, 1044351);
+        AddCraft(typeof(WritingTable), 1044291, 1022890, 63.1, 88.1, typeof(Log), 1044041, 17, 1044351);
+        AddCraft(typeof(YewWoodTable), 1044291, 1044307, 63.1, 88.1, typeof(Log), 1044041, 23, 1044351);
+        AddCraft(typeof(LargeTable), 1044291, 1044308, 84.2, 109.2, typeof(Log), 1044041, 27, 1044351);
 
-            index = AddCraft(typeof(Keg), 1044292, 1023711, 57.8, 82.8, typeof(BarrelStaves), 1044288, 3, 1044253);
-            AddRes(index, typeof(BarrelHoops), 1044289, 1, 1044253);
-            AddRes(index, typeof(BarrelLid), 1044251, 1, 1044253);
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(ElegantLowTable), 1044291, 1030265, 80.0, 105.0, typeof(Log), 1044041, 35, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(PlainLowTable), 1044291, 1030266, 80.0, 105.0, typeof(Log), 1044041, 35, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+        }
 
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(ArcaneBookshelfSouthDeed), 1044292, 1072871, 94.7, 119.7, typeof(Log), 1044041, 80, 1044351);
-                AddRecipe(index, 306);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ArcaneBookshelfEastDeed), 1044292, 1073371, 94.7, 119.7, typeof(Log), 1044041, 80, 1044351);
-                AddRecipe(index, 307);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft( typeof(OrnateElvenChestSouthDeed), 1044292, 1072862, 94.7, 119.7, typeof(Log), 1044041, 40, 1044351);
-                AddRecipe(index, 308);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft( typeof(OrnateElvenChestEastDeed), 1044292, 1073383, 94.7, 119.7, typeof(Log), 1044041, 40, 1044351);
-                AddRecipe(index, 309);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenWashBasinSouthDeed), 1044292, 1072865, 70.0, 95.0, typeof(Log), 1044041, 40, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenWashBasinEastDeed), 1044292, 1072865, 70.0, 95.0, typeof(Log), 1044041, 40, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenDresserSouthDeed), 1044292, 1072864, 75.0, 100.0, typeof(Log), 1044041, 45, 1044351);
-                AddRecipe(index, 310);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenDresserEastDeed), 1044292, 1073388, 75.0, 100.0, typeof(Log), 1044041, 45, 1044351);
-                AddRecipe(index, 311);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft( typeof(FancyElvenArmoire), 1044292, 1072866, 80.0, 105.0, typeof(Log), 1044041, 60, 1044351);
-                AddRecipe(index, 312);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(SimpleElvenArmoire), 1044292, 1073401, 80.0, 105.0, typeof(Log), 1044041, 60, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(RarewoodChest), 1044292, 1073402, 80.0, 105.0, typeof(Log), 1044041, 30, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(DecorativeBox), 1044292, 1073403, 80.0, 105.0, typeof(Log), 1044041, 25, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(FullBookcase), 1044292, 1071213, 60.0, 85.0, typeof(Log), 1044041, 25, 1044351);
-                AddRes(index, typeof(AcademicBooksArtifact), 1071202, 1, 1044253);
-                SetNeededExpansion(index, Expansion.ML);
-            }
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(OrnateElvenTableSouthDeed), 1044291, 1072869, 85.0, 110.0, typeof(Log), 1044041, 60, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(OrnateElvenTableEastDeed), 1044291, 1073384, 85.0, 110.0, typeof(Log), 1044041, 60, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(FancyElvenTableSouthDeed), 1044291, 1073385, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(FancyElvenTableEastDeed), 1044291, 1073386, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenPodium), 1044291, 1073399, 80.0, 105.0, typeof(Log), 1044041, 20, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(OrnateElvenChair), 1044291, 1072870, 80.0, 105.0, typeof(Log), 1044041, 30, 1044351);
+            AddRecipe(index, 305);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(BigElvenChair), 1044291, 1072872, 85.0, 110.0, typeof(Log), 1044041, 40, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenReadingChair), 1044291, 1072873, 80.0, 105.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+        }
 
-            // Staves and Shields
-            AddCraft(typeof(ShepherdsCrook), Core.ML ? 1044566 : 1044295, 1023713, 78.9, 103.9, typeof(Log), 1044041, 7, 1044351);
-            AddCraft(typeof(QuarterStaff), Core.ML ? 1044566 : 1044295, 1023721, 73.6, 98.6, typeof(Log), 1044041, 6, 1044351);
-            AddCraft(typeof(GnarledStaff), Core.ML ? 1044566 : 1044295, 1025112, 78.9, 103.9, typeof(Log), 1044041, 7, 1044351);
+        // Containers
+        AddCraft(typeof(WoodenBox), 1044292, 1023709, 21.0, 46.0, typeof(Log), 1044041, 10, 1044351);
+        AddCraft(typeof(SmallCrate), 1044292, 1044309, 10.0, 35.0, typeof(Log), 1044041, 8, 1044351);
+        AddCraft(typeof(MediumCrate), 1044292, 1044310, 31.0, 56.0, typeof(Log), 1044041, 15, 1044351);
+        AddCraft(typeof(LargeCrate), 1044292, 1044311, 47.3, 72.3, typeof(Log), 1044041, 18, 1044351);
+        AddCraft(typeof(WoodenChest), 1044292, 1023650, 73.6, 98.6, typeof(Log), 1044041, 20, 1044351);
+        AddCraft(typeof(EmptyBookcase), 1044292, 1022718, 31.5, 56.5, typeof(Log), 1044041, 25, 1044351);
+        AddCraft(typeof(FancyArmoire), 1044292, 1044312, 84.2, 109.2, typeof(Log), 1044041, 35, 1044351);
+        AddCraft(typeof(Armoire), 1044292, 1022643, 84.2, 109.2, typeof(Log), 1044041, 35, 1044351);
 
-            if (!Core.AOS) // Duplicate Entries to preserve ordering depending on era
-            {
-                index = AddCraft(typeof(FishingPole), Core.ML ? 1044294 : 1044295, 1023519, 68.4, 93.4, typeof(Log), 1044041, 5, 1044351);
-                AddSkill(index, SkillName.Tailoring, 40.0, 45.0);
-                AddRes(index, typeof(Cloth), 1044286, 5, 1044287);
-            }
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(PlainWoodenChest), 1044292, 1030251, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(OrnateWoodenChest), 1044292, 1030253, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(GildedWoodenChest), 1044292, 1030255, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(WoodenFootLocker), 1044292, 1030257, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(FinishedWoodenChest), 1044292, 1030259, 90.0, 115.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(TallCabinet), 1044292, 1030261, 90.0, 115.0, typeof(Log), 1044041, 35, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(ShortCabinet), 1044292, 1030263, 90.0, 115.0, typeof(Log), 1044041, 35, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(RedArmoire), 1044292, 1030328, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(ElegantArmoire), 1044292, 1030330, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(MapleArmoire), 1044292, 1030332, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(CherryArmoire), 1044292, 1030334, 90.0, 115.0, typeof(Log), 1044041, 40, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+        }
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(Bokuto), Core.ML ? 1044566 : 1044295, 1030227, 70.0, 95.0, typeof(Log), 1044041, 6, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Fukiya), Core.ML ? 1044566 : 1044295, 1030229, 60.0, 85.0, typeof(Log), 1044041, 6, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Tetsubo), Core.ML ? 1044566 : 1044295, 1030225, 80.0, 140.3, typeof(Log), 1044041, 10, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+        index = AddCraft(typeof(Keg), 1044292, 1023711, 57.8, 82.8, typeof(BarrelStaves), 1044288, 3, 1044253);
+        AddRes(index, typeof(BarrelHoops), 1044289, 1, 1044253);
+        AddRes(index, typeof(BarrelLid), 1044251, 1, 1044253);
 
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(WildStaff), 1044566, 1031557, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(PhantomStaff), 1044566, 1072919, 90.0, 130.0, typeof(Log), 1044041, 16, 1044351);
-                AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
-                AddRes(index, typeof(Taint), 1032679, 10, 1053098);
-                AddRareRecipe(index, 313);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ArcanistsWildStaff), 1044566, 1073549, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
-                AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
-                AddRecipe(index, 314);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(AncientWildStaff), 1044566, 1073550, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
-                AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
-                AddRecipe(index, 315);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ThornedWildStaff), 1044566, 1073551, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
-                AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
-                AddRecipe(index, 316);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(HardenedWildStaff), 1044566, 1073552, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
-                AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
-                AddRecipe(index, 317);
-                SetNeededExpansion(index, Expansion.ML);
-            }
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(ArcaneBookshelfSouthDeed), 1044292, 1072871, 94.7, 119.7, typeof(Log), 1044041, 80, 1044351);
+            AddRecipe(index, 306);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ArcaneBookshelfEastDeed), 1044292, 1073371, 94.7, 119.7, typeof(Log), 1044041, 80, 1044351);
+            AddRecipe(index, 307);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft( typeof(OrnateElvenChestSouthDeed), 1044292, 1072862, 94.7, 119.7, typeof(Log), 1044041, 40, 1044351);
+            AddRecipe(index, 308);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft( typeof(OrnateElvenChestEastDeed), 1044292, 1073383, 94.7, 119.7, typeof(Log), 1044041, 40, 1044351);
+            AddRecipe(index, 309);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenWashBasinSouthDeed), 1044292, 1072865, 70.0, 95.0, typeof(Log), 1044041, 40, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenWashBasinEastDeed), 1044292, 1072865, 70.0, 95.0, typeof(Log), 1044041, 40, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenDresserSouthDeed), 1044292, 1072864, 75.0, 100.0, typeof(Log), 1044041, 45, 1044351);
+            AddRecipe(index, 310);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenDresserEastDeed), 1044292, 1073388, 75.0, 100.0, typeof(Log), 1044041, 45, 1044351);
+            AddRecipe(index, 311);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft( typeof(FancyElvenArmoire), 1044292, 1072866, 80.0, 105.0, typeof(Log), 1044041, 60, 1044351);
+            AddRecipe(index, 312);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(SimpleElvenArmoire), 1044292, 1073401, 80.0, 105.0, typeof(Log), 1044041, 60, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(RarewoodChest), 1044292, 1073402, 80.0, 105.0, typeof(Log), 1044041, 30, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(DecorativeBox), 1044292, 1073403, 80.0, 105.0, typeof(Log), 1044041, 25, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(FullBookcase), 1044292, 1071213, 60.0, 85.0, typeof(Log), 1044041, 25, 1044351);
+            AddRes(index, typeof(AcademicBooksArtifact), 1071202, 1, 1044253);
+            SetNeededExpansion(index, Expansion.ML);
+        }
 
-            // Armor
-            AddCraft(typeof(WoodenShield), Core.ML ? 1062760 : 1044295, 1027034, 52.6, 77.6, typeof(Log), 1044041, 9, 1044351);
+        // Staves and Shields
+        AddCraft(typeof(ShepherdsCrook), Core.ML ? 1044566 : 1044295, 1023713, 78.9, 103.9, typeof(Log), 1044041, 7, 1044351);
+        AddCraft(typeof(QuarterStaff), Core.ML ? 1044566 : 1044295, 1023721, 73.6, 98.6, typeof(Log), 1044041, 6, 1044351);
+        AddCraft(typeof(GnarledStaff), Core.ML ? 1044566 : 1044295, 1025112, 78.9, 103.9, typeof(Log), 1044041, 7, 1044351);
 
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(WoodlandChest), 1062760, 1031111, 90.0, 115.0, typeof(Log), 1044041, 20, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 6, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WoodlandArms), 1062760, 1031116, 80.0, 105.0, typeof(Log), 1044041, 15, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WoodlandGloves), 1062760, 1031114, 85.0, 110.0, typeof(Log), 1044041, 15, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WoodlandLegs), 1062760, 1031115, 85.0, 110.0, typeof(Log), 1044041, 15, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WoodlandGorget), 1062760, 1031113, 85.0, 110.0, typeof(Log), 1044041, 15, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(RavenHelm), 1062760, 1031121, 65.0, 115.0, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                AddRes(index, typeof(Feather), 1027123, 25, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(VultureHelm), 1062760, 1031122, 63.9, 113.9, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                AddRes(index, typeof(Feather), 1027123, 25, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(WingedHelm), 1062760, 1031123, 58.4, 108.4, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
-                AddRes(index, typeof(Feather), 1027123, 60, 1053098);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(IronwoodCrown), 1062760, 1072924, 85.0, 120.0, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
-                AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
-                AddRareRecipe(index, 318);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(BrambleCoat), 1062760, 1072925, 85.0, 120.0, typeof(Log), 1044041, 10, 1044351);
-                AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
-                AddRes(index, typeof(Taint), 1032679, 10, 1053098);
-                AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
-                AddRareRecipe(index, 319);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
+        if (!Core.AOS) // Duplicate Entries to preserve ordering depending on era
+        {
+            index = AddCraft(typeof(FishingPole), Core.ML ? 1044294 : 1044295, 1023519, 68.4, 93.4, typeof(Log), 1044041, 5, 1044351);
+            AddSkill(index, SkillName.Tailoring, 40.0, 45.0);
+            AddRes(index, typeof(Cloth), 1044286, 5, 1044287);
+        }
 
-            // Instruments
-            index = AddCraft(typeof(LapHarp), 1044293, 1023762, 63.1, 88.1, typeof(Log), 1044041, 20, 1044351);
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(Bokuto), Core.ML ? 1044566 : 1044295, 1030227, 70.0, 95.0, typeof(Log), 1044041, 6, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Fukiya), Core.ML ? 1044566 : 1044295, 1030229, 60.0, 85.0, typeof(Log), 1044041, 6, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Tetsubo), Core.ML ? 1044566 : 1044295, 1030225, 80.0, 140.3, typeof(Log), 1044041, 10, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(WildStaff), 1044566, 1031557, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(PhantomStaff), 1044566, 1072919, 90.0, 130.0, typeof(Log), 1044041, 16, 1044351);
+            AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
+            AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+            AddRes(index, typeof(Taint), 1032679, 10, 1053098);
+            AddRareRecipe(index, 313);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ArcanistsWildStaff), 1044566, 1073549, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
+            AddRes(index, typeof(WhitePearl), 1026253, 1, 1053098);
+            AddRecipe(index, 314);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(AncientWildStaff), 1044566, 1073550, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
+            AddRes(index, typeof(PerfectEmerald), 1026251, 1, 1053098);
+            AddRecipe(index, 315);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ThornedWildStaff), 1044566, 1073551, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
+            AddRes(index, typeof(FireRuby), 1026254, 1, 1053098);
+            AddRecipe(index, 316);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(HardenedWildStaff), 1044566, 1073552, 63.8, 113.8, typeof(Log), 1044041, 16, 1044351);
+            AddRes(index, typeof(Turquoise), 1026250, 1, 1053098);
+            AddRecipe(index, 317);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        // Armor
+        AddCraft(typeof(WoodenShield), Core.ML ? 1062760 : 1044295, 1027034, 52.6, 77.6, typeof(Log), 1044041, 9, 1044351);
+
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(WoodlandChest), 1062760, 1031111, 90.0, 115.0, typeof(Log), 1044041, 20, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 6, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WoodlandArms), 1062760, 1031116, 80.0, 105.0, typeof(Log), 1044041, 15, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WoodlandGloves), 1062760, 1031114, 85.0, 110.0, typeof(Log), 1044041, 15, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WoodlandLegs), 1062760, 1031115, 85.0, 110.0, typeof(Log), 1044041, 15, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WoodlandGorget), 1062760, 1031113, 85.0, 110.0, typeof(Log), 1044041, 15, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(RavenHelm), 1062760, 1031121, 65.0, 115.0, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            AddRes(index, typeof(Feather), 1027123, 25, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(VultureHelm), 1062760, 1031122, 63.9, 113.9, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            AddRes(index, typeof(Feather), 1027123, 25, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(WingedHelm), 1062760, 1031123, 58.4, 108.4, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(BarkFragment), 1032687, 4, 1053098);
+            AddRes(index, typeof(Feather), 1027123, 60, 1053098);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(IronwoodCrown), 1062760, 1072924, 85.0, 120.0, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
+            AddRes(index, typeof(Corruption), 1032676, 10, 1053098);
+            AddRes(index, typeof(Putrefication), 1032678, 10, 1053098);
+            AddRareRecipe(index, 318);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(BrambleCoat), 1062760, 1072925, 85.0, 120.0, typeof(Log), 1044041, 10, 1044351);
+            AddRes(index, typeof(DiseasedBark), 1032683, 1, 1053098);
+            AddRes(index, typeof(Taint), 1032679, 10, 1053098);
+            AddRes(index, typeof(Scourge), 1032677, 10, 1053098);
+            AddRareRecipe(index, 319);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        // Instruments
+        index = AddCraft(typeof(LapHarp), 1044293, 1023762, 63.1, 88.1, typeof(Log), 1044041, 20, 1044351);
+        AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
+        AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
+        index = AddCraft(typeof(Harp), 1044293, 1023761, 78.9, 103.9, typeof(Log), 1044041, 35, 1044351);
+        AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
+        AddRes(index, typeof(Cloth), 1044286, 15, 1044287);
+        index = AddCraft(typeof(Drums), 1044293, 1023740, 57.8, 82.8, typeof(Log), 1044041, 20, 1044351);
+        AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
+        AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
+        index = AddCraft(typeof(Lute), 1044293, 1023763, 68.4, 93.4, typeof(Log), 1044041, 25, 1044351);
+        AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
+        AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
+        index = AddCraft(typeof(Tambourine), 1044293, 1023741, 57.8, 82.8, typeof(Log), 1044041, 15, 1044351);
+        AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
+        AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
+        index = AddCraft(typeof(TambourineTassel), 1044293, 1044320, 57.8, 82.8, typeof(Log), 1044041, 15, 1044351);
+        AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
+        AddRes(index, typeof(Cloth), 1044286, 15, 1044287);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(BambooFlute), 1044293, 1030247, 80.0, 105.0, typeof(Log), 1044041, 15, 1044351);
             AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-            AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-            index = AddCraft(typeof(Harp), 1044293, 1023761, 78.9, 103.9, typeof(Log), 1044041, 35, 1044351);
-            AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-            AddRes(index, typeof(Cloth), 1044286, 15, 1044287);
-            index = AddCraft(typeof(Drums), 1044293, 1023740, 57.8, 82.8, typeof(Log), 1044041, 20, 1044351);
-            AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-            AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-            index = AddCraft(typeof(Lute), 1044293, 1023763, 68.4, 93.4, typeof(Log), 1044041, 25, 1044351);
-            AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-            AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-            index = AddCraft(typeof(Tambourine), 1044293, 1023741, 57.8, 82.8, typeof(Log), 1044041, 15, 1044351);
-            AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-            AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-            index = AddCraft(typeof(TambourineTassel), 1044293, 1044320, 57.8, 82.8, typeof(Log), 1044041, 15, 1044351);
-            AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-            AddRes(index, typeof(Cloth), 1044286, 15, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(BambooFlute), 1044293, 1030247, 80.0, 105.0, typeof(Log), 1044041, 15, 1044351);
-                AddSkill(index, SkillName.Musicianship, 45.0, 50.0);
-                SetNeededExpansion(index, Expansion.SE);
-            }
+        // Misc
+        if (Core.AOS)
+        {
+            AddCraft(typeof(PlayerBBEast), 1044290, 1062420, 85.0, 110.0, typeof(Log), 1044041, 50, 1044351);
+            AddCraft(typeof(PlayerBBSouth), 1044290, 1062421, 85.0, 110.0, typeof(Log), 1044041, 50, 1044351);
+        }
 
-            // Misc
-            if (Core.AOS)
-            {
-                AddCraft(typeof(PlayerBBEast), 1044290, 1062420, 85.0, 110.0, typeof(Log), 1044041, 50, 1044351);
-                AddCraft(typeof(PlayerBBSouth), 1044290, 1062421, 85.0, 110.0, typeof(Log), 1044041, 50, 1044351);
-            }
-
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(ParrotPerchDeed), 1044290, 1072617, 50.0, 85.0, typeof(Log), 1044041, 100, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ArcaneCircleDeed), 1044290, 1072703, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
-                AddRes(index, typeof(BlueDiamond), 1026255, 2, 1053098);
-                AddRes(index, typeof(PerfectEmerald), 1026251, 2, 1053098);
-                AddRes(index, typeof(FireRuby), 1026254, 2, 1053098);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(TallElvenBedSouthDeed), 1044290, 1072858, 94.7, 119.7, typeof(Log), 1044041, 200, 1044351);
-                AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
-                AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                AddRecipe(index, 320);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(TallElvenBedEastDeed), 1044290, 1072859, 94.7, 119.7, typeof(Log), 1044041, 200, 1044351);
-                AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
-                AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                AddRecipe(index, 321);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenBedSouthDeed), 1044290, 1072860, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
-                AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenBedEastDeed), 1044290, 1072861, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
-                AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenLoveseatSouthDeed), 1044290, 1072867, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenLoveseatEastDeed), 1044290, 1073372, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(AlchemistTableSouthDeed), 1044290, 1073396, 85.0, 110.0, typeof(Log), 1044041, 70, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(AlchemistTableEastDeed), 1044290, 1073397, 85.0, 110.0, typeof(Log), 1044041, 70, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            index = AddCraft(typeof(SmallBedSouthDeed), 1044290, 1044321, 94.7, 119.8, typeof(Log), 1044041, 100, 1044351);
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(ParrotPerchDeed), 1044290, 1072617, 50.0, 85.0, typeof(Log), 1044041, 100, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ArcaneCircleDeed), 1044290, 1072703, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
+            AddRes(index, typeof(BlueDiamond), 1026255, 2, 1053098);
+            AddRes(index, typeof(PerfectEmerald), 1026251, 2, 1053098);
+            AddRes(index, typeof(FireRuby), 1026254, 2, 1053098);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(TallElvenBedSouthDeed), 1044290, 1072858, 94.7, 119.7, typeof(Log), 1044041, 200, 1044351);
             AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
             AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-            index = AddCraft(typeof(SmallBedEastDeed), 1044290, 1044322, 94.7, 119.8, typeof(Log), 1044041, 100, 1044351);
+            AddRecipe(index, 320);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(TallElvenBedEastDeed), 1044290, 1072859, 94.7, 119.7, typeof(Log), 1044041, 200, 1044351);
             AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
             AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
-            index = AddCraft(typeof(LargeBedSouthDeed), 1044290, 1044323, 94.7, 119.8, typeof(Log), 1044041, 150, 1044351);
-            AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
-            AddRes(index, typeof(Cloth), 1044286, 150, 1044287);
-            index = AddCraft(typeof(LargeBedEastDeed), 1044290, 1044324, 94.7, 119.8, typeof(Log), 1044041, 150, 1044351);
-            AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
-            AddRes(index, typeof(Cloth), 1044286, 150, 1044287);
-            AddCraft(typeof(DartBoardSouthDeed), 1044290, 1044325, 15.7, 40.7, typeof(Log), 1044041, 5, 1044351);
-            AddCraft(typeof(DartBoardEastDeed), 1044290, 1044326, 15.7, 40.7, typeof(Log), 1044041, 5, 1044351);
-            AddCraft(typeof(BallotBoxDeed), 1044290, 1044327, 47.3, 72.3, typeof(Log), 1044041, 5, 1044351);
-            index = AddCraft(typeof(PentagramDeed), 1044290, 1044328, 100.0, 125.0, typeof(Log), 1044041, 100, 1044351);
-            AddSkill(index, SkillName.Magery, 75.0, 80.0);
-            AddRes(index, typeof(IronIngot), 1044036, 40, 1044037);
-            index = AddCraft(typeof(AbbatoirDeed), 1044290, 1044329, 100.0, 125.0, typeof(Log), 1044041, 100, 1044351);
-            AddSkill(index, SkillName.Magery, 50.0, 55.0);
-            AddRes(index, typeof(IronIngot), 1044036, 40, 1044037);
-
-            // Blacksmithy - This changed to Anvils and Forges (1111809) for SA
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(ElvenForgeDeed), 1044296, 1072875, 94.7, 119.7, typeof(Log), 1044041, 200, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            index = AddCraft(typeof(SmallForgeDeed), 1044296, 1044330, 73.6, 98.6, typeof(Log), 1044041, 5, 1044351);
-            AddSkill(index, SkillName.Blacksmith, 75.0, 80.0);
-            AddRes(index, typeof(IronIngot), 1044036, 75, 1044037);
-            index = AddCraft(typeof(LargeForgeEastDeed), 1044296, 1044331, 78.9, 103.9, typeof(Log), 1044041, 5, 1044351);
-            AddSkill(index, SkillName.Blacksmith, 80.0, 85.0);
-            AddRes(index, typeof(IronIngot), 1044036, 100, 1044037);
-            index = AddCraft(typeof(LargeForgeSouthDeed), 1044296, 1044332, 78.9, 103.9, typeof(Log), 1044041, 5, 1044351);
-            AddSkill(index, SkillName.Blacksmith, 80.0, 85.0);
-            AddRes(index, typeof(IronIngot), 1044036, 100, 1044037);
-            index = AddCraft(typeof(AnvilEastDeed), 1044296, 1044333, 73.6, 98.6, typeof(Log), 1044041, 5, 1044351);
-            AddSkill(index, SkillName.Blacksmith, 75.0, 80.0);
-            AddRes(index, typeof(IronIngot), 1044036, 150, 1044037);
-            index = AddCraft(typeof(AnvilSouthDeed), 1044296, 1044334, 73.6, 98.6, typeof(Log), 1044041, 5, 1044351);
-            AddSkill(index, SkillName.Blacksmith, 75.0, 80.0);
-            AddRes(index, typeof(IronIngot), 1044036, 150, 1044037);
-
-            // Training
-            index = AddCraft(typeof(TrainingDummyEastDeed), 1044297, 1044335, 68.4, 93.4, typeof(Log), 1044041, 55, 1044351);
-            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-            AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-            index = AddCraft(typeof(TrainingDummySouthDeed), 1044297, 1044336, 68.4, 93.4, typeof(Log), 1044041, 55, 1044351);
-            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-            AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-            index = AddCraft(typeof(PickpocketDipEastDeed), 1044297, 1044337, 73.6, 98.6, typeof(Log), 1044041, 65, 1044351);
-            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-            AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-            index = AddCraft(typeof(PickpocketDipSouthDeed), 1044297, 1044338, 73.6, 98.6, typeof(Log), 1044041, 65, 1044351);
-            AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
-            AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
-
-            // Tailoring
-            index = AddCraft(typeof(Dressform), 1044298, 1044339, 63.1, 88.1, typeof(Log), 1044041, 25, 1044351);
-            AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
-            AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
-
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(ElvenSpinningWheelEastDeed), 1044298, 1073393, 75.0, 100.0, typeof(Log), 1044041, 60, 1044351);
-                AddSkill(index, SkillName.Tailoring, 65.0, 85.0);
-                AddRes(index, typeof(Cloth), 1044286, 40, 1044287);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenSpinningWheelSouthDeed), 1044298, 1072878, 75.0, 100.0, typeof(Log), 1044041, 60, 1044351);
-                AddSkill(index, SkillName.Tailoring, 65.0, 85.0);
-                AddRes(index, typeof(Cloth), 1044286, 40, 1044287);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenStoveSouthDeed), 1044298, 1073394, 85.0, 110.0, typeof(Log), 1044041, 80, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-                index = AddCraft(typeof(ElvenStoveEastDeed), 1044298, 1073395, 85.0, 110.0, typeof(Log), 1044041, 80, 1044351);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            index = AddCraft(typeof(SpinningWheelEastDeed), 1044298, 1044341, 73.6, 98.6, typeof(Log), 1044041, 75, 1044351);
-            AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
-            AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
-            index = AddCraft(typeof(SpinningWheelSouthDeed), 1044298, 1044342, 73.6, 98.6, typeof(Log), 1044041, 75, 1044351);
-            AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
-            AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
-            index = AddCraft(typeof(LoomEastDeed), 1044298, 1044343, 84.2, 109.2, typeof(Log), 1044041, 85, 1044351);
-            AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
-            AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
-            index = AddCraft(typeof(LoomSouthDeed), 1044298, 1044344, 84.2, 109.2, typeof(Log), 1044041, 85, 1044351);
-            AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
-            AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
-            index = AddCraft(typeof(StoneOvenEastDeed), Core.ML ? 1044298 : 1044299, 1044345, 68.4, 93.4, typeof(Log), 1044041, 85, 1044351);
-            AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
-            AddRes(index, typeof(IronIngot), 1044036, 125, 1044037);
-            index = AddCraft(typeof(StoneOvenSouthDeed), Core.ML ? 1044298 : 1044299, 1044346, 68.4, 93.4, typeof(Log), 1044041, 85, 1044351);
-            AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
-            AddRes(index, typeof(IronIngot), 1044036, 125, 1044037);
-            index = AddCraft(typeof(FlourMillEastDeed), Core.ML ? 1044298 : 1044299, 1044347, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
-            AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
-            AddRes(index, typeof(IronIngot), 1044036, 50, 1044037);
-            index = AddCraft(typeof(FlourMillSouthDeed), Core.ML ? 1044298 : 1044299, 1044348, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
-            AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
-            AddRes(index, typeof(IronIngot), 1044036, 50, 1044037);
-            AddCraft(typeof(WaterTroughEastDeed), Core.ML ? 1044298 : 1044299, 1044349, 94.7, 119.7, typeof(Log), 1044041, 150, 1044351);
-            AddCraft(typeof(WaterTroughSouthDeed), Core.ML ? 1044298 : 1044299, 1044350, 94.7, 119.7, typeof(Log), 1044041, 150, 1044351);
-
-            MarkOption = true;
-            Repair = Core.AOS;
-
-            SetSubRes(typeof(Log), 1072643);
-
-            // Add every material you want the player to be able to choose from
-            // This will override the overridable material	TODO: Verify the required skill amount
-            AddSubRes(typeof(Log), 1072643, 00.0, 1044041, 1072652);
-            AddSubRes(typeof(OakLog), 1072644, 65.0, 1044041, 1072652);
-            AddSubRes(typeof(AshLog), 1072645, 80.0, 1044041, 1072652);
-            AddSubRes(typeof(YewLog), 1072646, 95.0, 1044041, 1072652);
-            AddSubRes(typeof(HeartwoodLog), 1072647, 100.0, 1044041, 1072652);
-            AddSubRes(typeof(BloodwoodLog), 1072648, 100.0, 1044041, 1072652);
-            AddSubRes(typeof(FrostwoodLog), 1072649, 100.0, 1044041, 1072652);
+            AddRecipe(index, 321);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenBedSouthDeed), 1044290, 1072860, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
+            AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenBedEastDeed), 1044290, 1072861, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
+            AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenLoveseatSouthDeed), 1044290, 1072867, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenLoveseatEastDeed), 1044290, 1073372, 80.0, 105.0, typeof(Log), 1044041, 50, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(AlchemistTableSouthDeed), 1044290, 1073396, 85.0, 110.0, typeof(Log), 1044041, 70, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(AlchemistTableEastDeed), 1044290, 1073397, 85.0, 110.0, typeof(Log), 1044041, 70, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
         }
+
+        index = AddCraft(typeof(SmallBedSouthDeed), 1044290, 1044321, 94.7, 119.8, typeof(Log), 1044041, 100, 1044351);
+        AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
+        AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
+        index = AddCraft(typeof(SmallBedEastDeed), 1044290, 1044322, 94.7, 119.8, typeof(Log), 1044041, 100, 1044351);
+        AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
+        AddRes(index, typeof(Cloth), 1044286, 100, 1044287);
+        index = AddCraft(typeof(LargeBedSouthDeed), 1044290, 1044323, 94.7, 119.8, typeof(Log), 1044041, 150, 1044351);
+        AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
+        AddRes(index, typeof(Cloth), 1044286, 150, 1044287);
+        index = AddCraft(typeof(LargeBedEastDeed), 1044290, 1044324, 94.7, 119.8, typeof(Log), 1044041, 150, 1044351);
+        AddSkill(index, SkillName.Tailoring, 75.0, 80.0);
+        AddRes(index, typeof(Cloth), 1044286, 150, 1044287);
+        AddCraft(typeof(DartBoardSouthDeed), 1044290, 1044325, 15.7, 40.7, typeof(Log), 1044041, 5, 1044351);
+        AddCraft(typeof(DartBoardEastDeed), 1044290, 1044326, 15.7, 40.7, typeof(Log), 1044041, 5, 1044351);
+        AddCraft(typeof(BallotBoxDeed), 1044290, 1044327, 47.3, 72.3, typeof(Log), 1044041, 5, 1044351);
+        index = AddCraft(typeof(PentagramDeed), 1044290, 1044328, 100.0, 125.0, typeof(Log), 1044041, 100, 1044351);
+        AddSkill(index, SkillName.Magery, 75.0, 80.0);
+        AddRes(index, typeof(IronIngot), 1044036, 40, 1044037);
+        index = AddCraft(typeof(AbbatoirDeed), 1044290, 1044329, 100.0, 125.0, typeof(Log), 1044041, 100, 1044351);
+        AddSkill(index, SkillName.Magery, 50.0, 55.0);
+        AddRes(index, typeof(IronIngot), 1044036, 40, 1044037);
+
+        // Blacksmithy - This changed to Anvils and Forges (1111809) for SA
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(ElvenForgeDeed), 1044296, 1072875, 94.7, 119.7, typeof(Log), 1044041, 200, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        index = AddCraft(typeof(SmallForgeDeed), 1044296, 1044330, 73.6, 98.6, typeof(Log), 1044041, 5, 1044351);
+        AddSkill(index, SkillName.Blacksmith, 75.0, 80.0);
+        AddRes(index, typeof(IronIngot), 1044036, 75, 1044037);
+        index = AddCraft(typeof(LargeForgeEastDeed), 1044296, 1044331, 78.9, 103.9, typeof(Log), 1044041, 5, 1044351);
+        AddSkill(index, SkillName.Blacksmith, 80.0, 85.0);
+        AddRes(index, typeof(IronIngot), 1044036, 100, 1044037);
+        index = AddCraft(typeof(LargeForgeSouthDeed), 1044296, 1044332, 78.9, 103.9, typeof(Log), 1044041, 5, 1044351);
+        AddSkill(index, SkillName.Blacksmith, 80.0, 85.0);
+        AddRes(index, typeof(IronIngot), 1044036, 100, 1044037);
+        index = AddCraft(typeof(AnvilEastDeed), 1044296, 1044333, 73.6, 98.6, typeof(Log), 1044041, 5, 1044351);
+        AddSkill(index, SkillName.Blacksmith, 75.0, 80.0);
+        AddRes(index, typeof(IronIngot), 1044036, 150, 1044037);
+        index = AddCraft(typeof(AnvilSouthDeed), 1044296, 1044334, 73.6, 98.6, typeof(Log), 1044041, 5, 1044351);
+        AddSkill(index, SkillName.Blacksmith, 75.0, 80.0);
+        AddRes(index, typeof(IronIngot), 1044036, 150, 1044037);
+
+        // Training
+        index = AddCraft(typeof(TrainingDummyEastDeed), 1044297, 1044335, 68.4, 93.4, typeof(Log), 1044041, 55, 1044351);
+        AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+        AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
+        index = AddCraft(typeof(TrainingDummySouthDeed), 1044297, 1044336, 68.4, 93.4, typeof(Log), 1044041, 55, 1044351);
+        AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+        AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
+        index = AddCraft(typeof(PickpocketDipEastDeed), 1044297, 1044337, 73.6, 98.6, typeof(Log), 1044041, 65, 1044351);
+        AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+        AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
+        index = AddCraft(typeof(PickpocketDipSouthDeed), 1044297, 1044338, 73.6, 98.6, typeof(Log), 1044041, 65, 1044351);
+        AddSkill(index, SkillName.Tailoring, 50.0, 55.0);
+        AddRes(index, typeof(Cloth), 1044286, 60, 1044287);
+
+        // Tailoring
+        index = AddCraft(typeof(Dressform), 1044298, 1044339, 63.1, 88.1, typeof(Log), 1044041, 25, 1044351);
+        AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
+        AddRes(index, typeof(Cloth), 1044286, 10, 1044287);
+
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(ElvenSpinningWheelEastDeed), 1044298, 1073393, 75.0, 100.0, typeof(Log), 1044041, 60, 1044351);
+            AddSkill(index, SkillName.Tailoring, 65.0, 85.0);
+            AddRes(index, typeof(Cloth), 1044286, 40, 1044287);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenSpinningWheelSouthDeed), 1044298, 1072878, 75.0, 100.0, typeof(Log), 1044041, 60, 1044351);
+            AddSkill(index, SkillName.Tailoring, 65.0, 85.0);
+            AddRes(index, typeof(Cloth), 1044286, 40, 1044287);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenStoveSouthDeed), 1044298, 1073394, 85.0, 110.0, typeof(Log), 1044041, 80, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+            index = AddCraft(typeof(ElvenStoveEastDeed), 1044298, 1073395, 85.0, 110.0, typeof(Log), 1044041, 80, 1044351);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        index = AddCraft(typeof(SpinningWheelEastDeed), 1044298, 1044341, 73.6, 98.6, typeof(Log), 1044041, 75, 1044351);
+        AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
+        AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
+        index = AddCraft(typeof(SpinningWheelSouthDeed), 1044298, 1044342, 73.6, 98.6, typeof(Log), 1044041, 75, 1044351);
+        AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
+        AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
+        index = AddCraft(typeof(LoomEastDeed), 1044298, 1044343, 84.2, 109.2, typeof(Log), 1044041, 85, 1044351);
+        AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
+        AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
+        index = AddCraft(typeof(LoomSouthDeed), 1044298, 1044344, 84.2, 109.2, typeof(Log), 1044041, 85, 1044351);
+        AddSkill(index, SkillName.Tailoring, 65.0, 70.0);
+        AddRes(index, typeof(Cloth), 1044286, 25, 1044287);
+        index = AddCraft(typeof(StoneOvenEastDeed), Core.ML ? 1044298 : 1044299, 1044345, 68.4, 93.4, typeof(Log), 1044041, 85, 1044351);
+        AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
+        AddRes(index, typeof(IronIngot), 1044036, 125, 1044037);
+        index = AddCraft(typeof(StoneOvenSouthDeed), Core.ML ? 1044298 : 1044299, 1044346, 68.4, 93.4, typeof(Log), 1044041, 85, 1044351);
+        AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
+        AddRes(index, typeof(IronIngot), 1044036, 125, 1044037);
+        index = AddCraft(typeof(FlourMillEastDeed), Core.ML ? 1044298 : 1044299, 1044347, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
+        AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
+        AddRes(index, typeof(IronIngot), 1044036, 50, 1044037);
+        index = AddCraft(typeof(FlourMillSouthDeed), Core.ML ? 1044298 : 1044299, 1044348, 94.7, 119.7, typeof(Log), 1044041, 100, 1044351);
+        AddSkill(index, SkillName.Tinkering, 50.0, 55.0);
+        AddRes(index, typeof(IronIngot), 1044036, 50, 1044037);
+        AddCraft(typeof(WaterTroughEastDeed), Core.ML ? 1044298 : 1044299, 1044349, 94.7, 119.7, typeof(Log), 1044041, 150, 1044351);
+        AddCraft(typeof(WaterTroughSouthDeed), Core.ML ? 1044298 : 1044299, 1044350, 94.7, 119.7, typeof(Log), 1044041, 150, 1044351);
+
+        MarkOption = true;
+        Repair = Core.AOS;
+
+        SetSubRes(typeof(Log), 1072643);
+
+        // Add every material you want the player to be able to choose from
+        // This will override the overridable material	TODO: Verify the required skill amount
+        AddSubRes(typeof(Log), 1072643, 00.0, 1044041, 1072652);
+        AddSubRes(typeof(OakLog), 1072644, 65.0, 1044041, 1072652);
+        AddSubRes(typeof(AshLog), 1072645, 80.0, 1044041, 1072652);
+        AddSubRes(typeof(YewLog), 1072646, 95.0, 1044041, 1072652);
+        AddSubRes(typeof(HeartwoodLog), 1072647, 100.0, 1044041, 1072652);
+        AddSubRes(typeof(BloodwoodLog), 1072648, 100.0, 1044041, 1072652);
+        AddSubRes(typeof(FrostwoodLog), 1072649, 100.0, 1044041, 1072652);
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefCartography.cs
+++ b/Projects/UOContent/Engines/Craft/DefCartography.cs
@@ -1,88 +1,90 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefCartography : CraftSystem
 {
-    public class DefCartography : CraftSystem
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefCartography();
+    }
 
-        private DefCartography() : base(1, 1, 1.25) // base( 1, 1, 3.0 )
+    private DefCartography() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Cartography;
+
+    public override TextDefinition GumpTitle => 1044008;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item) => 0.0;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Cartography;
-
-        public override TextDefinition GumpTitle => 1044008;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefCartography();
-
-        public override double GetChanceAtMin(CraftItem item) => 0.0;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        return 0;
+    }
+
+    public override void PlayCraftEffect(Mobile from)
+    {
+        from.PlaySound(0x249);
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            from.PlaySound(0x249);
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (failed)
         {
-            if (toolBroken)
+            if (lostMaterial)
             {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
 
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 1044157; // You failed to create the item, but no materials were lost.
         }
 
-        public override void InitCraftList()
+        if (quality == 0)
         {
-            AddCraft(typeof(LocalMap), 1044448, 1015230, 10.0, 70.0, typeof(BlankMap), 1044449, 1, 1044450);
-            AddCraft(typeof(CityMap), 1044448, 1015231, 25.0, 85.0, typeof(BlankMap), 1044449, 1, 1044450);
-            AddCraft(typeof(SeaChart), 1044448, 1015232, 35.0, 95.0, typeof(BlankMap), 1044449, 1, 1044450);
-            AddCraft(typeof(WorldMap), 1044448, 1015233, 39.5, 99.5, typeof(BlankMap), 1044449, 1, 1044450);
+            return 502785; // You were barely able to make this item.  It's quality is below average.
         }
+
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
+
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override void InitCraftList()
+    {
+        AddCraft(typeof(LocalMap), 1044448, 1015230, 10.0, 70.0, typeof(BlankMap), 1044449, 1, 1044450);
+        AddCraft(typeof(CityMap), 1044448, 1015231, 25.0, 85.0, typeof(BlankMap), 1044449, 1, 1044450);
+        AddCraft(typeof(SeaChart), 1044448, 1015232, 35.0, 95.0, typeof(BlankMap), 1044449, 1, 1044450);
+        AddCraft(typeof(WorldMap), 1044448, 1015233, 39.5, 99.5, typeof(BlankMap), 1044449, 1, 1044450);
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefCooking.cs
+++ b/Projects/UOContent/Engines/Craft/DefCooking.cs
@@ -1,439 +1,437 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefCooking : CraftSystem
 {
-    public class DefCooking : CraftSystem
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefCooking();
+    }
 
-        private DefCooking() : base(1, 1, 1.25) // base( 1, 1, 1.5 )
+    private DefCooking() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Cooking;
+
+    public override TextDefinition GumpTitle => 1044003;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
+
+    public override double GetChanceAtMin(CraftItem item) => 0.0;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Cooking;
+        // The tool must be on your person to use.
+        return !BaseTool.CheckAccessible(tool, from) ? 1044263 : 0;
+    }
 
-        public override TextDefinition GumpTitle => 1044003;
+    public override void PlayCraftEffect(Mobile from)
+    {
+    }
 
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefCooking();
-
-        public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
-
-        public override double GetChanceAtMin(CraftItem item) => 0.0;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        if (failed)
         {
+            if (lostMaterial)
+            {
+                return 1044043; // You failed to create the item, and some of your materials are lost.
+            }
+
+            return 1044157; // You failed to create the item, but no materials were lost.
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (quality == 0)
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 502785; // You were barely able to make this item.  It's quality is below average.
         }
 
-        public override void InitCraftList()
+        if (makersMark && quality == 2)
         {
-            int index;
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
 
-            /* Begin Ingredients */
-            index = AddCraft(typeof(SackFlour), 1044495, 1024153, 0.0, 100.0, typeof(WheatSheaf), 1044489, 2, 1044490);
-            SetNeedMill(index, true);
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
 
-            index = AddCraft(typeof(Dough), 1044495, 1024157, 0.0, 100.0, typeof(SackFlour), 1044468, 1, 1044253);
-            AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+        return 1044154; // You create the item.
+    }
 
-            index = AddCraft(typeof(SweetDough), 1044495, 1041340, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
+    public override void InitCraftList()
+    {
+        int index;
 
-            index = AddCraft(typeof(CakeMix), 1044495, 1041002, 0.0, 100.0, typeof(SackFlour), 1044468, 1, 1044253);
-            AddRes(index, typeof(SweetDough), 1044475, 1, 1044253);
+        /* Begin Ingredients */
+        index = AddCraft(typeof(SackFlour), 1044495, 1024153, 0.0, 100.0, typeof(WheatSheaf), 1044489, 2, 1044490);
+        SetNeedMill(index, true);
 
-            index = AddCraft(typeof(CookieMix), 1044495, 1024159, 0.0, 100.0, typeof(JarHoney), 1044472, 1, 1044253);
-            AddRes(index, typeof(SweetDough), 1044475, 1, 1044253);
+        index = AddCraft(typeof(Dough), 1044495, 1024157, 0.0, 100.0, typeof(SackFlour), 1044468, 1, 1044253);
+        AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
 
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(CocoaButter), 1044495, 1079998, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
-                SetItemHue(index, 0x457);
-                SetNeededExpansion(index, Expansion.ML);
-                SetNeedOven(index, true);
+        index = AddCraft(typeof(SweetDough), 1044495, 1041340, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(JarHoney), 1044472, 1, 1044253);
 
-                index = AddCraft(typeof(CocoaLiquor), 1044495, 1079999, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
-                AddRes(index, typeof(EmptyPewterBowl), 1025629, 1, 1044253);
-                SetItemHue(index, 0x46A);
-                SetNeededExpansion(index, Expansion.ML);
-                SetNeedOven(index, true);
-            }
-            /* End Ingredients */
+        index = AddCraft(typeof(CakeMix), 1044495, 1041002, 0.0, 100.0, typeof(SackFlour), 1044468, 1, 1044253);
+        AddRes(index, typeof(SweetDough), 1044475, 1, 1044253);
 
-            /* Begin Preparations */
-            index = AddCraft(typeof(UnbakedQuiche), 1044496, 1041339, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(Eggs), 1044477, 1, 1044253);
+        index = AddCraft(typeof(CookieMix), 1044495, 1024159, 0.0, 100.0, typeof(JarHoney), 1044472, 1, 1044253);
+        AddRes(index, typeof(SweetDough), 1044475, 1, 1044253);
 
-            // TODO: This must also support chicken and lamb legs
-            index = AddCraft(typeof(UnbakedMeatPie), 1044496, 1041338, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(RawRibs), 1044482, 1, 1044253);
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(CocoaButter), 1044495, 1079998, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
+            SetItemHue(index, 0x457);
+            SetNeededExpansion(index, Expansion.ML);
+            SetNeedOven(index, true);
 
-            index = AddCraft(typeof(UncookedSausagePizza), 1044496, 1041337, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(Sausage), 1044483, 1, 1044253);
+            index = AddCraft(typeof(CocoaLiquor), 1044495, 1079999, 0.0, 100.0, typeof(CocoaPulp), 1080530, 1, 1044253);
+            AddRes(index, typeof(EmptyPewterBowl), 1025629, 1, 1044253);
+            SetItemHue(index, 0x46A);
+            SetNeededExpansion(index, Expansion.ML);
+            SetNeedOven(index, true);
+        }
+        /* End Ingredients */
 
-            index = AddCraft(typeof(UncookedCheesePizza), 1044496, 1041341, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(CheeseWheel), 1044486, 1, 1044253);
+        /* Begin Preparations */
+        index = AddCraft(typeof(UnbakedQuiche), 1044496, 1041339, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(Eggs), 1044477, 1, 1044253);
 
-            index = AddCraft(typeof(UnbakedFruitPie), 1044496, 1041334, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(Pear), 1044481, 1, 1044253);
+        // TODO: This must also support chicken and lamb legs
+        index = AddCraft(typeof(UnbakedMeatPie), 1044496, 1041338, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(RawRibs), 1044482, 1, 1044253);
 
-            index = AddCraft(typeof(UnbakedPeachCobbler), 1044496, 1041335, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(Peach), 1044480, 1, 1044253);
+        index = AddCraft(typeof(UncookedSausagePizza), 1044496, 1041337, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(Sausage), 1044483, 1, 1044253);
 
-            index = AddCraft(typeof(UnbakedApplePie), 1044496, 1041336, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(Apple), 1044479, 1, 1044253);
+        index = AddCraft(typeof(UncookedCheesePizza), 1044496, 1041341, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(CheeseWheel), 1044486, 1, 1044253);
 
-            index = AddCraft(typeof(UnbakedPumpkinPie), 1044496, 1041342, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            AddRes(index, typeof(Pumpkin), 1044484, 1, 1044253);
+        index = AddCraft(typeof(UnbakedFruitPie), 1044496, 1041334, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(Pear), 1044481, 1, 1044253);
 
-            if (Core.SE)
-            {
-                index = AddCraft(
-                    typeof(GreenTea),
-                    1044496,
-                    1030315,
-                    80.0,
-                    130.0,
-                    typeof(GreenTeaBasket),
-                    1030316,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-                SetNeedOven(index, true);
+        index = AddCraft(typeof(UnbakedPeachCobbler), 1044496, 1041335, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(Peach), 1044480, 1, 1044253);
 
-                index = AddCraft(
-                    typeof(WasabiClumps),
-                    1044496,
-                    1029451,
-                    70.0,
-                    120.0,
-                    typeof(BaseBeverage),
-                    1046458,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(WoodenBowlOfPeas), 1025633, 3, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
+        index = AddCraft(typeof(UnbakedApplePie), 1044496, 1041336, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(Apple), 1044479, 1, 1044253);
 
-                index = AddCraft(
-                    typeof(SushiRolls),
-                    1044496,
-                    1030303,
-                    90.0,
-                    120.0,
-                    typeof(BaseBeverage),
-                    1046458,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
+        index = AddCraft(typeof(UnbakedPumpkinPie), 1044496, 1041342, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        AddRes(index, typeof(Pumpkin), 1044484, 1, 1044253);
 
-                index = AddCraft(
-                    typeof(SushiPlatter),
-                    1044496,
-                    1030305,
-                    90.0,
-                    120.0,
-                    typeof(BaseBeverage),
-                    1046458,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
+        if (Core.SE)
+        {
             index = AddCraft(
-                typeof(TribalPaint),
+                typeof(GreenTea),
                 1044496,
-                1040000,
-                Core.ML ? 55.0 : 80.0,
-                Core.ML ? 105.0 : 80.0,
-                typeof(SackFlour),
-                1044468,
+                1030315,
+                80.0,
+                130.0,
+                typeof(GreenTeaBasket),
+                1030316,
                 1,
                 1044253
             );
-            AddRes(index, typeof(TribalBerry), 1046460, 1, 1044253);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(EggBomb), 1044496, 1030249, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
-                AddRes(index, typeof(SackFlour), 1044468, 3, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-            /* End Preparations */
-
-            /* Begin Baking */
-            index = AddCraft(typeof(BreadLoaf), 1044497, 1024156, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(Cookies), 1044497, 1025643, 0.0, 100.0, typeof(CookieMix), 1044474, 1, 1044253);
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(Cake), 1044497, 1022537, 0.0, 100.0, typeof(CakeMix), 1044471, 1, 1044253);
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(Muffins), 1044497, 1022539, 0.0, 100.0, typeof(SweetDough), 1044475, 1, 1044253);
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(Quiche), 1044497, 1041345, 0.0, 100.0, typeof(UnbakedQuiche), 1044518, 1, 1044253);
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(MeatPie), 1044497, 1041347, 0.0, 100.0, typeof(UnbakedMeatPie), 1044519, 1, 1044253);
+            AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
             SetNeedOven(index, true);
 
             index = AddCraft(
-                typeof(SausagePizza),
-                1044497,
-                1044517,
-                0.0,
-                100.0,
-                typeof(UncookedSausagePizza),
-                1044520,
+                typeof(WasabiClumps),
+                1044496,
+                1029451,
+                70.0,
+                120.0,
+                typeof(BaseBeverage),
+                1046458,
                 1,
                 1044253
             );
-            SetNeedOven(index, true);
+            AddRes(index, typeof(WoodenBowlOfPeas), 1025633, 3, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
 
             index = AddCraft(
-                typeof(CheesePizza),
-                1044497,
-                1044516,
-                0.0,
-                100.0,
-                typeof(UncookedCheesePizza),
-                1044521,
+                typeof(SushiRolls),
+                1044496,
+                1030303,
+                90.0,
+                120.0,
+                typeof(BaseBeverage),
+                1046458,
                 1,
                 1044253
             );
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(FruitPie), 1044497, 1041346, 0.0, 100.0, typeof(UnbakedFruitPie), 1044522, 1, 1044253);
-            SetNeedOven(index, true);
+            AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
 
             index = AddCraft(
-                typeof(PeachCobbler),
-                1044497,
-                1041344,
-                0.0,
-                100.0,
-                typeof(UnbakedPeachCobbler),
-                1044523,
+                typeof(SushiPlatter),
+                1044496,
+                1030305,
+                90.0,
+                120.0,
+                typeof(BaseBeverage),
+                1046458,
                 1,
                 1044253
             );
-            SetNeedOven(index, true);
-
-            index = AddCraft(typeof(ApplePie), 1044497, 1041343, 0.0, 100.0, typeof(UnbakedApplePie), 1044524, 1, 1044253);
-            SetNeedOven(index, true);
-
-            index = AddCraft(
-                typeof(PumpkinPie),
-                1044497,
-                1041348,
-                0.0,
-                100.0,
-                typeof(UnbakedPumpkinPie),
-                1046461,
-                1,
-                1044253
-            );
-            SetNeedOven(index, true);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(MisoSoup), 1044497, 1030317, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
-                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-                SetNeedOven(index, true);
-
-                index = AddCraft(
-                    typeof(WhiteMisoSoup),
-                    1044497,
-                    1030318,
-                    60.0,
-                    110.0,
-                    typeof(RawFishSteak),
-                    1044476,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-                SetNeedOven(index, true);
-
-                index = AddCraft(
-                    typeof(RedMisoSoup),
-                    1044497,
-                    1030319,
-                    60.0,
-                    110.0,
-                    typeof(RawFishSteak),
-                    1044476,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-                SetNeedOven(index, true);
-
-                index = AddCraft(
-                    typeof(AwaseMisoSoup),
-                    1044497,
-                    1030320,
-                    60.0,
-                    110.0,
-                    typeof(RawFishSteak),
-                    1044476,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
-                SetNeededExpansion(index, Expansion.SE);
-                SetNeedOven(index, true);
-            }
-            /* End Baking */
-
-            /* Begin Barbecue */
-            index = AddCraft(typeof(CookedBird), 1044498, 1022487, 0.0, 100.0, typeof(RawBird), 1044470, 1, 1044253);
-            SetNeedHeat(index, true);
-            SetUseAllRes(index, true);
-
-            index = AddCraft(typeof(ChickenLeg), 1044498, 1025640, 0.0, 100.0, typeof(RawChickenLeg), 1044473, 1, 1044253);
-            SetNeedHeat(index, true);
-            SetUseAllRes(index, true);
-
-            index = AddCraft(typeof(FishSteak), 1044498, 1022427, 0.0, 100.0, typeof(RawFishSteak), 1044476, 1, 1044253);
-            SetNeedHeat(index, true);
-            SetUseAllRes(index, true);
-
-            index = AddCraft(typeof(FriedEggs), 1044498, 1022486, 0.0, 100.0, typeof(Eggs), 1044477, 1, 1044253);
-            SetNeedHeat(index, true);
-            SetUseAllRes(index, true);
-
-            index = AddCraft(typeof(LambLeg), 1044498, 1025642, 0.0, 100.0, typeof(RawLambLeg), 1044478, 1, 1044253);
-            SetNeedHeat(index, true);
-            SetUseAllRes(index, true);
-
-            index = AddCraft(typeof(Ribs), 1044498, 1022546, 0.0, 100.0, typeof(RawRibs), 1044485, 1, 1044253);
-            SetNeedHeat(index, true);
-            SetUseAllRes(index, true);
-            /* End Barbecue */
-
-            /* Begin Chocolatiering */
-            if (Core.ML)
-            {
-                index = AddCraft(
-                    typeof(DarkChocolate),
-                    1080001,
-                    1079994,
-                    15.0,
-                    100.0,
-                    typeof(SackOfSugar),
-                    1079997,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
-                AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
-                SetItemHue(index, 0x465);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(MilkChocolate),
-                    1080001,
-                    1079995,
-                    32.5,
-                    107.5,
-                    typeof(SackOfSugar),
-                    1079997,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
-                AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
-                AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
-                SetBeverageType(index, BeverageType.Milk);
-                SetItemHue(index, 0x461);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(WhiteChocolate),
-                    1080001,
-                    1079996,
-                    52.5,
-                    127.5,
-                    typeof(SackOfSugar),
-                    1079997,
-                    1,
-                    1044253
-                );
-                AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
-                AddRes(index, typeof(Vanilla), 1080000, 1, 1044253);
-                AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
-                SetBeverageType(index, BeverageType.Milk);
-                SetItemHue(index, 0x47E);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            /* End Chocolatiering */
+            AddRes(index, typeof(RawFishSteak), 1044476, 10, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
         }
+
+        index = AddCraft(
+            typeof(TribalPaint),
+            1044496,
+            1040000,
+            Core.ML ? 55.0 : 80.0,
+            Core.ML ? 105.0 : 80.0,
+            typeof(SackFlour),
+            1044468,
+            1,
+            1044253
+        );
+        AddRes(index, typeof(TribalBerry), 1046460, 1, 1044253);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(EggBomb), 1044496, 1030249, 90.0, 120.0, typeof(Eggs), 1044477, 1, 1044253);
+            AddRes(index, typeof(SackFlour), 1044468, 3, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+        /* End Preparations */
+
+        /* Begin Baking */
+        index = AddCraft(typeof(BreadLoaf), 1044497, 1024156, 0.0, 100.0, typeof(Dough), 1044469, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(Cookies), 1044497, 1025643, 0.0, 100.0, typeof(CookieMix), 1044474, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(Cake), 1044497, 1022537, 0.0, 100.0, typeof(CakeMix), 1044471, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(Muffins), 1044497, 1022539, 0.0, 100.0, typeof(SweetDough), 1044475, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(Quiche), 1044497, 1041345, 0.0, 100.0, typeof(UnbakedQuiche), 1044518, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(MeatPie), 1044497, 1041347, 0.0, 100.0, typeof(UnbakedMeatPie), 1044519, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(
+            typeof(SausagePizza),
+            1044497,
+            1044517,
+            0.0,
+            100.0,
+            typeof(UncookedSausagePizza),
+            1044520,
+            1,
+            1044253
+        );
+        SetNeedOven(index, true);
+
+        index = AddCraft(
+            typeof(CheesePizza),
+            1044497,
+            1044516,
+            0.0,
+            100.0,
+            typeof(UncookedCheesePizza),
+            1044521,
+            1,
+            1044253
+        );
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(FruitPie), 1044497, 1041346, 0.0, 100.0, typeof(UnbakedFruitPie), 1044522, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(
+            typeof(PeachCobbler),
+            1044497,
+            1041344,
+            0.0,
+            100.0,
+            typeof(UnbakedPeachCobbler),
+            1044523,
+            1,
+            1044253
+        );
+        SetNeedOven(index, true);
+
+        index = AddCraft(typeof(ApplePie), 1044497, 1041343, 0.0, 100.0, typeof(UnbakedApplePie), 1044524, 1, 1044253);
+        SetNeedOven(index, true);
+
+        index = AddCraft(
+            typeof(PumpkinPie),
+            1044497,
+            1041348,
+            0.0,
+            100.0,
+            typeof(UnbakedPumpkinPie),
+            1046461,
+            1,
+            1044253
+        );
+        SetNeedOven(index, true);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(MisoSoup), 1044497, 1030317, 60.0, 110.0, typeof(RawFishSteak), 1044476, 1, 1044253);
+            AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
+            SetNeedOven(index, true);
+
+            index = AddCraft(
+                typeof(WhiteMisoSoup),
+                1044497,
+                1030318,
+                60.0,
+                110.0,
+                typeof(RawFishSteak),
+                1044476,
+                1,
+                1044253
+            );
+            AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
+            SetNeedOven(index, true);
+
+            index = AddCraft(
+                typeof(RedMisoSoup),
+                1044497,
+                1030319,
+                60.0,
+                110.0,
+                typeof(RawFishSteak),
+                1044476,
+                1,
+                1044253
+            );
+            AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
+            SetNeedOven(index, true);
+
+            index = AddCraft(
+                typeof(AwaseMisoSoup),
+                1044497,
+                1030320,
+                60.0,
+                110.0,
+                typeof(RawFishSteak),
+                1044476,
+                1,
+                1044253
+            );
+            AddRes(index, typeof(BaseBeverage), 1046458, 1, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
+            SetNeedOven(index, true);
+        }
+        /* End Baking */
+
+        /* Begin Barbecue */
+        index = AddCraft(typeof(CookedBird), 1044498, 1022487, 0.0, 100.0, typeof(RawBird), 1044470, 1, 1044253);
+        SetNeedHeat(index, true);
+        SetUseAllRes(index, true);
+
+        index = AddCraft(typeof(ChickenLeg), 1044498, 1025640, 0.0, 100.0, typeof(RawChickenLeg), 1044473, 1, 1044253);
+        SetNeedHeat(index, true);
+        SetUseAllRes(index, true);
+
+        index = AddCraft(typeof(FishSteak), 1044498, 1022427, 0.0, 100.0, typeof(RawFishSteak), 1044476, 1, 1044253);
+        SetNeedHeat(index, true);
+        SetUseAllRes(index, true);
+
+        index = AddCraft(typeof(FriedEggs), 1044498, 1022486, 0.0, 100.0, typeof(Eggs), 1044477, 1, 1044253);
+        SetNeedHeat(index, true);
+        SetUseAllRes(index, true);
+
+        index = AddCraft(typeof(LambLeg), 1044498, 1025642, 0.0, 100.0, typeof(RawLambLeg), 1044478, 1, 1044253);
+        SetNeedHeat(index, true);
+        SetUseAllRes(index, true);
+
+        index = AddCraft(typeof(Ribs), 1044498, 1022546, 0.0, 100.0, typeof(RawRibs), 1044485, 1, 1044253);
+        SetNeedHeat(index, true);
+        SetUseAllRes(index, true);
+        /* End Barbecue */
+
+        /* Begin Chocolatiering */
+        if (Core.ML)
+        {
+            index = AddCraft(
+                typeof(DarkChocolate),
+                1080001,
+                1079994,
+                15.0,
+                100.0,
+                typeof(SackOfSugar),
+                1079997,
+                1,
+                1044253
+            );
+            AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
+            AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
+            SetItemHue(index, 0x465);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(MilkChocolate),
+                1080001,
+                1079995,
+                32.5,
+                107.5,
+                typeof(SackOfSugar),
+                1079997,
+                1,
+                1044253
+            );
+            AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
+            AddRes(index, typeof(CocoaLiquor), 1079999, 1, 1044253);
+            AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
+            SetBeverageType(index, BeverageType.Milk);
+            SetItemHue(index, 0x461);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(WhiteChocolate),
+                1080001,
+                1079996,
+                52.5,
+                127.5,
+                typeof(SackOfSugar),
+                1079997,
+                1,
+                1044253
+            );
+            AddRes(index, typeof(CocoaButter), 1079998, 1, 1044253);
+            AddRes(index, typeof(Vanilla), 1080000, 1, 1044253);
+            AddRes(index, typeof(BaseBeverage), 1022544, 1, 1044253);
+            SetBeverageType(index, BeverageType.Milk);
+            SetItemHue(index, 0x47E);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        /* End Chocolatiering */
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefGlassblowing.cs
+++ b/Projects/UOContent/Engines/Craft/DefGlassblowing.cs
@@ -2,123 +2,125 @@ using System;
 using Server.Items;
 using Server.Mobiles;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefGlassblowing : CraftSystem
 {
-    public class DefGlassblowing : CraftSystem
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefGlassblowing();
+    }
 
-        private DefGlassblowing() : base(1, 1, 1.25) // base( 1, 2, 1.7 )
+    private DefGlassblowing() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Alchemy;
+
+    public override TextDefinition GumpTitle => 1044622;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item) => item.ItemType == typeof(HollowPrism) ? 0.5 : 0.0;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Alchemy;
-
-        public override TextDefinition GumpTitle => 1044622;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefGlassblowing();
-
-        public override double GetChanceAtMin(CraftItem item) => item.ItemType == typeof(HollowPrism) ? 0.5 : 0.0;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckTool(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckTool(tool, from))
-            {
-                return 1048146; // If you have a tool equipped, you must use that tool.
-            }
-
-            if (!(from is PlayerMobile mobile && mobile.Glassblowing && mobile.Skills.Alchemy.Base >= 100.0))
-            {
-                return 1044634; // You havent learned glassblowing.
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            DefBlacksmithy.CheckAnvilAndForge(from, 2, out _, out var forge);
-
-            return forge ? 0 : 1044628; // You must be near a forge to blow glass.
+            return 1048146; // If you have a tool equipped, you must use that tool.
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        if (!(from is PlayerMobile mobile && mobile.Glassblowing && mobile.Skills.Alchemy.Base >= 100.0))
         {
-            from.PlaySound(0x2B); // bellows
-
-            // if (from.Body.Type == BodyType.Human && !from.Mounted)
-            // from.Animate( 9, 5, 1, true, false, 0 );
-
-            // new InternalTimer( from ).Start();
+            return 1044634; // You havent learned glassblowing.
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            from.PlaySound(0x41); // glass breaking
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void InitCraftList()
+        DefBlacksmithy.CheckAnvilAndForge(from, 2, out _, out var forge);
+
+        return forge ? 0 : 1044628; // You must be near a forge to blow glass.
+    }
+
+    public override void PlayCraftEffect(Mobile from)
+    {
+        from.PlaySound(0x2B); // bellows
+
+        // if (from.Body.Type == BodyType.Human && !from.Mounted)
+        // from.Animate( 9, 5, 1, true, false, 0 );
+
+        // new InternalTimer( from ).Start();
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            var index = AddCraft(typeof(Bottle), 1044050, 1023854, 52.5, 102.5, typeof(Sand), 1044625, 1, 1044627);
-            SetUseAllRes(index, true);
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
+        }
 
-            AddCraft(typeof(SmallFlask), 1044050, 1044610, 52.5, 102.5, typeof(Sand), 1044625, 2, 1044627);
-            AddCraft(typeof(MediumFlask), 1044050, 1044611, 52.5, 102.5, typeof(Sand), 1044625, 3, 1044627);
-            AddCraft(typeof(CurvedFlask), 1044050, 1044612, 55.0, 105.0, typeof(Sand), 1044625, 2, 1044627);
-            AddCraft(typeof(LongFlask), 1044050, 1044613, 57.5, 107.5, typeof(Sand), 1044625, 4, 1044627);
-            AddCraft(typeof(LargeFlask), 1044050, 1044623, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
-            AddCraft(typeof(AniSmallBlueFlask), 1044050, 1044614, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
-            AddCraft(typeof(AniLargeVioletFlask), 1044050, 1044615, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
-            AddCraft(typeof(AniRedRibbedFlask), 1044050, 1044624, 60.0, 110.0, typeof(Sand), 1044625, 7, 1044627);
-            AddCraft(typeof(EmptyVialsWRack), 1044050, 1044616, 65.0, 115.0, typeof(Sand), 1044625, 8, 1044627);
-            AddCraft(typeof(FullVialsWRack), 1044050, 1044617, 65.0, 115.0, typeof(Sand), 1044625, 9, 1044627);
-            AddCraft(typeof(SpinningHourglass), 1044050, 1044618, 75.0, 125.0, typeof(Sand), 1044625, 10, 1044627);
-
-            if (Core.ML)
+        if (failed)
+        {
+            if (lostMaterial)
             {
-                index = AddCraft(typeof(HollowPrism), 1044050, 1072895, 100.0, 150.0, typeof(Sand), 1044625, 8, 1044627);
-                SetNeededExpansion(index, Expansion.ML);
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
+
+            return 1044157; // You failed to create the item, but no materials were lost.
+        }
+
+        from.PlaySound(0x41); // glass breaking
+
+        if (quality == 0)
+        {
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
+
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
+
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override void InitCraftList()
+    {
+        var index = AddCraft(typeof(Bottle), 1044050, 1023854, 52.5, 102.5, typeof(Sand), 1044625, 1, 1044627);
+        SetUseAllRes(index, true);
+
+        AddCraft(typeof(SmallFlask), 1044050, 1044610, 52.5, 102.5, typeof(Sand), 1044625, 2, 1044627);
+        AddCraft(typeof(MediumFlask), 1044050, 1044611, 52.5, 102.5, typeof(Sand), 1044625, 3, 1044627);
+        AddCraft(typeof(CurvedFlask), 1044050, 1044612, 55.0, 105.0, typeof(Sand), 1044625, 2, 1044627);
+        AddCraft(typeof(LongFlask), 1044050, 1044613, 57.5, 107.5, typeof(Sand), 1044625, 4, 1044627);
+        AddCraft(typeof(LargeFlask), 1044050, 1044623, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
+        AddCraft(typeof(AniSmallBlueFlask), 1044050, 1044614, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
+        AddCraft(typeof(AniLargeVioletFlask), 1044050, 1044615, 60.0, 110.0, typeof(Sand), 1044625, 5, 1044627);
+        AddCraft(typeof(AniRedRibbedFlask), 1044050, 1044624, 60.0, 110.0, typeof(Sand), 1044625, 7, 1044627);
+        AddCraft(typeof(EmptyVialsWRack), 1044050, 1044616, 65.0, 115.0, typeof(Sand), 1044625, 8, 1044627);
+        AddCraft(typeof(FullVialsWRack), 1044050, 1044617, 65.0, 115.0, typeof(Sand), 1044625, 9, 1044627);
+        AddCraft(typeof(SpinningHourglass), 1044050, 1044618, 75.0, 125.0, typeof(Sand), 1044625, 10, 1044627);
+
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(HollowPrism), 1044050, 1072895, 100.0, 150.0, typeof(Sand), 1044625, 8, 1044627);
+            SetNeededExpansion(index, Expansion.ML);
         }
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefInscription.cs
+++ b/Projects/UOContent/Engines/Craft/DefInscription.cs
@@ -4,622 +4,638 @@ using Server.Items;
 using Server.Spells;
 using Server.Utilities;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefInscription : CraftSystem
 {
-    public class DefInscription : CraftSystem
+    private static readonly Type typeofSpellScroll = typeof(SpellScroll);
+
+    private static readonly Type[] regTypes =
     {
-        private static CraftSystem m_CraftSystem;
+        typeof(BlackPearl),
+        typeof(Bloodmoss),
+        typeof(Garlic),
+        typeof(Ginseng),
+        typeof(MandrakeRoot),
+        typeof(Nightshade),
+        typeof(SulfurousAsh),
+        typeof(SpidersSilk)
+    };
 
-        private static readonly Type typeofSpellScroll = typeof(SpellScroll);
+    private int _circle, _mana;
+    private int _index;
 
-        private readonly Type[] m_RegTypes =
+    public static void Configure()
+    {
+        CraftSystem = new DefInscription();
+    }
+
+    private DefInscription() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Inscribe;
+
+    public override TextDefinition GumpTitle => 1044009;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item) => 0.0;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type typeItem)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
-            typeof(BlackPearl),
-            typeof(Bloodmoss),
-            typeof(Garlic),
-            typeof(Ginseng),
-            typeof(MandrakeRoot),
-            typeof(Nightshade),
-            typeof(SulfurousAsh),
-            typeof(SpidersSilk)
-        };
-
-        private int m_Circle, m_Mana;
-
-        private int m_Index;
-
-        private DefInscription()
-            : base(1, 1, 1.25) // base( 1, 1, 3.0 )
-        {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Inscribe;
-
-        public override TextDefinition GumpTitle => 1044009;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefInscription();
-
-        public override double GetChanceAtMin(CraftItem item) => 0.0;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type typeItem)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            if (typeItem != null)
-            {
-                var scroll = typeItem.CreateEntityInstance<SpellScroll>();
-
-                if (scroll != null)
-                {
-                    var hasSpell = Spellbook.Find(from, scroll.SpellID)?.HasSpell(scroll.SpellID) == true;
-
-                    scroll.Delete();
-
-                    return hasSpell ? 0 : 1042404; // null : You don't have that spell!
-                }
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        if (typeItem != null)
         {
-            from.PlaySound(0x249);
+            var scroll = typeItem.CreateEntityInstance<SpellScroll>();
+
+            if (scroll != null)
+            {
+                var hasSpell = Spellbook.Find(from, scroll.SpellID)?.HasSpell(scroll.SpellID) == true;
+
+                scroll.Delete();
+
+                return hasSpell ? 0 : 1042404; // null : You don't have that spell!
+            }
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        return 0;
+    }
+
+    public override void PlayCraftEffect(Mobile from)
+    {
+        from.PlaySound(0x249);
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
+        }
 
-            if (!typeofSpellScroll.IsAssignableFrom(item.ItemType)) // not a scroll
-            {
-                if (failed)
-                {
-                    if (lostMaterial)
-                    {
-                        return 1044043; // You failed to create the item, and some of your materials are lost.
-                    }
-
-                    return 1044157;     // You failed to create the item, but no materials were lost.
-                }
-
-                if (quality == 0)
-                {
-                    return 502785; // You were barely able to make this item.  It's quality is below average.
-                }
-
-                if (makersMark && quality == 2)
-                {
-                    return 1044156; // You create an exceptional quality item and affix your maker's mark.
-                }
-
-                if (quality == 2)
-                {
-                    return 1044155; // You create an exceptional quality item.
-                }
-
-                return 1044154;     // You create the item.
-            }
-
+        if (!typeofSpellScroll.IsAssignableFrom(item.ItemType)) // not a scroll
+        {
             if (failed)
             {
-                return 501630; // You fail to inscribe the scroll, and the scroll is ruined.
+                if (lostMaterial)
+                {
+                    return 1044043; // You failed to create the item, and some of your materials are lost.
+                }
+
+                return 1044157; // You failed to create the item, but no materials were lost.
             }
 
-            return 501629;     // You inscribe the spell and put the scroll in your backpack.
+            if (quality == 0)
+            {
+                return 502785; // You were barely able to make this item.  It's quality is below average.
+            }
+
+            if (makersMark && quality == 2)
+            {
+                return 1044156; // You create an exceptional quality item and affix your maker's mark.
+            }
+
+            if (quality == 2)
+            {
+                return 1044155; // You create an exceptional quality item.
+            }
+
+            return 1044154; // You create the item.
         }
 
-        private void AddSpell(Type type, params Reg[] regs)
+        if (failed)
         {
-            double minSkill, maxSkill;
+            return 501630; // You fail to inscribe the scroll, and the scroll is ruined.
+        }
 
-            switch (m_Circle)
-            {
-                default:
+        return 501629; // You inscribe the spell and put the scroll in your backpack.
+    }
+
+    private void AddSpell(Type type, params Reg[] regs)
+    {
+        double minSkill, maxSkill;
+
+        switch (_circle)
+        {
+            default:
+                {
                     minSkill = -25.0;
                     maxSkill = 25.0;
                     break;
-                case 1:
+                }
+            case 1:
+                {
                     minSkill = -10.8;
                     maxSkill = 39.2;
                     break;
-                case 2:
+                }
+            case 2:
+                {
                     minSkill = 03.5;
                     maxSkill = 53.5;
                     break;
-                case 3:
+                }
+            case 3:
+                {
                     minSkill = 17.8;
                     maxSkill = 67.8;
                     break;
-                case 4:
+                }
+            case 4:
+                {
                     minSkill = 32.1;
                     maxSkill = 82.1;
                     break;
-                case 5:
+                }
+            case 5:
+                {
                     minSkill = 46.4;
                     maxSkill = 96.4;
                     break;
-                case 6:
+                }
+            case 6:
+                {
                     minSkill = 60.7;
                     maxSkill = 110.7;
                     break;
-                case 7:
+                }
+            case 7:
+                {
                     minSkill = 75.0;
                     maxSkill = 125.0;
                     break;
-            }
+                }
+        }
 
-            var index = AddCraft(
-                type,
-                1044369 + m_Circle,
-                1044381 + m_Index++,
-                minSkill,
-                maxSkill,
-                m_RegTypes[(int)regs[0]],
-                1044353 + (int)regs[0],
-                1,
-                1044361 + (int)regs[0]
+        var index = AddCraft(
+            type,
+            1044369 + _circle,
+            1044381 + _index++,
+            minSkill,
+            maxSkill,
+            regTypes[(int)regs[0]],
+            1044353 + (int)regs[0],
+            1,
+            1044361 + (int)regs[0]
+        );
+
+        for (var i = 1; i < regs.Length; ++i)
+        {
+            AddRes(index, regTypes[(int)regs[i]], 1044353 + (int)regs[i], 1, 1044361 + (int)regs[i]);
+        }
+
+        AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
+
+        SetManaReq(index, _mana);
+    }
+
+    private void AddNecroSpell(int spell, int mana, double minSkill, Type type, params Type[] regs)
+    {
+        var index = AddCraft(
+            type,
+            1061677,
+            1060509 + spell,
+            minSkill,
+            minSkill + 1.0, // Yes, on OSI it's only 1.0 skill diff'.  Don't blame me, blame OSI.
+            regs[0],
+            CraftItem.LabelNumber(regs[0]),
+            1,
+            501627
+        );
+
+        for (var i = 1; i < regs.Length; ++i)
+        {
+            AddRes(index, regs[i], CraftItem.LabelNumber(regs[0]), 1, 501627);
+        }
+
+        AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
+        SetManaReq(index, mana);
+    }
+
+    private void AddMysticismSpell(int spell, int mana, double minSkill, double maxSkill, Type type, params Type[] regs)
+    {
+        var index = AddCraft(
+            type,
+            1111671,
+            1031678 + spell,
+            minSkill,
+            maxSkill,
+            regs[0],
+            CraftItem.LabelNumber(regs[0]),
+            1,
+            501627
+        );
+
+        for (var i = 1; i < regs.Length; ++i)
+        {
+            AddRes(index, regs[i], CraftItem.LabelNumber(regs[i]), 1, 501627);
+        }
+
+        AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
+        SetManaReq(index, mana);
+    }
+
+    public override void InitCraftList()
+    {
+        _circle = 0;
+        _mana = 4;
+
+        AddSpell(typeof(ReactiveArmorScroll), Reg.Garlic, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(ClumsyScroll), Reg.Bloodmoss, Reg.Nightshade);
+        AddSpell(typeof(CreateFoodScroll), Reg.Garlic, Reg.Ginseng, Reg.MandrakeRoot);
+        AddSpell(typeof(FeeblemindScroll), Reg.Nightshade, Reg.Ginseng);
+        AddSpell(typeof(HealScroll), Reg.Garlic, Reg.Ginseng, Reg.SpidersSilk);
+        AddSpell(typeof(MagicArrowScroll), Reg.SulfurousAsh);
+        AddSpell(typeof(NightSightScroll), Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(WeakenScroll), Reg.Garlic, Reg.Nightshade);
+
+        _circle = 1;
+        _mana = 6;
+
+        AddSpell(typeof(AgilityScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
+        AddSpell(typeof(CunningScroll), Reg.Nightshade, Reg.MandrakeRoot);
+        AddSpell(typeof(CureScroll), Reg.Garlic, Reg.Ginseng);
+        AddSpell(typeof(HarmScroll), Reg.Nightshade, Reg.SpidersSilk);
+        AddSpell(typeof(MagicTrapScroll), Reg.Garlic, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(MagicUnTrapScroll), Reg.Bloodmoss, Reg.SulfurousAsh);
+        AddSpell(typeof(ProtectionScroll), Reg.Garlic, Reg.Ginseng, Reg.SulfurousAsh);
+        AddSpell(typeof(StrengthScroll), Reg.Nightshade, Reg.MandrakeRoot);
+
+        _circle = 2;
+        _mana = 9;
+
+        AddSpell(typeof(BlessScroll), Reg.Garlic, Reg.MandrakeRoot);
+        AddSpell(typeof(FireballScroll), Reg.BlackPearl);
+        AddSpell(typeof(MagicLockScroll), Reg.Bloodmoss, Reg.Garlic, Reg.SulfurousAsh);
+        AddSpell(typeof(PoisonScroll), Reg.Nightshade);
+        AddSpell(typeof(TelekinesisScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
+        AddSpell(typeof(TeleportScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
+        AddSpell(typeof(UnlockScroll), Reg.Bloodmoss, Reg.SulfurousAsh);
+        AddSpell(typeof(WallOfStoneScroll), Reg.Bloodmoss, Reg.Garlic);
+
+        _circle = 3;
+        _mana = 11;
+
+        AddSpell(typeof(ArchCureScroll), Reg.Garlic, Reg.Ginseng, Reg.MandrakeRoot);
+        AddSpell(typeof(ArchProtectionScroll), Reg.Garlic, Reg.Ginseng, Reg.MandrakeRoot, Reg.SulfurousAsh);
+        AddSpell(typeof(CurseScroll), Reg.Garlic, Reg.Nightshade, Reg.SulfurousAsh);
+        AddSpell(typeof(FireFieldScroll), Reg.BlackPearl, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(GreaterHealScroll), Reg.Garlic, Reg.SpidersSilk, Reg.MandrakeRoot, Reg.Ginseng);
+        AddSpell(typeof(LightningScroll), Reg.MandrakeRoot, Reg.SulfurousAsh);
+        AddSpell(typeof(ManaDrainScroll), Reg.BlackPearl, Reg.SpidersSilk, Reg.MandrakeRoot);
+        AddSpell(typeof(RecallScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot);
+
+        _circle = 4;
+        _mana = 14;
+
+        AddSpell(typeof(BladeSpiritsScroll), Reg.BlackPearl, Reg.Nightshade, Reg.MandrakeRoot);
+        AddSpell(typeof(DispelFieldScroll), Reg.BlackPearl, Reg.Garlic, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(IncognitoScroll), Reg.Bloodmoss, Reg.Garlic, Reg.Nightshade);
+        AddSpell(typeof(MagicReflectScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.SpidersSilk);
+        AddSpell(typeof(MindBlastScroll), Reg.BlackPearl, Reg.MandrakeRoot, Reg.Nightshade, Reg.SulfurousAsh);
+        AddSpell(typeof(ParalyzeScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.SpidersSilk);
+        AddSpell(typeof(PoisonFieldScroll), Reg.BlackPearl, Reg.Nightshade, Reg.SpidersSilk);
+        AddSpell(typeof(SummonCreatureScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
+
+        _circle = 5;
+        _mana = 20;
+
+        AddSpell(typeof(DispelScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.SulfurousAsh);
+        AddSpell(typeof(EnergyBoltScroll), Reg.BlackPearl, Reg.Nightshade);
+        AddSpell(typeof(ExplosionScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
+        AddSpell(typeof(InvisibilityScroll), Reg.Bloodmoss, Reg.Nightshade);
+        AddSpell(typeof(MarkScroll), Reg.Bloodmoss, Reg.BlackPearl, Reg.MandrakeRoot);
+        AddSpell(typeof(MassCurseScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.Nightshade, Reg.SulfurousAsh);
+        AddSpell(typeof(ParalyzeFieldScroll), Reg.BlackPearl, Reg.Ginseng, Reg.SpidersSilk);
+        AddSpell(typeof(RevealScroll), Reg.Bloodmoss, Reg.SulfurousAsh);
+
+        _circle = 6;
+        _mana = 40;
+
+        AddSpell(typeof(ChainLightningScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SulfurousAsh);
+        AddSpell(typeof(EnergyFieldScroll), Reg.BlackPearl, Reg.MandrakeRoot, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(FlamestrikeScroll), Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(GateTravelScroll), Reg.BlackPearl, Reg.MandrakeRoot, Reg.SulfurousAsh);
+        AddSpell(typeof(ManaVampireScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
+        AddSpell(typeof(MassDispelScroll), Reg.BlackPearl, Reg.Garlic, Reg.MandrakeRoot, Reg.SulfurousAsh);
+        AddSpell(typeof(MeteorSwarmScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SulfurousAsh, Reg.SpidersSilk);
+        AddSpell(typeof(PolymorphScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
+
+        _circle = 7;
+        _mana = 50;
+
+        AddSpell(typeof(EarthquakeScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.Ginseng, Reg.SulfurousAsh);
+        AddSpell(typeof(EnergyVortexScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot, Reg.Nightshade);
+        AddSpell(typeof(ResurrectionScroll), Reg.Bloodmoss, Reg.Garlic, Reg.Ginseng);
+        AddSpell(typeof(SummonAirElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
+        AddSpell(typeof(SummonDaemonScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(SummonEarthElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
+        AddSpell(typeof(SummonFireElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk, Reg.SulfurousAsh);
+        AddSpell(typeof(SummonWaterElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
+
+        if (Core.SE)
+        {
+            AddNecroSpell(0, 23, 39.6, typeof(AnimateDeadScroll), Reagent.GraveDust, Reagent.DaemonBlood);
+            AddNecroSpell(1, 13, 19.6, typeof(BloodOathScroll), Reagent.DaemonBlood);
+            AddNecroSpell(2, 11, 19.6, typeof(CorpseSkinScroll), Reagent.BatWing, Reagent.GraveDust);
+            AddNecroSpell(3, 7, 19.6, typeof(CurseWeaponScroll), Reagent.PigIron);
+            AddNecroSpell(4, 11, 19.6, typeof(EvilOmenScroll), Reagent.BatWing, Reagent.NoxCrystal);
+            AddNecroSpell(5, 11, 39.6, typeof(HorrificBeastScroll), Reagent.BatWing, Reagent.DaemonBlood);
+            AddNecroSpell(
+                6,
+                23,
+                69.6,
+                typeof(LichFormScroll),
+                Reagent.GraveDust,
+                Reagent.DaemonBlood,
+                Reagent.NoxCrystal
             );
-
-            for (var i = 1; i < regs.Length; ++i)
-            {
-                AddRes(index, m_RegTypes[(int)regs[i]], 1044353 + (int)regs[i], 1, 1044361 + (int)regs[i]);
-            }
-
-            AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
-
-            SetManaReq(index, m_Mana);
-        }
-
-        private void AddNecroSpell(int spell, int mana, double minSkill, Type type, params Type[] regs)
-        {
-            var index = AddCraft(
-                type,
-                1061677,
-                1060509 + spell,
-                minSkill,
-                minSkill + 1.0, // Yes, on OSI it's only 1.0 skill diff'.  Don't blame me, blame OSI.
-                regs[0],
-                CraftItem.LabelNumber(regs[0]),
-                1,
-                501627
+            AddNecroSpell(7, 17, 29.6, typeof(MindRotScroll), Reagent.BatWing, Reagent.DaemonBlood, Reagent.PigIron);
+            AddNecroSpell(8, 5, 19.6, typeof(PainSpikeScroll), Reagent.GraveDust, Reagent.PigIron);
+            AddNecroSpell(9, 17, 49.6, typeof(PoisonStrikeScroll), Reagent.NoxCrystal);
+            AddNecroSpell(10, 29, 64.6, typeof(StrangleScroll), Reagent.DaemonBlood, Reagent.NoxCrystal);
+            AddNecroSpell(
+                11,
+                17,
+                29.6,
+                typeof(SummonFamiliarScroll),
+                Reagent.BatWing,
+                Reagent.GraveDust,
+                Reagent.DaemonBlood
             );
-
-            for (var i = 1; i < regs.Length; ++i)
-            {
-                AddRes(index, regs[i], CraftItem.LabelNumber(regs[0]), 1, 501627);
-            }
-
-            AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
-            SetManaReq(index, mana);
-        }
-
-        private void AddMysticismSpell(int spell, int mana, double minSkill, double maxSkill, Type type, params Type[] regs)
-        {
-            var index = AddCraft(
-                type,
-                1111671,
-                1031678 + spell,
-                minSkill,
-                maxSkill,
-                regs[0],
-                CraftItem.LabelNumber(regs[0]),
-                1,
-                501627
+            AddNecroSpell(
+                12,
+                23,
+                98.6,
+                typeof(VampiricEmbraceScroll),
+                Reagent.BatWing,
+                Reagent.NoxCrystal,
+                Reagent.PigIron
             );
-
-            for (var i = 1; i < regs.Length; ++i)
-            {
-                AddRes(index, regs[i], CraftItem.LabelNumber(regs[i]), 1, 501627);
-            }
-
-            AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
-            SetManaReq(index, mana);
+            AddNecroSpell(
+                13,
+                41,
+                79.6,
+                typeof(VengefulSpiritScroll),
+                Reagent.BatWing,
+                Reagent.GraveDust,
+                Reagent.PigIron
+            );
+            AddNecroSpell(14, 23, 59.6, typeof(WitherScroll), Reagent.GraveDust, Reagent.NoxCrystal, Reagent.PigIron);
+            AddNecroSpell(15, 17, 79.6, typeof(WraithFormScroll), Reagent.NoxCrystal, Reagent.PigIron);
+            AddNecroSpell(16, 40, 79.6, typeof(ExorcismScroll), Reagent.NoxCrystal, Reagent.GraveDust);
         }
 
-        public override void InitCraftList()
+        int index;
+
+        if (Core.ML)
         {
-            m_Circle = 0;
-            m_Mana = 4;
+            index = AddCraft(
+                typeof(EnchantedSwitch),
+                1044294,
+                1072893,
+                45.0,
+                95.0,
+                typeof(BlankScroll),
+                1044377,
+                1,
+                1044378
+            );
+            AddRes(index, typeof(SpidersSilk), 1044360, 1, 1044253);
+            AddRes(index, typeof(BlackPearl), 1044353, 1, 1044253);
+            AddRes(index, typeof(SwitchItem), 1073464, 1, 1044253);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
 
-            AddSpell(typeof(ReactiveArmorScroll), Reg.Garlic, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(ClumsyScroll), Reg.Bloodmoss, Reg.Nightshade);
-            AddSpell(typeof(CreateFoodScroll), Reg.Garlic, Reg.Ginseng, Reg.MandrakeRoot);
-            AddSpell(typeof(FeeblemindScroll), Reg.Nightshade, Reg.Ginseng);
-            AddSpell(typeof(HealScroll), Reg.Garlic, Reg.Ginseng, Reg.SpidersSilk);
-            AddSpell(typeof(MagicArrowScroll), Reg.SulfurousAsh);
-            AddSpell(typeof(NightSightScroll), Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(WeakenScroll), Reg.Garlic, Reg.Nightshade);
-
-            m_Circle = 1;
-            m_Mana = 6;
-
-            AddSpell(typeof(AgilityScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
-            AddSpell(typeof(CunningScroll), Reg.Nightshade, Reg.MandrakeRoot);
-            AddSpell(typeof(CureScroll), Reg.Garlic, Reg.Ginseng);
-            AddSpell(typeof(HarmScroll), Reg.Nightshade, Reg.SpidersSilk);
-            AddSpell(typeof(MagicTrapScroll), Reg.Garlic, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(MagicUnTrapScroll), Reg.Bloodmoss, Reg.SulfurousAsh);
-            AddSpell(typeof(ProtectionScroll), Reg.Garlic, Reg.Ginseng, Reg.SulfurousAsh);
-            AddSpell(typeof(StrengthScroll), Reg.Nightshade, Reg.MandrakeRoot);
-
-            m_Circle = 2;
-            m_Mana = 9;
-
-            AddSpell(typeof(BlessScroll), Reg.Garlic, Reg.MandrakeRoot);
-            AddSpell(typeof(FireballScroll), Reg.BlackPearl);
-            AddSpell(typeof(MagicLockScroll), Reg.Bloodmoss, Reg.Garlic, Reg.SulfurousAsh);
-            AddSpell(typeof(PoisonScroll), Reg.Nightshade);
-            AddSpell(typeof(TelekinesisScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
-            AddSpell(typeof(TeleportScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
-            AddSpell(typeof(UnlockScroll), Reg.Bloodmoss, Reg.SulfurousAsh);
-            AddSpell(typeof(WallOfStoneScroll), Reg.Bloodmoss, Reg.Garlic);
-
-            m_Circle = 3;
-            m_Mana = 11;
-
-            AddSpell(typeof(ArchCureScroll), Reg.Garlic, Reg.Ginseng, Reg.MandrakeRoot);
-            AddSpell(typeof(ArchProtectionScroll), Reg.Garlic, Reg.Ginseng, Reg.MandrakeRoot, Reg.SulfurousAsh);
-            AddSpell(typeof(CurseScroll), Reg.Garlic, Reg.Nightshade, Reg.SulfurousAsh);
-            AddSpell(typeof(FireFieldScroll), Reg.BlackPearl, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(GreaterHealScroll), Reg.Garlic, Reg.SpidersSilk, Reg.MandrakeRoot, Reg.Ginseng);
-            AddSpell(typeof(LightningScroll), Reg.MandrakeRoot, Reg.SulfurousAsh);
-            AddSpell(typeof(ManaDrainScroll), Reg.BlackPearl, Reg.SpidersSilk, Reg.MandrakeRoot);
-            AddSpell(typeof(RecallScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot);
-
-            m_Circle = 4;
-            m_Mana = 14;
-
-            AddSpell(typeof(BladeSpiritsScroll), Reg.BlackPearl, Reg.Nightshade, Reg.MandrakeRoot);
-            AddSpell(typeof(DispelFieldScroll), Reg.BlackPearl, Reg.Garlic, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(IncognitoScroll), Reg.Bloodmoss, Reg.Garlic, Reg.Nightshade);
-            AddSpell(typeof(MagicReflectScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.SpidersSilk);
-            AddSpell(typeof(MindBlastScroll), Reg.BlackPearl, Reg.MandrakeRoot, Reg.Nightshade, Reg.SulfurousAsh);
-            AddSpell(typeof(ParalyzeScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.SpidersSilk);
-            AddSpell(typeof(PoisonFieldScroll), Reg.BlackPearl, Reg.Nightshade, Reg.SpidersSilk);
-            AddSpell(typeof(SummonCreatureScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
-
-            m_Circle = 5;
-            m_Mana = 20;
-
-            AddSpell(typeof(DispelScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.SulfurousAsh);
-            AddSpell(typeof(EnergyBoltScroll), Reg.BlackPearl, Reg.Nightshade);
-            AddSpell(typeof(ExplosionScroll), Reg.Bloodmoss, Reg.MandrakeRoot);
-            AddSpell(typeof(InvisibilityScroll), Reg.Bloodmoss, Reg.Nightshade);
-            AddSpell(typeof(MarkScroll), Reg.Bloodmoss, Reg.BlackPearl, Reg.MandrakeRoot);
-            AddSpell(typeof(MassCurseScroll), Reg.Garlic, Reg.MandrakeRoot, Reg.Nightshade, Reg.SulfurousAsh);
-            AddSpell(typeof(ParalyzeFieldScroll), Reg.BlackPearl, Reg.Ginseng, Reg.SpidersSilk);
-            AddSpell(typeof(RevealScroll), Reg.Bloodmoss, Reg.SulfurousAsh);
-
-            m_Circle = 6;
-            m_Mana = 40;
-
-            AddSpell(typeof(ChainLightningScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SulfurousAsh);
-            AddSpell(typeof(EnergyFieldScroll), Reg.BlackPearl, Reg.MandrakeRoot, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(FlamestrikeScroll), Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(GateTravelScroll), Reg.BlackPearl, Reg.MandrakeRoot, Reg.SulfurousAsh);
-            AddSpell(typeof(ManaVampireScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
-            AddSpell(typeof(MassDispelScroll), Reg.BlackPearl, Reg.Garlic, Reg.MandrakeRoot, Reg.SulfurousAsh);
-            AddSpell(typeof(MeteorSwarmScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SulfurousAsh, Reg.SpidersSilk);
-            AddSpell(typeof(PolymorphScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
-
-            m_Circle = 7;
-            m_Mana = 50;
-
-            AddSpell(typeof(EarthquakeScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.Ginseng, Reg.SulfurousAsh);
-            AddSpell(typeof(EnergyVortexScroll), Reg.BlackPearl, Reg.Bloodmoss, Reg.MandrakeRoot, Reg.Nightshade);
-            AddSpell(typeof(ResurrectionScroll), Reg.Bloodmoss, Reg.Garlic, Reg.Ginseng);
-            AddSpell(typeof(SummonAirElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
-            AddSpell(typeof(SummonDaemonScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(SummonEarthElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
-            AddSpell(typeof(SummonFireElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk, Reg.SulfurousAsh);
-            AddSpell(typeof(SummonWaterElementalScroll), Reg.Bloodmoss, Reg.MandrakeRoot, Reg.SpidersSilk);
-
-            if (Core.SE)
-            {
-                AddNecroSpell(0, 23, 39.6, typeof(AnimateDeadScroll), Reagent.GraveDust, Reagent.DaemonBlood);
-                AddNecroSpell(1, 13, 19.6, typeof(BloodOathScroll), Reagent.DaemonBlood);
-                AddNecroSpell(2, 11, 19.6, typeof(CorpseSkinScroll), Reagent.BatWing, Reagent.GraveDust);
-                AddNecroSpell(3, 7, 19.6, typeof(CurseWeaponScroll), Reagent.PigIron);
-                AddNecroSpell(4, 11, 19.6, typeof(EvilOmenScroll), Reagent.BatWing, Reagent.NoxCrystal);
-                AddNecroSpell(5, 11, 39.6, typeof(HorrificBeastScroll), Reagent.BatWing, Reagent.DaemonBlood);
-                AddNecroSpell(
-                    6,
-                    23,
-                    69.6,
-                    typeof(LichFormScroll),
-                    Reagent.GraveDust,
-                    Reagent.DaemonBlood,
-                    Reagent.NoxCrystal
-                );
-                AddNecroSpell(7, 17, 29.6, typeof(MindRotScroll), Reagent.BatWing, Reagent.DaemonBlood, Reagent.PigIron);
-                AddNecroSpell(8, 5, 19.6, typeof(PainSpikeScroll), Reagent.GraveDust, Reagent.PigIron);
-                AddNecroSpell(9, 17, 49.6, typeof(PoisonStrikeScroll), Reagent.NoxCrystal);
-                AddNecroSpell(10, 29, 64.6, typeof(StrangleScroll), Reagent.DaemonBlood, Reagent.NoxCrystal);
-                AddNecroSpell(
-                    11,
-                    17,
-                    29.6,
-                    typeof(SummonFamiliarScroll),
-                    Reagent.BatWing,
-                    Reagent.GraveDust,
-                    Reagent.DaemonBlood
-                );
-                AddNecroSpell(
-                    12,
-                    23,
-                    98.6,
-                    typeof(VampiricEmbraceScroll),
-                    Reagent.BatWing,
-                    Reagent.NoxCrystal,
-                    Reagent.PigIron
-                );
-                AddNecroSpell(
-                    13,
-                    41,
-                    79.6,
-                    typeof(VengefulSpiritScroll),
-                    Reagent.BatWing,
-                    Reagent.GraveDust,
-                    Reagent.PigIron
-                );
-                AddNecroSpell(14, 23, 59.6, typeof(WitherScroll), Reagent.GraveDust, Reagent.NoxCrystal, Reagent.PigIron);
-                AddNecroSpell(15, 17, 79.6, typeof(WraithFormScroll), Reagent.NoxCrystal, Reagent.PigIron);
-                AddNecroSpell(16, 40, 79.6, typeof(ExorcismScroll), Reagent.NoxCrystal, Reagent.GraveDust);
-            }
-
-            int index;
-
-            if (Core.ML)
-            {
-                index = AddCraft(
-                    typeof(EnchantedSwitch),
-                    1044294,
-                    1072893,
-                    45.0,
-                    95.0,
-                    typeof(BlankScroll),
-                    1044377,
-                    1,
-                    1044378
-                );
-                AddRes(index, typeof(SpidersSilk), 1044360, 1, 1044253);
-                AddRes(index, typeof(BlackPearl), 1044353, 1, 1044253);
-                AddRes(index, typeof(SwitchItem), 1073464, 1, 1044253);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(RunedPrism), 1044294, 1073465, 45.0, 95.0, typeof(BlankScroll), 1044377, 1, 1044378);
-                AddRes(index, typeof(SpidersSilk), 1044360, 1, 1044253);
-                AddRes(index, typeof(BlackPearl), 1044353, 1, 1044253);
-                AddRes(index, typeof(HollowPrism), 1072895, 1, 1044253);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            // Runebook
-            index = AddCraft(typeof(Runebook), 1044294, 1041267, 45.0, 95.0, typeof(BlankScroll), 1044377, 8, 1044378);
-            AddRes(index, typeof(RecallScroll), 1044445, 1, 1044253);
-            AddRes(index, typeof(GateTravelScroll), 1044446, 1, 1044253);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(BulkOrderBook), 1044294, 1028793, 65.0, 115.0, typeof(BlankScroll), 1044377, 10, 1044378);
-            }
-
-            if (Core.SE)
-            {
-                AddCraft(typeof(Spellbook), 1044294, 1023834, 50.0, 126, typeof(BlankScroll), 1044377, 10, 1044378);
-            }
-
-            /* TODO
-            if (Core.ML)
-            {
-              index = AddCraft( typeof( ScrappersCompendium ), 1044294, 1072940, 75.0, 125.0, typeof( BlankScroll ), 1044377, 100, 1044378 );
-              AddRes( index, typeof( DreadHornMane ), 1032682, 1, 1044253 );
-              AddRes( index, typeof( Taint ), 1032679, 10, 1044253 );
-              AddRes( index, typeof( Corruption ), 1032676, 10, 1044253 );
-              AddRareRecipe( index, 400 );
-              ForceNonExceptional( index );
-              SetNeededExpansion( index, Expansion.ML );
-            }
-            */
-
-            if (Core.SA)
-            {
-                AddCraft(typeof(MysticSpellbook), 1044294, 1031677, 50.0, 150.0, typeof(BlankScroll), 1044377, 10, 1044378);
-
-                AddMysticismSpell(0, 4, -25.0, 25.0, typeof(NetherBoltScroll), Reagent.BlackPearl, Reagent.SulfurousAsh);
-                AddMysticismSpell(
-                    1,
-                    4,
-                    -25.0,
-                    25.0,
-                    typeof(HealingStoneScroll),
-                    Reagent.Bone,
-                    Reagent.Garlic,
-                    Reagent.Ginseng,
-                    Reagent.SpidersSilk
-                );
-                AddMysticismSpell(
-                    2,
-                    6,
-                    -10.8,
-                    39.2,
-                    typeof(PurgeMagicScroll),
-                    Reagent.FertileDirt,
-                    Reagent.Garlic,
-                    Reagent.MandrakeRoot,
-                    Reagent.SulfurousAsh
-                );
-                AddMysticismSpell(
-                    3,
-                    6,
-                    -10.8,
-                    39.2,
-                    typeof(EnchantScroll),
-                    Reagent.SpidersSilk,
-                    Reagent.MandrakeRoot,
-                    Reagent.SulfurousAsh
-                );
-                AddMysticismSpell(
-                    4,
-                    9,
-                    3.5,
-                    53.5,
-                    typeof(SleepScroll),
-                    Reagent.Nightshade,
-                    Reagent.SpidersSilk,
-                    Reagent.BlackPearl
-                );
-                AddMysticismSpell(
-                    5,
-                    9,
-                    3.5,
-                    53.5,
-                    typeof(EagleStrikeScroll),
-                    Reagent.Bloodmoss,
-                    Reagent.Bone,
-                    Reagent.SpidersSilk,
-                    Reagent.MandrakeRoot
-                );
-                AddMysticismSpell(
-                    6,
-                    11,
-                    17.8,
-                    67.8,
-                    typeof(AnimatedWeaponScroll),
-                    Reagent.Bone,
-                    Reagent.BlackPearl,
-                    Reagent.MandrakeRoot,
-                    Reagent.Nightshade
-                );
-                AddMysticismSpell(
-                    7,
-                    11,
-                    17.8,
-                    67.8,
-                    typeof(StoneFormScroll),
-                    Reagent.Bloodmoss,
-                    Reagent.FertileDirt,
-                    Reagent.Garlic
-                );
-                AddMysticismSpell(
-                    8,
-                    14,
-                    32.1,
-                    82.1,
-                    typeof(SpellTriggerScroll),
-                    Reagent.DragonsBlood,
-                    Reagent.Garlic,
-                    Reagent.MandrakeRoot,
-                    Reagent.SpidersSilk
-                );
-                AddMysticismSpell(
-                    9,
-                    14,
-                    32.1,
-                    82.1,
-                    typeof(MassSleepScroll),
-                    Reagent.Ginseng,
-                    Reagent.Nightshade,
-                    Reagent.SpidersSilk
-                );
-                AddMysticismSpell(
-                    10,
-                    20,
-                    46.4,
-                    96.4,
-                    typeof(CleansingWindsScroll),
-                    Reagent.DragonsBlood,
-                    Reagent.Garlic,
-                    Reagent.Ginseng,
-                    Reagent.MandrakeRoot
-                );
-                AddMysticismSpell(
-                    11,
-                    20,
-                    46.4,
-                    96.4,
-                    typeof(BombardScroll),
-                    Reagent.Bloodmoss,
-                    Reagent.DragonsBlood,
-                    Reagent.Garlic,
-                    Reagent.SulfurousAsh
-                );
-                AddMysticismSpell(
-                    12,
-                    40,
-                    60.7,
-                    110.7,
-                    typeof(SpellPlagueScroll),
-                    Reagent.DaemonBone,
-                    Reagent.DragonsBlood,
-                    Reagent.Nightshade,
-                    Reagent.SulfurousAsh
-                );
-                AddMysticismSpell(
-                    13,
-                    40,
-                    60.7,
-                    110.7,
-                    typeof(HailStormScroll),
-                    Reagent.DragonsBlood,
-                    Reagent.Bloodmoss,
-                    Reagent.BlackPearl,
-                    Reagent.MandrakeRoot
-                );
-                AddMysticismSpell(
-                    14,
-                    50,
-                    75.0,
-                    125.0,
-                    typeof(NetherCycloneScroll),
-                    Reagent.MandrakeRoot,
-                    Reagent.Nightshade,
-                    Reagent.SulfurousAsh,
-                    Reagent.Bloodmoss
-                );
-                AddMysticismSpell(
-                    15,
-                    50,
-                    75.0,
-                    125.0,
-                    typeof(RisingColossusScroll),
-                    Reagent.DaemonBone,
-                    Reagent.DragonsBlood,
-                    Reagent.FertileDirt,
-                    Reagent.Nightshade
-                );
-            }
-
-            MarkOption = true;
+            index = AddCraft(typeof(RunedPrism), 1044294, 1073465, 45.0, 95.0, typeof(BlankScroll), 1044377, 1, 1044378);
+            AddRes(index, typeof(SpidersSilk), 1044360, 1, 1044253);
+            AddRes(index, typeof(BlackPearl), 1044353, 1, 1044253);
+            AddRes(index, typeof(HollowPrism), 1072895, 1, 1044253);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
         }
 
-        private enum Reg
+        // Runebook
+        index = AddCraft(typeof(Runebook), 1044294, 1041267, 45.0, 95.0, typeof(BlankScroll), 1044377, 8, 1044378);
+        AddRes(index, typeof(RecallScroll), 1044445, 1, 1044253);
+        AddRes(index, typeof(GateTravelScroll), 1044446, 1, 1044253);
+
+        if (Core.AOS)
         {
-            BlackPearl,
-            Bloodmoss,
-            Garlic,
-            Ginseng,
-            MandrakeRoot,
-            Nightshade,
-            SulfurousAsh,
-            SpidersSilk
+            AddCraft(typeof(BulkOrderBook), 1044294, 1028793, 65.0, 115.0, typeof(BlankScroll), 1044377, 10, 1044378);
         }
+
+        if (Core.SE)
+        {
+            AddCraft(typeof(Spellbook), 1044294, 1023834, 50.0, 126, typeof(BlankScroll), 1044377, 10, 1044378);
+        }
+
+        /* TODO
+        if (Core.ML)
+        {
+          index = AddCraft( typeof( ScrappersCompendium ), 1044294, 1072940, 75.0, 125.0, typeof( BlankScroll ), 1044377, 100, 1044378 );
+          AddRes( index, typeof( DreadHornMane ), 1032682, 1, 1044253 );
+          AddRes( index, typeof( Taint ), 1032679, 10, 1044253 );
+          AddRes( index, typeof( Corruption ), 1032676, 10, 1044253 );
+          AddRareRecipe( index, 400 );
+          ForceNonExceptional( index );
+          SetNeededExpansion( index, Expansion.ML );
+        }
+        */
+
+        if (Core.SA)
+        {
+            AddCraft(typeof(MysticSpellbook), 1044294, 1031677, 50.0, 150.0, typeof(BlankScroll), 1044377, 10, 1044378);
+
+            AddMysticismSpell(0, 4, -25.0, 25.0, typeof(NetherBoltScroll), Reagent.BlackPearl, Reagent.SulfurousAsh);
+            AddMysticismSpell(
+                1,
+                4,
+                -25.0,
+                25.0,
+                typeof(HealingStoneScroll),
+                Reagent.Bone,
+                Reagent.Garlic,
+                Reagent.Ginseng,
+                Reagent.SpidersSilk
+            );
+            AddMysticismSpell(
+                2,
+                6,
+                -10.8,
+                39.2,
+                typeof(PurgeMagicScroll),
+                Reagent.FertileDirt,
+                Reagent.Garlic,
+                Reagent.MandrakeRoot,
+                Reagent.SulfurousAsh
+            );
+            AddMysticismSpell(
+                3,
+                6,
+                -10.8,
+                39.2,
+                typeof(EnchantScroll),
+                Reagent.SpidersSilk,
+                Reagent.MandrakeRoot,
+                Reagent.SulfurousAsh
+            );
+            AddMysticismSpell(
+                4,
+                9,
+                3.5,
+                53.5,
+                typeof(SleepScroll),
+                Reagent.Nightshade,
+                Reagent.SpidersSilk,
+                Reagent.BlackPearl
+            );
+            AddMysticismSpell(
+                5,
+                9,
+                3.5,
+                53.5,
+                typeof(EagleStrikeScroll),
+                Reagent.Bloodmoss,
+                Reagent.Bone,
+                Reagent.SpidersSilk,
+                Reagent.MandrakeRoot
+            );
+            AddMysticismSpell(
+                6,
+                11,
+                17.8,
+                67.8,
+                typeof(AnimatedWeaponScroll),
+                Reagent.Bone,
+                Reagent.BlackPearl,
+                Reagent.MandrakeRoot,
+                Reagent.Nightshade
+            );
+            AddMysticismSpell(
+                7,
+                11,
+                17.8,
+                67.8,
+                typeof(StoneFormScroll),
+                Reagent.Bloodmoss,
+                Reagent.FertileDirt,
+                Reagent.Garlic
+            );
+            AddMysticismSpell(
+                8,
+                14,
+                32.1,
+                82.1,
+                typeof(SpellTriggerScroll),
+                Reagent.DragonsBlood,
+                Reagent.Garlic,
+                Reagent.MandrakeRoot,
+                Reagent.SpidersSilk
+            );
+            AddMysticismSpell(
+                9,
+                14,
+                32.1,
+                82.1,
+                typeof(MassSleepScroll),
+                Reagent.Ginseng,
+                Reagent.Nightshade,
+                Reagent.SpidersSilk
+            );
+            AddMysticismSpell(
+                10,
+                20,
+                46.4,
+                96.4,
+                typeof(CleansingWindsScroll),
+                Reagent.DragonsBlood,
+                Reagent.Garlic,
+                Reagent.Ginseng,
+                Reagent.MandrakeRoot
+            );
+            AddMysticismSpell(
+                11,
+                20,
+                46.4,
+                96.4,
+                typeof(BombardScroll),
+                Reagent.Bloodmoss,
+                Reagent.DragonsBlood,
+                Reagent.Garlic,
+                Reagent.SulfurousAsh
+            );
+            AddMysticismSpell(
+                12,
+                40,
+                60.7,
+                110.7,
+                typeof(SpellPlagueScroll),
+                Reagent.DaemonBone,
+                Reagent.DragonsBlood,
+                Reagent.Nightshade,
+                Reagent.SulfurousAsh
+            );
+            AddMysticismSpell(
+                13,
+                40,
+                60.7,
+                110.7,
+                typeof(HailStormScroll),
+                Reagent.DragonsBlood,
+                Reagent.Bloodmoss,
+                Reagent.BlackPearl,
+                Reagent.MandrakeRoot
+            );
+            AddMysticismSpell(
+                14,
+                50,
+                75.0,
+                125.0,
+                typeof(NetherCycloneScroll),
+                Reagent.MandrakeRoot,
+                Reagent.Nightshade,
+                Reagent.SulfurousAsh,
+                Reagent.Bloodmoss
+            );
+            AddMysticismSpell(
+                15,
+                50,
+                75.0,
+                125.0,
+                typeof(RisingColossusScroll),
+                Reagent.DaemonBone,
+                Reagent.DragonsBlood,
+                Reagent.FertileDirt,
+                Reagent.Nightshade
+            );
+        }
+
+        MarkOption = true;
+    }
+
+    private enum Reg
+    {
+        BlackPearl,
+        Bloodmoss,
+        Garlic,
+        Ginseng,
+        MandrakeRoot,
+        Nightshade,
+        SulfurousAsh,
+        SpidersSilk
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefMasonry.cs
+++ b/Projects/UOContent/Engines/Craft/DefMasonry.cs
@@ -2,146 +2,148 @@ using System;
 using Server.Items;
 using Server.Mobiles;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefMasonry : CraftSystem
 {
-    public class DefMasonry : CraftSystem
+    public static void Configure()
     {
-        private static CraftSystem m_CraftSystem;
+        CraftSystem = new DefMasonry();
+    }
 
-        private DefMasonry() : base(1, 1, 1.25) // base( 1, 2, 1.7 )
+    private DefMasonry() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Carpentry;
+
+    public override TextDefinition GumpTitle => 1044500;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item) => 0.0;
+
+    public override bool RetainsColorFrom(CraftItem item, Type type) => true;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Carpentry;
-
-        public override TextDefinition GumpTitle => 1044500;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefMasonry();
-
-        public override double GetChanceAtMin(CraftItem item) => 0.0;
-
-        public override bool RetainsColorFrom(CraftItem item, Type type) => true;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckTool(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckTool(tool, from))
-            {
-                return 1048146; // If you have a tool equipped, you must use that tool.
-            }
-
-            if (!(from is PlayerMobile mobile && mobile.Masonry && mobile.Skills.Carpentry.Base >= 100.0))
-            {
-                return 1044633; // You havent learned stonecraft.
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            return 1048146; // If you have a tool equipped, you must use that tool.
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        if (!(from is PlayerMobile mobile && mobile.Masonry && mobile.Skills.Carpentry.Base >= 100.0))
         {
-            // no effects
-            // if (from.Body.Type == BodyType.Human && !from.Mounted)
-            // from.Animate( 9, 5, 1, true, false, 0 );
-            // new InternalTimer( from ).Start();
+            return 1044633; // You haven't learned stonecraft.
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override void InitCraftList()
+        return 0;
+    }
+
+    public override void PlayCraftEffect(Mobile from)
+    {
+        // no effects
+        // if (from.Body.Type == BodyType.Human && !from.Mounted)
+        // from.Animate( 9, 5, 1, true, false, 0 );
+        // new InternalTimer( from ).Start();
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            // Decorations
-            AddCraft(typeof(Vase), 1044501, 1022888, 52.5, 102.5, typeof(Granite), 1044514, 1, 1044513);
-            AddCraft(typeof(LargeVase), 1044501, 1022887, 52.5, 102.5, typeof(Granite), 1044514, 3, 1044513);
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
+        }
 
-            if (Core.SE)
+        if (failed)
+        {
+            if (lostMaterial)
             {
-                var index = AddCraft(typeof(SmallUrn), 1044501, 1029244, 82.0, 132.0, typeof(Granite), 1044514, 3, 1044513);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(
-                    typeof(SmallTowerSculpture),
-                    1044501,
-                    1029242,
-                    82.0,
-                    132.0,
-                    typeof(Granite),
-                    1044514,
-                    3,
-                    1044513
-                );
-                SetNeededExpansion(index, Expansion.SE);
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
 
-            // Furniture
-            AddCraft(typeof(StoneChair), 1044502, 1024635, 55.0, 105.0, typeof(Granite), 1044514, 4, 1044513);
-            AddCraft(typeof(MediumStoneTableEastDeed), 1044502, 1044508, 65.0, 115.0, typeof(Granite), 1044514, 6, 1044513);
-            AddCraft(typeof(MediumStoneTableSouthDeed), 1044502, 1044509, 65.0, 115.0, typeof(Granite), 1044514, 6, 1044513);
-            AddCraft(typeof(LargeStoneTableEastDeed), 1044502, 1044511, 75.0, 125.0, typeof(Granite), 1044514, 9, 1044513);
-            AddCraft(typeof(LargeStoneTableSouthDeed), 1044502, 1044512, 75.0, 125.0, typeof(Granite), 1044514, 9, 1044513);
-
-            // Statues
-            AddCraft(typeof(StatueSouth), 1044503, 1044505, 60.0, 120.0, typeof(Granite), 1044514, 3, 1044513);
-            AddCraft(typeof(StatueNorth), 1044503, 1044506, 60.0, 120.0, typeof(Granite), 1044514, 3, 1044513);
-            AddCraft(typeof(StatueEast), 1044503, 1044507, 60.0, 120.0, typeof(Granite), 1044514, 3, 1044513);
-            AddCraft(typeof(StatuePegasus), 1044503, 1044510, 70.0, 130.0, typeof(Granite), 1044514, 4, 1044513);
-
-            SetSubRes(typeof(Granite), 1044525);
-
-            AddSubRes(typeof(Granite), 1044525, 00.0, 1044514, 1044526);
-            AddSubRes(typeof(DullCopperGranite), 1044023, 65.0, 1044514, 1044527);
-            AddSubRes(typeof(ShadowIronGranite), 1044024, 70.0, 1044514, 1044527);
-            AddSubRes(typeof(CopperGranite), 1044025, 75.0, 1044514, 1044527);
-            AddSubRes(typeof(BronzeGranite), 1044026, 80.0, 1044514, 1044527);
-            AddSubRes(typeof(GoldGranite), 1044027, 85.0, 1044514, 1044527);
-            AddSubRes(typeof(AgapiteGranite), 1044028, 90.0, 1044514, 1044527);
-            AddSubRes(typeof(VeriteGranite), 1044029, 95.0, 1044514, 1044527);
-            AddSubRes(typeof(ValoriteGranite), 1044030, 99.0, 1044514, 1044527);
+            return 1044157; // You failed to create the item, but no materials were lost.
         }
+
+        if (quality == 0)
+        {
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
+
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
+
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override void InitCraftList()
+    {
+        // Decorations
+        AddCraft(typeof(Vase), 1044501, 1022888, 52.5, 102.5, typeof(Granite), 1044514, 1, 1044513);
+        AddCraft(typeof(LargeVase), 1044501, 1022887, 52.5, 102.5, typeof(Granite), 1044514, 3, 1044513);
+
+        if (Core.SE)
+        {
+            var index = AddCraft(typeof(SmallUrn), 1044501, 1029244, 82.0, 132.0, typeof(Granite), 1044514, 3, 1044513);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(
+                typeof(SmallTowerSculpture),
+                1044501,
+                1029242,
+                82.0,
+                132.0,
+                typeof(Granite),
+                1044514,
+                3,
+                1044513
+            );
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        // Furniture
+        AddCraft(typeof(StoneChair), 1044502, 1024635, 55.0, 105.0, typeof(Granite), 1044514, 4, 1044513);
+        AddCraft(typeof(MediumStoneTableEastDeed), 1044502, 1044508, 65.0, 115.0, typeof(Granite), 1044514, 6, 1044513);
+        AddCraft(typeof(MediumStoneTableSouthDeed), 1044502, 1044509, 65.0, 115.0, typeof(Granite), 1044514, 6, 1044513);
+        AddCraft(typeof(LargeStoneTableEastDeed), 1044502, 1044511, 75.0, 125.0, typeof(Granite), 1044514, 9, 1044513);
+        AddCraft(typeof(LargeStoneTableSouthDeed), 1044502, 1044512, 75.0, 125.0, typeof(Granite), 1044514, 9, 1044513);
+
+        // Statues
+        AddCraft(typeof(StatueSouth), 1044503, 1044505, 60.0, 120.0, typeof(Granite), 1044514, 3, 1044513);
+        AddCraft(typeof(StatueNorth), 1044503, 1044506, 60.0, 120.0, typeof(Granite), 1044514, 3, 1044513);
+        AddCraft(typeof(StatueEast), 1044503, 1044507, 60.0, 120.0, typeof(Granite), 1044514, 3, 1044513);
+        AddCraft(typeof(StatuePegasus), 1044503, 1044510, 70.0, 130.0, typeof(Granite), 1044514, 4, 1044513);
+
+        SetSubRes(typeof(Granite), 1044525);
+
+        AddSubRes(typeof(Granite), 1044525, 00.0, 1044514, 1044526);
+        AddSubRes(typeof(DullCopperGranite), 1044023, 65.0, 1044514, 1044527);
+        AddSubRes(typeof(ShadowIronGranite), 1044024, 70.0, 1044514, 1044527);
+        AddSubRes(typeof(CopperGranite), 1044025, 75.0, 1044514, 1044527);
+        AddSubRes(typeof(BronzeGranite), 1044026, 80.0, 1044514, 1044527);
+        AddSubRes(typeof(GoldGranite), 1044027, 85.0, 1044514, 1044527);
+        AddSubRes(typeof(AgapiteGranite), 1044028, 90.0, 1044514, 1044527);
+        AddSubRes(typeof(VeriteGranite), 1044029, 95.0, 1044514, 1044527);
+        AddSubRes(typeof(ValoriteGranite), 1044030, 99.0, 1044514, 1044527);
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefTailoring.cs
+++ b/Projects/UOContent/Engines/Craft/DefTailoring.cs
@@ -1,669 +1,671 @@
 using System;
 using Server.Items;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefTailoring : CraftSystem
 {
-    public class DefTailoring : CraftSystem
+    private static readonly Type[] tailorColorables =
     {
-        private static CraftSystem m_CraftSystem;
+        typeof(GozaMatEastDeed), typeof(GozaMatSouthDeed),
+        typeof(SquareGozaMatEastDeed), typeof(SquareGozaMatSouthDeed),
+        typeof(BrocadeGozaMatEastDeed), typeof(BrocadeGozaMatSouthDeed),
+        typeof(BrocadeSquareGozaMatEastDeed), typeof(BrocadeSquareGozaMatSouthDeed)
+    };
 
-        private static readonly Type[] m_TailorColorables =
-        {
-            typeof(GozaMatEastDeed), typeof(GozaMatSouthDeed),
-            typeof(SquareGozaMatEastDeed), typeof(SquareGozaMatSouthDeed),
-            typeof(BrocadeGozaMatEastDeed), typeof(BrocadeGozaMatSouthDeed),
-            typeof(BrocadeSquareGozaMatEastDeed), typeof(BrocadeSquareGozaMatSouthDeed)
-        };
+    public static void Configure()
+    {
+        CraftSystem = new DefTailoring();
+    }
 
-        private DefTailoring() : base(1, 1, 1.25) // base( 1, 1, 4.5 )
+    private DefTailoring() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Tailoring;
+
+    public override TextDefinition GumpTitle => 1044005; // Tailoring Menu
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
+
+    public override double GetChanceAtMin(CraftItem item) => 0.5;
+
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
+            return 1044038; // You have worn out your tool!
         }
 
-        public override SkillName MainSkill => SkillName.Tailoring;
-
-        public override TextDefinition GumpTitle => 1044005; // Tailoring Menu
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefTailoring();
-
-        public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
-
-        public override double GetChanceAtMin(CraftItem item) => 0.5;
-
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override bool RetainsColorFrom(CraftItem item, Type type)
+        return 0;
+    }
+
+    public override bool RetainsColorFrom(CraftItem item, Type type)
+    {
+        if (type != typeof(Cloth) && type != typeof(UncutCloth))
         {
-            if (type != typeof(Cloth) && type != typeof(UncutCloth))
-            {
-                return false;
-            }
-
-            type = item.ItemType;
-
-            var contains = false;
-
-            for (var i = 0; !contains && i < m_TailorColorables.Length; ++i)
-            {
-                contains = m_TailorColorables[i] == type;
-            }
-
-            return contains;
+            return false;
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        type = item.ItemType;
+
+        var contains = false;
+
+        for (var i = 0; !contains && i < tailorColorables.Length; ++i)
         {
-            from.PlaySound(0x248);
+            contains = tailorColorables[i] == type;
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        return contains;
+    }
+
+    public override void PlayCraftEffect(Mobile from)
+    {
+        from.PlaySound(0x248);
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public override void InitCraftList()
+        if (failed)
         {
-            int index;
-
-            AddCraft(typeof(SkullCap), 1011375, 1025444, 0.0, 25.0, typeof(Cloth), 1044286, 2, 1044287);
-            AddCraft(typeof(Bandana), 1011375, 1025440, 0.0, 25.0, typeof(Cloth), 1044286, 2, 1044287);
-            AddCraft(typeof(FloppyHat), 1011375, 1025907, 6.2, 31.2, typeof(Cloth), 1044286, 11, 1044287);
-            AddCraft(typeof(Cap), 1011375, 1025909, 6.2, 31.2, typeof(Cloth), 1044286, 11, 1044287);
-            AddCraft(typeof(WideBrimHat), 1011375, 1025908, 6.2, 31.2, typeof(Cloth), 1044286, 12, 1044287);
-            AddCraft(typeof(StrawHat), 1011375, 1025911, 6.2, 31.2, typeof(Cloth), 1044286, 10, 1044287);
-            AddCraft(typeof(TallStrawHat), 1011375, 1025910, 6.7, 31.7, typeof(Cloth), 1044286, 13, 1044287);
-            AddCraft(typeof(WizardsHat), 1011375, 1025912, 7.2, 32.2, typeof(Cloth), 1044286, 15, 1044287);
-            AddCraft(typeof(Bonnet), 1011375, 1025913, 6.2, 31.2, typeof(Cloth), 1044286, 11, 1044287);
-            AddCraft(typeof(FeatheredHat), 1011375, 1025914, 6.2, 31.2, typeof(Cloth), 1044286, 12, 1044287);
-            AddCraft(typeof(TricorneHat), 1011375, 1025915, 6.2, 31.2, typeof(Cloth), 1044286, 12, 1044287);
-            AddCraft(typeof(JesterHat), 1011375, 1025916, 7.2, 32.2, typeof(Cloth), 1044286, 15, 1044287);
-
-            if (Core.AOS)
+            if (lostMaterial)
             {
-                AddCraft(typeof(FlowerGarland), 1011375, 1028965, 10.0, 35.0, typeof(Cloth), 1044286, 5, 1044287);
+                return 1044043; // You failed to create the item, and some of your materials are lost.
             }
 
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(ClothNinjaHood), 1011375, 1030202, 80.0, 105.0, typeof(Cloth), 1044286, 13, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(Kasa), 1011375, 1030211, 60.0, 85.0, typeof(Cloth), 1044286, 12, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddCraft(typeof(Doublet), 1015269, 1028059, 0, 25.0, typeof(Cloth), 1044286, 8, 1044287);
-            AddCraft(typeof(Shirt), 1015269, 1025399, 20.7, 45.7, typeof(Cloth), 1044286, 8, 1044287);
-            AddCraft(typeof(FancyShirt), 1015269, 1027933, 24.8, 49.8, typeof(Cloth), 1044286, 8, 1044287);
-            AddCraft(typeof(Tunic), 1015269, 1028097, 00.0, 25.0, typeof(Cloth), 1044286, 12, 1044287);
-            AddCraft(typeof(Surcoat), 1015269, 1028189, 8.2, 33.2, typeof(Cloth), 1044286, 14, 1044287);
-            AddCraft(typeof(PlainDress), 1015269, 1027937, 12.4, 37.4, typeof(Cloth), 1044286, 10, 1044287);
-            AddCraft(typeof(FancyDress), 1015269, 1027935, 33.1, 58.1, typeof(Cloth), 1044286, 12, 1044287);
-            AddCraft(typeof(Cloak), 1015269, 1025397, 41.4, 66.4, typeof(Cloth), 1044286, 14, 1044287);
-            AddCraft(typeof(Robe), 1015269, 1027939, 53.9, 78.9, typeof(Cloth), 1044286, 16, 1044287);
-            AddCraft(typeof(JesterSuit), 1015269, 1028095, 8.2, 33.2, typeof(Cloth), 1044286, 24, 1044287);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(FurCape), 1015269, 1028969, 35.0, 60.0, typeof(Cloth), 1044286, 13, 1044287);
-                AddCraft(typeof(GildedDress), 1015269, 1028973, 37.5, 62.5, typeof(Cloth), 1044286, 16, 1044287);
-                AddCraft(typeof(FormalShirt), 1015269, 1028975, 26.0, 51.0, typeof(Cloth), 1044286, 16, 1044287);
-            }
-
-            if (Core.SE)
-            {
-                index = AddCraft(
-                    typeof(ClothNinjaJacket),
-                    1015269,
-                    1030207,
-                    75.0,
-                    100.0,
-                    typeof(Cloth),
-                    1044286,
-                    12,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(Kamishimo), 1015269, 1030212, 75.0, 100.0, typeof(Cloth), 1044286, 15, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(HakamaShita), 1015269, 1030215, 40.0, 65.0, typeof(Cloth), 1044286, 14, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(MaleKimono), 1015269, 1030189, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(FemaleKimono), 1015269, 1030190, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(JinBaori), 1015269, 1030220, 30.0, 55.0, typeof(Cloth), 1044286, 12, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddCraft(typeof(ShortPants), 1015279, 1025422, 24.8, 49.8, typeof(Cloth), 1044286, 6, 1044287);
-            AddCraft(typeof(LongPants), 1015279, 1025433, 24.8, 49.8, typeof(Cloth), 1044286, 8, 1044287);
-            AddCraft(typeof(Kilt), 1015279, 1025431, 20.7, 45.7, typeof(Cloth), 1044286, 8, 1044287);
-            AddCraft(typeof(Skirt), 1015279, 1025398, 29.0, 54.0, typeof(Cloth), 1044286, 10, 1044287);
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(FurSarong), 1015279, 1028971, 35.0, 60.0, typeof(Cloth), 1044286, 12, 1044287);
-            }
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(Hakama), 1015279, 1030213, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(TattsukeHakama), 1015279, 1030214, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddCraft(typeof(BodySash), 1015283, 1025441, 4.1, 29.1, typeof(Cloth), 1044286, 4, 1044287);
-            AddCraft(typeof(HalfApron), 1015283, 1025435, 20.7, 45.7, typeof(Cloth), 1044286, 6, 1044287);
-            AddCraft(typeof(FullApron), 1015283, 1025437, 29.0, 54.0, typeof(Cloth), 1044286, 10, 1044287);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(Obi), 1015283, 1030219, 20.0, 45.0, typeof(Cloth), 1044286, 6, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            if (Core.ML)
-            {
-                index = AddCraft(typeof(ElvenQuiver), 1015283, 1032657, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
-                AddRecipe(index, 501);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(QuiverOfFire), 1015283, 1073109, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
-                AddRes(index, typeof(FireRuby), 1032695, 15, 1042081);
-                AddRecipe(index, 502);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(typeof(QuiverOfIce), 1015283, 1073110, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
-                AddRes(index, typeof(WhitePearl), 1032694, 15, 1042081);
-                AddRecipe(index, 503);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(QuiverOfBlight),
-                    1015283,
-                    1073111,
-                    65.0,
-                    115.0,
-                    typeof(Leather),
-                    1044462,
-                    28,
-                    1044463
-                );
-                AddRes(index, typeof(Blight), 1032675, 10, 1042081);
-                AddRecipe(index, 504);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(QuiverOfLightning),
-                    1015283,
-                    1073112,
-                    65.0,
-                    115.0,
-                    typeof(Leather),
-                    1044462,
-                    28,
-                    1044463
-                );
-                AddRes(index, typeof(Corruption), 1032676, 10, 1042081);
-                AddRecipe(index, 505);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            AddCraft(typeof(OilCloth), 1015283, 1041498, 74.6, 99.6, typeof(Cloth), 1044286, 1, 1044287);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(GozaMatEastDeed), 1015283, 1030404, 55.0, 80.0, typeof(Cloth), 1044286, 25, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(GozaMatSouthDeed),
-                    1015283,
-                    1030405,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(SquareGozaMatEastDeed),
-                    1015283,
-                    1030407,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(SquareGozaMatSouthDeed),
-                    1015283,
-                    1030406,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(BrocadeGozaMatEastDeed),
-                    1015283,
-                    1030408,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(BrocadeGozaMatSouthDeed),
-                    1015283,
-                    1030409,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(BrocadeSquareGozaMatEastDeed),
-                    1015283,
-                    1030411,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(BrocadeSquareGozaMatSouthDeed),
-                    1015283,
-                    1030410,
-                    55.0,
-                    80.0,
-                    typeof(Cloth),
-                    1044286,
-                    25,
-                    1044287
-                );
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            if (Core.AOS)
-            {
-                AddCraft(typeof(FurBoots), 1015288, 1028967, 50.0, 75.0, typeof(Cloth), 1044286, 12, 1044287);
-            }
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(NinjaTabi), 1015288, 1030210, 70.0, 95.0, typeof(Cloth), 1044286, 10, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(SamuraiTabi), 1015288, 1030209, 20.0, 45.0, typeof(Cloth), 1044286, 6, 1044287);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddCraft(typeof(Sandals), 1015288, 1025901, 12.4, 37.4, typeof(Leather), 1044462, 4, 1044463);
-            AddCraft(typeof(Shoes), 1015288, 1025904, 16.5, 41.5, typeof(Leather), 1044462, 6, 1044463);
-            AddCraft(typeof(Boots), 1015288, 1025899, 33.1, 58.1, typeof(Leather), 1044462, 8, 1044463);
-            AddCraft(typeof(ThighBoots), 1015288, 1025906, 41.4, 66.4, typeof(Leather), 1044462, 10, 1044463);
-
-            if (Core.ML)
-            {
-                index = AddCraft(
-                    typeof(SpellWovenBritches),
-                    1015293,
-                    1072929,
-                    92.5,
-                    117.5,
-                    typeof(Leather),
-                    1044462,
-                    15,
-                    1044463
-                );
-                AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
-                AddRes(index, typeof(Putrefication), 1032678, 10, 1044253);
-                AddRes(index, typeof(Scourge), 1032677, 10, 1044253);
-                AddRareRecipe(index, 506);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(SongWovenMantle),
-                    1015293,
-                    1072931,
-                    92.5,
-                    117.5,
-                    typeof(Leather),
-                    1044462,
-                    15,
-                    1044463
-                );
-                AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
-                AddRes(index, typeof(Blight), 1032675, 10, 1044253);
-                AddRes(index, typeof(Muculent), 1032680, 10, 1044253);
-                AddRareRecipe(index, 507);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(StitchersMittens),
-                    1015293,
-                    1072932,
-                    92.5,
-                    117.5,
-                    typeof(Leather),
-                    1044462,
-                    15,
-                    1044463
-                );
-                AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
-                AddRes(index, typeof(Corruption), 1032676, 10, 1044253);
-                AddRes(index, typeof(Taint), 1032679, 10, 1044253);
-                AddRareRecipe(index, 508);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            AddCraft(typeof(LeatherGorget), 1015293, 1025063, 53.9, 78.9, typeof(Leather), 1044462, 4, 1044463);
-            AddCraft(typeof(LeatherCap), 1015293, 1027609, 6.2, 31.2, typeof(Leather), 1044462, 2, 1044463);
-            AddCraft(typeof(LeatherGloves), 1015293, 1025062, 51.8, 76.8, typeof(Leather), 1044462, 3, 1044463);
-            AddCraft(typeof(LeatherArms), 1015293, 1025061, 53.9, 78.9, typeof(Leather), 1044462, 4, 1044463);
-            AddCraft(typeof(LeatherLegs), 1015293, 1025067, 66.3, 91.3, typeof(Leather), 1044462, 10, 1044463);
-            AddCraft(typeof(LeatherChest), 1015293, 1025068, 70.5, 95.5, typeof(Leather), 1044462, 12, 1044463);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(LeatherJingasa), 1015293, 1030177, 45.0, 70.0, typeof(Leather), 1044462, 4, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(LeatherMempo), 1015293, 1030181, 80.0, 105.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(LeatherDo), 1015293, 1030182, 75.0, 100.0, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherHiroSode),
-                    1015293,
-                    1030185,
-                    55.0,
-                    80.0,
-                    typeof(Leather),
-                    1044462,
-                    5,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherSuneate),
-                    1015293,
-                    1030193,
-                    68.0,
-                    93.0,
-                    typeof(Leather),
-                    1044462,
-                    12,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherHaidate),
-                    1015293,
-                    1030197,
-                    68.0,
-                    93.0,
-                    typeof(Leather),
-                    1044462,
-                    12,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherNinjaPants),
-                    1015293,
-                    1030204,
-                    80.0,
-                    105.0,
-                    typeof(Leather),
-                    1044462,
-                    13,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherNinjaJacket),
-                    1015293,
-                    1030206,
-                    85.0,
-                    110.0,
-                    typeof(Leather),
-                    1044462,
-                    13,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherNinjaBelt),
-                    1015293,
-                    1030203,
-                    50.0,
-                    75.0,
-                    typeof(Leather),
-                    1044462,
-                    5,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherNinjaMitts),
-                    1015293,
-                    1030205,
-                    65.0,
-                    90.0,
-                    typeof(Leather),
-                    1044462,
-                    12,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(LeatherNinjaHood),
-                    1015293,
-                    1030201,
-                    90.0,
-                    115.0,
-                    typeof(Leather),
-                    1044462,
-                    14,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-            }
-            if (Core.SA)
-            {
-                index = AddCraft(typeof(GargishLeatherArmsType1), 1015293, 1020769, 53.9, 78.9, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherArmsType2), 1015293, 1020770, 53.9, 78.9, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherKiltType1), 1015293, 1020784, 58.0, 83.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherKiltType2), 1015293, 1020785, 58.0, 83.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherLegsType1), 1015293, 1020773, 66.3, 91.3, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherLegsType2), 1015293, 1020774, 66.3, 91.3, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherChestType1), 1015293, 1020772, 70.5, 95.5, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherChestType2), 1015293, 1020771, 70.5, 95.5, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishLeatherWingArmor), 1015293, 1096662, 65.3, 90.3, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-            }
-
-            AddCraft(typeof(StuddedGorget), 1015300, 1025078, 78.8, 103.8, typeof(Leather), 1044462, 6, 1044463);
-            AddCraft(typeof(StuddedGloves), 1015300, 1025077, 82.9, 107.9, typeof(Leather), 1044462, 8, 1044463);
-            AddCraft(typeof(StuddedArms), 1015300, 1025076, 87.1, 112.1, typeof(Leather), 1044462, 10, 1044463);
-            AddCraft(typeof(StuddedLegs), 1015300, 1025082, 91.2, 116.2, typeof(Leather), 1044462, 12, 1044463);
-            AddCraft(typeof(StuddedChest), 1015300, 1025083, 94.0, 119.0, typeof(Leather), 1044462, 14, 1044463);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(StuddedMempo), 1015300, 1030216, 80.0, 105.0, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(typeof(StuddedDo), 1015300, 1030183, 95.0, 120.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(StuddedHiroSode),
-                    1015300,
-                    1030186,
-                    85.0,
-                    110.0,
-                    typeof(Leather),
-                    1044462,
-                    8,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(StuddedSuneate),
-                    1015300,
-                    1030194,
-                    92.0,
-                    117.0,
-                    typeof(Leather),
-                    1044462,
-                    14,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-                index = AddCraft(
-                    typeof(StuddedHaidate),
-                    1015300,
-                    1030198,
-                    92.0,
-                    117.0,
-                    typeof(Leather),
-                    1044462,
-                    14,
-                    1044463
-                );
-                SetNeededExpansion(index, Expansion.SE);
-            }
-            if (Core.SA)
-            {
-                index = AddCraft(typeof(GargishStuddedArmsType1), 1015300, 1020643, 87.1, 112.1, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedArmsType2), 1015300, 1020644, 87.1, 112.1, typeof(Leather), 1044462, 8, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedKiltType1), 1015300, 1020647, 89.5, 114.5, typeof(Leather), 1044462, 10, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedKiltType2), 1015300, 1020648, 89.5, 114.5, typeof(Leather), 1044462, 10, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedLegsType1), 1015300, 1020649, 91.2, 116.2, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedLegsType2), 1015300, 1020650, 91.2, 116.2, typeof(Leather), 1044462, 12, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedChestType1), 1015300, 1020645, 94.0, 119.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-                index = AddCraft(typeof(GargishStuddedChestType2), 1015300, 1020646, 94.0, 119.0, typeof(Leather), 1044462, 14, 1044463);
-                SetNeededExpansion(index, Expansion.SA);
-            }
-
-            AddCraft(typeof(LeatherShorts), 1015306, 1027168, 62.2, 87.2, typeof(Leather), 1044462, 8, 1044463);
-            AddCraft(typeof(LeatherSkirt), 1015306, 1027176, 58.0, 83.0, typeof(Leather), 1044462, 6, 1044463);
-            AddCraft(typeof(LeatherBustierArms), 1015306, 1027178, 58.0, 83.0, typeof(Leather), 1044462, 6, 1044463);
-            AddCraft(typeof(StuddedBustierArms), 1015306, 1027180, 82.9, 107.9, typeof(Leather), 1044462, 8, 1044463);
-            AddCraft(typeof(FemaleLeatherChest), 1015306, 1027174, 62.2, 87.2, typeof(Leather), 1044462, 8, 1044463);
-            AddCraft(typeof(FemaleStuddedChest), 1015306, 1027170, 87.1, 112.1, typeof(Leather), 1044462, 10, 1044463);
-
-            index = AddCraft(typeof(BoneHelm), 1049149, 1025206, 85.0, 110.0, typeof(Leather), 1044462, 4, 1044463);
-            AddRes(index, typeof(Bone), 1049064, 2, 1049063);
-
-            index = AddCraft(typeof(BoneGloves), 1049149, 1025205, 89.0, 114.0, typeof(Leather), 1044462, 6, 1044463);
-            AddRes(index, typeof(Bone), 1049064, 2, 1049063);
-
-            index = AddCraft(typeof(BoneArms), 1049149, 1025203, 92.0, 117.0, typeof(Leather), 1044462, 8, 1044463);
-            AddRes(index, typeof(Bone), 1049064, 4, 1049063);
-
-            index = AddCraft(typeof(BoneLegs), 1049149, 1025202, 95.0, 120.0, typeof(Leather), 1044462, 10, 1044463);
-            AddRes(index, typeof(Bone), 1049064, 6, 1049063);
-
-            index = AddCraft(typeof(BoneChest), 1049149, 1025199, 96.0, 121.0, typeof(Leather), 1044462, 12, 1044463);
-            AddRes(index, typeof(Bone), 1049064, 10, 1049063);
-
-            index = AddCraft(typeof(OrcHelm), 1049149, 1027947, 90.0, 115.0, typeof(Leather), 1044462, 6, 1044463);
-            AddRes(index, typeof(Bone), 1049064, 4, 1049063);
-
-            // Set the overridable material
-            SetSubRes(typeof(Leather), 1049150);
-
-            // Add every material you want the player to be able to choose from
-            // This will override the overridable material
-            AddSubRes(typeof(Leather), 1049150, 00.0, 1044462, 1049311);
-            AddSubRes(typeof(SpinedLeather), 1049151, 65.0, 1044462, 1049311);
-            AddSubRes(typeof(HornedLeather), 1049152, 80.0, 1044462, 1049311);
-            AddSubRes(typeof(BarbedLeather), 1049153, 99.0, 1044462, 1049311);
-
-            MarkOption = true;
-            Repair = Core.AOS;
-            CanEnhance = Core.AOS;
+            return 1044157; // You failed to create the item, but no materials were lost.
         }
+
+        if (quality == 0)
+        {
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
+
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
+
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override void InitCraftList()
+    {
+        int index;
+
+        AddCraft(typeof(SkullCap), 1011375, 1025444, 0.0, 25.0, typeof(Cloth), 1044286, 2, 1044287);
+        AddCraft(typeof(Bandana), 1011375, 1025440, 0.0, 25.0, typeof(Cloth), 1044286, 2, 1044287);
+        AddCraft(typeof(FloppyHat), 1011375, 1025907, 6.2, 31.2, typeof(Cloth), 1044286, 11, 1044287);
+        AddCraft(typeof(Cap), 1011375, 1025909, 6.2, 31.2, typeof(Cloth), 1044286, 11, 1044287);
+        AddCraft(typeof(WideBrimHat), 1011375, 1025908, 6.2, 31.2, typeof(Cloth), 1044286, 12, 1044287);
+        AddCraft(typeof(StrawHat), 1011375, 1025911, 6.2, 31.2, typeof(Cloth), 1044286, 10, 1044287);
+        AddCraft(typeof(TallStrawHat), 1011375, 1025910, 6.7, 31.7, typeof(Cloth), 1044286, 13, 1044287);
+        AddCraft(typeof(WizardsHat), 1011375, 1025912, 7.2, 32.2, typeof(Cloth), 1044286, 15, 1044287);
+        AddCraft(typeof(Bonnet), 1011375, 1025913, 6.2, 31.2, typeof(Cloth), 1044286, 11, 1044287);
+        AddCraft(typeof(FeatheredHat), 1011375, 1025914, 6.2, 31.2, typeof(Cloth), 1044286, 12, 1044287);
+        AddCraft(typeof(TricorneHat), 1011375, 1025915, 6.2, 31.2, typeof(Cloth), 1044286, 12, 1044287);
+        AddCraft(typeof(JesterHat), 1011375, 1025916, 7.2, 32.2, typeof(Cloth), 1044286, 15, 1044287);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(FlowerGarland), 1011375, 1028965, 10.0, 35.0, typeof(Cloth), 1044286, 5, 1044287);
+        }
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(ClothNinjaHood), 1011375, 1030202, 80.0, 105.0, typeof(Cloth), 1044286, 13, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+
+            index = AddCraft(typeof(Kasa), 1011375, 1030211, 60.0, 85.0, typeof(Cloth), 1044286, 12, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        AddCraft(typeof(Doublet), 1015269, 1028059, 0, 25.0, typeof(Cloth), 1044286, 8, 1044287);
+        AddCraft(typeof(Shirt), 1015269, 1025399, 20.7, 45.7, typeof(Cloth), 1044286, 8, 1044287);
+        AddCraft(typeof(FancyShirt), 1015269, 1027933, 24.8, 49.8, typeof(Cloth), 1044286, 8, 1044287);
+        AddCraft(typeof(Tunic), 1015269, 1028097, 00.0, 25.0, typeof(Cloth), 1044286, 12, 1044287);
+        AddCraft(typeof(Surcoat), 1015269, 1028189, 8.2, 33.2, typeof(Cloth), 1044286, 14, 1044287);
+        AddCraft(typeof(PlainDress), 1015269, 1027937, 12.4, 37.4, typeof(Cloth), 1044286, 10, 1044287);
+        AddCraft(typeof(FancyDress), 1015269, 1027935, 33.1, 58.1, typeof(Cloth), 1044286, 12, 1044287);
+        AddCraft(typeof(Cloak), 1015269, 1025397, 41.4, 66.4, typeof(Cloth), 1044286, 14, 1044287);
+        AddCraft(typeof(Robe), 1015269, 1027939, 53.9, 78.9, typeof(Cloth), 1044286, 16, 1044287);
+        AddCraft(typeof(JesterSuit), 1015269, 1028095, 8.2, 33.2, typeof(Cloth), 1044286, 24, 1044287);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(FurCape), 1015269, 1028969, 35.0, 60.0, typeof(Cloth), 1044286, 13, 1044287);
+            AddCraft(typeof(GildedDress), 1015269, 1028973, 37.5, 62.5, typeof(Cloth), 1044286, 16, 1044287);
+            AddCraft(typeof(FormalShirt), 1015269, 1028975, 26.0, 51.0, typeof(Cloth), 1044286, 16, 1044287);
+        }
+
+        if (Core.SE)
+        {
+            index = AddCraft(
+                typeof(ClothNinjaJacket),
+                1015269,
+                1030207,
+                75.0,
+                100.0,
+                typeof(Cloth),
+                1044286,
+                12,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(Kamishimo), 1015269, 1030212, 75.0, 100.0, typeof(Cloth), 1044286, 15, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(HakamaShita), 1015269, 1030215, 40.0, 65.0, typeof(Cloth), 1044286, 14, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(MaleKimono), 1015269, 1030189, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(FemaleKimono), 1015269, 1030190, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(JinBaori), 1015269, 1030220, 30.0, 55.0, typeof(Cloth), 1044286, 12, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        AddCraft(typeof(ShortPants), 1015279, 1025422, 24.8, 49.8, typeof(Cloth), 1044286, 6, 1044287);
+        AddCraft(typeof(LongPants), 1015279, 1025433, 24.8, 49.8, typeof(Cloth), 1044286, 8, 1044287);
+        AddCraft(typeof(Kilt), 1015279, 1025431, 20.7, 45.7, typeof(Cloth), 1044286, 8, 1044287);
+        AddCraft(typeof(Skirt), 1015279, 1025398, 29.0, 54.0, typeof(Cloth), 1044286, 10, 1044287);
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(FurSarong), 1015279, 1028971, 35.0, 60.0, typeof(Cloth), 1044286, 12, 1044287);
+        }
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(Hakama), 1015279, 1030213, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(TattsukeHakama), 1015279, 1030214, 50.0, 75.0, typeof(Cloth), 1044286, 16, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        AddCraft(typeof(BodySash), 1015283, 1025441, 4.1, 29.1, typeof(Cloth), 1044286, 4, 1044287);
+        AddCraft(typeof(HalfApron), 1015283, 1025435, 20.7, 45.7, typeof(Cloth), 1044286, 6, 1044287);
+        AddCraft(typeof(FullApron), 1015283, 1025437, 29.0, 54.0, typeof(Cloth), 1044286, 10, 1044287);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(Obi), 1015283, 1030219, 20.0, 45.0, typeof(Cloth), 1044286, 6, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        if (Core.ML)
+        {
+            index = AddCraft(typeof(ElvenQuiver), 1015283, 1032657, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
+            AddRecipe(index, 501);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(QuiverOfFire), 1015283, 1073109, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
+            AddRes(index, typeof(FireRuby), 1032695, 15, 1042081);
+            AddRecipe(index, 502);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(typeof(QuiverOfIce), 1015283, 1073110, 65.0, 115.0, typeof(Leather), 1044462, 28, 1044463);
+            AddRes(index, typeof(WhitePearl), 1032694, 15, 1042081);
+            AddRecipe(index, 503);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(QuiverOfBlight),
+                1015283,
+                1073111,
+                65.0,
+                115.0,
+                typeof(Leather),
+                1044462,
+                28,
+                1044463
+            );
+            AddRes(index, typeof(Blight), 1032675, 10, 1042081);
+            AddRecipe(index, 504);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(QuiverOfLightning),
+                1015283,
+                1073112,
+                65.0,
+                115.0,
+                typeof(Leather),
+                1044462,
+                28,
+                1044463
+            );
+            AddRes(index, typeof(Corruption), 1032676, 10, 1042081);
+            AddRecipe(index, 505);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        AddCraft(typeof(OilCloth), 1015283, 1041498, 74.6, 99.6, typeof(Cloth), 1044286, 1, 1044287);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(GozaMatEastDeed), 1015283, 1030404, 55.0, 80.0, typeof(Cloth), 1044286, 25, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(GozaMatSouthDeed),
+                1015283,
+                1030405,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(SquareGozaMatEastDeed),
+                1015283,
+                1030407,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(SquareGozaMatSouthDeed),
+                1015283,
+                1030406,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(BrocadeGozaMatEastDeed),
+                1015283,
+                1030408,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(BrocadeGozaMatSouthDeed),
+                1015283,
+                1030409,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(BrocadeSquareGozaMatEastDeed),
+                1015283,
+                1030411,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(BrocadeSquareGozaMatSouthDeed),
+                1015283,
+                1030410,
+                55.0,
+                80.0,
+                typeof(Cloth),
+                1044286,
+                25,
+                1044287
+            );
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        if (Core.AOS)
+        {
+            AddCraft(typeof(FurBoots), 1015288, 1028967, 50.0, 75.0, typeof(Cloth), 1044286, 12, 1044287);
+        }
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(NinjaTabi), 1015288, 1030210, 70.0, 95.0, typeof(Cloth), 1044286, 10, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(SamuraiTabi), 1015288, 1030209, 20.0, 45.0, typeof(Cloth), 1044286, 6, 1044287);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        AddCraft(typeof(Sandals), 1015288, 1025901, 12.4, 37.4, typeof(Leather), 1044462, 4, 1044463);
+        AddCraft(typeof(Shoes), 1015288, 1025904, 16.5, 41.5, typeof(Leather), 1044462, 6, 1044463);
+        AddCraft(typeof(Boots), 1015288, 1025899, 33.1, 58.1, typeof(Leather), 1044462, 8, 1044463);
+        AddCraft(typeof(ThighBoots), 1015288, 1025906, 41.4, 66.4, typeof(Leather), 1044462, 10, 1044463);
+
+        if (Core.ML)
+        {
+            index = AddCraft(
+                typeof(SpellWovenBritches),
+                1015293,
+                1072929,
+                92.5,
+                117.5,
+                typeof(Leather),
+                1044462,
+                15,
+                1044463
+            );
+            AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
+            AddRes(index, typeof(Putrefication), 1032678, 10, 1044253);
+            AddRes(index, typeof(Scourge), 1032677, 10, 1044253);
+            AddRareRecipe(index, 506);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(SongWovenMantle),
+                1015293,
+                1072931,
+                92.5,
+                117.5,
+                typeof(Leather),
+                1044462,
+                15,
+                1044463
+            );
+            AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
+            AddRes(index, typeof(Blight), 1032675, 10, 1044253);
+            AddRes(index, typeof(Muculent), 1032680, 10, 1044253);
+            AddRareRecipe(index, 507);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(StitchersMittens),
+                1015293,
+                1072932,
+                92.5,
+                117.5,
+                typeof(Leather),
+                1044462,
+                15,
+                1044463
+            );
+            AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
+            AddRes(index, typeof(Corruption), 1032676, 10, 1044253);
+            AddRes(index, typeof(Taint), 1032679, 10, 1044253);
+            AddRareRecipe(index, 508);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        AddCraft(typeof(LeatherGorget), 1015293, 1025063, 53.9, 78.9, typeof(Leather), 1044462, 4, 1044463);
+        AddCraft(typeof(LeatherCap), 1015293, 1027609, 6.2, 31.2, typeof(Leather), 1044462, 2, 1044463);
+        AddCraft(typeof(LeatherGloves), 1015293, 1025062, 51.8, 76.8, typeof(Leather), 1044462, 3, 1044463);
+        AddCraft(typeof(LeatherArms), 1015293, 1025061, 53.9, 78.9, typeof(Leather), 1044462, 4, 1044463);
+        AddCraft(typeof(LeatherLegs), 1015293, 1025067, 66.3, 91.3, typeof(Leather), 1044462, 10, 1044463);
+        AddCraft(typeof(LeatherChest), 1015293, 1025068, 70.5, 95.5, typeof(Leather), 1044462, 12, 1044463);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(LeatherJingasa), 1015293, 1030177, 45.0, 70.0, typeof(Leather), 1044462, 4, 1044463);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(LeatherMempo), 1015293, 1030181, 80.0, 105.0, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(LeatherDo), 1015293, 1030182, 75.0, 100.0, typeof(Leather), 1044462, 12, 1044463);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherHiroSode),
+                1015293,
+                1030185,
+                55.0,
+                80.0,
+                typeof(Leather),
+                1044462,
+                5,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherSuneate),
+                1015293,
+                1030193,
+                68.0,
+                93.0,
+                typeof(Leather),
+                1044462,
+                12,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherHaidate),
+                1015293,
+                1030197,
+                68.0,
+                93.0,
+                typeof(Leather),
+                1044462,
+                12,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherNinjaPants),
+                1015293,
+                1030204,
+                80.0,
+                105.0,
+                typeof(Leather),
+                1044462,
+                13,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherNinjaJacket),
+                1015293,
+                1030206,
+                85.0,
+                110.0,
+                typeof(Leather),
+                1044462,
+                13,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherNinjaBelt),
+                1015293,
+                1030203,
+                50.0,
+                75.0,
+                typeof(Leather),
+                1044462,
+                5,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherNinjaMitts),
+                1015293,
+                1030205,
+                65.0,
+                90.0,
+                typeof(Leather),
+                1044462,
+                12,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(LeatherNinjaHood),
+                1015293,
+                1030201,
+                90.0,
+                115.0,
+                typeof(Leather),
+                1044462,
+                14,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+        }
+        if (Core.SA)
+        {
+            index = AddCraft(typeof(GargishLeatherArmsType1), 1015293, 1020769, 53.9, 78.9, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherArmsType2), 1015293, 1020770, 53.9, 78.9, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherKiltType1), 1015293, 1020784, 58.0, 83.0, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherKiltType2), 1015293, 1020785, 58.0, 83.0, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherLegsType1), 1015293, 1020773, 66.3, 91.3, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherLegsType2), 1015293, 1020774, 66.3, 91.3, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherChestType1), 1015293, 1020772, 70.5, 95.5, typeof(Leather), 1044462, 12, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherChestType2), 1015293, 1020771, 70.5, 95.5, typeof(Leather), 1044462, 12, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishLeatherWingArmor), 1015293, 1096662, 65.3, 90.3, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+        }
+
+        AddCraft(typeof(StuddedGorget), 1015300, 1025078, 78.8, 103.8, typeof(Leather), 1044462, 6, 1044463);
+        AddCraft(typeof(StuddedGloves), 1015300, 1025077, 82.9, 107.9, typeof(Leather), 1044462, 8, 1044463);
+        AddCraft(typeof(StuddedArms), 1015300, 1025076, 87.1, 112.1, typeof(Leather), 1044462, 10, 1044463);
+        AddCraft(typeof(StuddedLegs), 1015300, 1025082, 91.2, 116.2, typeof(Leather), 1044462, 12, 1044463);
+        AddCraft(typeof(StuddedChest), 1015300, 1025083, 94.0, 119.0, typeof(Leather), 1044462, 14, 1044463);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(StuddedMempo), 1015300, 1030216, 80.0, 105.0, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(typeof(StuddedDo), 1015300, 1030183, 95.0, 120.0, typeof(Leather), 1044462, 14, 1044463);
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(StuddedHiroSode),
+                1015300,
+                1030186,
+                85.0,
+                110.0,
+                typeof(Leather),
+                1044462,
+                8,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(StuddedSuneate),
+                1015300,
+                1030194,
+                92.0,
+                117.0,
+                typeof(Leather),
+                1044462,
+                14,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+            index = AddCraft(
+                typeof(StuddedHaidate),
+                1015300,
+                1030198,
+                92.0,
+                117.0,
+                typeof(Leather),
+                1044462,
+                14,
+                1044463
+            );
+            SetNeededExpansion(index, Expansion.SE);
+        }
+        if (Core.SA)
+        {
+            index = AddCraft(typeof(GargishStuddedArmsType1), 1015300, 1020643, 87.1, 112.1, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedArmsType2), 1015300, 1020644, 87.1, 112.1, typeof(Leather), 1044462, 8, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedKiltType1), 1015300, 1020647, 89.5, 114.5, typeof(Leather), 1044462, 10, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedKiltType2), 1015300, 1020648, 89.5, 114.5, typeof(Leather), 1044462, 10, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedLegsType1), 1015300, 1020649, 91.2, 116.2, typeof(Leather), 1044462, 12, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedLegsType2), 1015300, 1020650, 91.2, 116.2, typeof(Leather), 1044462, 12, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedChestType1), 1015300, 1020645, 94.0, 119.0, typeof(Leather), 1044462, 14, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+            index = AddCraft(typeof(GargishStuddedChestType2), 1015300, 1020646, 94.0, 119.0, typeof(Leather), 1044462, 14, 1044463);
+            SetNeededExpansion(index, Expansion.SA);
+        }
+
+        AddCraft(typeof(LeatherShorts), 1015306, 1027168, 62.2, 87.2, typeof(Leather), 1044462, 8, 1044463);
+        AddCraft(typeof(LeatherSkirt), 1015306, 1027176, 58.0, 83.0, typeof(Leather), 1044462, 6, 1044463);
+        AddCraft(typeof(LeatherBustierArms), 1015306, 1027178, 58.0, 83.0, typeof(Leather), 1044462, 6, 1044463);
+        AddCraft(typeof(StuddedBustierArms), 1015306, 1027180, 82.9, 107.9, typeof(Leather), 1044462, 8, 1044463);
+        AddCraft(typeof(FemaleLeatherChest), 1015306, 1027174, 62.2, 87.2, typeof(Leather), 1044462, 8, 1044463);
+        AddCraft(typeof(FemaleStuddedChest), 1015306, 1027170, 87.1, 112.1, typeof(Leather), 1044462, 10, 1044463);
+
+        index = AddCraft(typeof(BoneHelm), 1049149, 1025206, 85.0, 110.0, typeof(Leather), 1044462, 4, 1044463);
+        AddRes(index, typeof(Bone), 1049064, 2, 1049063);
+
+        index = AddCraft(typeof(BoneGloves), 1049149, 1025205, 89.0, 114.0, typeof(Leather), 1044462, 6, 1044463);
+        AddRes(index, typeof(Bone), 1049064, 2, 1049063);
+
+        index = AddCraft(typeof(BoneArms), 1049149, 1025203, 92.0, 117.0, typeof(Leather), 1044462, 8, 1044463);
+        AddRes(index, typeof(Bone), 1049064, 4, 1049063);
+
+        index = AddCraft(typeof(BoneLegs), 1049149, 1025202, 95.0, 120.0, typeof(Leather), 1044462, 10, 1044463);
+        AddRes(index, typeof(Bone), 1049064, 6, 1049063);
+
+        index = AddCraft(typeof(BoneChest), 1049149, 1025199, 96.0, 121.0, typeof(Leather), 1044462, 12, 1044463);
+        AddRes(index, typeof(Bone), 1049064, 10, 1049063);
+
+        index = AddCraft(typeof(OrcHelm), 1049149, 1027947, 90.0, 115.0, typeof(Leather), 1044462, 6, 1044463);
+        AddRes(index, typeof(Bone), 1049064, 4, 1049063);
+
+        // Set the overridable material
+        SetSubRes(typeof(Leather), 1049150);
+
+        // Add every material you want the player to be able to choose from
+        // This will override the overridable material
+        AddSubRes(typeof(Leather), 1049150, 00.0, 1044462, 1049311);
+        AddSubRes(typeof(SpinedLeather), 1049151, 65.0, 1044462, 1049311);
+        AddSubRes(typeof(HornedLeather), 1049152, 80.0, 1044462, 1049311);
+        AddSubRes(typeof(BarbedLeather), 1049153, 99.0, 1044462, 1049311);
+
+        MarkOption = true;
+        Repair = Core.AOS;
+        CanEnhance = Core.AOS;
     }
 }

--- a/Projects/UOContent/Engines/Craft/DefTinkering.cs
+++ b/Projects/UOContent/Engines/Craft/DefTinkering.cs
@@ -3,759 +3,761 @@ using Server.Factions;
 using Server.Items;
 using Server.Targeting;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class DefTinkering : CraftSystem
 {
-    public class DefTinkering : CraftSystem
+    private static readonly Type[] _tinkerColorables =
     {
-        private static CraftSystem m_CraftSystem;
+        typeof(ForkLeft), typeof(ForkRight),
+        typeof(SpoonLeft), typeof(SpoonRight),
+        typeof(KnifeLeft), typeof(KnifeRight),
+        typeof(Plate),
+        typeof(Goblet), typeof(PewterMug),
+        typeof(KeyRing),
+        typeof(Candelabra), typeof(Scales),
+        typeof(Key), typeof(Globe),
+        typeof(Spyglass), typeof(Lantern),
+        typeof(HeatingStand)
+    };
 
-        private static readonly Type[] m_TinkerColorables =
-        {
-            typeof(ForkLeft), typeof(ForkRight),
-            typeof(SpoonLeft), typeof(SpoonRight),
-            typeof(KnifeLeft), typeof(KnifeRight),
-            typeof(Plate),
-            typeof(Goblet), typeof(PewterMug),
-            typeof(KeyRing),
-            typeof(Candelabra), typeof(Scales),
-            typeof(Key), typeof(Globe),
-            typeof(Spyglass), typeof(Lantern),
-            typeof(HeatingStand)
-        };
+    public static void Configure()
+    {
+        CraftSystem = new DefTinkering();
+    }
 
-        private DefTinkering() : base(1, 1, 1.25) // base( 1, 1, 3.0 )
+    private DefTinkering() : base(1, 1, 1.25)
+    {
+    }
+
+    public override SkillName MainSkill => SkillName.Tinkering;
+
+    public override TextDefinition GumpTitle => 1044007;
+
+    public static CraftSystem CraftSystem { get; private set; }
+
+    public override double GetChanceAtMin(CraftItem item)
+    {
+        if (item.NameNumber is 1044258 or 1046445) // potion keg and faction trap removal kit
         {
+            return 0.5; // 50%
         }
 
-        public override SkillName MainSkill => SkillName.Tinkering;
+        return 0.0; // 0%
+    }
 
-        public override TextDefinition GumpTitle => 1044007;
-
-        public static CraftSystem CraftSystem => m_CraftSystem ??= new DefTinkering();
-
-        public override double GetChanceAtMin(CraftItem item)
+    public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+    {
+        if (tool?.Deleted != false || tool.UsesRemaining < 0)
         {
-            if (item.NameNumber is 1044258 or 1046445) // potion keg and faction trap removal kit
-            {
-                return 0.5; // 50%
-            }
-
-            return 0.0; // 0%
+            return 1044038; // You have worn out your tool!
         }
 
-        public override int CanCraft(Mobile from, BaseTool tool, Type itemType)
+        if (!BaseTool.CheckAccessible(tool, from))
         {
-            if (tool?.Deleted != false || tool.UsesRemaining < 0)
-            {
-                return 1044038; // You have worn out your tool!
-            }
-
-            if (!BaseTool.CheckAccessible(tool, from))
-            {
-                return 1044263; // The tool must be on your person to use.
-            }
-
-            if (itemType != null &&
-                (itemType.IsSubclassOf(typeof(BaseFactionTrapDeed)) || itemType == typeof(FactionTrapRemovalKit)) &&
-                Faction.Find(from) == null)
-            {
-                return 1044573; // You have to be in a faction to do that.
-            }
-
-            return 0;
+            return 1044263; // The tool must be on your person to use.
         }
 
-        public override bool RetainsColorFrom(CraftItem item, Type type)
+        if (itemType != null &&
+            (itemType.IsSubclassOf(typeof(BaseFactionTrapDeed)) || itemType == typeof(FactionTrapRemovalKit)) &&
+            Faction.Find(from) == null)
         {
-            if (!type.IsSubclassOf(typeof(BaseIngot)))
-            {
-                return false;
-            }
-
-            type = item.ItemType;
-
-            var contains = false;
-
-            for (var i = 0; !contains && i < m_TinkerColorables.Length; ++i)
-            {
-                contains = m_TinkerColorables[i] == type;
-            }
-
-            return contains;
+            return 1044573; // You have to be in a faction to do that.
         }
 
-        public override void PlayCraftEffect(Mobile from)
+        return 0;
+    }
+
+    public override bool RetainsColorFrom(CraftItem item, Type type)
+    {
+        if (!type.IsSubclassOf(typeof(BaseIngot)))
         {
-            // no sound
-            // from.PlaySound( 0x241 );
+            return false;
         }
 
-        public override int PlayEndingEffect(
-            Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
-            bool makersMark, CraftItem item
-        )
+        type = item.ItemType;
+
+        var contains = false;
+
+        for (var i = 0; !contains && i < _tinkerColorables.Length; ++i)
         {
-            if (toolBroken)
-            {
-                from.SendLocalizedMessage(1044038); // You have worn out your tool
-            }
-
-            if (failed)
-            {
-                if (lostMaterial)
-                {
-                    return 1044043; // You failed to create the item, and some of your materials are lost.
-                }
-
-                return 1044157;     // You failed to create the item, but no materials were lost.
-            }
-
-            if (quality == 0)
-            {
-                return 502785; // You were barely able to make this item.  It's quality is below average.
-            }
-
-            if (makersMark && quality == 2)
-            {
-                return 1044156; // You create an exceptional quality item and affix your maker's mark.
-            }
-
-            if (quality == 2)
-            {
-                return 1044155; // You create an exceptional quality item.
-            }
-
-            return 1044154;     // You create the item.
+            contains = _tinkerColorables[i] == type;
         }
 
-        public override bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
-        {
-            if (resourceType == typeof(Silver))
-            {
-                return false;
-            }
+        return contains;
+    }
 
-            return base.ConsumeOnFailure(from, resourceType, craftItem);
+    public override void PlayCraftEffect(Mobile from)
+    {
+        // no sound
+        // from.PlaySound( 0x241 );
+    }
+
+    public override int PlayEndingEffect(
+        Mobile from, bool failed, bool lostMaterial, bool toolBroken, int quality,
+        bool makersMark, CraftItem item
+    )
+    {
+        if (toolBroken)
+        {
+            from.SendLocalizedMessage(1044038); // You have worn out your tool
         }
 
-        public void AddJewelrySet(GemType gemType, Type itemType)
+        if (failed)
         {
-            var offset = (int)gemType - 1;
+            if (lostMaterial)
+            {
+                return 1044043; // You failed to create the item, and some of your materials are lost.
+            }
 
-            var index = AddCraft(
-                typeof(GoldRing),
-                1044049,
-                1044176 + offset,
-                40.0,
-                90.0,
+            return 1044157; // You failed to create the item, but no materials were lost.
+        }
+
+        if (quality == 0)
+        {
+            return 502785; // You were barely able to make this item.  It's quality is below average.
+        }
+
+        if (makersMark && quality == 2)
+        {
+            return 1044156; // You create an exceptional quality item and affix your maker's mark.
+        }
+
+        if (quality == 2)
+        {
+            return 1044155; // You create an exceptional quality item.
+        }
+
+        return 1044154; // You create the item.
+    }
+
+    public override bool ConsumeOnFailure(Mobile from, Type resourceType, CraftItem craftItem)
+    {
+        if (resourceType == typeof(Silver))
+        {
+            return false;
+        }
+
+        return base.ConsumeOnFailure(from, resourceType, craftItem);
+    }
+
+    public void AddJewelrySet(GemType gemType, Type itemType)
+    {
+        var offset = (int)gemType - 1;
+
+        var index = AddCraft(
+            typeof(GoldRing),
+            1044049,
+            1044176 + offset,
+            40.0,
+            90.0,
+            typeof(IronIngot),
+            1044036,
+            2,
+            1044037
+        );
+        AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+
+        index = AddCraft(
+            typeof(SilverBeadNecklace),
+            1044049,
+            1044185 + offset,
+            40.0,
+            90.0,
+            typeof(IronIngot),
+            1044036,
+            2,
+            1044037
+        );
+        AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+
+        index = AddCraft(
+            typeof(GoldNecklace),
+            1044049,
+            1044194 + offset,
+            40.0,
+            90.0,
+            typeof(IronIngot),
+            1044036,
+            2,
+            1044037
+        );
+        AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+
+        index = AddCraft(
+            typeof(GoldEarrings),
+            1044049,
+            1044203 + offset,
+            40.0,
+            90.0,
+            typeof(IronIngot),
+            1044036,
+            2,
+            1044037
+        );
+        AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+
+        index = AddCraft(
+            typeof(GoldBeadNecklace),
+            1044049,
+            1044212 + offset,
+            40.0,
+            90.0,
+            typeof(IronIngot),
+            1044036,
+            2,
+            1044037
+        );
+        AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+
+        index = AddCraft(
+            typeof(GoldBracelet),
+            1044049,
+            1044221 + offset,
+            40.0,
+            90.0,
+            typeof(IronIngot),
+            1044036,
+            2,
+            1044037
+        );
+        AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+    }
+
+    public override void InitCraftList()
+    {
+        int index;
+
+        AddCraft(typeof(JointingPlane), 1044042, 1024144, 0.0, 50.0, typeof(Log), 1044041, 4, 1044351);
+        AddCraft(typeof(MouldingPlane), 1044042, 1024140, 0.0, 50.0, typeof(Log), 1044041, 4, 1044351);
+        AddCraft(typeof(SmoothingPlane), 1044042, 1024146, 0.0, 50.0, typeof(Log), 1044041, 4, 1044351);
+        AddCraft(typeof(ClockFrame), 1044042, 1024173, 0.0, 50.0, typeof(Log), 1044041, 6, 1044351);
+        AddCraft(typeof(Axle), 1044042, 1024187, -25.0, 25.0, typeof(Log), 1044041, 2, 1044351);
+        AddCraft(typeof(RollingPin), 1044042, 1024163, 0.0, 50.0, typeof(Log), 1044041, 5, 1044351);
+
+        if (Core.SE)
+        {
+            index = AddCraft(typeof(Nunchaku), 1044042, 1030158, 70.0, 120.0, typeof(IronIngot), 1044036, 3, 1044037);
+            AddRes(index, typeof(Log), 1044041, 8, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
+        }
+
+        AddCraft(typeof(Scissors), 1044046, 1023998, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(MortarPestle), 1044046, 1023739, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
+        AddCraft(typeof(Scorp), 1044046, 1024327, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(TinkerTools), 1044046, 1044164, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(Hatchet), 1044046, 1023907, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(DrawKnife), 1044046, 1024324, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(SewingKit), 1044046, 1023997, 10.0, 70.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(Saw), 1044046, 1024148, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(DovetailSaw), 1044046, 1024136, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Froe), 1044046, 1024325, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(Shovel), 1044046, 1023898, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Hammer), 1044046, 1024138, 30.0, 80.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(Tongs), 1044046, 1024028, 35.0, 85.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(SmithHammer), 1044046, 1025091, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(SledgeHammer), 1044046, 1024021, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Inshave), 1044046, 1024326, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(Pickaxe), 1044046, 1023718, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Lockpick), 1044046, 1025371, 45.0, 95.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(Skillet), 1044046, 1044567, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(FlourSifter), 1044046, 1024158, 50.0, 100.0, typeof(IronIngot), 1044036, 3, 1044037);
+        AddCraft(typeof(FletcherTools), 1044046, 1044166, 35.0, 85.0, typeof(IronIngot), 1044036, 3, 1044037);
+        AddCraft(typeof(MapmakersPen), 1044046, 1044167, 25.0, 75.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(ScribesPen), 1044046, 1044168, 25.0, 75.0, typeof(IronIngot), 1044036, 1, 1044037);
+
+        AddCraft(typeof(Gears), 1044047, 1024179, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(ClockParts), 1044047, 1024175, 25.0, 75.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(BarrelTap), 1044047, 1024100, 35.0, 85.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(Springs), 1044047, 1024189, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(SextantParts), 1044047, 1024185, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(BarrelHoops), 1044047, 1024321, -15.0, 35.0, typeof(IronIngot), 1044036, 5, 1044037);
+        AddCraft(typeof(Hinge), 1044047, 1024181, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(BolaBall), 1044047, 1023699, 45.0, 95.0, typeof(IronIngot), 1044036, 10, 1044037);
+
+        if (Core.ML)
+        {
+            index = AddCraft(
+                typeof(JeweledFiligree),
+                1044047,
+                1072894,
+                70.0,
+                110.0,
                 typeof(IronIngot),
                 1044036,
                 2,
                 1044037
             );
-            AddRes(index, itemType, 1044231 + offset, 1, 1044240);
-
-            index = AddCraft(
-                typeof(SilverBeadNecklace),
-                1044049,
-                1044185 + offset,
-                40.0,
-                90.0,
-                typeof(IronIngot),
-                1044036,
-                2,
-                1044037
-            );
-            AddRes(index, itemType, 1044231 + offset, 1, 1044240);
-
-            index = AddCraft(
-                typeof(GoldNecklace),
-                1044049,
-                1044194 + offset,
-                40.0,
-                90.0,
-                typeof(IronIngot),
-                1044036,
-                2,
-                1044037
-            );
-            AddRes(index, itemType, 1044231 + offset, 1, 1044240);
-
-            index = AddCraft(
-                typeof(GoldEarrings),
-                1044049,
-                1044203 + offset,
-                40.0,
-                90.0,
-                typeof(IronIngot),
-                1044036,
-                2,
-                1044037
-            );
-            AddRes(index, itemType, 1044231 + offset, 1, 1044240);
-
-            index = AddCraft(
-                typeof(GoldBeadNecklace),
-                1044049,
-                1044212 + offset,
-                40.0,
-                90.0,
-                typeof(IronIngot),
-                1044036,
-                2,
-                1044037
-            );
-            AddRes(index, itemType, 1044231 + offset, 1, 1044240);
-
-            index = AddCraft(
-                typeof(GoldBracelet),
-                1044049,
-                1044221 + offset,
-                40.0,
-                90.0,
-                typeof(IronIngot),
-                1044036,
-                2,
-                1044037
-            );
-            AddRes(index, itemType, 1044231 + offset, 1, 1044240);
+            AddRes(index, typeof(StarSapphire), 1044231, 1, 1044253);
+            AddRes(index, typeof(Ruby), 1044234, 1, 1044253);
+            SetNeededExpansion(index, Expansion.ML);
         }
 
-        public override void InitCraftList()
+        AddCraft(typeof(ButcherKnife), 1044048, 1025110, 25.0, 75.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(SpoonLeft), 1044048, 1044158, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(SpoonRight), 1044048, 1044159, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(Plate), 1044048, 1022519, 0.0, 50.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(ForkLeft), 1044048, 1044160, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(ForkRight), 1044048, 1044161, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(Cleaver), 1044048, 1023778, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
+        AddCraft(typeof(KnifeLeft), 1044048, 1044162, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(KnifeRight), 1044048, 1044163, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddCraft(typeof(Goblet), 1044048, 1022458, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(PewterMug), 1044048, 1024097, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(SkinningKnife), 1044048, 1023781, 25.0, 75.0, typeof(IronIngot), 1044036, 2, 1044037);
+
+        AddCraft(typeof(KeyRing), 1044050, 1024113, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(Candelabra), 1044050, 1022599, 55.0, 105.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Scales), 1044050, 1026225, 60.0, 110.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Key), 1044050, 1024112, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
+        AddCraft(typeof(Globe), 1044050, 1024167, 55.0, 105.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Spyglass), 1044050, 1025365, 60.0, 110.0, typeof(IronIngot), 1044036, 4, 1044037);
+        AddCraft(typeof(Lantern), 1044050, 1022597, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
+        AddCraft(typeof(HeatingStand), 1044050, 1026217, 60.0, 110.0, typeof(IronIngot), 1044036, 4, 1044037);
+
+        if (Core.SE)
         {
-            int index;
-
-            AddCraft(typeof(JointingPlane), 1044042, 1024144, 0.0, 50.0, typeof(Log), 1044041, 4, 1044351);
-            AddCraft(typeof(MouldingPlane), 1044042, 1024140, 0.0, 50.0, typeof(Log), 1044041, 4, 1044351);
-            AddCraft(typeof(SmoothingPlane), 1044042, 1024146, 0.0, 50.0, typeof(Log), 1044041, 4, 1044351);
-            AddCraft(typeof(ClockFrame), 1044042, 1024173, 0.0, 50.0, typeof(Log), 1044041, 6, 1044351);
-            AddCraft(typeof(Axle), 1044042, 1024187, -25.0, 25.0, typeof(Log), 1044041, 2, 1044351);
-            AddCraft(typeof(RollingPin), 1044042, 1024163, 0.0, 50.0, typeof(Log), 1044041, 5, 1044351);
-
-            if (Core.SE)
-            {
-                index = AddCraft(typeof(Nunchaku), 1044042, 1030158, 70.0, 120.0, typeof(IronIngot), 1044036, 3, 1044037);
-                AddRes(index, typeof(Log), 1044041, 8, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddCraft(typeof(Scissors), 1044046, 1023998, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(MortarPestle), 1044046, 1023739, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
-            AddCraft(typeof(Scorp), 1044046, 1024327, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(TinkerTools), 1044046, 1044164, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(Hatchet), 1044046, 1023907, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(DrawKnife), 1044046, 1024324, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(SewingKit), 1044046, 1023997, 10.0, 70.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(Saw), 1044046, 1024148, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(DovetailSaw), 1044046, 1024136, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Froe), 1044046, 1024325, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(Shovel), 1044046, 1023898, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Hammer), 1044046, 1024138, 30.0, 80.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(Tongs), 1044046, 1024028, 35.0, 85.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(SmithHammer), 1044046, 1025091, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(SledgeHammer), 1044046, 1024021, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Inshave), 1044046, 1024326, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(Pickaxe), 1044046, 1023718, 40.0, 90.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Lockpick), 1044046, 1025371, 45.0, 95.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(Skillet), 1044046, 1044567, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(FlourSifter), 1044046, 1024158, 50.0, 100.0, typeof(IronIngot), 1044036, 3, 1044037);
-            AddCraft(typeof(FletcherTools), 1044046, 1044166, 35.0, 85.0, typeof(IronIngot), 1044036, 3, 1044037);
-            AddCraft(typeof(MapmakersPen), 1044046, 1044167, 25.0, 75.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(ScribesPen), 1044046, 1044168, 25.0, 75.0, typeof(IronIngot), 1044036, 1, 1044037);
-
-            AddCraft(typeof(Gears), 1044047, 1024179, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(ClockParts), 1044047, 1024175, 25.0, 75.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(BarrelTap), 1044047, 1024100, 35.0, 85.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(Springs), 1044047, 1024189, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(SextantParts), 1044047, 1024185, 30.0, 80.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(BarrelHoops), 1044047, 1024321, -15.0, 35.0, typeof(IronIngot), 1044036, 5, 1044037);
-            AddCraft(typeof(Hinge), 1044047, 1024181, 5.0, 55.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(BolaBall), 1044047, 1023699, 45.0, 95.0, typeof(IronIngot), 1044036, 10, 1044037);
-
-            if (Core.ML)
-            {
-                index = AddCraft(
-                    typeof(JeweledFiligree),
-                    1044047,
-                    1072894,
-                    70.0,
-                    110.0,
-                    typeof(IronIngot),
-                    1044036,
-                    2,
-                    1044037
-                );
-                AddRes(index, typeof(StarSapphire), 1044231, 1, 1044253);
-                AddRes(index, typeof(Ruby), 1044234, 1, 1044253);
-                SetNeededExpansion(index, Expansion.ML);
-            }
-
-            AddCraft(typeof(ButcherKnife), 1044048, 1025110, 25.0, 75.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(SpoonLeft), 1044048, 1044158, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(SpoonRight), 1044048, 1044159, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(Plate), 1044048, 1022519, 0.0, 50.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(ForkLeft), 1044048, 1044160, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(ForkRight), 1044048, 1044161, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(Cleaver), 1044048, 1023778, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
-            AddCraft(typeof(KnifeLeft), 1044048, 1044162, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(KnifeRight), 1044048, 1044163, 0.0, 50.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddCraft(typeof(Goblet), 1044048, 1022458, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(PewterMug), 1044048, 1024097, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(SkinningKnife), 1044048, 1023781, 25.0, 75.0, typeof(IronIngot), 1044036, 2, 1044037);
-
-            AddCraft(typeof(KeyRing), 1044050, 1024113, 10.0, 60.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(Candelabra), 1044050, 1022599, 55.0, 105.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Scales), 1044050, 1026225, 60.0, 110.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Key), 1044050, 1024112, 20.0, 70.0, typeof(IronIngot), 1044036, 3, 1044037);
-            AddCraft(typeof(Globe), 1044050, 1024167, 55.0, 105.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Spyglass), 1044050, 1025365, 60.0, 110.0, typeof(IronIngot), 1044036, 4, 1044037);
-            AddCraft(typeof(Lantern), 1044050, 1022597, 30.0, 80.0, typeof(IronIngot), 1044036, 2, 1044037);
-            AddCraft(typeof(HeatingStand), 1044050, 1026217, 60.0, 110.0, typeof(IronIngot), 1044036, 4, 1044037);
-
-            if (Core.SE)
-            {
-                index = AddCraft(
-                    typeof(ShojiLantern),
-                    1044050,
-                    1029404,
-                    65.0,
-                    115.0,
-                    typeof(IronIngot),
-                    1044036,
-                    10,
-                    1044037
-                );
-                AddRes(index, typeof(Log), 1044041, 5, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(
-                    typeof(PaperLantern),
-                    1044050,
-                    1029406,
-                    65.0,
-                    115.0,
-                    typeof(IronIngot),
-                    1044036,
-                    10,
-                    1044037
-                );
-                AddRes(index, typeof(Log), 1044041, 5, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(
-                    typeof(RoundPaperLantern),
-                    1044050,
-                    1029418,
-                    65.0,
-                    115.0,
-                    typeof(IronIngot),
-                    1044036,
-                    10,
-                    1044037
-                );
-                AddRes(index, typeof(Log), 1044041, 5, 1044351);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(typeof(WindChimes), 1044050, 1030290, 80.0, 130.0, typeof(IronIngot), 1044036, 15, 1044037);
-                SetNeededExpansion(index, Expansion.SE);
-
-                index = AddCraft(
-                    typeof(FancyWindChimes),
-                    1044050,
-                    1030291,
-                    80.0,
-                    130.0,
-                    typeof(IronIngot),
-                    1044036,
-                    15,
-                    1044037
-                );
-                SetNeededExpansion(index, Expansion.SE);
-            }
-
-            AddJewelrySet(GemType.StarSapphire, typeof(StarSapphire));
-            AddJewelrySet(GemType.Emerald, typeof(Emerald));
-            AddJewelrySet(GemType.Sapphire, typeof(Sapphire));
-            AddJewelrySet(GemType.Ruby, typeof(Ruby));
-            AddJewelrySet(GemType.Citrine, typeof(Citrine));
-            AddJewelrySet(GemType.Amethyst, typeof(Amethyst));
-            AddJewelrySet(GemType.Tourmaline, typeof(Tourmaline));
-            AddJewelrySet(GemType.Amber, typeof(Amber));
-            AddJewelrySet(GemType.Diamond, typeof(Diamond));
-
-            index = AddCraft(typeof(AxleGears), 1044051, 1024177, 0.0, 0.0, typeof(Axle), 1044169, 1, 1044253);
-            AddRes(index, typeof(Gears), 1044254, 1, 1044253);
-
-            index = AddCraft(typeof(ClockParts), 1044051, 1024175, 0.0, 0.0, typeof(AxleGears), 1044170, 1, 1044253);
-            AddRes(index, typeof(Springs), 1044171, 1, 1044253);
-
-            index = AddCraft(typeof(SextantParts), 1044051, 1024185, 0.0, 0.0, typeof(AxleGears), 1044170, 1, 1044253);
-            AddRes(index, typeof(Hinge), 1044172, 1, 1044253);
-
-            index = AddCraft(typeof(ClockRight), 1044051, 1044257, 0.0, 0.0, typeof(ClockFrame), 1044174, 1, 1044253);
-            AddRes(index, typeof(ClockParts), 1044173, 1, 1044253);
-
-            index = AddCraft(typeof(ClockLeft), 1044051, 1044256, 0.0, 0.0, typeof(ClockFrame), 1044174, 1, 1044253);
-            AddRes(index, typeof(ClockParts), 1044173, 1, 1044253);
-
-            AddCraft(typeof(Sextant), 1044051, 1024183, 0.0, 0.0, typeof(SextantParts), 1044175, 1, 1044253);
-
-            index = AddCraft(typeof(Bola), 1044051, 1046441, 60.0, 80.0, typeof(BolaBall), 1046440, 4, 1042613);
-            AddRes(index, typeof(Leather), 1044462, 3, 1044463);
-
-            index = AddCraft(typeof(PotionKeg), 1044051, 1044258, 75.0, 100.0, typeof(Keg), 1044255, 1, 1044253);
-            AddRes(index, typeof(Bottle), 1044250, 10, 1044253);
-            AddRes(index, typeof(BarrelLid), 1044251, 1, 1044253);
-            AddRes(index, typeof(BarrelTap), 1044252, 1, 1044253);
-
-            // Dart Trap
-            index = AddCraft(typeof(DartTrapCraft), 1044052, 1024396, 30.0, 80.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddRes(index, typeof(Bolt), 1044570, 1, 1044253);
-
-            // Poison Trap
-            index = AddCraft(typeof(PoisonTrapCraft), 1044052, 1044593, 30.0, 80.0, typeof(IronIngot), 1044036, 1, 1044037);
-            AddRes(index, typeof(BasePoisonPotion), 1044571, 1, 1044253);
-
-            // Explosion Trap
             index = AddCraft(
-                typeof(ExplosionTrapCraft),
-                1044052,
-                1044597,
-                55.0,
-                105.0,
-                typeof(IronIngot),
-                1044036,
-                1,
-                1044037
-            );
-            AddRes(index, typeof(BaseExplosionPotion), 1044569, 1, 1044253);
-
-            // Faction Gas Trap
-            index = AddCraft(
-                typeof(FactionGasTrapDeed),
-                1044052,
-                1044598,
+                typeof(ShojiLantern),
+                1044050,
+                1029404,
                 65.0,
                 115.0,
-                typeof(Silver),
-                1044572,
-                Core.AOS ? 250 : 1000,
-                1044253
+                typeof(IronIngot),
+                1044036,
+                10,
+                1044037
             );
-            AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
-            AddRes(index, typeof(BasePoisonPotion), 1044571, 1, 1044253);
+            AddRes(index, typeof(Log), 1044041, 5, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
 
-            // Faction explosion Trap
             index = AddCraft(
-                typeof(FactionExplosionTrapDeed),
-                1044052,
-                1044599,
+                typeof(PaperLantern),
+                1044050,
+                1029406,
                 65.0,
                 115.0,
-                typeof(Silver),
-                1044572,
-                Core.AOS ? 250 : 1000,
-                1044253
+                typeof(IronIngot),
+                1044036,
+                10,
+                1044037
             );
-            AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
-            AddRes(index, typeof(BaseExplosionPotion), 1044569, 1, 1044253);
+            AddRes(index, typeof(Log), 1044041, 5, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
 
-            // Faction Saw Trap
             index = AddCraft(
-                typeof(FactionSawTrapDeed),
-                1044052,
-                1044600,
+                typeof(RoundPaperLantern),
+                1044050,
+                1029418,
                 65.0,
                 115.0,
-                typeof(Silver),
-                1044572,
-                Core.AOS ? 250 : 1000,
-                1044253
+                typeof(IronIngot),
+                1044036,
+                10,
+                1044037
             );
-            AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
-            AddRes(index, typeof(Gears), 1044254, 1, 1044253);
+            AddRes(index, typeof(Log), 1044041, 5, 1044351);
+            SetNeededExpansion(index, Expansion.SE);
 
-            // Faction Spike Trap
+            index = AddCraft(typeof(WindChimes), 1044050, 1030290, 80.0, 130.0, typeof(IronIngot), 1044036, 15, 1044037);
+            SetNeededExpansion(index, Expansion.SE);
+
             index = AddCraft(
-                typeof(FactionSpikeTrapDeed),
-                1044052,
-                1044601,
-                65.0,
-                115.0,
-                typeof(Silver),
-                1044572,
-                Core.AOS ? 250 : 1000,
-                1044253
+                typeof(FancyWindChimes),
+                1044050,
+                1030291,
+                80.0,
+                130.0,
+                typeof(IronIngot),
+                1044036,
+                15,
+                1044037
             );
-            AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
-            AddRes(index, typeof(Springs), 1044171, 1, 1044253);
+            SetNeededExpansion(index, Expansion.SE);
+        }
 
-            // Faction trap removal kit
+        AddJewelrySet(GemType.StarSapphire, typeof(StarSapphire));
+        AddJewelrySet(GemType.Emerald, typeof(Emerald));
+        AddJewelrySet(GemType.Sapphire, typeof(Sapphire));
+        AddJewelrySet(GemType.Ruby, typeof(Ruby));
+        AddJewelrySet(GemType.Citrine, typeof(Citrine));
+        AddJewelrySet(GemType.Amethyst, typeof(Amethyst));
+        AddJewelrySet(GemType.Tourmaline, typeof(Tourmaline));
+        AddJewelrySet(GemType.Amber, typeof(Amber));
+        AddJewelrySet(GemType.Diamond, typeof(Diamond));
+
+        index = AddCraft(typeof(AxleGears), 1044051, 1024177, 0.0, 0.0, typeof(Axle), 1044169, 1, 1044253);
+        AddRes(index, typeof(Gears), 1044254, 1, 1044253);
+
+        index = AddCraft(typeof(ClockParts), 1044051, 1024175, 0.0, 0.0, typeof(AxleGears), 1044170, 1, 1044253);
+        AddRes(index, typeof(Springs), 1044171, 1, 1044253);
+
+        index = AddCraft(typeof(SextantParts), 1044051, 1024185, 0.0, 0.0, typeof(AxleGears), 1044170, 1, 1044253);
+        AddRes(index, typeof(Hinge), 1044172, 1, 1044253);
+
+        index = AddCraft(typeof(ClockRight), 1044051, 1044257, 0.0, 0.0, typeof(ClockFrame), 1044174, 1, 1044253);
+        AddRes(index, typeof(ClockParts), 1044173, 1, 1044253);
+
+        index = AddCraft(typeof(ClockLeft), 1044051, 1044256, 0.0, 0.0, typeof(ClockFrame), 1044174, 1, 1044253);
+        AddRes(index, typeof(ClockParts), 1044173, 1, 1044253);
+
+        AddCraft(typeof(Sextant), 1044051, 1024183, 0.0, 0.0, typeof(SextantParts), 1044175, 1, 1044253);
+
+        index = AddCraft(typeof(Bola), 1044051, 1046441, 60.0, 80.0, typeof(BolaBall), 1046440, 4, 1042613);
+        AddRes(index, typeof(Leather), 1044462, 3, 1044463);
+
+        index = AddCraft(typeof(PotionKeg), 1044051, 1044258, 75.0, 100.0, typeof(Keg), 1044255, 1, 1044253);
+        AddRes(index, typeof(Bottle), 1044250, 10, 1044253);
+        AddRes(index, typeof(BarrelLid), 1044251, 1, 1044253);
+        AddRes(index, typeof(BarrelTap), 1044252, 1, 1044253);
+
+        // Dart Trap
+        index = AddCraft(typeof(DartTrapCraft), 1044052, 1024396, 30.0, 80.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddRes(index, typeof(Bolt), 1044570, 1, 1044253);
+
+        // Poison Trap
+        index = AddCraft(typeof(PoisonTrapCraft), 1044052, 1044593, 30.0, 80.0, typeof(IronIngot), 1044036, 1, 1044037);
+        AddRes(index, typeof(BasePoisonPotion), 1044571, 1, 1044253);
+
+        // Explosion Trap
+        index = AddCraft(
+            typeof(ExplosionTrapCraft),
+            1044052,
+            1044597,
+            55.0,
+            105.0,
+            typeof(IronIngot),
+            1044036,
+            1,
+            1044037
+        );
+        AddRes(index, typeof(BaseExplosionPotion), 1044569, 1, 1044253);
+
+        // Faction Gas Trap
+        index = AddCraft(
+            typeof(FactionGasTrapDeed),
+            1044052,
+            1044598,
+            65.0,
+            115.0,
+            typeof(Silver),
+            1044572,
+            Core.AOS ? 250 : 1000,
+            1044253
+        );
+        AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
+        AddRes(index, typeof(BasePoisonPotion), 1044571, 1, 1044253);
+
+        // Faction explosion Trap
+        index = AddCraft(
+            typeof(FactionExplosionTrapDeed),
+            1044052,
+            1044599,
+            65.0,
+            115.0,
+            typeof(Silver),
+            1044572,
+            Core.AOS ? 250 : 1000,
+            1044253
+        );
+        AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
+        AddRes(index, typeof(BaseExplosionPotion), 1044569, 1, 1044253);
+
+        // Faction Saw Trap
+        index = AddCraft(
+            typeof(FactionSawTrapDeed),
+            1044052,
+            1044600,
+            65.0,
+            115.0,
+            typeof(Silver),
+            1044572,
+            Core.AOS ? 250 : 1000,
+            1044253
+        );
+        AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
+        AddRes(index, typeof(Gears), 1044254, 1, 1044253);
+
+        // Faction Spike Trap
+        index = AddCraft(
+            typeof(FactionSpikeTrapDeed),
+            1044052,
+            1044601,
+            65.0,
+            115.0,
+            typeof(Silver),
+            1044572,
+            Core.AOS ? 250 : 1000,
+            1044253
+        );
+        AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
+        AddRes(index, typeof(Springs), 1044171, 1, 1044253);
+
+        // Faction trap removal kit
+        index = AddCraft(
+            typeof(FactionTrapRemovalKit),
+            1044052,
+            1046445,
+            90.0,
+            115.0,
+            typeof(Silver),
+            1044572,
+            500,
+            1044253
+        );
+        AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
+
+        // Magic Jewelry
+        if (Core.ML)
+        {
             index = AddCraft(
-                typeof(FactionTrapRemovalKit),
-                1044052,
-                1046445,
-                90.0,
-                115.0,
-                typeof(Silver),
-                1044572,
-                500,
-                1044253
+                typeof(ResilientBracer),
+                1073107,
+                1072933,
+                100.0,
+                125.0,
+                typeof(IronIngot),
+                1044036,
+                2,
+                1044037
             );
-            AddRes(index, typeof(IronIngot), 1044036, 10, 1044037);
+            AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
+            AddRes(index, typeof(BlueDiamond), 1032696, 10, 1044253);
+            AddRes(index, typeof(Diamond), 1062608, 50, 1044253);
+            AddRareRecipe(index, 600);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
 
-            // Magic Jewelry
-            if (Core.ML)
+            index = AddCraft(
+                typeof(EssenceOfBattle),
+                1073107,
+                1072935,
+                100.0,
+                125.0,
+                typeof(IronIngot),
+                1044036,
+                2,
+                1044037
+            );
+            AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
+            AddRes(index, typeof(FireRuby), 1032695, 10, 1044253);
+            AddRes(index, typeof(Ruby), 1062603, 50, 1044253);
+            AddRareRecipe(index, 601);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+
+            index = AddCraft(
+                typeof(PendantOfTheMagi),
+                1073107,
+                1072937,
+                100.0,
+                125.0,
+                typeof(IronIngot),
+                1044036,
+                2,
+                1044037
+            );
+            AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
+            AddRes(index, typeof(WhitePearl), 1032694, 10, 1044253);
+            AddRes(index, typeof(StarSapphire), 1062600, 50, 1044253);
+            AddRareRecipe(index, 602);
+            ForceNonExceptional(index);
+            SetNeededExpansion(index, Expansion.ML);
+        }
+
+        // Set the overridable material
+        SetSubRes(typeof(IronIngot), 1044022);
+
+        // Add every material you want the player to be able to choose from
+        // This will override the overridable material
+        AddSubRes(typeof(IronIngot), 1044022, 00.0, 1044036, 1044267);
+        AddSubRes(typeof(DullCopperIngot), 1044023, 65.0, 1044036, 1044268);
+        AddSubRes(typeof(ShadowIronIngot), 1044024, 70.0, 1044036, 1044268);
+        AddSubRes(typeof(CopperIngot), 1044025, 75.0, 1044036, 1044268);
+        AddSubRes(typeof(BronzeIngot), 1044026, 80.0, 1044036, 1044268);
+        AddSubRes(typeof(GoldIngot), 1044027, 85.0, 1044036, 1044268);
+        AddSubRes(typeof(AgapiteIngot), 1044028, 90.0, 1044036, 1044268);
+        AddSubRes(typeof(VeriteIngot), 1044029, 95.0, 1044036, 1044268);
+        AddSubRes(typeof(ValoriteIngot), 1044030, 99.0, 1044036, 1044268);
+
+        MarkOption = true;
+        Repair = true;
+        CanEnhance = Core.AOS;
+    }
+}
+
+public abstract class TrapCraft : CustomCraft
+{
+    public TrapCraft(Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool, int quality)
+        : base(from, craftItem, craftSystem, typeRes, tool, quality)
+    {
+    }
+
+    public LockableContainer Container { get; private set; }
+
+    public abstract TrapType TrapType { get; }
+
+    private int Verify(LockableContainer container)
+    {
+        if (container == null || container.KeyValue == 0)
+        {
+            return 1005638; // You can only trap lockable chests.
+        }
+
+        if (From.Map != container.Map || !From.InRange(container.GetWorldLocation(), 2))
+        {
+            return 500446; // That is too far away.
+        }
+
+        if (!container.Movable)
+        {
+            return 502944; // You cannot trap this item because it is locked down.
+        }
+
+        if (!container.IsAccessibleTo(From))
+        {
+            return 502946; // That belongs to someone else.
+        }
+
+        if (container.Locked)
+        {
+            return 502943; // You can only trap an unlocked object.
+        }
+
+        if (container.TrapType != TrapType.None)
+        {
+            return 502945; // You can only place one trap on an object at a time.
+        }
+
+        return 0;
+    }
+
+    private bool Acquire(object target, out int message)
+    {
+        var container = target as LockableContainer;
+
+        message = Verify(container);
+
+        if (message > 0)
+        {
+            return false;
+        }
+
+        Container = container;
+        return true;
+    }
+
+    public override void EndCraftAction()
+    {
+        From.SendLocalizedMessage(502921); // What would you like to set a trap on?
+        From.Target = new ContainerTarget(this);
+    }
+
+    public override Item CompleteCraft(out int message)
+    {
+        message = Verify(Container);
+
+        if (message == 0)
+        {
+            var trapLevel = (int)(From.Skills.Tinkering.Value / 10);
+
+            Container.TrapType = TrapType;
+            Container.TrapPower = trapLevel * 9;
+            Container.TrapLevel = trapLevel;
+            Container.TrapOnLockpick = true;
+
+            message = 1005639; // Trap is disabled until you lock the chest.
+        }
+
+        return null;
+    }
+
+    private class ContainerTarget : Target
+    {
+        private readonly TrapCraft m_TrapCraft;
+
+        public ContainerTarget(TrapCraft trapCraft) : base(-1, false, TargetFlags.None) => m_TrapCraft = trapCraft;
+
+        protected override void OnTarget(Mobile from, object targeted)
+        {
+            if (m_TrapCraft.Acquire(targeted, out var message))
             {
-                index = AddCraft(
-                    typeof(ResilientBracer),
-                    1073107,
-                    1072933,
-                    100.0,
-                    125.0,
-                    typeof(IronIngot),
-                    1044036,
-                    2,
-                    1044037
+                m_TrapCraft.CraftItem.CompleteCraft(
+                    m_TrapCraft.Quality,
+                    false,
+                    m_TrapCraft.From,
+                    m_TrapCraft.CraftSystem,
+                    m_TrapCraft.TypeRes,
+                    m_TrapCraft.Tool,
+                    m_TrapCraft
                 );
-                AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
-                AddRes(index, typeof(BlueDiamond), 1032696, 10, 1044253);
-                AddRes(index, typeof(Diamond), 1062608, 50, 1044253);
-                AddRareRecipe(index, 600);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(EssenceOfBattle),
-                    1073107,
-                    1072935,
-                    100.0,
-                    125.0,
-                    typeof(IronIngot),
-                    1044036,
-                    2,
-                    1044037
-                );
-                AddRes(index, typeof(CapturedEssence), 1032686, 1, 1044253);
-                AddRes(index, typeof(FireRuby), 1032695, 10, 1044253);
-                AddRes(index, typeof(Ruby), 1062603, 50, 1044253);
-                AddRareRecipe(index, 601);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
-
-                index = AddCraft(
-                    typeof(PendantOfTheMagi),
-                    1073107,
-                    1072937,
-                    100.0,
-                    125.0,
-                    typeof(IronIngot),
-                    1044036,
-                    2,
-                    1044037
-                );
-                AddRes(index, typeof(EyeOfTheTravesty), 1032685, 1, 1044253);
-                AddRes(index, typeof(WhitePearl), 1032694, 10, 1044253);
-                AddRes(index, typeof(StarSapphire), 1062600, 50, 1044253);
-                AddRareRecipe(index, 602);
-                ForceNonExceptional(index);
-                SetNeededExpansion(index, Expansion.ML);
             }
+            else
+            {
+                Failure(message);
+            }
+        }
 
-            // Set the overridable material
-            SetSubRes(typeof(IronIngot), 1044022);
+        protected override void OnTargetCancel(Mobile from, TargetCancelType cancelType)
+        {
+            if (cancelType == TargetCancelType.Canceled)
+            {
+                Failure(0);
+            }
+        }
 
-            // Add every material you want the player to be able to choose from
-            // This will override the overridable material
-            AddSubRes(typeof(IronIngot), 1044022, 00.0, 1044036, 1044267);
-            AddSubRes(typeof(DullCopperIngot), 1044023, 65.0, 1044036, 1044268);
-            AddSubRes(typeof(ShadowIronIngot), 1044024, 70.0, 1044036, 1044268);
-            AddSubRes(typeof(CopperIngot), 1044025, 75.0, 1044036, 1044268);
-            AddSubRes(typeof(BronzeIngot), 1044026, 80.0, 1044036, 1044268);
-            AddSubRes(typeof(GoldIngot), 1044027, 85.0, 1044036, 1044268);
-            AddSubRes(typeof(AgapiteIngot), 1044028, 90.0, 1044036, 1044268);
-            AddSubRes(typeof(VeriteIngot), 1044029, 95.0, 1044036, 1044268);
-            AddSubRes(typeof(ValoriteIngot), 1044030, 99.0, 1044036, 1044268);
+        private void Failure(int message)
+        {
+            var from = m_TrapCraft.From;
+            var tool = m_TrapCraft.Tool;
 
-            MarkOption = true;
-            Repair = true;
-            CanEnhance = Core.AOS;
+            if (tool?.Deleted == false && tool.UsesRemaining > 0)
+            {
+                from.SendGump(new CraftGump(from, m_TrapCraft.CraftSystem, tool, message));
+            }
+            else if (message > 0)
+            {
+                from.SendLocalizedMessage(message);
+            }
         }
     }
+}
 
-    public abstract class TrapCraft : CustomCraft
+[CraftItemID(0x1BFC)]
+public class DartTrapCraft : TrapCraft
+{
+    public DartTrapCraft(
+        Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool,
+        int quality
+    ) : base(from, craftItem, craftSystem, typeRes, tool, quality)
     {
-        public TrapCraft(Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool, int quality)
-            : base(from, craftItem, craftSystem, typeRes, tool, quality)
-        {
-        }
-
-        public LockableContainer Container { get; private set; }
-
-        public abstract TrapType TrapType { get; }
-
-        private int Verify(LockableContainer container)
-        {
-            if (container == null || container.KeyValue == 0)
-            {
-                return 1005638; // You can only trap lockable chests.
-            }
-
-            if (From.Map != container.Map || !From.InRange(container.GetWorldLocation(), 2))
-            {
-                return 500446; // That is too far away.
-            }
-
-            if (!container.Movable)
-            {
-                return 502944; // You cannot trap this item because it is locked down.
-            }
-
-            if (!container.IsAccessibleTo(From))
-            {
-                return 502946; // That belongs to someone else.
-            }
-
-            if (container.Locked)
-            {
-                return 502943; // You can only trap an unlocked object.
-            }
-
-            if (container.TrapType != TrapType.None)
-            {
-                return 502945; // You can only place one trap on an object at a time.
-            }
-
-            return 0;
-        }
-
-        private bool Acquire(object target, out int message)
-        {
-            var container = target as LockableContainer;
-
-            message = Verify(container);
-
-            if (message > 0)
-            {
-                return false;
-            }
-
-            Container = container;
-            return true;
-        }
-
-        public override void EndCraftAction()
-        {
-            From.SendLocalizedMessage(502921); // What would you like to set a trap on?
-            From.Target = new ContainerTarget(this);
-        }
-
-        public override Item CompleteCraft(out int message)
-        {
-            message = Verify(Container);
-
-            if (message == 0)
-            {
-                var trapLevel = (int)(From.Skills.Tinkering.Value / 10);
-
-                Container.TrapType = TrapType;
-                Container.TrapPower = trapLevel * 9;
-                Container.TrapLevel = trapLevel;
-                Container.TrapOnLockpick = true;
-
-                message = 1005639; // Trap is disabled until you lock the chest.
-            }
-
-            return null;
-        }
-
-        private class ContainerTarget : Target
-        {
-            private readonly TrapCraft m_TrapCraft;
-
-            public ContainerTarget(TrapCraft trapCraft) : base(-1, false, TargetFlags.None) => m_TrapCraft = trapCraft;
-
-            protected override void OnTarget(Mobile from, object targeted)
-            {
-                if (m_TrapCraft.Acquire(targeted, out var message))
-                {
-                    m_TrapCraft.CraftItem.CompleteCraft(
-                        m_TrapCraft.Quality,
-                        false,
-                        m_TrapCraft.From,
-                        m_TrapCraft.CraftSystem,
-                        m_TrapCraft.TypeRes,
-                        m_TrapCraft.Tool,
-                        m_TrapCraft
-                    );
-                }
-                else
-                {
-                    Failure(message);
-                }
-            }
-
-            protected override void OnTargetCancel(Mobile from, TargetCancelType cancelType)
-            {
-                if (cancelType == TargetCancelType.Canceled)
-                {
-                    Failure(0);
-                }
-            }
-
-            private void Failure(int message)
-            {
-                var from = m_TrapCraft.From;
-                var tool = m_TrapCraft.Tool;
-
-                if (tool?.Deleted == false && tool.UsesRemaining > 0)
-                {
-                    from.SendGump(new CraftGump(from, m_TrapCraft.CraftSystem, tool, message));
-                }
-                else if (message > 0)
-                {
-                    from.SendLocalizedMessage(message);
-                }
-            }
-        }
     }
 
-    [CraftItemID(0x1BFC)]
-    public class DartTrapCraft : TrapCraft
+    public override TrapType TrapType => TrapType.DartTrap;
+}
+
+[CraftItemID(0x113E)]
+public class PoisonTrapCraft : TrapCraft
+{
+    public PoisonTrapCraft(
+        Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool,
+        int quality
+    ) : base(from, craftItem, craftSystem, typeRes, tool, quality)
     {
-        public DartTrapCraft(
-            Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool,
-            int quality
-        ) : base(from, craftItem, craftSystem, typeRes, tool, quality)
-        {
-        }
-
-        public override TrapType TrapType => TrapType.DartTrap;
     }
 
-    [CraftItemID(0x113E)]
-    public class PoisonTrapCraft : TrapCraft
+    public override TrapType TrapType => TrapType.PoisonTrap;
+}
+
+[CraftItemID(0x370C)]
+public class ExplosionTrapCraft : TrapCraft
+{
+    public ExplosionTrapCraft(
+        Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool,
+        int quality
+    ) : base(from, craftItem, craftSystem, typeRes, tool, quality)
     {
-        public PoisonTrapCraft(
-            Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool,
-            int quality
-        ) : base(from, craftItem, craftSystem, typeRes, tool, quality)
-        {
-        }
-
-        public override TrapType TrapType => TrapType.PoisonTrap;
     }
 
-    [CraftItemID(0x370C)]
-    public class ExplosionTrapCraft : TrapCraft
-    {
-        public ExplosionTrapCraft(
-            Mobile from, CraftItem craftItem, CraftSystem craftSystem, Type typeRes, BaseTool tool,
-            int quality
-        ) : base(from, craftItem, craftSystem, typeRes, tool, quality)
-        {
-        }
-
-        public override TrapType TrapType => TrapType.ExplosionTrap;
-    }
+    public override TrapType TrapType => TrapType.ExplosionTrap;
 }


### PR DESCRIPTION
The `[LearnAllRecipes` command does not work unless all of the crafting systems are initialized. This is a really old bug that went completely unnoticed.

Since memory and speed is not really a concern during initialization of the server, this change initializes all crafting systems before the world is loaded.