### PR TITLE
fix: Adds better error message for missing assemblies

### DIFF
--- a/Projects/Server/AssemblyHandler.cs
+++ b/Projects/Server/AssemblyHandler.cs
@@ -32,8 +32,8 @@ namespace Server
         internal static Assembly AssemblyResolver(object sender, ResolveEventArgs args)
         {
             var assemblyName = new AssemblyName(args.Name);
-            var assemblyFile = $"{assemblyName}.dll";
-            var assembly = LoadAssemblyByAssemblyName(args.Name, assemblyFile);
+            var assemblyFile = $"{assemblyName.Name}.dll";
+            var assembly = LoadAssemblyByAssemblyName(assemblyName);
             if (assembly == null)
             {
                 throw new FileNotFoundException(
@@ -54,18 +54,26 @@ namespace Server
             }
         }
 
-        public static Assembly LoadAssemblyByAssemblyName(string fullAssemblyName, string assemblyFile)
+        public static Assembly LoadAssemblyByAssemblyName(AssemblyName assemblyName)
         {
+            if (assemblyName?.Name == null)
+            {
+                return null;
+            }
+
+            var fullName = assemblyName.FullName;
+            var fileName = $"{assemblyName.Name}.dll";
+
             EnsureAssemblyDirectories();
             var assemblyDirectories = ServerConfiguration.AssemblyDirectories;
 
             foreach (var assemblyDir in assemblyDirectories)
             {
-                var assemblyPath = Path.Combine(assemblyDir, assemblyFile);
+                var assemblyPath = PathUtility.GetFullPath(Path.Combine(assemblyDir, fileName), Core.BaseDirectory);
                 if (File.Exists(assemblyPath))
                 {
                     var assemblyNameCheck = AssemblyName.GetAssemblyName(assemblyPath);
-                    if (assemblyNameCheck.FullName == fullAssemblyName)
+                    if (assemblyNameCheck.FullName == fullName)
                     {
                         return AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
                     }

--- a/Projects/Server/AssemblyHandler.cs
+++ b/Projects/Server/AssemblyHandler.cs
@@ -32,13 +32,12 @@ namespace Server
         internal static Assembly AssemblyResolver(object sender, ResolveEventArgs args)
         {
             var assemblyName = new AssemblyName(args.Name);
-            var assemblyFile = $"{assemblyName.Name}.dll";
             var assembly = LoadAssemblyByAssemblyName(assemblyName);
             if (assembly == null)
             {
                 throw new FileNotFoundException(
                     $"Could not load file or assembly {assemblyName}. The system cannot find the file specified. Review the assemblyDirectories field in {ServerConfiguration.ConfigurationFilePath}",
-                    assemblyFile
+                    $"{assemblyName.Name}.dll"
                 );
             }
 
@@ -111,7 +110,7 @@ namespace Server
                 if (assembly == null)
                 {
                     throw new FileNotFoundException(
-                        $"Cannot find assembly. Review the assemblyDirectories field in {ServerConfiguration.ConfigurationFilePath}",
+                        $"Could not load file or assembly {assemblyFile}. The system cannot find the file specified. Review the assemblyDirectories field in {ServerConfiguration.ConfigurationFilePath}",
                         assemblyFile
                     );
                 }

--- a/Projects/Server/Configuration/ServerConfiguration.cs
+++ b/Projects/Server/Configuration/ServerConfiguration.cs
@@ -37,6 +37,8 @@ public static class ServerConfiguration
 
     public static List<IPEndPoint> Listeners => m_Settings.Listeners;
 
+    public static string ConfigurationFilePath => _relPath;
+
     public static ClientVersion GetSetting(string key, ClientVersion defaultValue) =>
         m_Settings.Settings.TryGetValue(key, out var value) ? new ClientVersion(value) : defaultValue;
 


### PR DESCRIPTION
Adds better error messaging for when the server cannot find a dependency. The most common error is MimeKit is missing because the assemblyDirectories field in modernuo.json does not have any valid paths.