### PR TITLE
fix: Delays getting item id of craftables until they are needed

### DIFF
--- a/Projects/Server/AssemblyHandler.cs
+++ b/Projects/Server/AssemblyHandler.cs
@@ -15,7 +15,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Projects/Server/AssemblyHandler.cs
+++ b/Projects/Server/AssemblyHandler.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Server.ContextMenus;
 using Server.Items;

--- a/Projects/Server/MultiData.cs
+++ b/Projects/Server/MultiData.cs
@@ -171,8 +171,6 @@ public static class MultiData
             bin.BaseStream.Seek(lookup, SeekOrigin.Begin);
             _components[i] = new MultiComponentList(bin, length, postHSMulFormat);
         }
-
-        idxReader.Close();
     }
 }
 
@@ -358,17 +356,6 @@ public sealed class MultiComponentList
         var tiles = new TileList[Width][];
         Tiles = new StaticTile[Width][][];
 
-        for (var x = 0; x < Width; ++x)
-        {
-            tiles[x] = new TileList[Height];
-            Tiles[x] = new StaticTile[Height][];
-
-            for (var y = 0; y < Height; ++y)
-            {
-                tiles[x][y] = new TileList();
-            }
-        }
-
         for (var i = 0; i < allTiles.Length; ++i)
         {
             if (i == 0 || allTiles[i].Flags != 0)
@@ -376,15 +363,21 @@ public sealed class MultiComponentList
                 var xOffset = allTiles[i].OffsetX + Center.m_X;
                 var yOffset = allTiles[i].OffsetY + Center.m_Y;
 
+                tiles[xOffset] ??= new TileList[Height];
+                Tiles[xOffset] ??= new StaticTile[Height][];
+
+                tiles[xOffset][yOffset] ??= new TileList();
                 tiles[xOffset][yOffset].Add(allTiles[i].ItemId, (sbyte)allTiles[i].OffsetZ);
             }
         }
 
         for (var x = 0; x < Width; ++x)
         {
+            Tiles[x] ??= new StaticTile[Height][];
             for (var y = 0; y < Height; ++y)
             {
-                Tiles[x][y] = tiles[x][y].ToArray();
+                var tileList = tiles[x]?[y];
+                Tiles[x][y] = tileList?.ToArray() ?? Array.Empty<StaticTile>();
             }
         }
     }

--- a/Projects/UOContent/Engines/Craft/Core/CraftGumpItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftGumpItem.cs
@@ -139,7 +139,7 @@ namespace Server.Engines.Craft
             }
         }
 
-        private TextDefinition RequiredExpansionMessage(Expansion expansion)
+        private static TextDefinition RequiredExpansionMessage(Expansion expansion)
         {
             return expansion switch
             {
@@ -153,7 +153,7 @@ namespace Server.Engines.Craft
         {
             var type = m_CraftItem.ItemType;
 
-            AddItem(20, 50, CraftItem.ItemIDOf(type), m_CraftItem.ItemHue);
+            AddItem(20, 50, m_CraftItem.NameNumber, m_CraftItem.ItemHue);
 
             if (m_CraftItem.IsMarkable(type))
             {

--- a/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
@@ -256,10 +256,9 @@ namespace Server.Engines.Craft
             return itemId;
         }
 
-        public void AddRes(Type type, TextDefinition name, int amount)
-        {
-            AddRes(type, name, amount, "");
-        }
+        public void AddRes(Type type, int amount, TextDefinition message) => AddRes(type, null, amount, message);
+
+        public void AddRes(Type type, TextDefinition name, int amount) => AddRes(type, name, amount, "");
 
         public void AddRes(Type type, TextDefinition name, int amount, TextDefinition message)
         {
@@ -275,17 +274,11 @@ namespace Server.Engines.Craft
 
         public bool ConsumeAttributes(Mobile from, ref TextDefinition message, bool consume)
         {
-            bool consumMana;
-            bool consumHits;
-            bool consumStam;
-
             if (Hits > 0 && from.Hits < Hits)
             {
                 message = "You lack the required hit points to make that.";
                 return false;
             }
-
-            consumHits = consume;
 
             if (Mana > 0 && from.Mana < Mana)
             {
@@ -293,28 +286,16 @@ namespace Server.Engines.Craft
                 return false;
             }
 
-            consumMana = consume;
-
             if (Stam > 0 && from.Stam < Stam)
             {
                 message = "You lack the required stamina to make that.";
                 return false;
             }
 
-            consumStam = consume;
-
-            if (consumMana)
+            if (consume)
             {
                 from.Mana -= Mana;
-            }
-
-            if (consumHits)
-            {
                 from.Hits -= Hits;
-            }
-
-            if (consumStam)
-            {
                 from.Stam -= Stam;
             }
 
@@ -819,7 +800,7 @@ namespace Server.Engines.Craft
             chance = system.ECA switch
             {
                 CraftECA.FiftyPercentChanceMinusTenPercent => chance * 0.5 - 0.1,
-                CraftECA.ChanceMinusSixtyToFourtyFive => chance - Math.Clamp(
+                CraftECA.ChanceMinusSixtyToFortyFive => chance - Math.Clamp(
                     0.60 - (from.Skills[system.MainSkill].Value - 95.0) * 0.03,
                     0.45,
                     0.60

--- a/Projects/UOContent/Engines/Craft/Core/CraftRes.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftRes.cs
@@ -1,40 +1,41 @@
 using System;
 
-namespace Server.Engines.Craft
+namespace Server.Engines.Craft;
+
+public class CraftRes
 {
-    public class CraftRes
+    private TextDefinition _name;
+
+    public CraftRes(Type type, TextDefinition name, int amount, TextDefinition message = null)
     {
-        public CraftRes(Type type, TextDefinition name, int amount, TextDefinition message = null)
-        {
-            ItemType = type;
-            Amount = amount;
+        ItemType = type;
+        Amount = amount;
 
-            Name = name;
-            Message = message;
+        _name = name;
+        Message = message;
+    }
+
+    public Type ItemType { get; }
+
+    public TextDefinition Message { get; }
+
+    public TextDefinition Name => _name ??= CraftItem.LabelNumber(ItemType);
+
+    public int Amount { get; }
+
+    public void SendMessage(Mobile from)
+    {
+        if (Message?.Number > 0)
+        {
+            from.SendLocalizedMessage(Message.Number);
         }
-
-        public Type ItemType { get; }
-
-        public TextDefinition Message { get; }
-
-        public TextDefinition Name { get; }
-
-        public int Amount { get; }
-
-        public void SendMessage(Mobile from)
+        else if (!string.IsNullOrEmpty(Message?.String))
         {
-            if (Message?.Number > 0)
-            {
-                from.SendLocalizedMessage(Message.Number);
-            }
-            else if (!string.IsNullOrEmpty(Message?.String))
-            {
-                from.SendMessage(Message.String);
-            }
-            else
-            {
-                from.SendLocalizedMessage(502925); // You don't have the resources required to make that item.
-            }
+            from.SendMessage(Message.String);
+        }
+        else
+        {
+            from.SendLocalizedMessage(502925); // You don't have the resources required to make that item.
         }
     }
 }

--- a/Projects/UOContent/Engines/Craft/Core/CraftSystem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Server.Items;
 
 namespace Server.Engines.Craft
@@ -8,7 +9,7 @@ namespace Server.Engines.Craft
     {
         ChanceMinusSixty,
         FiftyPercentChanceMinusTenPercent,
-        ChanceMinusSixtyToFourtyFive
+        ChanceMinusSixtyToFortyFive
     }
 
     public abstract class CraftSystem
@@ -126,20 +127,17 @@ namespace Server.Engines.Craft
         public int AddCraft(
             Type typeItem, TextDefinition group, TextDefinition name, double minSkill, double maxSkill,
             Type typeRes, TextDefinition nameRes, int amount
-        ) =>
-            AddCraft(typeItem, group, name, MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, "");
+        ) => AddCraft(typeItem, group, name, MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, "");
 
         public int AddCraft(
             Type typeItem, TextDefinition group, TextDefinition name, double minSkill, double maxSkill,
             Type typeRes, TextDefinition nameRes, int amount, TextDefinition message
-        ) =>
-            AddCraft(typeItem, group, name, MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, message);
+        ) => AddCraft(typeItem, group, name, MainSkill, minSkill, maxSkill, typeRes, nameRes, amount, message);
 
         public int AddCraft(
             Type typeItem, TextDefinition group, TextDefinition name, SkillName skillToMake, double minSkill,
             double maxSkill, Type typeRes, TextDefinition nameRes, int amount
-        ) =>
-            AddCraft(typeItem, group, name, skillToMake, minSkill, maxSkill, typeRes, nameRes, amount, "");
+        ) => AddCraft(typeItem, group, name, skillToMake, minSkill, maxSkill, typeRes, nameRes, amount, "");
 
         public int AddCraft(
             Type typeItem, TextDefinition group, TextDefinition name, SkillName skillToMake, double minSkill,

--- a/Projects/UOContent/Engines/Craft/DefAlchemy.cs
+++ b/Projects/UOContent/Engines/Craft/DefAlchemy.cs
@@ -84,10 +84,8 @@ public class DefAlchemy : CraftSystem
 
     public override void InitCraftList()
     {
-        int index;
-
         // Refresh Potion
-        index = AddCraft(typeof(RefreshPotion), 1044530, 1044538, -25, 25.0, typeof(BlackPearl), 1044353, 1, 1044361);
+        var index = AddCraft(typeof(RefreshPotion), 1044530, 1044538, -25, 25.0, typeof(BlackPearl), 1044353, 1, 1044361);
         AddRes(index, typeof(Bottle), 1044529, 1, 500315);
         index = AddCraft(
             typeof(TotalRefreshPotion),

--- a/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
+++ b/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
@@ -23,7 +23,7 @@ public class DefBlacksmithy : CraftSystem
 
     public static CraftSystem CraftSystem { get; private set; }
 
-    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
+    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFortyFive;
 
     public override double GetChanceAtMin(CraftItem item) => 0.0;
 

--- a/Projects/UOContent/Engines/Craft/DefCooking.cs
+++ b/Projects/UOContent/Engines/Craft/DefCooking.cs
@@ -20,7 +20,7 @@ public class DefCooking : CraftSystem
 
     public static CraftSystem CraftSystem { get; private set; }
 
-    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
+    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFortyFive;
 
     public override double GetChanceAtMin(CraftItem item) => 0.0;
 

--- a/Projects/UOContent/Engines/Craft/DefInscription.cs
+++ b/Projects/UOContent/Engines/Craft/DefInscription.cs
@@ -54,18 +54,15 @@ public class DefInscription : CraftSystem
             return 1044263; // The tool must be on your person to use.
         }
 
-        if (typeItem != null)
+        var scroll = typeItem?.CreateEntityInstance<SpellScroll>();
+
+        if (scroll != null)
         {
-            var scroll = typeItem.CreateEntityInstance<SpellScroll>();
+            var hasSpell = Spellbook.Find(from, scroll.SpellID)?.HasSpell(scroll.SpellID) == true;
 
-            if (scroll != null)
-            {
-                var hasSpell = Spellbook.Find(from, scroll.SpellID)?.HasSpell(scroll.SpellID) == true;
+            scroll.Delete();
 
-                scroll.Delete();
-
-                return hasSpell ? 0 : 1042404; // null : You don't have that spell!
-            }
+            return hasSpell ? 0 : 1042404; // null : You don't have that spell!
         }
 
         return 0;
@@ -211,14 +208,14 @@ public class DefInscription : CraftSystem
             minSkill,
             minSkill + 1.0, // Yes, on OSI it's only 1.0 skill diff'.  Don't blame me, blame OSI.
             regs[0],
-            CraftItem.LabelNumber(regs[0]),
+            null,
             1,
             501627
         );
 
         for (var i = 1; i < regs.Length; ++i)
         {
-            AddRes(index, regs[i], CraftItem.LabelNumber(regs[0]), 1, 501627);
+            AddRes(index, regs[i], 1, 501627);
         }
 
         AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);
@@ -234,14 +231,14 @@ public class DefInscription : CraftSystem
             minSkill,
             maxSkill,
             regs[0],
-            CraftItem.LabelNumber(regs[0]),
+            null,
             1,
             501627
         );
 
         for (var i = 1; i < regs.Length; ++i)
         {
-            AddRes(index, regs[i], CraftItem.LabelNumber(regs[i]), 1, 501627);
+            AddRes(index, regs[i], 1, 501627);
         }
 
         AddRes(index, typeof(BlankScroll), 1044377, 1, 1044378);

--- a/Projects/UOContent/Engines/Craft/DefTailoring.cs
+++ b/Projects/UOContent/Engines/Craft/DefTailoring.cs
@@ -28,7 +28,7 @@ public class DefTailoring : CraftSystem
 
     public static CraftSystem CraftSystem { get; private set; }
 
-    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFourtyFive;
+    public override CraftECA ECA => CraftECA.ChanceMinusSixtyToFortyFive;
 
     public override double GetChanceAtMin(CraftItem item) => 0.5;
 


### PR DESCRIPTION
- [X] Fixes world loading for multi.mul. It was taking 10-15s, now takes 1s or less.
- [X] Fixes loading the crafting system by offloading getting a label number to when the item needs it.