### PR TITLE
fix: Adds ReadType/Write(Type) and improves type referencing

### DIFF
--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -31,25 +31,15 @@ public abstract class BaseGuild : ISerializable
     {
         Serial = World.NewGuild;
         World.AddGuild(this);
-
-        SetTypeRef(GetType());
     }
 
     protected BaseGuild(Serial serial)
     {
         Serial = serial;
-        SetTypeRef(GetType());
     }
 
     public void SetTypeRef(Type type)
     {
-        TypeRef = World.GuildTypes.IndexOf(type);
-
-        if (TypeRef == -1)
-        {
-            World.GuildTypes.Add(type);
-            TypeRef = World.GuildTypes.Count - 1;
-        }
     }
 
     public abstract string Abbreviation { get; set; }

--- a/Projects/Server/IEntity.cs
+++ b/Projects/Server/IEntity.cs
@@ -43,10 +43,6 @@ public class Entity : IEntity
 
     public Entity(Serial serial) => Serial = serial;
 
-    public void SetTypeRef(Type type)
-    {
-    }
-
     DateTime ISerializable.Created { get; set; } = Core.Now;
 
     DateTime ISerializable.LastSerialized { get; set; } = DateTime.MaxValue;

--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -1809,8 +1809,7 @@ public class Container : Item
 
 public class ContainerData
 {
-    private static ILogger _logger;
-    private static ILogger Logger => _logger ??= LogFactory.GetLogger(typeof(ContainerData));
+    private static ILogger logger = LogFactory.GetLogger(typeof(ContainerData));
     private static readonly Dictionary<int, ContainerData> m_Table;
 
     static ContainerData()
@@ -1875,7 +1874,7 @@ public class ContainerData
 
                                 if (m_Table.ContainsKey(id))
                                 {
-                                    Logger.Warning("double ItemID entry in Data\\containers.cfg");
+                                    logger.Warning("double ItemID entry in Data\\containers.cfg");
                                 }
                                 else
                                 {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -217,24 +217,15 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         SetLastMoved();
 
         World.AddEntity(this);
-        SetTypeRef(GetType());
     }
 
     public Item(Serial serial)
     {
         Serial = serial;
-        SetTypeRef(GetType());
     }
 
     public void SetTypeRef(Type type)
     {
-        TypeRef = World.ItemTypes.IndexOf(type);
-
-        if (TypeRef == -1)
-        {
-            World.ItemTypes.Add(type);
-            TypeRef = World.ItemTypes.Count - 1;
-        }
     }
 
     public int TempFlags
@@ -785,8 +776,6 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
 
     [CommandProperty(AccessLevel.Counselor)]
     public Serial Serial { get; }
-
-    public int TypeRef { get; private set; }
 
     public virtual void Serialize(IGenericWriter writer)
     {

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -340,7 +340,6 @@ public class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPropertyLis
         DefaultMobileInit();
 
         World.AddEntity(this);
-        SetTypeRef(GetType());
     }
 
     public Mobile(Serial serial)
@@ -351,19 +350,10 @@ public class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPropertyLis
         Aggressed = new List<AggressorInfo>();
         NextSkillTime = Core.TickCount;
         DamageEntries = new List<DamageEntry>();
-
-        SetTypeRef(GetType());
     }
 
     public void SetTypeRef(Type type)
     {
-        TypeRef = World.MobileTypes.IndexOf(type);
-
-        if (TypeRef == -1)
-        {
-            World.MobileTypes.Add(type);
-            TypeRef = World.MobileTypes.Count - 1;
-        }
     }
 
     public static bool DragEffects { get; set; } = true;
@@ -2271,8 +2261,6 @@ public class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPropertyLis
 
     [CommandProperty(AccessLevel.Counselor)]
     public Serial Serial { get; }
-
-    public int TypeRef { get; private set; }
 
     public virtual void Serialize(IGenericWriter writer)
     {

--- a/Projects/Server/Serialization/BinaryFileWriter.cs
+++ b/Projects/Server/Serialization/BinaryFileWriter.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 
 namespace Server;
@@ -23,11 +24,11 @@ public class BinaryFileWriter : BufferWriter, IDisposable
     private readonly Stream _file;
     private long _position;
 
-    public BinaryFileWriter(string filename, bool prefixStr) :
-        this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None), prefixStr)
+    public BinaryFileWriter(string filename, bool prefixStr, ConcurrentQueue<Type> types = null) :
+        this(new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None), prefixStr, types)
     {}
 
-    public BinaryFileWriter(Stream stream, bool prefixStr) : base(prefixStr)
+    public BinaryFileWriter(Stream stream, bool prefixStr, ConcurrentQueue<Type> types = null) : base(prefixStr, types)
     {
         _file = stream;
         _position = _file.Position;

--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -139,6 +139,7 @@ public class BufferWriter : IGenericWriter
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(BitArray bitArray)
     {
         var byteLength = BitArray.GetByteArrayLengthFromBitLength(bitArray.Length);
@@ -149,6 +150,7 @@ public class BufferWriter : IGenericWriter
         Index += byteLength;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public virtual long Seek(long offset, SeekOrigin origin)
     {
         Debug.Assert(
@@ -172,6 +174,7 @@ public class BufferWriter : IGenericWriter
         });
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(string value)
     {
         if (_prefixStrings)
@@ -192,6 +195,7 @@ public class BufferWriter : IGenericWriter
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(long value)
     {
         FlushIfNeeded(8);
@@ -206,6 +210,7 @@ public class BufferWriter : IGenericWriter
         _buffer[Index++] = (byte)(value >> 56);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(ulong value)
     {
         FlushIfNeeded(8);
@@ -220,6 +225,7 @@ public class BufferWriter : IGenericWriter
         _buffer[Index++] = (byte)(value >> 56);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(int value)
     {
         FlushIfNeeded(4);
@@ -230,6 +236,7 @@ public class BufferWriter : IGenericWriter
         _buffer[Index++] = (byte)(value >> 24);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(uint value)
     {
         FlushIfNeeded(4);
@@ -240,6 +247,7 @@ public class BufferWriter : IGenericWriter
         _buffer[Index++] = (byte)(value >> 24);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(short value)
     {
         FlushIfNeeded(2);
@@ -248,6 +256,7 @@ public class BufferWriter : IGenericWriter
         _buffer[Index++] = (byte)(value >> 8);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(ushort value)
     {
         FlushIfNeeded(2);
@@ -256,6 +265,7 @@ public class BufferWriter : IGenericWriter
         _buffer[Index++] = (byte)(value >> 8);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe void Write(double value)
     {
         FlushIfNeeded(8);
@@ -268,6 +278,7 @@ public class BufferWriter : IGenericWriter
         Index += 8;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe void Write(float value)
     {
         FlushIfNeeded(4);
@@ -304,6 +315,7 @@ public class BufferWriter : IGenericWriter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(Serial serial) => Write(serial.Value);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Write(Type type)
     {
         if (type == null)
@@ -318,6 +330,7 @@ public class BufferWriter : IGenericWriter
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void InternalWriteString(string value)
     {
         var remaining = _encoding.GetByteCount(value);

--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Server;
@@ -31,7 +32,7 @@ public static class GenericPersistence
 
         void Serialize()
         {
-            saveBuffer ??= new BufferWriter(true);
+            saveBuffer ??= new BufferWriter(true, World.SerializedTypes);
             saveBuffer.Seek(0, SeekOrigin.Begin);
 
             serializer(saveBuffer);
@@ -41,10 +42,10 @@ public static class GenericPersistence
         {
             string binPath = Path.Combine(savePath, name, $"{name}.bin");
             var buffer = saveBuffer!.Buffer.AsSpan(0, (int)saveBuffer.Position);
-            AdhocPersistence.WriteSnapshot(binPath, buffer);
+            AdhocPersistence.WriteSnapshot(new FileInfo(binPath), buffer);
         }
 
-        void Deserialize(string savePath) =>
+        void Deserialize(string savePath, Dictionary<ulong, string> typesDb) =>
             AdhocPersistence.Deserialize(Path.Combine(savePath, name, $"{name}.bin"), deserializer);
 
         Persistence.Register(name, Serialize, WriterSnapshot, Deserialize, priority);

--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 
@@ -38,7 +39,7 @@ public static class GenericPersistence
             serializer(saveBuffer);
         }
 
-        void WriterSnapshot(string savePath)
+        void WriteSnapshot(string savePath)
         {
             string binPath = Path.Combine(savePath, name, $"{name}.bin");
             var buffer = saveBuffer!.Buffer.AsSpan(0, (int)saveBuffer.Position);
@@ -48,6 +49,6 @@ public static class GenericPersistence
         void Deserialize(string savePath, Dictionary<ulong, string> typesDb) =>
             AdhocPersistence.Deserialize(Path.Combine(savePath, name, $"{name}.bin"), deserializer);
 
-        Persistence.Register(name, Serialize, WriterSnapshot, Deserialize, priority);
+        Persistence.Register(name, Serialize, WriteSnapshot, Deserialize, priority);
     }
 }

--- a/Projects/Server/Serialization/IGenericReader.cs
+++ b/Projects/Server/Serialization/IGenericReader.cs
@@ -38,6 +38,7 @@ public interface IGenericReader
     sbyte ReadSByte();
     bool ReadBool();
     Serial ReadSerial();
+    Type ReadType();
 
     DateTime ReadDateTime() => new(ReadLong(), DateTimeKind.Utc);
     TimeSpan ReadTimeSpan() => new(ReadLong());

--- a/Projects/Server/Serialization/IGenericWriter.cs
+++ b/Projects/Server/Serialization/IGenericWriter.cs
@@ -37,6 +37,7 @@ public interface IGenericWriter
     void Write(sbyte value);
     void Write(bool value);
     void Write(Serial serial);
+    void Write(Type type);
 
     void Write(DateTime value)
     {

--- a/Projects/Server/Serialization/ISerializable.cs
+++ b/Projects/Server/Serialization/ISerializable.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 
 namespace Server;
@@ -28,7 +29,6 @@ public interface ISerializable
     long SavePosition { get; protected internal set; }
     BufferWriter SaveBuffer { get; protected internal set; }
 
-    int TypeRef { get; }
     Serial Serial { get; }
 
     // Executed on every entity, before it's serialized.
@@ -39,11 +39,9 @@ public interface ISerializable
     void Delete();
     bool Deleted { get; }
 
-    void SetTypeRef(Type type);
-
-    public void InitializeSaveBuffer(byte[] buffer)
+    public void InitializeSaveBuffer(byte[] buffer, ConcurrentQueue<Type> types)
     {
-        SaveBuffer = new BufferWriter(buffer, true);
+        SaveBuffer = new BufferWriter(buffer, true, types);
         if (World.DirtyTrackingEnabled)
         {
             SavePosition = SaveBuffer.Position;
@@ -54,9 +52,9 @@ public interface ISerializable
         }
     }
 
-    public void Serialize()
+    public void Serialize(ConcurrentQueue<Type> types)
     {
-        SaveBuffer ??= new BufferWriter(true);
+        SaveBuffer ??= new BufferWriter(true, types);
 
         BeforeSerialize();
 

--- a/Projects/Server/Serialization/Persistence.cs
+++ b/Projects/Server/Serialization/Persistence.cs
@@ -14,13 +14,14 @@
  *************************************************************************/
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
 namespace Server;
 
-public class Persistence
+public static class Persistence
 {
     public const int DefaultPriority = 100;
 
@@ -30,7 +31,7 @@ public class Persistence
         string name,
         Action serializer,
         Action<string> snapshotWriter,
-        Action<string> deserializer,
+        Action<string, Dictionary<ulong, string>> deserializer,
         int priority = DefaultPriority
     )
     {
@@ -50,11 +51,44 @@ public class Persistence
 
     public static void Load(string path)
     {
+        var typesDb = LoadTypes(path);
+
         // This should probably not be parallel since Mobiles must be loaded before Items
         foreach (var entry in _registry)
         {
-            entry.Deserialize(path);
+            entry.Deserialize(path, typesDb);
         }
+    }
+
+    private static Dictionary<ulong, string> LoadTypes(string path)
+    {
+        var db = new Dictionary<ulong, string>();
+
+        string tdbPath = Path.Combine(path, "SerializedTypes.db");
+        if (!File.Exists(tdbPath))
+        {
+            return db;
+        }
+
+        using FileStream tdb = new FileStream(tdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        BinaryReader tdbReader = new BinaryReader(tdb);
+
+        var version = tdbReader.ReadInt32();
+        var count = tdbReader.ReadInt32();
+
+        for (var i = 0; i < count; ++i)
+        {
+            var hash = tdbReader.ReadUInt64();
+            var typeName = tdbReader.ReadString();
+            db[hash] = typeName;
+        }
+
+        return db;
+    }
+
+    private static void SaveTypes(string path)
+    {
+
     }
 
     public static void Serialize()
@@ -62,11 +96,38 @@ public class Persistence
         Parallel.ForEach(_registry, entry => entry.Serialize());
     }
 
-    public static void WriteSnapshot(string path)
+    public static void WriteSnapshot(string path, ConcurrentQueue<Type> types)
     {
         foreach (var entry in _registry)
         {
             entry.WriteSnapshot(path);
+        }
+
+        // Dedupe the queue.
+        foreach (var type in types)
+        {
+            _typesSet.Add(type);
+        }
+
+        WriteSerializedTypesSnapshot(path, _typesSet);
+        _typesSet.Clear();
+    }
+
+    private static HashSet<Type> _typesSet = new();
+
+    public static void WriteSerializedTypesSnapshot(string path, HashSet<Type> types)
+    {
+        string tdbPath = Path.Combine(path, "SerializedTypes.db");
+        using var tdb = new BinaryFileWriter(tdbPath, false);
+
+        tdb.Write(0); // version
+        tdb.Write(types.Count);
+
+        foreach (var type in types)
+        {
+            var fullName = type.FullName;
+            tdb.Write(HashUtility.ComputeHash64(fullName));
+            tdb.Write(fullName);
         }
     }
 
@@ -76,7 +137,7 @@ public class Persistence
         public int Priority { get; init; }
         public Action Serialize { get; init; } // Serializing to memory buffers
         public Action<string> WriteSnapshot { get; init; }
-        public Action<string> Deserialize { get; init; }
+        public Action<string, Dictionary<ulong, string>> Deserialize { get; init; }
     }
 
     internal class RegistryEntryComparer : IComparer<RegistryEntry>

--- a/Projects/Server/Serialization/Persistence.cs
+++ b/Projects/Server/Serialization/Persistence.cs
@@ -86,11 +86,6 @@ public static class Persistence
         return db;
     }
 
-    private static void SaveTypes(string path)
-    {
-
-    }
-
     public static void Serialize()
     {
         Parallel.ForEach(_registry, entry => entry.Serialize());

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -38,6 +38,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
         <PackageReference Include="PollGroup" Version="1.2.1" />
+        <PackageReference Include="Standart.Hash.xxHash.Signed" Version="4.0.4" />
         <PackageReference Include="Zlib.Bindings" Version="1.9.2" />
 
         <PackageReference Include="ModernUO.Serialization.Annotations" Version="2.2.0" />

--- a/Projects/Server/Utilities/HashUtility.cs
+++ b/Projects/Server/Utilities/HashUtility.cs
@@ -1,0 +1,47 @@
+﻿/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2022 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: HashUtility.cs                                                  *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Runtime.CompilerServices;
+using Standart.Hash.xxHash;
+
+namespace Server;
+
+/// <summary>
+/// Represents supported non-cryptographic fast hash algorithms.
+/// </summary>
+public enum FastHashAlgorithm
+{
+    None, // Used for collisions where full-data is serialized instead
+    XXHash3_64, // xxHash3 64bit
+}
+
+public static class HashUtility
+{
+    // *************** DO NOT CHANGE THIS NUMBER ****************
+    // * Computed hashes might be serialized against this seed! *
+    // **********************************************************
+    private const ulong xxHash3Seed = 9609125370673258709ul; // Randomly generated 64-bit prime number
+
+    public static ulong ComputeHash64(string? data, FastHashAlgorithm algorithm = FastHashAlgorithm.XXHash3_64) =>
+        algorithm switch
+        {
+            FastHashAlgorithm.XXHash3_64 => ComputeXXHash3_64(data),
+            _                            => throw new NotSupportedException($"Hash {algorithm} is not supported.")
+        };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong ComputeXXHash3_64(string? data) => data == null ? 0 : xxHash3.ComputeHash(data, xxHash3Seed);
+}

--- a/Projects/Server/Utilities/HashUtility.cs
+++ b/Projects/Server/Utilities/HashUtility.cs
@@ -35,6 +35,7 @@ public static class HashUtility
     // **********************************************************
     private const ulong xxHash3Seed = 9609125370673258709ul; // Randomly generated 64-bit prime number
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong ComputeHash64(string? data, FastHashAlgorithm algorithm = FastHashAlgorithm.XXHash3_64) =>
         algorithm switch
         {

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -120,8 +120,10 @@ public static class Utility
         sb.Append(value);
     }
 
-    public static string Intern(string str) => str?.Length > 0 ? string.Intern(str) : str;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string Intern(this string str) => str?.Length > 0 ? string.Intern(str) : str;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Intern(ref string str)
     {
         str = Intern(str);

--- a/Projects/Server/World/EntityPersistence.cs
+++ b/Projects/Server/World/EntityPersistence.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
@@ -25,12 +26,9 @@ namespace Server;
 
 public static class EntityPersistence
 {
-    private const int _idxVersion = 1;
-
     public static void WriteEntities<I, T>(
         IIndexInfo<I> indexInfo,
         Dictionary<I, T> entities,
-        List<Type> types,
         string savePath,
         out Dictionary<string, int> counts
     ) where T : class, ISerializable
@@ -44,20 +42,19 @@ public static class EntityPersistence
         PathUtility.EnsureDirectory(path);
 
         string idxPath = Path.Combine(path, $"{typeName}.idx");
-        string tdbPath = Path.Combine(path, $"{typeName}.tdb");
         string binPath = Path.Combine(path, $"{typeName}.bin");
 
         using var idx = new BinaryFileWriter(idxPath, false);
-        using var tdb = new BinaryFileWriter(tdbPath, false);
         using var bin = new BinaryFileWriter(binPath, true);
 
-        idx.Write(1); // Version
+        idx.Write(2); // Version
         idx.Write(entities.Count);
         foreach (var e in entities.Values)
         {
             long start = bin.Position;
 
-            idx.Write(e.TypeRef);
+            var t = e.GetType();
+            idx.Write(t);
             idx.Write(e.Serial);
             idx.Write(e.Created.Ticks);
             idx.Write(e.LastSerialized.Ticks);
@@ -73,12 +70,6 @@ public static class EntityPersistence
                 counts[type] = (counts.TryGetValue(type, out var count) ? count : 0) + 1;
             }
         }
-
-        tdb.Write(types.Count);
-        for (int i = 0; i < types.Count; ++i)
-        {
-            tdb.Write(types[i].FullName);
-        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -90,6 +81,7 @@ public static class EntityPersistence
     public static Dictionary<I, T> LoadIndex<I, T>(
         string path,
         IIndexInfo<I> indexInfo,
+        Dictionary<ulong, string> typeDb,
         out List<EntitySpan<T>> entities
     ) where T : class, ISerializable
     {
@@ -99,11 +91,10 @@ public static class EntityPersistence
         var indexType = indexInfo.TypeName;
 
         string indexPath = Path.Combine(path, indexType, $"{indexType}.idx");
-        string typesPath = Path.Combine(path, indexType, $"{indexType}.tdb");
 
         entities = new List<EntitySpan<T>>();
 
-        if (!File.Exists(indexPath) || !File.Exists(typesPath))
+        if (!File.Exists(indexPath))
         {
             return map;
         }
@@ -111,58 +102,77 @@ public static class EntityPersistence
         using FileStream idx = new FileStream(indexPath, FileMode.Open, FileAccess.Read, FileShare.Read);
         BinaryReader idxReader = new BinaryReader(idx);
 
-        using FileStream tdb = new FileStream(typesPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        BinaryReader tdbReader = new BinaryReader(tdb);
-
-        List<Tuple<ConstructorInfo, string>> types = ReadTypes<I>(tdbReader);
-
-        int count;
         var version = idxReader.ReadInt32();
+        int count = idxReader.ReadInt32();
 
-        // Handle non-versioned (version 0).
-        if (version > _idxVersion || idx.Length - 4 - version * 20 == 0)
+        var ctorArguments = new[] { typeof(I) };
+        List<ConstructorInfo> types;
+
+        string typesPath = Path.Combine(path, indexType, $"{indexType}.tdb");
+        if (File.Exists(typesPath))
         {
-            count = version;
-            version = 0;
+            using FileStream tdb = new FileStream(typesPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            BinaryReader tdbReader = new BinaryReader(tdb);
+            types = ReadTypes(tdbReader, ctorArguments);
+            tdbReader.Close();
         }
         else
         {
-            count = idxReader.ReadInt32();
+            types = null;
+        }
+
+        // We must have a typeDb from SerializedTypes.db, or a tdb file
+        if (typeDb == null && types == null)
+        {
+            return map;
         }
 
         var now = DateTime.UtcNow;
 
         for (int i = 0; i < count; ++i)
         {
-            var typeID = idxReader.ReadInt32();
+            ConstructorInfo ctor;
+            if (version >= 2)
+            {
+                var flag = idxReader.ReadByte();
+                if (flag != 2)
+                {
+                    throw new Exception($"Invalid type flag, expected 2 but received {flag}.");
+                }
+
+                var hash = idxReader.ReadUInt64();
+                typeDb!.TryGetValue(hash, out var typeName);
+                ctor = GetConstructorFor(typeName, AssemblyHandler.FindTypeByHash(hash), ctorArguments);
+            }
+            else
+            {
+                ctor = types?[idxReader.ReadInt32()];
+            }
+
             var serial = idxReader.ReadUInt32();
             var created = version == 0 ? now : new DateTime(idxReader.ReadInt64(), DateTimeKind.Utc);
             var lastSerialized = version == 0 ? DateTime.MinValue : new DateTime(idxReader.ReadInt64(), DateTimeKind.Utc);
             var pos = idxReader.ReadInt64();
             var length = idxReader.ReadInt32();
 
-            Tuple<ConstructorInfo, string> objs = types[typeID];
-
-            if (objs == null)
+            if (ctor == null)
             {
                 continue;
             }
 
-            ConstructorInfo ctor = objs.Item1;
             I indexer = indexInfo.CreateIndex(serial);
 
             ctorArgs[0] = indexer;
 
-            if (ctor.Invoke(ctorArgs) is T t)
+            if (ctor.Invoke(ctorArgs) is T entity)
             {
-                t.Created = created;
-                t.LastSerialized = lastSerialized;
-                entities.Add(new EntitySpan<T>(t, typeID, pos, length));
-                map[indexer] = t;
+                entity.Created = created;
+                entity.LastSerialized = lastSerialized;
+                entities.Add(new EntitySpan<T>(entity, pos, length));
+                map[indexer] = entity;
             }
         }
 
-        tdbReader.Close();
         idxReader.Close();
 
         return map;
@@ -171,6 +181,7 @@ public static class EntityPersistence
     public static void LoadData<I, T>(
         string path,
         IIndexInfo<I> indexInfo,
+        Dictionary<ulong, string> serializedTypes,
         List<EntitySpan<T>> entities
     ) where T : class, ISerializable
     {
@@ -211,7 +222,7 @@ public static class EntityPersistence
             var buffer = GC.AllocateUninitializedArray<byte>(entry.Length);
             if (br == null)
             {
-                br = new BufferReader(buffer, t.LastSerialized);
+                br = new BufferReader(buffer, t.LastSerialized, serializedTypes);
             }
             else
             {
@@ -236,7 +247,7 @@ public static class EntityPersistence
 
             if (error == null)
             {
-                t.InitializeSaveBuffer(buffer);
+                t.InitializeSaveBuffer(buffer, World.SerializedTypes);
             }
             else
             {
@@ -265,50 +276,52 @@ public static class EntityPersistence
         }
     }
 
-    private static List<Tuple<ConstructorInfo, string>> ReadTypes<I>(BinaryReader tdbReader)
+    private static ConstructorInfo GetConstructorFor(string typeName, Type t, Type[] constructorTypes)
     {
-        var constructorTypes = new[] { typeof(I) };
+        if (t?.IsAbstract != false)
+        {
+            Console.WriteLine("failed");
 
+            var issue = t?.IsAbstract == true ? "marked abstract" : "not found";
+
+            Console.WriteLine($"Error: Type '{typeName}' was {issue}. Delete all of those types? (y/n)");
+
+            if (Console.ReadKey(true).Key == ConsoleKey.Y)
+            {
+                Console.WriteLine("Loading...");
+                return null;
+            }
+
+            Console.WriteLine("Types will not be deleted. An exception will be thrown.");
+
+            throw new Exception($"Bad type '{typeName}'");
+        }
+
+        var ctor = t.GetConstructor(constructorTypes);
+
+        if (ctor == null)
+        {
+            throw new Exception($"Type '{t}' does not have a serialization constructor");
+        }
+
+        return ctor;
+    }
+
+    /**
+     * Legacy ReadTypes for backward compatibility with old saves that still have a tdb file
+     */
+    private static List<ConstructorInfo> ReadTypes(BinaryReader tdbReader, Type[] ctorArguments)
+    {
         var count = tdbReader.ReadInt32();
 
-        var types = new List<Tuple<ConstructorInfo, string>>(count);
+        var types = new List<ConstructorInfo>(count);
 
         for (var i = 0; i < count; ++i)
         {
             var typeName = tdbReader.ReadString();
-
             var t = AssemblyHandler.FindTypeByFullName(typeName, false);
-
-            if (t?.IsAbstract != false)
-            {
-                Console.WriteLine("failed");
-
-                var issue = t?.IsAbstract == true ? "marked abstract" : "not found";
-
-                Console.WriteLine($"Error: Type '{typeName}' was {issue}. Delete all of those types? (y/n)");
-
-                if (Console.ReadKey(true).Key == ConsoleKey.Y)
-                {
-                    types.Add(null);
-                    Console.WriteLine("Loading...");
-                    continue;
-                }
-
-                Console.WriteLine("Types will not be deleted. An exception will be thrown.");
-
-                throw new Exception($"Bad type '{typeName}'");
-            }
-
-            var ctor = t.GetConstructor(constructorTypes);
-
-            if (ctor != null)
-            {
-                types.Add(new Tuple<ConstructorInfo, string>(ctor, typeName));
-            }
-            else
-            {
-                throw new Exception($"Type '{t}' does not have a serialization constructor");
-            }
+            var ctor = GetConstructorFor(typeName, t, ctorArguments);
+            types.Add(ctor);
         }
 
         return types;

--- a/Projects/Server/World/EntitySpan.cs
+++ b/Projects/Server/World/EntitySpan.cs
@@ -19,16 +19,13 @@ public struct EntitySpan<T> where T : ISerializable
 {
     public T Entity { get; }
 
-    public int TypeID { get;  }
-
     public long Position { get; }
 
     public int Length { get; }
 
-    public EntitySpan(T entity, int typeID, long position, int length)
+    public EntitySpan(T entity, long position, int length)
     {
         Entity = entity;
-        TypeID = typeID;
         Position = position;
         Length = length;
     }

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -38,12 +38,12 @@ public enum WorldState
 
 public static class World
 {
-    private static readonly ILogger logger = LogFactory.GetLogger(typeof(World));
+    private static ILogger logger = LogFactory.GetLogger(typeof(World));
 
-    private static readonly ManualResetEvent m_DiskWriteHandle = new(true);
-    private static readonly Dictionary<Serial, IEntity> _pendingAdd = new();
-    private static readonly Dictionary<Serial, IEntity> _pendingDelete = new();
-    private static readonly ConcurrentQueue<Item> _decayQueue = new();
+    private static ManualResetEvent m_DiskWriteHandle = new(true);
+    private static Dictionary<Serial, IEntity> _pendingAdd = new();
+    private static Dictionary<Serial, IEntity> _pendingDelete = new();
+    private static ConcurrentQueue<Item> _decayQueue = new();
 
     private static string _tempSavePath; // Path to the temporary folder for the save
     private static bool _enableSaveStats;
@@ -124,10 +124,6 @@ public static class World
     }
 
     private static void OutOfMemory(string message) => throw new OutOfMemoryException(message);
-
-    internal static List<Type> ItemTypes { get; } = new();
-    internal static List<Type> MobileTypes { get; } = new();
-    internal static List<Type> GuildTypes { get; } = new();
 
     public static string SavePath { get; private set; }
 
@@ -232,15 +228,15 @@ public static class World
     public static void Broadcast(int hue, bool ascii, string format, params object[] args) =>
         Broadcast(hue, ascii, string.Format(format, args));
 
-    internal static void LoadEntities(string basePath)
+    internal static void LoadEntities(string basePath, Dictionary<ulong, string> typesDb)
     {
         IIndexInfo<Serial> itemIndexInfo = new EntityTypeIndex("Items");
         IIndexInfo<Serial> mobileIndexInfo = new EntityTypeIndex("Mobiles");
         IIndexInfo<Serial> guildIndexInfo = new EntityTypeIndex("Guilds");
 
-        Mobiles = EntityPersistence.LoadIndex(basePath, mobileIndexInfo, out List<EntitySpan<Mobile>> mobiles);
-        Items = EntityPersistence.LoadIndex(basePath, itemIndexInfo, out List<EntitySpan<Item>> items);
-        Guilds = EntityPersistence.LoadIndex(basePath, guildIndexInfo, out List<EntitySpan<BaseGuild>> guilds);
+        Mobiles = EntityPersistence.LoadIndex(basePath, mobileIndexInfo, typesDb, out List<EntitySpan<Mobile>> mobiles);
+        Items = EntityPersistence.LoadIndex(basePath, itemIndexInfo, typesDb, out List<EntitySpan<Item>> items);
+        Guilds = EntityPersistence.LoadIndex(basePath, guildIndexInfo, typesDb, out List<EntitySpan<BaseGuild>> guilds);
 
         if (Mobiles.Count > 0)
         {
@@ -257,9 +253,9 @@ public static class World
             _lastGuild = Guilds.Keys.Max();
         }
 
-        EntityPersistence.LoadData(basePath, mobileIndexInfo, mobiles);
-        EntityPersistence.LoadData(basePath, itemIndexInfo, items);
-        EntityPersistence.LoadData(basePath, guildIndexInfo, guilds);
+        EntityPersistence.LoadData(basePath, mobileIndexInfo, typesDb, mobiles);
+        EntityPersistence.LoadData(basePath, itemIndexInfo, typesDb,  items);
+        EntityPersistence.LoadData(basePath, guildIndexInfo, typesDb, guilds);
     }
 
     public static void Load()
@@ -392,9 +388,9 @@ public static class World
         IIndexInfo<Serial> mobileIndexInfo = new EntityTypeIndex("Mobiles");
         IIndexInfo<Serial> guildIndexInfo = new EntityTypeIndex("Guilds");
 
-        EntityPersistence.WriteEntities(mobileIndexInfo, Mobiles, MobileTypes, basePath, out var mobileCounts);
-        EntityPersistence.WriteEntities(itemIndexInfo, Items, ItemTypes, basePath, out var itemCounts);
-        EntityPersistence.WriteEntities(guildIndexInfo, Guilds, GuildTypes, basePath, out var guildCounts);
+        EntityPersistence.WriteEntities(mobileIndexInfo, Mobiles, basePath, out var mobileCounts);
+        EntityPersistence.WriteEntities(itemIndexInfo, Items, basePath, out var itemCounts);
+        EntityPersistence.WriteEntities(guildIndexInfo, Guilds, basePath, out var guildCounts);
 
         if (_enableSaveStats)
         {
@@ -413,7 +409,7 @@ public static class World
             var watch = Stopwatch.StartNew();
             logger.Information("Writing world save snapshot");
 
-            Persistence.WriteSnapshot(tempPath);
+            Persistence.WriteSnapshot(tempPath, SerializedTypes);
 
             watch.Stop();
 
@@ -444,6 +440,9 @@ public static class World
             }
         }
 
+        // Clear types
+        SerializedTypes.Clear();
+
         m_DiskWriteHandle.Set();
 
         Core.LoopContext.Post(FinishWorldSave);
@@ -463,6 +462,36 @@ public static class World
 
     private static DateTime _serializationStart;
 
+    /**
+     * Duplicates can be weeded out asynchronously while flushing
+     * If performance becomes a problem, we need to build a dual mode concurrent array.
+     * The structure is initialized with a large capacity to avoid unnecessary resizing.
+     * Write Mode:
+     * - Multiple threads can add a single, or a range of elements concurrently.
+     * - Elements can be Peeked, but there are no guarantees.
+     * - To resize the internal array, replaced it with the next size up from an array pool.
+     * - The structure cannot be cleared in this mode.
+     *
+     * Read Mode:
+     * - The array can be read from multiple threads using a ref struct enumerator.
+     * - Elements cannot be added or reassigned.
+     * - Cleared by replacing the internal array with another one from the pool.
+     * - Note: Upon clearing, the existing array is not sent back to the pool until there are zero enumerators.
+     *
+     * Enumeration:
+     * - Multiple threads can enumerate while in read mode. The enumerator will Interlocked.Increment a read counter.
+     * - Upon dispose of the enumerator, the read counter will be lowered with an Interlocked.Decrement
+     * - When the read counter reaches 0, if there is a cleared array, the array is sent back to the pool zeroed.
+     *
+     * Notes:
+     * - Elements can never be removed.
+     *
+     * How is this different from ConcurrentQueue?
+     * The functionality is very similar, except the constraints allow the implementation to be done without locks.
+     * Since this implementation uses pooled arrays, allocations will approach zero over time.
+     */
+    public static ConcurrentQueue<Type> SerializedTypes { get; } = new();
+
     internal static void SaveEntities()
     {
         _serializationStart = DateTime.UtcNow;
@@ -479,7 +508,7 @@ public static class World
             EnqueueForDecay(item);
         }
 
-        entity.Serialize();
+        entity.Serialize(SerializedTypes);
     }
 
     public static void Save()
@@ -632,7 +661,10 @@ public static class World
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void AddGuild(BaseGuild guild) => Guilds[guild.Serial] = guild;
+    public static void AddGuild(BaseGuild guild)
+    {
+        Guilds[guild.Serial] = guild;
+    }
 
     public static void RemoveEntity<T>(T entity) where T : class, IEntity
     {

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -465,6 +465,8 @@ public static class World
     /**
      * Duplicates can be weeded out asynchronously while flushing
      * If performance becomes a problem, we need to build a dual mode concurrent array.
+     *
+     ****************************************************** Proposal ******************************************************
      * The structure is initialized with a large capacity to avoid unnecessary resizing.
      * Write Mode:
      * - Multiple threads can add a single, or a range of elements concurrently.
@@ -489,6 +491,7 @@ public static class World
      * How is this different from ConcurrentQueue?
      * The functionality is very similar, except the constraints allow the implementation to be done without locks.
      * Since this implementation uses pooled arrays, allocations will approach zero over time.
+     **********************************************************************************************************************
      */
     public static ConcurrentQueue<Type> SerializedTypes { get; } = new();
 

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -388,9 +388,9 @@ public static class World
         IIndexInfo<Serial> mobileIndexInfo = new EntityTypeIndex("Mobiles");
         IIndexInfo<Serial> guildIndexInfo = new EntityTypeIndex("Guilds");
 
-        EntityPersistence.WriteEntities(mobileIndexInfo, Mobiles, basePath, out var mobileCounts);
-        EntityPersistence.WriteEntities(itemIndexInfo, Items, basePath, out var itemCounts);
-        EntityPersistence.WriteEntities(guildIndexInfo, Guilds, basePath, out var guildCounts);
+        EntityPersistence.WriteEntities(mobileIndexInfo, Mobiles, basePath, SerializedTypes, out var mobileCounts);
+        EntityPersistence.WriteEntities(itemIndexInfo, Items, basePath, SerializedTypes, out var itemCounts);
+        EntityPersistence.WriteEntities(guildIndexInfo, Guilds, basePath, SerializedTypes, out var guildCounts);
 
         if (_enableSaveStats)
         {

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -15,6 +15,10 @@ namespace Server.Accounting
     [SerializationGenerator(4)]
     public partial class Account : IAccount, IComparable<Account>, ISerializable
     {
+        public void SetTypeRef(Type type)
+        {
+        }
+
         public static readonly TimeSpan YoungDuration = TimeSpan.FromHours(40.0);
         public static readonly TimeSpan InactiveDuration = TimeSpan.FromDays(180.0);
         public static readonly TimeSpan EmptyInactiveDuration = TimeSpan.FromDays(30.0);
@@ -145,7 +149,6 @@ namespace Server.Accounting
         public Account(XmlElement node)
         {
             Serial = Accounts.NewAccount;
-            SetTypeRef(GetType());
 
             _username = Utility.GetText(node["username"], "empty");
 
@@ -216,17 +219,6 @@ namespace Server.Accounting
 
             Accounts.Add(this);
             this.MarkDirty();
-        }
-
-        public void SetTypeRef(Type type)
-        {
-            TypeRef = Accounts.Types.IndexOf(type);
-
-            if (TypeRef == -1)
-            {
-                Accounts.Types.Add(type);
-                TypeRef = Accounts.Types.Count - 1;
-            }
         }
 
         /// <summary>
@@ -304,8 +296,6 @@ namespace Server.Accounting
 
         [CommandProperty(AccessLevel.GameMaster)]
         DateTime ISerializable.LastSerialized { get; set; } = Core.Now;
-
-        public int TypeRef { get; private set; }
 
         public Serial Serial { get; set; }
 

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -54,7 +54,7 @@ namespace Server.Accounting
         internal static void WriteSnapshot(string basePath)
         {
             IIndexInfo<Serial> indexInfo = new EntityTypeIndex("Accounts");
-            EntityPersistence.WriteEntities(indexInfo, _accountsById, basePath, out _);
+            EntityPersistence.WriteEntities(indexInfo, _accountsById, basePath,World.SerializedTypes, out _);
         }
 
         public static IEnumerable<IAccount> GetAccounts() => _accountsByName.Values;

--- a/Projects/UOContent/Accounting/Accounts.cs
+++ b/Projects/UOContent/Accounting/Accounts.cs
@@ -14,7 +14,6 @@ namespace Server.Accounting
         private static readonly Dictionary<string, Account> _accountsByName = new(32, StringComparer.OrdinalIgnoreCase);
         private static Dictionary<Serial, Account> _accountsById = new(32);
         private static Serial _lastAccount;
-        internal static List<Type> Types { get; } = new();
 
         private static void OutOfMemory(string message) => throw new OutOfMemoryException(message);
 
@@ -44,13 +43,18 @@ namespace Server.Accounting
         public static void Configure() =>
             Persistence.Register("Accounts", Serialize, WriteSnapshot, Deserialize);
 
-        internal static void Serialize() =>
-            EntityPersistence.SaveEntities(_accountsById.Values, account => ((ISerializable)account).Serialize());
+        internal static void Serialize()
+        {
+            EntityPersistence.SaveEntities(
+                _accountsById.Values,
+                account => ((ISerializable)account).Serialize(World.SerializedTypes)
+            );
+        }
 
         internal static void WriteSnapshot(string basePath)
         {
             IIndexInfo<Serial> indexInfo = new EntityTypeIndex("Accounts");
-            EntityPersistence.WriteEntities(indexInfo, _accountsById, Types, basePath, out _);
+            EntityPersistence.WriteEntities(indexInfo, _accountsById, basePath, out _);
         }
 
         public static IEnumerable<IAccount> GetAccounts() => _accountsByName.Values;
@@ -73,7 +77,7 @@ namespace Server.Accounting
             _accountsById.Remove(a.Serial);
         }
 
-        internal static void Deserialize(string path)
+        internal static void Deserialize(string path, Dictionary<ulong, string> typesDb)
         {
             var filePath = Path.Combine(path, "Accounts", "accounts.xml");
 
@@ -86,14 +90,14 @@ namespace Server.Accounting
 
             IIndexInfo<Serial> indexInfo = new EntityTypeIndex("Accounts");
 
-            _accountsById = EntityPersistence.LoadIndex(path, indexInfo, out List<EntitySpan<Account>> accounts);
+            _accountsById = EntityPersistence.LoadIndex(path, indexInfo, typesDb, out List<EntitySpan<Account>> accounts);
 
             if (_accountsById.Count > 0)
             {
                 _lastAccount = _accountsById.Keys.Max();
             }
 
-            EntityPersistence.LoadData(path, indexInfo, accounts);
+            EntityPersistence.LoadData(path, indexInfo, typesDb, accounts);
 
             foreach (var a in _accountsById.Values)
             {

--- a/Projects/UOContent/Items/Armor/Cloth/GargishClothKiltType2.cs
+++ b/Projects/UOContent/Items/Armor/Cloth/GargishClothKiltType2.cs
@@ -3,7 +3,6 @@ using ModernUO.Serialization;
 namespace Server.Items
 {
     [SerializationGenerator(0)]
-    [TypeAlias("Server.Items.GargishClothKilt", "Server.Items.GargishClothKiltArmor")]
     public partial class GargishClothKiltType2 : BaseArmor
     {
         [Constructible]

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SkeletalDragon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SkeletalDragon.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Server.Mobiles
 {
     public class SkeletalDragon : BaseCreature

--- a/Projects/UOContent/Spells/Chivalry/NobleSacrifice.cs
+++ b/Projects/UOContent/Spells/Chivalry/NobleSacrifice.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Server.Collections;
 using Server.Gumps;
 using Server.Items;

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.9.3"
+  "version": "0.9.4"
 }


### PR DESCRIPTION
## Changes
* Improves type hashing by introducing xxHash3 (64bit)
* Removes individual `tdb` files in favor of a single `SerializedTypes.db` file. This file is only used to identify a type that is being deserialized, which doesn't exist.
* Adds duplicate type alias detection
* Adds `AssemblyHandler.FindTypeByHash`

View changed files whitespaces: https://github.com/modernuo/ModernUO/pull/1172/files?diff=split&w=1

## SerializedTypes.db
The serialized types file is used to get back the original name of a type in case it no longer exists in code. This can easily be necessary if a class is renamed in code and no `TypeAlias` is provided.

### Format
byte[4] - version
byte[4] - count
--array--
byte[8] - xxHash
byte[1] - flag, 0 - null, 1 - not null
byte[n] - Full class name in UTF8

### Example
<img width="472" alt="SerializedTypes_Example" src="https://user-images.githubusercontent.com/3953314/195255429-31d24293-6bd1-419e-811b-07874dd0f78d.png">

## Benchmarks
Serialized 500 Type fields. The 8192bytes comes from the _ConcurrentQueue_ that would later be used for SerializedTypes.
Note that the queue is never cleared, so it's size grew considerably.
```cs
|               Method |     Mean |    Error |   StdDev | Allocated |
|--------------------- |---------:|---------:|---------:|----------:|
|      BenchmarkXXHash | 18.44 us | 0.278 us | 0.260 us |    8192 B |
| BenchmarkTypeStrings | 25.09 us | 0.292 us | 0.259 us |         - |
```

TODO:
* Add support in the Serialization Generator for `ReadType()` and `Write(Type)`
* Remove `SetTypeRef` from Serialization Generator