### PR TITLE
* Fix players casting is sometimes not disturbed

### DIFF
--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
@@ -386,15 +386,8 @@ namespace Server.Mobiles
                 Disturb(DisturbType.Hurt, false);
             }
 
-            public override bool CheckDisturb(DisturbType type, bool checkFirst, bool resistable)
-            {
-                if (type is DisturbType.EquipRequest or DisturbType.UseRequest /* || type == DisturbType.Hurt*/)
-                {
-                    return false;
-                }
-
-                return true;
-            }
+            public override bool CheckDisturb(DisturbType type, bool checkFirst, bool resistable) =>
+                type != DisturbType.EquipRequest && type != DisturbType.UseRequest;
 
             public override void DoHurtFizzle()
             {

--- a/Projects/UOContent/Skills/SpiritSpeak.cs
+++ b/Projects/UOContent/Skills/SpiritSpeak.cs
@@ -113,15 +113,8 @@ namespace Server.SkillHandlers
                 base.OnDisturb(type, message);
             }
 
-            public override bool CheckDisturb(DisturbType type, bool checkFirst, bool resistable)
-            {
-                if (type is DisturbType.EquipRequest or DisturbType.UseRequest)
-                {
-                    return false;
-                }
-
-                return true;
-            }
+            public override bool CheckDisturb(DisturbType type, bool checkFirst, bool resistable) =>
+                type != DisturbType.EquipRequest && type != DisturbType.UseRequest;
 
             public override void SayMantra()
             {

--- a/Projects/UOContent/Spells/Base/Spell.cs
+++ b/Projects/UOContent/Spells/Base/Spell.cs
@@ -400,36 +400,29 @@ namespace Server.Spells
                 return;
             }
 
-            if (State == SpellState.Casting)
+            if (State == SpellState.None)
+                return;
+
+            var wasCasting = IsCasting; //need to take a copy SpellState will be reset to none
+            State = SpellState.None;
+            Caster.Spell = null;
+
+            OnDisturb(type, wasCasting);
+
+            if (wasCasting)
             {
-                State = SpellState.None;
-                Caster.Spell = null;
-
-                OnDisturb(type, true);
-
                 _castTimer?.Stop();
                 _animTimer?.Stop();
-
-                if (Core.AOS && Caster.Player && type == DisturbType.Hurt)
-                {
-                    DoHurtFizzle();
-                }
-
                 Caster.NextSpellTime = Core.TickCount + (int)GetDisturbRecovery().TotalMilliseconds;
             }
-            else if (State == SpellState.Sequencing)
+            else
             {
-                State = SpellState.None;
-                Caster.Spell = null;
-
-                OnDisturb(type, false);
-
                 Target.Cancel(Caster);
+            }
 
-                if (Core.AOS && Caster.Player && type == DisturbType.Hurt)
-                {
-                    DoHurtFizzle();
-                }
+            if (Core.AOS && Caster.Player && type == DisturbType.Hurt)
+            {
+                DoHurtFizzle();
             }
         }
 

--- a/Projects/UOContent/Spells/Base/Spell.cs
+++ b/Projects/UOContent/Spells/Base/Spell.cs
@@ -395,15 +395,12 @@ namespace Server.Spells
                 return;
             }
 
-            if (!firstCircle && !Core.AOS && (this as MagerySpell)?.Circle == SpellCircle.First)
+            if (State == SpellState.None || !firstCircle && !Core.AOS && (this as MagerySpell)?.Circle == SpellCircle.First)
             {
                 return;
             }
 
-            if (State == SpellState.None)
-                return;
-
-            var wasCasting = IsCasting; //need to take a copy SpellState will be reset to none
+            var wasCasting = IsCasting; // Copy SpellState before resetting it to none
             State = SpellState.None;
             Caster.Spell = null;
 

--- a/Projects/UOContent/Spells/Base/Spell.cs
+++ b/Projects/UOContent/Spells/Base/Spell.cs
@@ -400,11 +400,11 @@ namespace Server.Spells
                 return;
             }
 
-            State = SpellState.None;
-            Caster.Spell = null;
-
             if (State == SpellState.Casting)
             {
+                State = SpellState.None;
+                Caster.Spell = null;
+
                 OnDisturb(type, true);
 
                 _castTimer?.Stop();
@@ -419,6 +419,9 @@ namespace Server.Spells
             }
             else if (State == SpellState.Sequencing)
             {
+                State = SpellState.None;
+                Caster.Spell = null;
+
                 OnDisturb(type, false);
 
                 Target.Cancel(Caster);

--- a/Projects/UOContent/Spells/Base/SpellState.cs
+++ b/Projects/UOContent/Spells/Base/SpellState.cs
@@ -1,13 +1,12 @@
-namespace Server.Spells
+namespace Server.Spells;
+
+public enum SpellState
 {
-    public enum SpellState
-    {
-        None = 0,
+    None = 0,
 
-        Casting =
-            1, // We are in the process of casting (that is, waiting GetCastTime() and doing animations). Spell casting may be interupted in this state.
+    // We are in the process of casting (that is, waiting GetCastTime() and doing animations). Spell casting may be interupted in this state.
+    Casting = 1,
 
-        Sequencing =
-            2 // Casting completed, but the full spell sequence isn't. Usually waiting for a target response. Some actions are restricted in this state (using skills for example).
-    }
+    // Casting completed, but the full spell sequence isn't. Usually waiting for a target response. Some actions are restricted in this state (using skills for example).
+    Sequencing = 2
 }


### PR DESCRIPTION
Hi @kamronbatman,

I've fixed the fizzle bug and done some refactoring of the code to avoid duplicating. 

There is one thing extra I have changed as well which might seem irrelevant, but I think it should still be changed:
* Instead of checking if someone is casting by: using State == SpellState.Casting
* I use the Spell.IsCasting bool which underneath does exactly the same check: State == SpellState.Casting
* The reason is that this bool is what's used by other parts of the server e.g. dont let someone move if they are casting.
* In the future if someone does a custom change like letting people use spirit speak whilst holding a spell, they will want to make changes to the Spell.IsCasting bool so that the other parts are also checking if they are casting spirit speak