### PR TITLE
BaseAI: Fix wrong min/max delay for detect hidden NPC ability

### DIFF
--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -1079,26 +1079,24 @@ public abstract class BaseAI
 
     public virtual bool DoActionBackoff() => true;
 
-    public virtual bool Obey()
-    {
-        return !m_Mobile.Deleted && m_Mobile.ControlOrder switch
+    public virtual bool Obey() =>
+        !m_Mobile.Deleted && m_Mobile.ControlOrder switch
         {
-            OrderType.None => DoOrderNone(),
-            OrderType.Come => DoOrderCome(),
-            OrderType.Drop => DoOrderDrop(),
-            OrderType.Friend => DoOrderFriend(),
+            OrderType.None     => DoOrderNone(),
+            OrderType.Come     => DoOrderCome(),
+            OrderType.Drop     => DoOrderDrop(),
+            OrderType.Friend   => DoOrderFriend(),
             OrderType.Unfriend => DoOrderUnfriend(),
-            OrderType.Guard => DoOrderGuard(),
-            OrderType.Attack => DoOrderAttack(),
-            OrderType.Patrol => DoOrderPatrol(),
-            OrderType.Release => DoOrderRelease(),
-            OrderType.Stay => DoOrderStay(),
-            OrderType.Stop => DoOrderStop(),
-            OrderType.Follow => DoOrderFollow(),
+            OrderType.Guard    => DoOrderGuard(),
+            OrderType.Attack   => DoOrderAttack(),
+            OrderType.Patrol   => DoOrderPatrol(),
+            OrderType.Release  => DoOrderRelease(),
+            OrderType.Stay     => DoOrderStay(),
+            OrderType.Stop     => DoOrderStop(),
+            OrderType.Follow   => DoOrderFollow(),
             OrderType.Transfer => DoOrderTransfer(),
-            _ => false
+            _                  => false
         };
-    }
 
     public virtual void OnCurrentOrderChanged()
     {

--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -1083,20 +1083,20 @@ public abstract class BaseAI
     {
         return !m_Mobile.Deleted && m_Mobile.ControlOrder switch
         {
-            OrderType.None     => DoOrderNone(),
-            OrderType.Come     => DoOrderCome(),
-            OrderType.Drop     => DoOrderDrop(),
-            OrderType.Friend   => DoOrderFriend(),
+            OrderType.None => DoOrderNone(),
+            OrderType.Come => DoOrderCome(),
+            OrderType.Drop => DoOrderDrop(),
+            OrderType.Friend => DoOrderFriend(),
             OrderType.Unfriend => DoOrderUnfriend(),
-            OrderType.Guard    => DoOrderGuard(),
-            OrderType.Attack   => DoOrderAttack(),
-            OrderType.Patrol   => DoOrderPatrol(),
-            OrderType.Release  => DoOrderRelease(),
-            OrderType.Stay     => DoOrderStay(),
-            OrderType.Stop     => DoOrderStop(),
-            OrderType.Follow   => DoOrderFollow(),
+            OrderType.Guard => DoOrderGuard(),
+            OrderType.Attack => DoOrderAttack(),
+            OrderType.Patrol => DoOrderPatrol(),
+            OrderType.Release => DoOrderRelease(),
+            OrderType.Stay => DoOrderStay(),
+            OrderType.Stop => DoOrderStop(),
+            OrderType.Follow => DoOrderFollow(),
             OrderType.Transfer => DoOrderTransfer(),
-            _                  => false
+            _ => false
         };
     }
 
@@ -3214,11 +3214,10 @@ public abstract class BaseAI
                 // Not exactly OSI style, approximation.
                 var delay = Math.Min(15000 / m_Owner.m_Mobile.Int, 60);
 
-                var min = delay * (9 / 10); // 13s at 1000 int, 33s at 400 int, 54s at <250 int
-                var max = delay * (10 / 9); // 16s at 1000 int, 41s at 400 int, 66s at <250 int
+                var min = delay * 900; // 13s at 1000 int, 33s at 400 int, 54s at <250 int
+                var max = delay * 1100; // 16s at 1000 int, 41s at 400 int, 66s at <250 int
 
-                m_Owner.m_NextDetectHidden = Core.TickCount +
-                                             (int)TimeSpan.FromSeconds(Utility.RandomMinMax(min, max)).TotalMilliseconds;
+                m_Owner.m_NextDetectHidden = Core.TickCount + Utility.RandomMinMax(min, max);
             }
         }
     }


### PR DESCRIPTION
min/max were calculated with this formula:
```cs
var min = delay * (9 / 10); // 13s at 1000 int, 33s at 400 int, 54s at <250 int
var max = delay * (10 / 9); // 16s at 1000 int, 41s at 400 int, 66s at <250 int
```

Because of int type:
- (9 / 10) is always 0
- (10 / 9) is always 1

Changed to milliseconds and removed the need of TimeSpan conversion
