### PR TITLE
fix: Casting changes player direction to Down

### DIFF
--- a/Projects/UOContent/Spells/Base/SpellHelper.cs
+++ b/Projects/UOContent/Spells/Base/SpellHelper.cs
@@ -196,7 +196,7 @@ namespace Server.Spells
                     from.Direction = from.GetDirectionTo(item.GetWorldLocation());
                 }
             }
-            else if (from.Equals(target))
+            else if (!from.Equals(target))
             {
                 from.Direction = from.GetDirectionTo(target);
             }


### PR DESCRIPTION
Hi @kamronbatman,

As we see together a minor bug fix so that Mobile.GetDirectionTo() is only called when the target mobile is different from the current mobile