### PR TITLE
Fix abusing summons offscreen

### DIFF
--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -2635,7 +2635,8 @@ public abstract class BaseAI
             var bc = m as BaseCreature;
             var pm = m as PlayerMobile;
 
-            if (Core.AOS && bc?.Summoned == true && bc?.Controlled != true)
+            // Monster don't attack it's own summon
+            if (Core.AOS && bc != null && bc.Summoned && bc.SummonMaster == m_Mobile)
             {
                 continue;
             }
@@ -2722,17 +2723,17 @@ public abstract class BaseAI
             }
 
             var theirVal = m_Mobile.GetFightModeRanking(m, acqType, bPlayerOnly);
-            //The summon is targeted when nothing else around. Otherwise this monster enters idle mode, 
-            //which players can abuse by casting EVs offscreen and this monster wont fight back
-            if (Core.AOS && theirVal > enemySummonVal && m_Mobile.InLOS(m) && bc?.Summoned == true && bc?.Controlled != true)
-            {
-                enemySummonMob = m;
-                enemySummonVal = theirVal;
-            }
-            else if (theirVal > val && m_Mobile.InLOS(m))
+            if (theirVal > val && m_Mobile.InLOS(m))
             {
                 newFocusMob = m;
                 val = theirVal;
+            }
+            //The summon is targeted when nothing else around. Otherwise this monster enters idle mode, 
+            //which players can abuse by casting EVs offscreen and this monster wont fight back
+            else if (Core.AOS && theirVal > enemySummonVal && m_Mobile.InLOS(m) && bc?.Summoned == true && bc?.Controlled != true)
+            {
+                enemySummonMob = m;
+                enemySummonVal = theirVal;
             }
         }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -2590,6 +2590,8 @@ public abstract class BaseAI
 
         Mobile newFocusMob = null;
         var val = double.MinValue;
+        Mobile enemySummonMob = null;
+        var enemySummonVal = double.MinValue;
 
         var eable = map.GetMobilesInRange(m_Mobile.Location, iRange);
 
@@ -2720,8 +2722,14 @@ public abstract class BaseAI
             }
 
             var theirVal = m_Mobile.GetFightModeRanking(m, acqType, bPlayerOnly);
-
-            if (theirVal > val && m_Mobile.InLOS(m))
+            //The summon is targeted when nothing else around. Otherwise this monster enters idle mode, 
+            //which players can abuse by casting EVs offscreen and this monster wont fight back
+            if (Core.AOS && theirVal > enemySummonVal && m_Mobile.InLOS(m) && bc?.Summoned == true && bc?.Controlled != true)
+            {
+                enemySummonMob = m;
+                enemySummonVal = theirVal;
+            }
+            else if (theirVal > val && m_Mobile.InLOS(m))
             {
                 newFocusMob = m;
                 val = theirVal;
@@ -2730,7 +2738,7 @@ public abstract class BaseAI
 
         eable.Free();
 
-        m_Mobile.FocusMob = newFocusMob;
+        m_Mobile.FocusMob = newFocusMob ?? enemySummonMob;
         return m_Mobile.FocusMob != null;
     }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -2726,8 +2726,8 @@ public abstract class BaseAI
                 newFocusMob = m;
                 val = theirVal;
             }
-            //The summon is targeted when nothing else around. Otherwise this monster enters idle mode, 
-            //which players can abuse by casting EVs offscreen and this monster wont fight back
+            // The summon is targeted when nothing else around. Otherwise this monster enters idle mode. 
+            // Do a check for this edge case so players cannot abuse by casting EVs offscreen to kill an idle monster.
             else if (Core.AOS && theirVal > enemySummonVal && m_Mobile.InLOS(m) && bc?.Summoned == true && bc?.Controlled != true)
             {
                 enemySummonMob = m;


### PR DESCRIPTION
Hey @kamronbatman,

Previously the monster AcquireFocusMob() would ignore player summons which was being abused by casting energy vortexes etc. out of range, the monster would not detect any players around and enter idle mode and die easily to the EVs; "player versus engine". 

With this change the monster still tries to acquire players but falls back to a player summon target if no valid player targets can be found.