### PR TITLE
fix: Fixes timer orphaning issue

### DIFF
--- a/Projects/Server/Timer/Timer.DelayCall.cs
+++ b/Projects/Server/Timer/Timer.DelayCall.cs
@@ -16,8 +16,8 @@
 using System;
 #if DEBUG_TIMERS
 using System.Collections.Generic;
-#endif
 using System.Diagnostics;
+#endif
 using System.Runtime.CompilerServices;
 
 namespace Server;

--- a/Projects/Server/Timer/Timer.TimerWheel.cs
+++ b/Projects/Server/Timer/Timer.TimerWheel.cs
@@ -33,7 +33,6 @@ public partial class Timer
     private static Timer[] _executingRings = new Timer[_ringLayers];
 
     private static long _lastTickTurned = -1;
-    private static bool _timerWheelExecuting;
 
     public static void Init(long tickCount)
     {
@@ -59,7 +58,6 @@ public partial class Timer
 
     private static void Turn()
     {
-        _timerWheelExecuting = true;
         var turnNextWheel = false;
 
         // Detach the chain from the timer wheel. This allows adding timers to the same slot during execution.
@@ -86,15 +84,12 @@ public partial class Timer
 
         for (var i = 0; i < _ringLayers; i++)
         {
-            var timer = _executingRings[i];
-            if (timer == null)
+            while (_executingRings[i] != null)
             {
-                continue;
-            }
+                var timer = _executingRings[i];
 
-            do
-            {
-                var next = timer._nextTimer;
+                // Set the executing timer to the next in the link list because we will be detaching.
+                _executingRings[i] = timer._nextTimer;
 
                 timer.Detach();
 
@@ -116,15 +111,8 @@ public partial class Timer
                 {
                     timer.OnDetach();
                 }
-
-                timer = next;
-            } while (timer != null);
-
-            // Clear out the rings
-            _executingRings[i] = null;
+            }
         }
-
-        _timerWheelExecuting = false;
     }
 
     private static void Execute(Timer timer)
@@ -232,7 +220,7 @@ public partial class Timer
 
                     total++;
 
-                    t = t?._nextTimer;
+                    t = t._nextTimer;
                 }
             }
         }

--- a/Projects/Server/Timer/Timer.cs
+++ b/Projects/Server/Timer/Timer.cs
@@ -153,13 +153,13 @@ public partial class Timer
 
         Running = false;
 
-        // We are at the head on the timer ring
+        // We are the head on the timer ring
         if (_rings[_ring][_slot] == this)
         {
             _rings[_ring][_slot] = _nextTimer;
         }
 
-        // We are head on the executing ring
+        // We are the head on the executing ring
         if (_executingRings[_ring] == this)
         {
             _executingRings[_ring] = _nextTimer;

--- a/Projects/Server/Timer/Timer.cs
+++ b/Projects/Server/Timer/Timer.cs
@@ -153,20 +153,22 @@ public partial class Timer
 
         Running = false;
 
-        // Do not detach if we are in the middle of executing the timer wheel for this ring/slot
-        if (!_timerWheelExecuting || _ringIndexes[_ring] != _slot)
+        // We are at the head on the timer ring
+        if (_rings[_ring][_slot] == this)
         {
-            // We are at the head
-            if (_rings[_ring][_slot] == this)
-            {
-                _rings[_ring][_slot] = _nextTimer;
-            }
-
-            Detach();
-            OnDetach();
+            _rings[_ring][_slot] = _nextTimer;
         }
 
+        // We are head on the executing ring
+        if (_executingRings[_ring] == this)
+        {
+            _executingRings[_ring] = _nextTimer;
+        }
+
+        Detach();
+
         Version++;
+        OnDetach();
 
         var prof = GetProfile();
         if (prof != null)


### PR DESCRIPTION
* Fixes an edge case where a check to see if a timer was being executed resulted in it not being properly detached on stop. Fixed this by changing how we determine what timer is currently being executed.
* Adds execution count to #DEBUG_TIMERS so shards can get notified (rudimentarily for now) about sequentially executing long chains of timers.

Unfortunately, for now, there is no good option when it comes to executing timers. If we execute let's say 500, and defer the rest, that makes all timers effectively 8ms off until it "catches up". Depending on the shard, that may never happen.