### PR TITLE
Town Crier Crash Fix

### DIFF
--- a/Projects/UOContent/Mobiles/Townfolk/TownCrier.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/TownCrier.cs
@@ -383,7 +383,7 @@ namespace Server.Mobiles
                 return entry;
             }
 
-            return Entries.RandomElement();
+            return Entries?.RandomElement();
         }
 
         public TownCrierEntry AddEntry(string[] lines, TimeSpan duration)


### PR DESCRIPTION
- Double clicking a town crier as staff results in server crash every time. This extra null check prevented that in testing.

`System.NullReferenceException: Object reference not set to an instance of an object.
   at Server.Mobiles.TownCrier.GetRandomEntry() in C:\Users\Dan\Desktop\ModernUO\Projects\UOContent\Mobiles\Townfolk\TownCrier.cs:line 386
   at Server.Mobiles.TownCrierGump..ctor(Mobile from, ITownCrierEntryList owner) in C:\Users\Dan\Desktop\ModernUO\Projects\UOContent\Mobiles\Townfolk\TownCrier.cs:line 210
   at Server.Mobiles.TownCrier.OnDoubleClick(Mobile from) in C:\Users\Dan\Desktop\ModernUO\Projects\UOContent\Mobiles\Townfolk\TownCrier.cs:line 468
   at Server.Mobile.Use(Mobile m) in C:\Users\Dan\Desktop\ModernUO\Projects\Server\Mobiles\Mobile.cs:line 4888
   at Server.Network.IncomingEntityPackets.UseReq(NetState state, CircularBufferReader reader, Int32 packetLength) in C:\Users\Dan\Desktop\ModernUO\Projects\Server\Network\Packets\IncomingEntityPackets.cs:line 81
   at Server.Network.NetState.HandlePacket(CircularBufferReader packetReader, Byte packetId, Int32& packetLength) in C:\Users\Dan\Desktop\ModernUO\Projects\Server\Network\NetState\NetState.cs:line 824
   at Server.Network.NetState.HandleReceive() in C:\Users\Dan\Desktop\ModernUO\Projects\Server\Network\NetState\NetState.cs:line 703`