### PR TITLE
fix: Adds logging for possible duplicate objects being added

### DIFF
--- a/Projects/Server/Serial.cs
+++ b/Projects/Server/Serial.cs
@@ -30,13 +30,13 @@ public readonly struct Serial : IComparable<Serial>, IComparable<uint>, IEquatab
     public bool IsMobile
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Value > 0 && Value < World.ItemOffset;
+        get => Value is > 0 and < World.ItemOffset;
     }
 
     public bool IsItem
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Value >= World.ItemOffset && Value < World.MaxItemSerial;
+        get => Value is >= World.ItemOffset and < World.MaxItemSerial;
     }
 
     public bool IsValid

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Server.Guilds;
 using Server.Logging;
@@ -664,22 +665,93 @@ public static class World
                 {
                     if (entity.Serial.IsItem)
                     {
-                        Items[entity.Serial] = entity as Item;
+                        if (!Items.TryAdd(entity.Serial, entity as Item))
+                        {
+                            var existing = Items[entity.Serial];
+
+                            if (existing == entity)
+                            {
+                                logger.Error(
+                                    "Attempted to add '{Entity}' ({Serial}) to World.Items but it already exists in the collection.\n{StackTrace}",
+                                    entity.GetType().FullName,
+                                    entity.Serial,
+                                    new StackTrace()
+                                );
+                            }
+                            else
+                            {
+                                logger.Error(
+                                    "Attempted to add '{Entity}' ({Serial}) to World.Items but found '{ExistingEntity}' ({ExistingSerial}).\n{StackTrace}",
+                                    entity.GetType().FullName,
+                                    entity.Serial,
+                                    existing.GetType().FullName,
+                                    existing.Serial,
+                                    new StackTrace()
+                                );
+                            }
+                        }
                     }
 
                     if (entity.Serial.IsMobile)
                     {
-                        Mobiles[entity.Serial] = entity as Mobile;
+                        if (!Mobiles.TryAdd(entity.Serial, entity as Mobile))
+                        {
+                            var existing = Mobiles[entity.Serial];
+
+                            if (existing == entity)
+                            {
+                                logger.Error(
+                                    "Attempted to add '{Entity}' ({Serial}) to World.Mobiles but it already exists in the collection.\n{StackTrace}",
+                                    entity.GetType().FullName,
+                                    entity.Serial,
+                                    new StackTrace()
+                                );
+                            }
+                            else
+                            {
+                                logger.Error(
+                                    "Attempted to add '{{Entity}}' ({{Serial}}) to World.Mobiles but found '{{ExistingEntity}}' ({{ExistingSerial}}).\n{StackTrace}",
+                                    entity.GetType().FullName,
+                                    entity.Serial,
+                                    existing.GetType().FullName,
+                                    existing.Serial,
+                                    new StackTrace()
+                                );
+                            }
+                        }
                     }
                     break;
                 }
         }
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void AddGuild(BaseGuild guild)
     {
-        Guilds[guild.Serial] = guild;
+        if (!Guilds.TryAdd(guild.Serial, guild))
+        {
+            var existing = Guilds[guild.Serial];
+
+            if (existing == guild)
+            {
+                logger.Error(
+                    "Attempted to add '{Entity}' ({Serial}) to World.Guilds but it already exists in the collection.\n{StackTrace}",
+                    guild.GetType().FullName,
+                    guild.Serial,
+                    new StackTrace()
+                );
+            }
+            else
+            {
+                logger.Error(
+                    "Attempted to add '{{Entity}}' ({{Serial}}) to World.Guilds but found '{{ExistingEntity}}' ({{ExistingSerial}}).\n{StackTrace}",
+                    guild.GetType().FullName,
+                    guild.Serial,
+                    existing.GetType().FullName,
+                    existing.Serial,
+                    new StackTrace()
+                );
+            }
+        }
     }
 
     public static void RemoveEntity<T>(T entity) where T : class, IEntity


### PR DESCRIPTION
Adds logging for `World.AddEntity<T>` and `World.AddGuild` just in case.