### PR TITLE
fix: init Entries to prevent client crash

### DIFF
--- a/Projects/UOContent/Mobiles/Townfolk/TownCrier.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/TownCrier.cs
@@ -361,7 +361,8 @@ namespace Server.Mobiles
 
         public TownCrierEntry GetRandomEntry()
         {
-            for (var i = (Entries?.Count ?? 0) - 1; i >= 0; --i)
+            var count = Entries?.Count ?? 0;
+            for (var i = count - 1; i >= 0; --i)
             {
                 if (i >= Entries!.Count)
                 {
@@ -377,12 +378,12 @@ namespace Server.Mobiles
             }
 
             var entry = GlobalTownCrierEntryList.Instance.GetRandomEntry();
-            if (entry == null || Entries?.Count > 0 && Utility.RandomBool())
+            if (count > 0 && entry != null && Utility.RandomBool())
             {
-                entry = Entries.RandomElement();
+                return entry;
             }
 
-            return entry;
+            return Entries.RandomElement();
         }
 
         public TownCrierEntry AddEntry(string[] lines, TimeSpan duration)


### PR DESCRIPTION
That list being null on a fresh town crier would cause this error on MUO and forces the client to disconnect.

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Server.Mobiles.TownCrier.GetRandomEntry() in D:\Programming\ModernUO\Projects\UOContent\Mobiles\Townfolk\TownCrier.cs:line 382
   at Server.Mobiles.TownCrierGump..ctor(Mobile from, ITownCrierEntryList owner) in D:\Programming\ModernUO\Projects\UOContent\Mobiles\Townfolk\TownCrier.cs:line 210
   at Server.Mobiles.TownCrier.OnDoubleClick(Mobile from) in D:\Programming\ModernUO\Projects\UOContent\Mobiles\Townfolk\TownCrier.cs:line 467
   at Server.Mobile.Use(Mobile m) in D:\Programming\ModernUO\Projects\Server\Mobiles\Mobile.cs:line 4885
   at Server.Network.IncomingEntityPackets.UseReq(NetState state, CircularBufferReader reader, Int32 packetLength) in D:\Programming\ModernUO\Projects\Server\Network\Packets\IncomingEntityPackets.cs:line 81
   at Server.Network.NetState.HandlePacket(CircularBufferReader packetReader, Byte packetId, Int32& packetLength) in D:\Programming\ModernUO\Projects\Server\Network\NetState\NetState.cs:line 824
   at Server.Network.NetState.HandleReceive() in D:\Programming\ModernUO\Projects\Server\Network\NetState\NetState.cs:line 703
```
