### PR TITLE
fix: Use the latest number for the next serial after world load.

### DIFF
--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -242,6 +242,21 @@ namespace Server
             Items = EntityPersistence.LoadIndex(basePath, itemIndexInfo, out List<EntityIndex<Item>> items);
             Guilds = EntityPersistence.LoadIndex(basePath, guildIndexInfo, out List<EntityIndex<BaseGuild>> guilds);
 
+            if (Mobiles.Count > 0)
+            {
+                _lastMobile = Mobiles.Keys.Max();
+            }
+
+            if (Items.Count > 0)
+            {
+                _lastItem = Items.Keys.Max();
+            }
+
+            if (Guilds.Count > 0)
+            {
+                _lastGuild = Guilds.Keys.Max();
+            }
+
             EntityPersistence.LoadData(basePath, mobileIndexInfo, mobiles);
             EntityPersistence.LoadData(basePath, itemIndexInfo, items);
             EntityPersistence.LoadData(basePath, guildIndexInfo, guilds);

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using Server.Logging;
 
@@ -86,6 +87,12 @@ namespace Server.Accounting
             IIndexInfo<Serial> indexInfo = new EntityTypeIndex("Accounts");
 
             _accountsById = EntityPersistence.LoadIndex(path, indexInfo, out List<EntityIndex<Account>> accounts);
+
+            if (_accountsById.Count > 0)
+            {
+                _lastAccount = _accountsById.Keys.Max();
+            }
+
             EntityPersistence.LoadData(path, indexInfo, accounts);
 
             foreach (var a in _accountsById.Values)


### PR DESCRIPTION
Note: Max() is not very fast because `Serial` is a struct, and we don't use int directly. This is ok since we really don't care about world loading performance.