### PR TITLE
fix: Changes on Monsters to use code generation

### DIFF
--- a/Projects/UOContent/Migrations/Server.Mobiles.Abscess.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Abscess.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Abscess"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AbysmalHorror.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AbysmalHorror.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AbysmalHorror"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AcidElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AcidElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AcidElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AgapiteElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AgapiteElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AgapiteElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AirElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AirElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AirElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AncientWyrm.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AncientWyrm.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AncientWyrm"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AnimatedWeapon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AnimatedWeapon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AnimatedWeapon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.AntLion.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.AntLion.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.AntLion"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BakeKitsune.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BakeKitsune.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BakeKitsune"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BaseEnraged.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BaseEnraged.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BaseEnraged"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenInfiltratorQueen.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenInfiltratorQueen.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BlackSolenInfiltratorQueen"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenInfiltratorWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenInfiltratorWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BlackSolenInfiltratorWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenQueen.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenQueen.v0.json
@@ -1,0 +1,14 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BlackSolenQueen",
+  "properties": [
+    {
+      "name": "BurstSac",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenWarrior.v0.json
@@ -1,0 +1,14 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BlackSolenWarrior",
+  "properties": [
+    {
+      "name": "BurstSac",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenWorker.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BlackSolenWorker.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BlackSolenWorker"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BladeSpirits.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BladeSpirits.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BladeSpirits"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BloodElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BloodElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BloodElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BogThing.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BogThing.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BogThing"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Bogling.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Bogling.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Bogling"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BoneDemon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BoneDemon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BoneDemon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BronzeElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BronzeElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.BronzeElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Centaur.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Centaur.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Centaur"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Changeling.ClonedItem.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Changeling.ClonedItem.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Changeling.ClonedItem"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Changeling.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Changeling.v0.json
@@ -1,0 +1,11 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Changeling",
+  "properties": [
+    {
+      "name": "MorphedInto",
+      "type": "Server.Mobile",
+      "rule": "SerializableInterfaceMigrationRule"
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ChaosDragoon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ChaosDragoon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ChaosDragoon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ChaosDragoonElite.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ChaosDragoonElite.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ChaosDragoonElite"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Chiikkaha.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Chiikkaha.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Chiikkaha"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Coil.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Coil.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Coil"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CopperElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CopperElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CopperElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CorporealBrume.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CorporealBrume.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CorporealBrume"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Corpser.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Corpser.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Corpser"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CorrosiveSlime.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CorrosiveSlime.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CorrosiveSlime"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CorruptedSoul.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CorruptedSoul.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CorruptedSoul"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CrystalDaemon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CrystalDaemon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CrystalDaemon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CrystalElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CrystalElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CrystalElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CrystalLatticeSeeker.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CrystalLatticeSeeker.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CrystalLatticeSeeker"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CrystalSeaSerpent.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CrystalSeaSerpent.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CrystalSeaSerpent"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CrystalVortex.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CrystalVortex.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CrystalVortex"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CrystalWisp.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CrystalWisp.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CrystalWisp"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.CuSidhe.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.CuSidhe.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.CuSidhe"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DarkWisp.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DarkWisp.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DarkWisp"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DarknightCreeper.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DarknightCreeper.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DarknightCreeper"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DeathwatchBeetle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DeathwatchBeetle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DeathwatchBeetle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DeathwatchBeetleHatchling.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DeathwatchBeetleHatchling.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DeathwatchBeetleHatchling"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DeepSeaSerpent.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DeepSeaSerpent.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DeepSeaSerpent"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DemonKnight.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DemonKnight.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DemonKnight"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Devourer.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Devourer.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Devourer"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Dragon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Dragon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Dragon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Drake.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Drake.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Drake"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DreadSpider.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DreadSpider.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DreadSpider"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.DullCopperElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.DullCopperElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.DullCopperElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EarthElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EarthElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EarthElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Efreet.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Efreet.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Efreet"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EliteNinja.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EliteNinja.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EliteNinja"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnergyVortex.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnergyVortex.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnergyVortex"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnragedBlackBear.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnragedBlackBear.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnragedBlackBear"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnragedEagle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnragedEagle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnragedEagle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnragedHart.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnragedHart.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnragedHart"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnragedHind.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnragedHind.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnragedHind"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnragedRabbit.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnragedRabbit.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnragedRabbit"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EnslavedSatyr.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EnslavedSatyr.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EnslavedSatyr"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.EtherealWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.EtherealWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.EtherealWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ExodusMinion.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ExodusMinion.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ExodusMinion"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ExodusOverseer.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ExodusOverseer.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ExodusOverseer"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FanDancer.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FanDancer.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FanDancer"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FeralTreefellow.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FeralTreefellow.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FeralTreefellow"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Ferret.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Ferret.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Ferret"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FetidEssence.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FetidEssence.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FetidEssence"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FireBeetle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FireBeetle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FireBeetle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FireElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FireElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FireElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FleshGolem.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FleshGolem.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FleshGolem"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FleshRenderer.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FleshRenderer.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FleshRenderer"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FrostOoze.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FrostOoze.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FrostOoze"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.FrostSpider.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.FrostSpider.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.FrostSpider"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.GiantBlackWidow.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.GiantBlackWidow.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.GiantBlackWidow"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.GiantSpider.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.GiantSpider.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.GiantSpider"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Gibberling.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Gibberling.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Gibberling"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Gnaw.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Gnaw.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Gnaw"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.GoldenElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.GoldenElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.GoldenElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Golem.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Golem.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Golem"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.GoreFiend.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.GoreFiend.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.GoreFiend"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.GreaterDragon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.GreaterDragon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.GreaterDragon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Grobu.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Grobu.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Grobu"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Guile.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Guile.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Guile"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Harpy.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Harpy.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Harpy"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.HellHound.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.HellHound.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.HellHound"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Hydra.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Hydra.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Hydra"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.IceElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.IceElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.IceElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Ilhenir.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Ilhenir.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Ilhenir"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Impaler.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Impaler.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Impaler"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.InsaneDryad.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.InsaneDryad.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.InsaneDryad"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.InterredGrizzle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.InterredGrizzle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.InterredGrizzle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Irk.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Irk.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Irk"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.JukaLord.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.JukaLord.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.JukaLord"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.JukaMage.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.JukaMage.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.JukaMage"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.JukaWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.JukaWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.JukaWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Kappa.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Kappa.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Kappa"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.KazeKemono.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.KazeKemono.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.KazeKemono"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Kraken.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Kraken.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Kraken"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.LadyJennifyr.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.LadyJennifyr.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.LadyJennifyr"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.LadyLissith.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.LadyLissith.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.LadyLissith"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.LadyMarai.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.LadyMarai.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.LadyMarai"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.LadyOfTheSnow.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.LadyOfTheSnow.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.LadyOfTheSnow"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.LadySabrix.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.LadySabrix.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.LadySabrix"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Leviathan.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Leviathan.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Leviathan"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Lizardman.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Lizardman.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Lizardman"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Lurg.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Lurg.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Lurg"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MLDryad.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MLDryad.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MLDryad"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Malefic.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Malefic.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Malefic"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MantraEffervescence.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MantraEffervescence.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MantraEffervescence"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MasterJonath.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MasterJonath.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MasterJonath"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MasterMikael.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MasterMikael.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MasterMikael"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MasterTheophilus.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MasterTheophilus.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MasterTheophilus"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MeerCaptain.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MeerCaptain.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MeerCaptain"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MeerEternal.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MeerEternal.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MeerEternal"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MeerMage.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MeerMage.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MeerMage"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MeerWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MeerWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MeerWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Meraktus.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Meraktus.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Meraktus"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Miasma.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Miasma.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Miasma"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Minotaur.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Minotaur.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Minotaur"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MinotaurCaptain.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MinotaurCaptain.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MinotaurCaptain"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MinotaurScout.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MinotaurScout.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MinotaurScout"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MougGuur.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MougGuur.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MougGuur"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.MoundOfMaggots.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.MoundOfMaggots.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.MoundOfMaggots"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Oni.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Oni.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Oni"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.OphidianArchmage.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.OphidianArchmage.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.OphidianArchmage"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.OphidianKnight.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.OphidianKnight.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.OphidianKnight"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.OphidianMage.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.OphidianMage.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.OphidianMage"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.OphidianMatriarch.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.OphidianMatriarch.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.OphidianMatriarch"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.OphidianWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.OphidianWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.OphidianWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.PatchworkSkeleton.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.PatchworkSkeleton.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.PatchworkSkeleton"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.PestilentBandage.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.PestilentBandage.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.PestilentBandage"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Pixie.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Pixie.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Pixie"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.PlagueBeast.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.PlagueBeast.v0.json
@@ -1,0 +1,30 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.PlagueBeast",
+  "properties": [
+    {
+      "name": "HasMetalChest",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "TotalDevoured",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "DevourGoal",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.PlagueBeastLord.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.PlagueBeastLord.v0.json
@@ -1,0 +1,35 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.PlagueBeastLord",
+  "properties": [
+    {
+      "name": "Count",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Deadline",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "IsNotNullTimer",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "OpenedBy",
+      "type": "Server.Mobile",
+      "rule": "SerializableInterfaceMigrationRule"
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.PlagueSpawn.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.PlagueSpawn.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.PlagueSpawn"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.PoisonElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.PoisonElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.PoisonElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Protector.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Protector.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Protector"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Putrefier.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Putrefier.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Putrefier"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Pyre.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Pyre.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Pyre"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Quagmire.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Quagmire.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Quagmire"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RagingGrizzlyBear.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RagingGrizzlyBear.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RagingGrizzlyBear"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RaiJu.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RaiJu.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RaiJu"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Ravager.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Ravager.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Ravager"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Reaper.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Reaper.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Reaper"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RedDeath.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RedDeath.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RedDeath"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RedSolenInfiltratorQueen.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RedSolenInfiltratorQueen.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RedSolenInfiltratorQueen"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RedSolenInfiltratorWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RedSolenInfiltratorWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RedSolenInfiltratorWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RedSolenQueen.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RedSolenQueen.v0.json
@@ -1,0 +1,14 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RedSolenQueen",
+  "properties": [
+    {
+      "name": "BurstSac",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RedSolenWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RedSolenWarrior.v0.json
@@ -1,0 +1,14 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RedSolenWarrior",
+  "properties": [
+    {
+      "name": "BurstSac",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RedSolenWorker.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RedSolenWorker.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RedSolenWorker"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Rend.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Rend.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Rend"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Reptalon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Reptalon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Reptalon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Revenant.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Revenant.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Revenant"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RevenantLion.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RevenantLion.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RevenantLion"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Ronin.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Ronin.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Ronin"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.RuneBeetle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.RuneBeetle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.RuneBeetle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Saliva.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Saliva.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Saliva"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SandVortex.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SandVortex.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SandVortex"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Satyr.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Satyr.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Satyr"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Scorpion.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Scorpion.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Scorpion"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SeaSerpent.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SeaSerpent.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SeaSerpent"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SerpentineDragon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SerpentineDragon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SerpentineDragon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ShadowIronElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ShadowIronElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ShadowIronElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ShadowKnight.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ShadowKnight.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ShadowKnight"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ShadowWisp.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ShadowWisp.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ShadowWisp"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ShadowWyrm.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ShadowWyrm.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ShadowWyrm"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Silk.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Silk.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Silk"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SirPatrick.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SirPatrick.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SirPatrick"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SkeletalDragon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SkeletalDragon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SkeletalDragon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SkitteringHopper.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SkitteringHopper.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SkitteringHopper"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Slime.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Slime.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Slime"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SnowElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SnowElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SnowElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Spite.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Spite.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Spite"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Squirrel.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Squirrel.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Squirrel"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.StainedOoze.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.StainedOoze.v0.json
@@ -1,0 +1,14 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.StainedOoze",
+  "properties": [
+    {
+      "name": "Corrosive",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.StoneHarpy.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.StoneHarpy.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.StoneHarpy"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SummonedAirElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SummonedAirElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SummonedAirElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SummonedDaemon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SummonedDaemon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SummonedDaemon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SummonedEarthElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SummonedEarthElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SummonedEarthElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SummonedFireElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SummonedFireElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SummonedFireElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SummonedWaterElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SummonedWaterElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SummonedWaterElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.SwampTentacle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.SwampTentacle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.SwampTentacle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Swoop.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Swoop.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Swoop"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Szavetra.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Szavetra.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Szavetra"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Tangle.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Tangle.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Tangle"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.TerathanAvenger.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.TerathanAvenger.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.TerathanAvenger"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.TerathanDrone.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.TerathanDrone.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.TerathanDrone"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.TerathanMatriarch.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.TerathanMatriarch.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.TerathanMatriarch"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.TerathanWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.TerathanWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.TerathanWarrior"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Thrasher.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Thrasher.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Thrasher"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.TormentedMinotaur.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.TormentedMinotaur.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.TormentedMinotaur"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Treefellow.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Treefellow.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Treefellow"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Troglodyte.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Troglodyte.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Troglodyte"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.TsukiWolf.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.TsukiWolf.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.TsukiWolf"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Twaulo.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Twaulo.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Twaulo"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.UnfrozenMummy.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.UnfrozenMummy.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.UnfrozenMummy"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.ValoriteElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.ValoriteElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.ValoriteElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.VampireBat.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.VampireBat.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.VampireBat"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.VeriteElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.VeriteElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.VeriteElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Virulent.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Virulent.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Virulent"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.VorpalBunny.BunnyHole.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.VorpalBunny.BunnyHole.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.VorpalBunny.BunnyHole"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.VorpalBunny.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.VorpalBunny.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.VorpalBunny"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.WailingBanshee.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.WailingBanshee.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.WailingBanshee"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.WandererOfTheVoid.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.WandererOfTheVoid.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.WandererOfTheVoid"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.WaterElemental.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.WaterElemental.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.WaterElemental"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.WhippingVine.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.WhippingVine.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.WhippingVine"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.WhiteWyrm.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.WhiteWyrm.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.WhiteWyrm"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Wisp.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Wisp.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Wisp"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Wyvern.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Wyvern.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Wyvern"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.Yamandon.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.Yamandon.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.Yamandon"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.YomotsuElder.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.YomotsuElder.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.YomotsuElder"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.YomotsuPriest.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.YomotsuPriest.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.YomotsuPriest"
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.YomotsuWarrior.v0.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.YomotsuWarrior.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Mobiles.YomotsuWarrior"
+}

--- a/Projects/UOContent/Mobiles/Monsters/AOS/AbysmalHorror.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/AbysmalHorror.cs
@@ -71,14 +71,5 @@ namespace Server.Mobiles
                 DemonKnight.DistributeArtifact(this);
             }
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 357)
-            {
-                BaseSoundID = 0x451;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/AbysmalHorror.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/AbysmalHorror.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class AbysmalHorror : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AbysmalHorror : BaseCreature
     {
         [Constructible]
         public AbysmalHorror() : base(AIType.AI_Mage)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 54;
         }
 
-        public AbysmalHorror(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an abysmal horror corpse";
 
         public override bool IgnoreYoungProtection => Core.ML;
@@ -74,17 +72,9 @@ namespace Server.Mobiles
             }
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 357)
             {
                 BaseSoundID = 0x451;

--- a/Projects/UOContent/Mobiles/Monsters/AOS/BoneDemon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/BoneDemon.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class BoneDemon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BoneDemon : BaseCreature
     {
         [Constructible]
         public BoneDemon() : base(AIType.AI_Mage)
@@ -39,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 44;
         }
 
-        public BoneDemon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a bone demon corpse";
         public override string DefaultName => "a bone demon";
 
@@ -55,18 +54,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 8);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/CrystalElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/CrystalElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class CrystalElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CrystalElemental : BaseCreature
     {
         [Constructible]
         public CrystalElemental() : base(AIType.AI_Mage)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 54;
         }
 
-        public CrystalElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a crystal elemental corpse";
 
         public override string DefaultName => "a crystal elemental";
@@ -58,18 +56,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/DarknightCreeper.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/DarknightCreeper.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class DarknightCreeper : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class DarknightCreeper : BaseCreature
     {
         [Constructible]
         public DarknightCreeper() : base(AIType.AI_Mage)
@@ -45,10 +47,6 @@ namespace Server.Mobiles
             VirtualArmor = 34;
         }
 
-        public DarknightCreeper(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a darknight creeper corpse";
         public override bool IgnoreYoungProtection => Core.ML;
 
@@ -76,17 +74,9 @@ namespace Server.Mobiles
             }
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 471)
             {
                 BaseSoundID = 0xE0;

--- a/Projects/UOContent/Mobiles/Monsters/AOS/DarknightCreeper.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/DarknightCreeper.cs
@@ -73,14 +73,5 @@ namespace Server.Mobiles
                 DemonKnight.DistributeArtifact(this);
             }
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 471)
-            {
-                BaseSoundID = 0xE0;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/DemonKnight.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/DemonKnight.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class DemonKnight : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class DemonKnight : BaseCreature
     {
         private static bool m_InHere;
 
@@ -51,10 +53,6 @@ namespace Server.Mobiles
             Karma = -28000;
 
             VirtualArmor = 64;
-        }
-
-        public DemonKnight(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a demon knight corpse";
@@ -283,18 +281,6 @@ namespace Server.Mobiles
 
                 bone.MoveToWorld(new Point3D(x, y, z), map);
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Devourer.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Devourer.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Devourer : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Devourer : BaseCreature
     {
         [Constructible]
         public Devourer() : base(AIType.AI_Mage)
@@ -41,10 +44,6 @@ namespace Server.Mobiles
             PackNecroReg(24, 45);
         }
 
-        public Devourer(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a devourer of souls corpse";
         public override string DefaultName => "a devourer of souls";
 
@@ -55,18 +54,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/FleshGolem.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/FleshGolem.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class FleshGolem : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class FleshGolem : BaseCreature
     {
         [Constructible]
         public FleshGolem() : base(AIType.AI_Melee)
@@ -36,10 +38,6 @@ namespace Server.Mobiles
             VirtualArmor = 34;
         }
 
-        public FleshGolem(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a flesh golem corpse";
 
         public override string DefaultName => "a flesh golem";
@@ -52,18 +50,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/FleshRenderer.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/FleshRenderer.cs
@@ -81,14 +81,5 @@ namespace Server.Mobiles
         public override int GetIdleSound() => 0x34C;
 
         public override int GetDeathSound() => 0x354;
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 660)
-            {
-                BaseSoundID = -1;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/FleshRenderer.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/FleshRenderer.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class FleshRenderer : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class FleshRenderer : BaseCreature
     {
         [Constructible]
         public FleshRenderer() : base(AIType.AI_Melee)
@@ -36,10 +38,6 @@ namespace Server.Mobiles
             Karma = -23000;
 
             VirtualArmor = 24;
-        }
-
-        public FleshRenderer(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a fleshrenderer corpse";
@@ -84,17 +82,9 @@ namespace Server.Mobiles
 
         public override int GetDeathSound() => 0x354;
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 660)
             {
                 BaseSoundID = -1;

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Gibberling.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Gibberling.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Gibberling : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Gibberling : BaseCreature
     {
         [Constructible]
         public Gibberling() : base(AIType.AI_Melee)
@@ -38,10 +40,6 @@ namespace Server.Mobiles
             VirtualArmor = 27;
         }
 
-        public Gibberling(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a gibberling corpse";
 
         public override string DefaultName => "a gibberling";
@@ -53,18 +51,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/GoreFiend.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/GoreFiend.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class GoreFiend : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class GoreFiend : BaseCreature
     {
         [Constructible]
         public GoreFiend() : base(AIType.AI_Melee)
@@ -35,10 +38,6 @@ namespace Server.Mobiles
             VirtualArmor = 24;
         }
 
-        public GoreFiend(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a gore fiend corpse";
         public override string DefaultName => "a gore fiend";
 
@@ -50,17 +49,5 @@ namespace Server.Mobiles
         }
 
         public override int GetDeathSound() => 1218;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Impaler.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Impaler.cs
@@ -72,14 +72,5 @@ namespace Server.Mobiles
                 DemonKnight.DistributeArtifact(this);
             }
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 1200)
-            {
-                BaseSoundID = 0x2A7;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Impaler.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Impaler.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Impaler : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Impaler : BaseCreature
     {
         [Constructible]
         public Impaler() : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 49;
         }
 
-        public Impaler(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an impaler corpse";
 
         public override bool IgnoreYoungProtection => Core.ML;
@@ -75,17 +73,9 @@ namespace Server.Mobiles
             }
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 1200)
             {
                 BaseSoundID = 0x2A7;

--- a/Projects/UOContent/Mobiles/Monsters/AOS/MoundOfMaggots.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/MoundOfMaggots.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class MoundOfMaggots : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MoundOfMaggots : BaseCreature
     {
         [Constructible]
         public MoundOfMaggots() : base(AIType.AI_Melee)
@@ -31,10 +34,6 @@ namespace Server.Mobiles
             VirtualArmor = 24;
         }
 
-        public MoundOfMaggots(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a maggoty corpse";
         public override string DefaultName => "a mound of maggots";
 
@@ -46,18 +45,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Meager);
             AddLoot(LootPack.Gems);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/PatchworkSkeleton.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/PatchworkSkeleton.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class PatchworkSkeleton : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class PatchworkSkeleton : BaseCreature
     {
         [Constructible]
         public PatchworkSkeleton() : base(AIType.AI_Melee)
@@ -37,10 +39,6 @@ namespace Server.Mobiles
             VirtualArmor = 54;
         }
 
-        public PatchworkSkeleton(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a patchwork skeletal corpse";
 
         public override string DefaultName => "a patchwork skeleton";
@@ -55,18 +53,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Ravager.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Ravager.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Ravager : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Ravager : BaseCreature
     {
         [Constructible]
         public Ravager() : base(AIType.AI_Melee)
@@ -36,10 +38,6 @@ namespace Server.Mobiles
             VirtualArmor = 54;
         }
 
-        public Ravager(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a ravager corpse";
 
         public override string DefaultName => "a ravager";
@@ -50,18 +48,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Rich);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Revenant.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Revenant.cs
@@ -173,7 +173,7 @@ namespace Server.Mobiles
             return false;
         }
 
-        [AfterDeserialization]
+        [AfterDeserialization(false)]
         private void AfterDeserialization()
         {
             Delete();

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Revenant.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Revenant.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Revenant : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Revenant : BaseCreature
     {
         private readonly DateTime m_ExpireTime;
         private readonly Mobile m_Target;
@@ -53,10 +55,6 @@ namespace Server.Mobiles
 
             AddItem(new DeathShroud { Hue = 0x455, Movable = false });
             AddItem(new Halberd { Hue = 1, Movable = false });
-        }
-
-        public Revenant(Serial serial) : base(serial)
-        {
         }
 
         public override Mobile ConstantFocus => m_Target;
@@ -175,19 +173,9 @@ namespace Server.Mobiles
             return false;
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
             Delete();
         }
     }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/ShadowKnight.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/ShadowKnight.cs
@@ -180,14 +180,5 @@ namespace Server.Mobiles
 
             base.OnThink();
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 357)
-            {
-                BaseSoundID = -1;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/ShadowKnight.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/ShadowKnight.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class ShadowKnight : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class ShadowKnight : BaseCreature
     {
         private bool m_HasTeleportedAway;
 
@@ -46,10 +48,6 @@ namespace Server.Mobiles
             Karma = -25000;
 
             VirtualArmor = 54;
-        }
-
-        public ShadowKnight(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a shadow knight corpse";
@@ -183,17 +181,9 @@ namespace Server.Mobiles
             base.OnThink();
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 357)
             {
                 BaseSoundID = -1;

--- a/Projects/UOContent/Mobiles/Monsters/AOS/SkitteringHopper.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/SkitteringHopper.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SkitteringHopper : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SkitteringHopper : BaseCreature
     {
         [Constructible]
         public SkitteringHopper() : base(AIType.AI_Melee, FightMode.Aggressor)
@@ -36,10 +39,6 @@ namespace Server.Mobiles
             VirtualArmor = 12;
         }
 
-        public SkitteringHopper(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a skittering hopper corpse";
         public override string DefaultName => "a skittering hopper";
 
@@ -48,18 +47,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Treefellow.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Treefellow.cs
@@ -57,14 +57,5 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Average);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 442)
-            {
-                BaseSoundID = -1;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/Treefellow.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/Treefellow.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Treefellow : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Treefellow : BaseCreature
     {
         [Constructible]
         public Treefellow() : base(AIType.AI_Melee, FightMode.Evil)
@@ -35,10 +37,6 @@ namespace Server.Mobiles
             PackItem(new Log(Utility.RandomMinMax(23, 34)));
         }
 
-        public Treefellow(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a treefellow corpse";
 
         public override string DefaultName => "a treefellow";
@@ -60,17 +58,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Average);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 442)
             {
                 BaseSoundID = -1;

--- a/Projects/UOContent/Mobiles/Monsters/AOS/VampireBat.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/VampireBat.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class VampireBat : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class VampireBat : BaseCreature
     {
         [Constructible]
         public VampireBat() : base(AIType.AI_Melee)
@@ -35,10 +38,6 @@ namespace Server.Mobiles
             VirtualArmor = 14;
         }
 
-        public VampireBat(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a vampire bat corpse";
         public override string DefaultName => "a vampire bat";
 
@@ -48,17 +47,5 @@ namespace Server.Mobiles
         }
 
         public override int GetIdleSound() => 0x29B;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/WailingBanshee.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/WailingBanshee.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class WailingBanshee : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class WailingBanshee : BaseCreature
     {
         [Constructible]
         public WailingBanshee() : base(AIType.AI_Melee)
@@ -38,10 +40,6 @@ namespace Server.Mobiles
             VirtualArmor = 19;
         }
 
-        public WailingBanshee(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wailing banshee corpse";
 
         public override string DefaultName => "a wailing banshee";
@@ -53,18 +51,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/AOS/WandererOfTheVoid.cs
+++ b/Projects/UOContent/Mobiles/Monsters/AOS/WandererOfTheVoid.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class WandererOfTheVoid : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class WandererOfTheVoid : BaseCreature
     {
         [Constructible]
         public WandererOfTheVoid() : base(AIType.AI_Mage)
@@ -48,10 +50,6 @@ namespace Server.Mobiles
             }
         }
 
-        public WandererOfTheVoid(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wanderer of the void corpse";
         public override string DefaultName => "a wanderer of the void";
 
@@ -62,18 +60,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/AntLion.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/AntLion.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class AntLion : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AntLion : BaseCreature
     {
         [Constructible]
         public AntLion() : base(AIType.AI_Melee)
@@ -59,11 +61,6 @@ namespace Server.Mobiles
 
             // TODO: skeleton
         }
-
-        public AntLion(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ant lion corpse";
         public override string DefaultName => "an ant lion";
 
@@ -80,18 +77,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenInfiltratorQueen.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenInfiltratorQueen.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class BlackSolenInfiltratorQueen : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BlackSolenInfiltratorQueen : BaseCreature
     {
         [Constructible]
         public BlackSolenInfiltratorQueen() : base(AIType.AI_Melee)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(new ZoogiFungus(Utility.RandomDouble() < 0.05 ? 16 : 4));
         }
 
-        public BlackSolenInfiltratorQueen(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen infiltrator corpse";
         public override string DefaultName => "a black solen infiltrator";
 
@@ -79,18 +77,6 @@ namespace Server.Mobiles
             SolenHelper.OnBlackDamage(from);
 
             base.OnDamage(amount, from, willKill);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenInfiltratorWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenInfiltratorWarrior.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class BlackSolenInfiltratorWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BlackSolenInfiltratorWarrior : BaseCreature
     {
         [Constructible]
         public BlackSolenInfiltratorWarrior() : base(AIType.AI_Melee)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(new ZoogiFungus(Utility.RandomDouble() < 0.05 ? 13 : 3));
         }
 
-        public BlackSolenInfiltratorWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen infiltrator corpse";
         public override string DefaultName => "a black solen infiltrator";
 
@@ -80,18 +78,6 @@ namespace Server.Mobiles
             SolenHelper.OnBlackDamage(from);
 
             base.OnDamage(amount, from, willKill);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenQueen.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenQueen.cs
@@ -1,10 +1,16 @@
+using ModernUO.Serialization;
+using Org.BouncyCastle.Security;
 using Server.Items;
 using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class BlackSolenQueen : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BlackSolenQueen : BaseCreature
     {
+        [SerializableField(0, setter: "private")]
+        private bool _burstSac;
+
         [Constructible]
         public BlackSolenQueen() : base(AIType.AI_Melee)
         {
@@ -48,12 +54,7 @@ namespace Server.Mobiles
             }
         }
 
-        public BlackSolenQueen(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen queen corpse";
-        public bool BurstSac { get; private set; }
 
         public override string DefaultName => "a black solen queen";
 
@@ -110,28 +111,6 @@ namespace Server.Mobiles
             SpillAcid(4);
 
             return base.OnBeforeDeath();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(1);
-            writer.Write(BurstSac);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
-            switch (version)
-            {
-                case 1:
-                    {
-                        BurstSac = reader.ReadBool();
-                        break;
-                    }
-            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenWarrior.cs
@@ -1,10 +1,15 @@
+using ModernUO.Serialization;
 using Server.Items;
 using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class BlackSolenWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BlackSolenWarrior : BaseCreature
     {
+        [SerializableField(0, setter: "private")]
+        private bool _burstSac;
+
         [Constructible]
         public BlackSolenWarrior() : base(AIType.AI_Melee)
         {
@@ -48,12 +53,7 @@ namespace Server.Mobiles
             }
         }
 
-        public BlackSolenWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen warrior corpse";
-        public bool BurstSac { get; private set; }
 
         public override string DefaultName => "a black solen warrior";
 
@@ -111,28 +111,6 @@ namespace Server.Mobiles
             SpillAcid(4);
 
             return base.OnBeforeDeath();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(1);
-            writer.Write(BurstSac);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
-            switch (version)
-            {
-                case 1:
-                    {
-                        BurstSac = reader.ReadBool();
-                        break;
-                    }
-            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenWorker.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/BlackSolenWorker.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class BlackSolenWorker : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BlackSolenWorker : BaseCreature
     {
         [Constructible]
         public BlackSolenWorker() : base(AIType.AI_Melee)
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             PackItem(new ZoogiFungus());
         }
 
-        public BlackSolenWorker(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen worker corpse";
         public override string DefaultName => "a black solen worker";
 
@@ -80,18 +78,6 @@ namespace Server.Mobiles
             SolenHelper.OnBlackDamage(from);
 
             base.OnDamage(amount, from, willKill);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenInfiltratorQueen.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenInfiltratorQueen.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class RedSolenInfiltratorQueen : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RedSolenInfiltratorQueen : BaseCreature
     {
         [Constructible]
         public RedSolenInfiltratorQueen() : base(AIType.AI_Melee)
@@ -41,10 +43,6 @@ namespace Server.Mobiles
             PackItem(new ZoogiFungus(Utility.RandomDouble() < 0.95 ? 4 : 16));
         }
 
-        public RedSolenInfiltratorQueen(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen infiltrator corpse";
         public override string DefaultName => "a red solen infiltrator";
 
@@ -78,18 +76,6 @@ namespace Server.Mobiles
             SolenHelper.OnRedDamage(from);
 
             base.OnDamage(amount, from, willKill);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenInfiltratorWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenInfiltratorWarrior.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class RedSolenInfiltratorWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RedSolenInfiltratorWarrior : BaseCreature
     {
         [Constructible]
         public RedSolenInfiltratorWarrior() : base(AIType.AI_Melee)
@@ -41,10 +43,6 @@ namespace Server.Mobiles
             PackItem(new ZoogiFungus(Utility.RandomDouble() < 0.95 ? 3 : 13));
         }
 
-        public RedSolenInfiltratorWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen infiltrator corpse";
         public override string DefaultName => "a red solen infiltrator";
 
@@ -79,18 +77,6 @@ namespace Server.Mobiles
             SolenHelper.OnRedDamage(from);
 
             base.OnDamage(amount, from, willKill);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenQueen.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenQueen.cs
@@ -1,10 +1,15 @@
+using ModernUO.Serialization;
 using Server.Items;
 using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class RedSolenQueen : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RedSolenQueen : BaseCreature
     {
+        [SerializableField(0, setter: "private")]
+        private bool _burstSac;
+
         [Constructible]
         public RedSolenQueen() : base(AIType.AI_Melee)
         {
@@ -47,12 +52,7 @@ namespace Server.Mobiles
             }
         }
 
-        public RedSolenQueen(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen queen corpse";
-        public bool BurstSac { get; private set; }
 
         public override string DefaultName => "a red solen queen";
 
@@ -109,28 +109,6 @@ namespace Server.Mobiles
             SpillAcid(4);
 
             return base.OnBeforeDeath();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(1);
-            writer.Write(BurstSac);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
-            switch (version)
-            {
-                case 1:
-                    {
-                        BurstSac = reader.ReadBool();
-                        break;
-                    }
-            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenWarrior.cs
@@ -1,10 +1,15 @@
+using ModernUO.Serialization;
 using Server.Items;
 using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class RedSolenWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RedSolenWarrior : BaseCreature
     {
+        [SerializableField(0, setter: "private")]
+        private bool _burstSac;
+
         [Constructible]
         public RedSolenWarrior() : base(AIType.AI_Melee)
         {
@@ -46,12 +51,7 @@ namespace Server.Mobiles
             }
         }
 
-        public RedSolenWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen warrior corpse";
-        public bool BurstSac { get; private set; }
 
         public override string DefaultName => "a red solen warrior";
 
@@ -109,28 +109,6 @@ namespace Server.Mobiles
             SpillAcid(4);
 
             return base.OnBeforeDeath();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(1);
-            writer.Write(BurstSac);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
-            switch (version)
-            {
-                case 1:
-                    {
-                        BurstSac = reader.ReadBool();
-                        break;
-                    }
-            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenWorker.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ants/RedSolenWorker.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class RedSolenWorker : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RedSolenWorker : BaseCreature
     {
         [Constructible]
         public RedSolenWorker() : base(AIType.AI_Melee)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(new ZoogiFungus());
         }
 
-        public RedSolenWorker(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a solen worker corpse";
         public override string DefaultName => "a red solen worker";
 
@@ -79,18 +77,6 @@ namespace Server.Mobiles
             SolenHelper.OnRedDamage(from);
 
             base.OnDamage(amount, from, willKill);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/DreadSpider.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/DreadSpider.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class DreadSpider : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class DreadSpider : BaseCreature
     {
         [Constructible]
         public DreadSpider() : base(AIType.AI_Mage)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(new SpidersSilk(8));
         }
 
-        public DreadSpider(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a dread spider corpse";
         public override string DefaultName => "a dread spider";
 
@@ -58,17 +56,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.FilthyRich);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 263)
             {
                 BaseSoundID = 1170;

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/DreadSpider.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/DreadSpider.cs
@@ -55,14 +55,5 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.FilthyRich);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 263)
-            {
-                BaseSoundID = 1170;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/TerathanAvenger.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/TerathanAvenger.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class TerathanAvenger : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class TerathanAvenger : BaseCreature
     {
         [Constructible]
         public TerathanAvenger() : base(AIType.AI_Mage)
@@ -39,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 50;
         }
 
-        public TerathanAvenger(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a terathan avenger corpse";
         public override string DefaultName => "a terathan avenger";
 
@@ -58,17 +57,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Rich, 2);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 263)
             {
                 BaseSoundID = 0x24D;

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/TerathanAvenger.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/TerathanAvenger.cs
@@ -56,14 +56,5 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Rich, 2);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 263)
-            {
-                BaseSoundID = 0x24D;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/TerathanMatriarch.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Magic/TerathanMatriarch.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class TerathanMatriarch : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class TerathanMatriarch : BaseCreature
     {
         [Constructible]
         public TerathanMatriarch() : base(AIType.AI_Mage)
@@ -39,10 +41,6 @@ namespace Server.Mobiles
             PackNecroReg(Utility.RandomMinMax(4, 10));
         }
 
-        public TerathanMatriarch(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a terathan matriarch corpse";
         public override string DefaultName => "a terathan matriarch";
 
@@ -56,18 +54,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.Average, 2);
             AddLoot(LootPack.MedScrolls, 2);
             AddLoot(LootPack.Potions);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/FrostSpider.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/FrostSpider.cs
@@ -57,14 +57,5 @@ namespace Server.Mobiles
             AddLoot(LootPack.Meager);
             AddLoot(LootPack.Poor);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 387)
-            {
-                BaseSoundID = 0x388;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/FrostSpider.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/FrostSpider.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class FrostSpider : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class FrostSpider : BaseCreature
     {
         [Constructible]
         public FrostSpider() : base(AIType.AI_Melee)
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             PackItem(new SpidersSilk(7));
         }
 
-        public FrostSpider(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a frost spider corpse";
         public override string DefaultName => "a frost spider";
 
@@ -60,17 +58,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Poor);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 387)
             {
                 BaseSoundID = 0x388;

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/GiantBlackWidow.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/GiantBlackWidow.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class GiantBlackWidow : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class GiantBlackWidow : BaseCreature
     {
         [Constructible]
         public GiantBlackWidow() : base(AIType.AI_Melee)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(new LesserPoisonPotion());
         }
 
-        public GiantBlackWidow(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a giant black widow spider corpse";
         public override string DefaultName => "a giant black wide";
 
@@ -56,18 +54,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/GiantSpider.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/GiantSpider.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class GiantSpider : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class GiantSpider : BaseCreature
     {
         [Constructible]
         public GiantSpider() : base(AIType.AI_Melee)
@@ -41,10 +43,6 @@ namespace Server.Mobiles
             PackItem(new SpidersSilk(5));
         }
 
-        public GiantSpider(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a giant spider corpse";
         public override string DefaultName => "a giant spider";
 
@@ -56,18 +54,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Poor);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/TerathanDrone.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/TerathanDrone.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class TerathanDrone : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class TerathanDrone : BaseCreature
     {
         [Constructible]
         public TerathanDrone() : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             PackItem(new SpidersSilk(2));
         }
 
-        public TerathanDrone(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a terathan drone corpse";
         public override string DefaultName => "a terathan drone";
 
@@ -57,17 +55,9 @@ namespace Server.Mobiles
             // TODO: weapon?
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 589)
             {
                 BaseSoundID = 594;

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/TerathanDrone.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/TerathanDrone.cs
@@ -54,14 +54,5 @@ namespace Server.Mobiles
             AddLoot(LootPack.Meager);
             // TODO: weapon?
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 589)
-            {
-                BaseSoundID = 594;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/TerathanWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Arachnid/Melee/TerathanWarrior.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 
 namespace Server.Mobiles
 {
-    public class TerathanWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class TerathanWarrior : BaseCreature
     {
         [Constructible]
         public TerathanWarrior() : base(AIType.AI_Melee)
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             }
         }
 
-        public TerathanWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a terathan warrior corpse";
         public override string DefaultName => "a terathan warrior";
 
@@ -58,18 +56,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AcidElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AcidElemental.cs
@@ -57,24 +57,5 @@ namespace Server.Mobiles
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Average);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 263)
-            {
-                BaseSoundID = 278;
-            }
-
-            if (Body == 13)
-            {
-                Body = 0x9E;
-            }
-
-            if (Hue == 0x4001)
-            {
-                Hue = 0;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AcidElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AcidElemental.cs
@@ -1,7 +1,10 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.ToxicElemental")]
-    public class AcidElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AcidElemental : BaseCreature
     {
         [Constructible]
         public AcidElemental() : base(AIType.AI_Mage)
@@ -40,11 +43,6 @@ namespace Server.Mobiles
             VirtualArmor = 40;
         }
 
-        public AcidElemental(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an acid elemental corpse";
         public override string DefaultName => "an acid elemental";
 
@@ -60,17 +58,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Average);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 263)
             {
                 BaseSoundID = 278;

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AirElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AirElemental.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class AirElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AirElemental : BaseCreature
     {
         [Constructible]
         public AirElemental() : base(AIType.AI_Mage)
@@ -40,10 +43,6 @@ namespace Server.Mobiles
             ControlSlots = 2;
         }
 
-        public AirElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an air elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
@@ -61,17 +60,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.MedScrolls);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 263)
             {
                 BaseSoundID = 655;

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AirElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/AirElemental.cs
@@ -59,14 +59,5 @@ namespace Server.Mobiles
             AddLoot(LootPack.LowScrolls);
             AddLoot(LootPack.MedScrolls);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 263)
-            {
-                BaseSoundID = 655;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/BloodElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/BloodElemental.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class BloodElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BloodElemental : BaseCreature
     {
         [Constructible]
         public BloodElemental() : base(AIType.AI_Mage)
@@ -39,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 60;
         }
 
-        public BloodElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a blood elemental corpse";
         public override string DefaultName => "a blood elemental";
 
@@ -52,18 +51,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.FilthyRich);
             AddLoot(LootPack.Rich);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/Efreet.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/Efreet.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Efreet : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Efreet : BaseCreature
     {
         [Constructible]
         public Efreet() : base(AIType.AI_Mage)
@@ -39,10 +41,6 @@ namespace Server.Mobiles
             VirtualArmor = 56;
         }
 
-        public Efreet(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an efreet corpse";
         public override string DefaultName => "an efreet";
 
@@ -75,18 +73,6 @@ namespace Server.Mobiles
                         break;
                 }
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/FireElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/FireElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class FireElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class FireElemental : BaseCreature
     {
         [Constructible]
         public FireElemental() : base(AIType.AI_Mage)
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             AddItem(new LightSource());
         }
 
-        public FireElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a fire elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
@@ -64,17 +62,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Gems);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 274)
             {
                 BaseSoundID = 838;

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/FireElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/FireElemental.cs
@@ -61,14 +61,5 @@ namespace Server.Mobiles
             AddLoot(LootPack.Meager);
             AddLoot(LootPack.Gems);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 274)
-            {
-                BaseSoundID = 838;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/IceElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/IceElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class IceElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class IceElemental : BaseCreature
     {
         [Constructible]
         public IceElemental() : base(AIType.AI_Mage)
@@ -41,11 +43,6 @@ namespace Server.Mobiles
             PackItem(new BlackPearl());
             PackReg(3);
         }
-
-        public IceElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ice elemental corpse";
         public override string DefaultName => "an ice elemental";
         public override bool BleedImmune => true;
@@ -54,18 +51,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Average, 2);
             AddLoot(LootPack.Gems, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/PoisonElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/PoisonElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class PoisonElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class PoisonElemental : BaseCreature
     {
         [Constructible]
         public PoisonElemental() : base(AIType.AI_Mage)
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             PackItem(new LesserPoisonPotion());
         }
 
-        public PoisonElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a poison elementals corpse";
         public override string DefaultName => "a poison elemental";
 
@@ -64,18 +62,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.FilthyRich);
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.MedScrolls);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/WaterElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Magic/WaterElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class WaterElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class WaterElemental : BaseCreature
     {
         [Constructible]
         public WaterElemental() : base(AIType.AI_Mage)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(new BlackPearl(3));
         }
 
-        public WaterElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a water elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
@@ -60,18 +58,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Meager);
             AddLoot(LootPack.Potions);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Melee/EarthElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Melee/EarthElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class EarthElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class EarthElemental : BaseCreature
     {
         [Constructible]
         public EarthElemental() : base(AIType.AI_Melee)
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             PackItem(ore);
         }
 
-        public EarthElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an earth elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
@@ -62,18 +60,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Meager);
             AddLoot(LootPack.Gems);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Elemental/Melee/SnowElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Elemental/Melee/SnowElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class SnowElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SnowElemental : BaseCreature
     {
         [Constructible]
         public SnowElemental() : base(AIType.AI_Melee)
@@ -42,10 +44,6 @@ namespace Server.Mobiles
             PackItem(ore);
         }
 
-        public SnowElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a snow elemental corpse";
         public override string DefaultName => "a snow elemental";
 
@@ -56,18 +54,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Rich);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Exodus/ExodusMinion.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Exodus/ExodusMinion.cs
@@ -1,107 +1,94 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class ExodusMinion : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public ExodusMinion() : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class ExodusMinion : BaseCreature
     {
-        Body = 0x2F5;
-
-        SetStr(851, 950);
-        SetDex(71, 80);
-        SetInt(61, 90);
-
-        SetHits(511, 570);
-
-        SetDamage(16, 22);
-
-        SetResistance(ResistanceType.Physical, 60, 70);
-        SetResistance(ResistanceType.Fire, 40, 50);
-        SetResistance(ResistanceType.Cold, 15, 25);
-        SetResistance(ResistanceType.Poison, 15, 25);
-        SetResistance(ResistanceType.Energy, 15, 25);
-
-        SetSkill(SkillName.MagicResist, 90.1, 100.0);
-        SetSkill(SkillName.Tactics, 90.1, 100.0);
-        SetSkill(SkillName.Wrestling, 90.1, 100.0);
-
-        Fame = 18000;
-        Karma = -18000;
-        VirtualArmor = 65;
-
-        PackItem(new PowerCrystal());
-        PackItem(new ArcaneGem());
-        PackItem(new ClockworkAssembly());
-
-        switch (Utility.Random(3))
+        [Constructible]
+        public ExodusMinion() : base(AIType.AI_Melee)
         {
-            case 0:
-                {
-                    PackItem(new PowerCrystal());
-                    break;
-                }
-            case 1:
-                {
-                    PackItem(new ArcaneGem());
-                    break;
-                }
-            case 2:
-                {
-                    PackItem(new ClockworkAssembly());
-                    break;
-                }
+            Body = 0x2F5;
+
+            SetStr(851, 950);
+            SetDex(71, 80);
+            SetInt(61, 90);
+
+            SetHits(511, 570);
+
+            SetDamage(16, 22);
+
+            SetResistance(ResistanceType.Physical, 60, 70);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 15, 25);
+            SetResistance(ResistanceType.Poison, 15, 25);
+            SetResistance(ResistanceType.Energy, 15, 25);
+
+            SetSkill(SkillName.MagicResist, 90.1, 100.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 90.1, 100.0);
+
+            Fame = 18000;
+            Karma = -18000;
+            VirtualArmor = 65;
+
+            PackItem(new PowerCrystal());
+            PackItem(new ArcaneGem());
+            PackItem(new ClockworkAssembly());
+
+            switch (Utility.Random(3))
+            {
+                case 0:
+                    {
+                        PackItem(new PowerCrystal());
+                        break;
+                    }
+                case 1:
+                    {
+                        PackItem(new ArcaneGem());
+                        break;
+                    }
+                case 2:
+                    {
+                        PackItem(new ClockworkAssembly());
+                        break;
+                    }
+            }
         }
-    }
 
-    public ExodusMinion(Serial serial) : base(serial)
-    {
-    }
+        public override string CorpseName => "a minion's corpse";
+        public override bool IsScaredOfScaryThings => false;
+        public override bool IsScaryToPets => true;
 
-    public override string CorpseName => "a minion's corpse";
-    public override bool IsScaredOfScaryThings => false;
-    public override bool IsScaryToPets => true;
+        public override string DefaultName => "an exodus minion";
 
-    public override string DefaultName => "an exodus minion";
+        public override bool AutoDispel => true;
+        public override bool BardImmune => !Core.AOS;
+        public override Poison PoisonImmune => Poison.Lethal;
 
-    public override bool AutoDispel => true;
-    public override bool BardImmune => !Core.AOS;
-    public override Poison PoisonImmune => Poison.Lethal;
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Rich);
+        }
 
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Average);
-        AddLoot(LootPack.Rich);
-    }
+        public override int GetIdleSound() => 0x218;
 
-    public override int GetIdleSound() => 0x218;
+        public override int GetAngerSound() => 0x26C;
 
-    public override int GetAngerSound() => 0x26C;
+        public override int GetDeathSound() => 0x211;
 
-    public override int GetDeathSound() => 0x211;
+        public override int GetAttackSound() => 0x232;
 
-    public override int GetAttackSound() => 0x232;
+        public override int GetHurtSound() => 0x140;
 
-    public override int GetHurtSound() => 0x140;
+        private static MonsterAbility[] _abilities =
+        {
+            // OSI changed the ability some time around UOML
+            Core.ML ? MonsterAbilities.EnergyBoltCounter : MonsterAbilities.MagicalBarrier
+        };
 
-    private static MonsterAbility[] _abilities =
-    {
-        // OSI changed the ability some time around UOML
-        Core.ML ? MonsterAbilities.EnergyBoltCounter : MonsterAbilities.MagicalBarrier
-    };
-
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Exodus/ExodusOverseer.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Exodus/ExodusOverseer.cs
@@ -1,96 +1,83 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class ExodusOverseer : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public ExodusOverseer() : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class ExodusOverseer : BaseCreature
     {
-        Body = 0x2F4;
-
-        SetStr(561, 650);
-        SetDex(76, 95);
-        SetInt(61, 90);
-
-        SetHits(331, 390);
-
-        SetDamage(13, 19);
-
-        SetDamageType(ResistanceType.Physical, 50);
-        SetDamageType(ResistanceType.Energy, 50);
-
-        SetResistance(ResistanceType.Physical, 45, 55);
-        SetResistance(ResistanceType.Fire, 40, 60);
-        SetResistance(ResistanceType.Cold, 25, 35);
-        SetResistance(ResistanceType.Poison, 25, 35);
-        SetResistance(ResistanceType.Energy, 25, 35);
-
-        SetSkill(SkillName.MagicResist, 80.2, 98.0);
-        SetSkill(SkillName.Tactics, 80.2, 98.0);
-        SetSkill(SkillName.Wrestling, 80.2, 98.0);
-
-        Fame = 10000;
-        Karma = -10000;
-        VirtualArmor = 50;
-
-        if (Utility.Random(2) == 0)
+        [Constructible]
+        public ExodusOverseer() : base(AIType.AI_Melee)
         {
-            PackItem(new PowerCrystal());
+            Body = 0x2F4;
+
+            SetStr(561, 650);
+            SetDex(76, 95);
+            SetInt(61, 90);
+
+            SetHits(331, 390);
+
+            SetDamage(13, 19);
+
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Energy, 50);
+
+            SetResistance(ResistanceType.Physical, 45, 55);
+            SetResistance(ResistanceType.Fire, 40, 60);
+            SetResistance(ResistanceType.Cold, 25, 35);
+            SetResistance(ResistanceType.Poison, 25, 35);
+            SetResistance(ResistanceType.Energy, 25, 35);
+
+            SetSkill(SkillName.MagicResist, 80.2, 98.0);
+            SetSkill(SkillName.Tactics, 80.2, 98.0);
+            SetSkill(SkillName.Wrestling, 80.2, 98.0);
+
+            Fame = 10000;
+            Karma = -10000;
+            VirtualArmor = 50;
+
+            if (Utility.Random(2) == 0)
+            {
+                PackItem(new PowerCrystal());
+            }
+            else
+            {
+                PackItem(new ArcaneGem());
+            }
         }
-        else
+
+        public override string CorpseName => "an overseer's corpse";
+
+        public override bool IsScaredOfScaryThings => false;
+        public override bool IsScaryToPets => true;
+
+        public override string DefaultName => "an exodus overseer";
+
+        public override bool AutoDispel => true;
+        public override bool BardImmune => !Core.AOS;
+        public override Poison PoisonImmune => Poison.Lethal;
+
+        public override void GenerateLoot()
         {
-            PackItem(new ArcaneGem());
+            AddLoot(LootPack.Rich);
         }
-    }
 
-    public ExodusOverseer(Serial serial) : base(serial)
-    {
-    }
+        public override int GetIdleSound() => 0xFD;
 
-    public override string CorpseName => "an overseer's corpse";
+        public override int GetAngerSound() => 0x26C;
 
-    public override bool IsScaredOfScaryThings => false;
-    public override bool IsScaryToPets => true;
+        public override int GetDeathSound() => 0x211;
 
-    public override string DefaultName => "an exodus overseer";
+        public override int GetAttackSound() => 0x23B;
 
-    public override bool AutoDispel => true;
-    public override bool BardImmune => !Core.AOS;
-    public override Poison PoisonImmune => Poison.Lethal;
+        public override int GetHurtSound() => 0x140;
 
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Rich);
-    }
+        private static MonsterAbility[] _abilities =
+        {
+            // OSI changed the ability some time around UOML
+            Core.ML ? MonsterAbilities.EnergyBoltCounter : MonsterAbilities.MagicalBarrier
+        };
 
-    public override int GetIdleSound() => 0xFD;
-
-    public override int GetAngerSound() => 0x26C;
-
-    public override int GetDeathSound() => 0x211;
-
-    public override int GetAttackSound() => 0x23B;
-
-    public override int GetHurtSound() => 0x140;
-
-    private static MonsterAbility[] _abilities =
-    {
-        // OSI changed the ability some time around UOML
-        Core.ML ? MonsterAbilities.EnergyBoltCounter : MonsterAbilities.MagicalBarrier
-    };
-
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/ChaosDragoon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/ChaosDragoon.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class ChaosDragoon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class ChaosDragoon : BaseCreature
     {
         [Constructible]
         public ChaosDragoon() : base(AIType.AI_Melee)
@@ -89,10 +91,6 @@ namespace Server.Mobiles
             new SwampDragon().Rider = this;
         }
 
-        public ChaosDragoon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a chaos dragoon corpse";
         public override string DefaultName => "a chaos dragoon";
 
@@ -137,18 +135,6 @@ namespace Server.Mobiles
             {
                 damage *= 3;
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/ChaosDragoonElite.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/ChaosDragoonElite.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class ChaosDragoonElite : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class ChaosDragoonElite : BaseCreature
     {
         [Constructible]
         public ChaosDragoonElite() : base(AIType.AI_Mage)
@@ -155,18 +157,6 @@ namespace Server.Mobiles
             {
                 damage *= 3;
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaLord.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaLord.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class JukaLord : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class JukaLord : BaseCreature
     {
         [Constructible]
         public JukaLord() : base(AIType.AI_Archer, FightMode.Closest, 10, 3)
@@ -54,10 +56,6 @@ namespace Server.Mobiles
             // TODO: Bandage self
         }
 
-        public JukaLord(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a jukan corpse";
         public override string DefaultName => "a juka lord";
 
@@ -97,17 +95,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x1D0;
 
         public override int GetDeathSound() => 0x28D;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaMage.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaMage.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
@@ -5,7 +6,8 @@ using Server.Spells;
 
 namespace Server.Mobiles
 {
-    public class JukaMage : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class JukaMage : BaseCreature
     {
         private DateTime m_NextAbilityTime;
 
@@ -72,10 +74,6 @@ namespace Server.Mobiles
             }
 
             m_NextAbilityTime = Core.Now + TimeSpan.FromSeconds(Utility.RandomMinMax(2, 5));
-        }
-
-        public JukaMage(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a jukan corpse";
@@ -190,18 +188,6 @@ namespace Server.Mobiles
 
             toDebuff.Hits = toDebuff.Hits;
             toDebuff.Stam = toDebuff.Stam;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaWarrior.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class JukaWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class JukaWarrior : BaseCreature
     {
         [Constructible]
         public JukaWarrior() : base(AIType.AI_Melee)
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             {
                 PackItem(new ArcaneGem());
             }
-        }
-
-        public JukaWarrior(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a jukan corpse";
@@ -101,18 +99,6 @@ namespace Server.Mobiles
                         break;
                     }
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Meers/EnragedCreatures.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Meers/EnragedCreatures.cs
@@ -1,14 +1,12 @@
+using ModernUO.Serialization;
 using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class EnragedRabbit : BaseEnraged
+    [SerializationGenerator(0, false)]
+    public partial class EnragedRabbit : BaseEnraged
     {
         public EnragedRabbit(Mobile summoner) : base(summoner) => Body = 0xcd;
-
-        public EnragedRabbit(Serial serial) : base(serial)
-        {
-        }
 
         public override string CorpseName => "a hare corpse";
         public override string DefaultName => "a rabbit";
@@ -18,27 +16,12 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0xCA;
 
         public override int GetDeathSound() => 0xCB;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 
-    public class EnragedHart : BaseEnraged
+    [SerializationGenerator(0, false)]
+    public partial class EnragedHart : BaseEnraged
     {
         public EnragedHart(Mobile summoner) : base(summoner) => Body = 0xea;
-
-        public EnragedHart(Serial serial) : base(serial)
-        {
-        }
 
         public override string CorpseName => "a deer corpse";
         public override string DefaultName => "a great hart";
@@ -48,27 +31,12 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x83;
 
         public override int GetDeathSound() => 0x84;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 
-    public class EnragedHind : BaseEnraged
+    [SerializationGenerator(0, false)]
+    public partial class EnragedHind : BaseEnraged
     {
         public EnragedHind(Mobile summoner) : base(summoner) => Body = 0xed;
-
-        public EnragedHind(Serial serial) : base(serial)
-        {
-        }
 
         public override string CorpseName => "a deer corpse";
         public override string DefaultName => "a hind";
@@ -78,21 +46,10 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x83;
 
         public override int GetDeathSound() => 0x84;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 
-    public class EnragedBlackBear : BaseEnraged
+    [SerializationGenerator(0, false)]
+    public partial class EnragedBlackBear : BaseEnraged
     {
         public EnragedBlackBear(Mobile summoner) : base(summoner)
         {
@@ -100,36 +57,17 @@ namespace Server.Mobiles
             BaseSoundID = 0xa3;
         }
 
-        public EnragedBlackBear(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a bear corpse";
         public override string DefaultName => "a black bear";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 
-    public class EnragedEagle : BaseEnraged
+    [SerializationGenerator(0, false)]
+    public partial class EnragedEagle : BaseEnraged
     {
         public EnragedEagle(Mobile summoner) : base(summoner)
         {
             Body = 0x5;
             BaseSoundID = 0x2ee;
-        }
-
-        public EnragedEagle(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "an eagle corpse";
@@ -148,7 +86,8 @@ namespace Server.Mobiles
         }
     }
 
-    public class BaseEnraged : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BaseEnraged : BaseCreature
     {
         public BaseEnraged(Mobile summoner) : base(AIType.AI_Melee)
         {
@@ -167,10 +106,6 @@ namespace Server.Mobiles
             Tamable = false;
 
             SummonMaster = summoner;
-        }
-
-        public BaseEnraged(Serial serial) : base(serial)
-        {
         }
 
         public override void OnThink()
@@ -223,18 +158,6 @@ namespace Server.Mobiles
         {
             base.AddNameProperties(list);
             list.Add(1060768); // enraged
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Meers/EnragedCreatures.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Meers/EnragedCreatures.cs
@@ -72,18 +72,6 @@ namespace Server.Mobiles
 
         public override string CorpseName => "an eagle corpse";
         public override string DefaultName => "an eagle";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 
     [SerializationGenerator(0, false)]

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerCaptain.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerCaptain.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 using Server.Spells;
 
 namespace Server.Mobiles
 {
-    public class MeerCaptain : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MeerCaptain : BaseCreature
     {
         private DateTime m_NextAbilityTime;
 
@@ -84,10 +86,6 @@ namespace Server.Mobiles
             m_NextAbilityTime = Core.Now + TimeSpan.FromSeconds(Utility.RandomMinMax(2, 5));
         }
 
-        public MeerCaptain(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a meer corpse";
         public override string DefaultName => "a meer captain";
 
@@ -146,18 +144,6 @@ namespace Server.Mobiles
             }
 
             base.OnThink();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerEternal.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerEternal.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Collections;
 
 namespace Server.Mobiles
 {
-    public class MeerEternal : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MeerEternal : BaseCreature
     {
         private DateTime m_NextAbilityTime;
 
@@ -41,10 +43,6 @@ namespace Server.Mobiles
             VirtualArmor = 34;
 
             m_NextAbilityTime = Core.Now + TimeSpan.FromSeconds(Utility.RandomMinMax(2, 5));
-        }
-
-        public MeerEternal(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a meer's corpse";
@@ -198,18 +196,6 @@ namespace Server.Mobiles
             }
 
             base.OnThink();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerMage.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerMage.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 using Server.Items;
@@ -5,7 +6,8 @@ using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class MeerMage : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MeerMage : BaseCreature
     {
         private static readonly Dictionary<Mobile, TimerExecutionToken> m_Table = new();
 
@@ -45,10 +47,6 @@ namespace Server.Mobiles
             VirtualArmor = 16;
 
             m_NextAbilityTime = Core.Now + TimeSpan.FromSeconds(Utility.RandomMinMax(2, 5));
-        }
-
-        public MeerMage(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a meer's corpse";
@@ -213,18 +211,6 @@ namespace Server.Mobiles
             {
                 StopEffect(m, false);
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Meers/MeerWarrior.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Spells;
 
 namespace Server.Mobiles
 {
-    public class MeerWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MeerWarrior : BaseCreature
     {
         [Constructible]
         public MeerWarrior() : base(AIType.AI_Melee, FightMode.Evil)
@@ -34,10 +36,6 @@ namespace Server.Mobiles
 
             Fame = 2000;
             Karma = 5000;
-        }
-
-        public MeerWarrior(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a meer corpse";
@@ -77,17 +75,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x156;
 
         public override int GetDeathSound() => 0x15C;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Animal/CuSidhe.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Animal/CuSidhe.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class CuSidhe : BaseMount
+    [SerializationGenerator(0, false)]
+    public partial class CuSidhe : BaseMount
     {
         [Constructible]
         public CuSidhe() : base(277, 0x3E91, AIType.AI_Animal, FightMode.Aggressor)
@@ -66,10 +68,6 @@ namespace Server.Mobiles
             // TODO 0-2 spellweaving scroll
         }
 
-        public CuSidhe(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a cu sidhe corpse";
         public override string DefaultName => "a cu sidhe";
 
@@ -117,24 +115,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x576;
 
         public override int GetDeathSound() => 0x579;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(1); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
-            if (version < 1 && Name == "a Cu Sidhe")
-            {
-                Name = null;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Animal/Ferret.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Animal/Ferret.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Quests;
 
 namespace Server.Mobiles
 {
-    public class Ferret : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Ferret : BaseCreature
     {
         private static readonly string[] m_Vocabulary =
         {
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             MinTameSkill = -21.3;
 
             m_CanTalk = true;
-        }
-
-        public Ferret(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a ferret corpse";
@@ -96,19 +94,9 @@ namespace Server.Mobiles
             m_CanTalk = true;
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        public void AfterDeserialization()
         {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
             m_CanTalk = true;
         }
     }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Animal/RagingGrizzlyBear.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Animal/RagingGrizzlyBear.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class RagingGrizzlyBear : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RagingGrizzlyBear : BaseCreature
     {
         [Constructible]
         public RagingGrizzlyBear() : base(AIType.AI_Animal, FightMode.Aggressor)
@@ -37,29 +40,11 @@ namespace Server.Mobiles
             Tamable = false;
         }
 
-        public RagingGrizzlyBear(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a grizzly bear corpse";
         public override string DefaultName => "a raging grizzly bear";
 
         public override int Meat => 4;
         public override int Hides => 32;
         public override PackInstinct PackInstinct => PackInstinct.Bear;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Animal/Squirrel.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Animal/Squirrel.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Squirrel : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Squirrel : BaseCreature
     {
         [Constructible]
         public Squirrel() : base(AIType.AI_Animal, FightMode.Aggressor)
@@ -32,28 +35,10 @@ namespace Server.Mobiles
             MinTameSkill = -21.3;
         }
 
-        public Squirrel(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a squirrel corpse";
         public override string DefaultName => "a squirrell";
 
         public override int Meat => 1;
         public override FoodType FavoriteFood => FoodType.FruitsAndVegies;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/LadyJennifyr.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/LadyJennifyr.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Mobiles
 {
-    public class LadyJennifyr : SkeletalKnight
+    [SerializationGenerator(0, false)]
+    public partial class LadyJennifyr : SkeletalKnight
     {
         private static readonly Dictionary<Mobile, ExpireTimer> m_Table = new();
 
@@ -38,11 +40,6 @@ namespace Server.Mobiles
 
             Fame = 18000;
             Karma = -18000;
-        }
-
-        public LadyJennifyr(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a Lady Jennifyr corpse";
@@ -93,20 +90,6 @@ namespace Server.Mobiles
 
             m_Table[defender] = timer = new ExpireTimer(defender, mod);
             timer.Start();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         private class ExpireTimer : Timer

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/LadyMarai.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/LadyMarai.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class LadyMarai : SkeletalKnight
+    [SerializationGenerator(0, false)]
+    partial class LadyMarai : SkeletalKnight
     {
         [Constructible]
         public LadyMarai()
@@ -37,11 +39,6 @@ namespace Server.Mobiles
             Karma = -18000;
         }
 
-        public LadyMarai(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Lady Marai corpse";
         public override string DefaultName => "Lady Marai";
 
@@ -49,12 +46,12 @@ namespace Server.Mobiles
         // TODO: Uncomment once added
         public override void OnDeath( Container c )
         {
-          base.OnDeath( c );
+            base.OnDeath( c );
     
-          if (Utility.RandomDouble() < 0.15)
+            if (Utility.RandomDouble() < 0.15)
             c.DropItem( new DisintegratingThesisNotes() );
     
-          if (Utility.RandomDouble() < 0.1)
+            if (Utility.RandomDouble() < 0.1)
             c.DropItem( new ParrotItem() );
         }
         */
@@ -67,19 +64,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.CrushingBlow;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/MasterJonath.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/MasterJonath.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class MasterJonath : BoneMagi
+    [SerializationGenerator(0, false)]
+    public partial class MasterJonath : BoneMagi
     {
         [Constructible]
         public MasterJonath()
@@ -50,11 +53,6 @@ namespace Server.Mobiles
             PackReg(8);
         }
 
-        public MasterJonath(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Master Jonath corpse";
         public override string DefaultName => "Master Jonath";
 
@@ -80,20 +78,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.UltraRich, 3);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/MasterMikael.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/MasterMikael.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class MasterMikael : BoneMagi
+    [SerializationGenerator(0, false)]
+    public partial class MasterMikael : BoneMagi
     {
         [Constructible]
         public MasterMikael()
@@ -49,11 +52,6 @@ namespace Server.Mobiles
             PackNecroReg(1, 10);
         }
 
-        public MasterMikael(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Master Mikael corpse";
         public override string DefaultName => "Master Mikael";
 
@@ -78,20 +76,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.UltraRich, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/MasterTheophilus.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/MasterTheophilus.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class MasterTheophilus : EvilMageLord
+    [SerializationGenerator(0, false)]
+    public partial class MasterTheophilus : EvilMageLord
     {
         [Constructible]
         public MasterTheophilus()
@@ -60,11 +62,6 @@ namespace Server.Mobiles
             PackReg(8);
         }
 
-        public MasterTheophilus(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Master Theophilus corpse";
         public override string DefaultName => "Master Theophilus";
 
@@ -77,19 +74,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.ParalyzingBlow;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/RedDeath.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/RedDeath.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class RedDeath : SkeletalMount
+    [SerializationGenerator(0, false)]
+    public partial class RedDeath : SkeletalMount
     {
         [Constructible]
         public RedDeath() : base()
@@ -51,10 +53,6 @@ namespace Server.Mobiles
             }
         }
 
-        public RedDeath(Serial serial) : base(serial)
-        {
-        }
-
         public override string DefaultName => "Red Death";
 
         public override string CorpseName => "a Red Death corpse";
@@ -77,20 +75,6 @@ namespace Server.Mobiles
             base.OnDeath(c);
 
             c.DropItem(new ResolvesBridle());
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/SirPatrick.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Bedlam/SirPatrick.cs
@@ -1,96 +1,82 @@
-namespace Server.Mobiles;
+using ModernUO.Serialization;
 
-public class SirPatrick : SkeletalKnight
+namespace Server.Mobiles
 {
-    [Constructible]
-    public SirPatrick()
+    [SerializationGenerator(0, false)]
+    public partial class SirPatrick : SkeletalKnight
     {
-        IsParagon = true;
-
-        Hue = 0x47E;
-
-        SetStr(208, 319);
-        SetDex(98, 132);
-        SetInt(45, 91);
-
-        SetHits(616, 884);
-
-        SetDamage(15, 25);
-
-        SetDamageType(ResistanceType.Physical, 40);
-        SetDamageType(ResistanceType.Cold, 60);
-
-        SetResistance(ResistanceType.Physical, 55, 62);
-        SetResistance(ResistanceType.Fire, 40, 48);
-        SetResistance(ResistanceType.Cold, 71, 80);
-        SetResistance(ResistanceType.Poison, 40, 50);
-        SetResistance(ResistanceType.Energy, 50, 60);
-
-        SetSkill(SkillName.Wrestling, 126.3, 136.5);
-        SetSkill(SkillName.Tactics, 128.5, 143.8);
-        SetSkill(SkillName.MagicResist, 102.8, 117.9);
-        SetSkill(SkillName.Anatomy, 127.5, 137.2);
-
-        Fame = 18000;
-        Karma = -18000;
-    }
-
-    public SirPatrick(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "a Sir Patrick corpse";
-    public override string DefaultName => "Sir Patrick";
-
-    /*
-    // TODO: uncomment once added
-    public override void OnDeath( Container c )
-    {
-      base.OnDeath( c );
-
-      if (Utility.RandomDouble() < 0.15)
-        c.DropItem( new DisintegratingThesisNotes() );
-
-      if (Utility.RandomDouble() < 0.05)
-        c.DropItem( new AssassinChest() );
-    }
-    */
-
-    public override bool GivesMLMinorArtifact => true;
-
-    private static MonsterAbility[] _abilities = { new SirPatrickDrainLife() };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.UltraRich, 2);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-
-        writer.Write(0); // version
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
-    }
-
-    private class SirPatrickDrainLife : DrainLifeAreaAttack
-    {
-        public override int MinDamage => 14;
-        public override int MaxDamage => 30;
-
-        protected override void DoEffectTarget(BaseCreature source, Mobile defender)
+        [Constructible]
+        public SirPatrick()
         {
-            defender.FixedParticles(0x374A, 10, 15, 5013, 0x455, 0, EffectLayer.Waist);
-            defender.PlaySound(0x1EA);
+            IsParagon = true;
 
-            DrainLife(source, defender);
+            Hue = 0x47E;
+
+            SetStr(208, 319);
+            SetDex(98, 132);
+            SetInt(45, 91);
+
+            SetHits(616, 884);
+
+            SetDamage(15, 25);
+
+            SetDamageType(ResistanceType.Physical, 40);
+            SetDamageType(ResistanceType.Cold, 60);
+
+            SetResistance(ResistanceType.Physical, 55, 62);
+            SetResistance(ResistanceType.Fire, 40, 48);
+            SetResistance(ResistanceType.Cold, 71, 80);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 50, 60);
+
+            SetSkill(SkillName.Wrestling, 126.3, 136.5);
+            SetSkill(SkillName.Tactics, 128.5, 143.8);
+            SetSkill(SkillName.MagicResist, 102.8, 117.9);
+            SetSkill(SkillName.Anatomy, 127.5, 137.2);
+
+            Fame = 18000;
+            Karma = -18000;
+        }
+
+        public override string CorpseName => "a Sir Patrick corpse";
+        public override string DefaultName => "Sir Patrick";
+
+        /*
+        // TODO: uncomment once added
+        public override void OnDeath( Container c )
+        {
+          base.OnDeath( c );
+
+          if (Utility.RandomDouble() < 0.15)
+            c.DropItem( new DisintegratingThesisNotes() );
+
+          if (Utility.RandomDouble() < 0.05)
+            c.DropItem( new AssassinChest() );
+        }
+        */
+
+        public override bool GivesMLMinorArtifact => true;
+
+        private static MonsterAbility[] _abilities = { new SirPatrickDrainLife() };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.UltraRich, 2);
+        }
+
+        private class SirPatrickDrainLife : DrainLifeAreaAttack
+        {
+            public override int MinDamage => 14;
+            public override int MaxDamage => 30;
+
+            protected override void DoEffectTarget(BaseCreature source, Mobile defender)
+            {
+                defender.FixedParticles(0x374A, 10, 15, 5013, 0x455, 0, EffectLayer.Waist);
+                defender.PlaySound(0x1EA);
+
+                DrainLife(source, defender);
+            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Abscess.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Abscess.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Abscess : Hydra
+    [SerializationGenerator(0, false)]
+    public partial class Abscess : Hydra
     {
         [Constructible]
         public Abscess()
@@ -39,11 +41,6 @@ namespace Server.Mobiles
             // TODO: Fame/Karma
         }
 
-        public Abscess(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an Abscess corpse";
         public override string DefaultName => "Abscess";
 
@@ -59,20 +56,6 @@ namespace Server.Mobiles
             base.OnDeath(c);
 
             c.DropItem(new AbscessTail());
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Coil.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Coil.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Coil : SilverSerpent
+    [SerializationGenerator(0, false)]
+    public partial class Coil : SilverSerpent
     {
         [Constructible]
         public Coil()
@@ -38,11 +40,6 @@ namespace Server.Mobiles
 
             PackGem(2);
             PackItem(new Bone());
-        }
-
-        public Coil(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a Coil corpse";
@@ -83,20 +80,6 @@ namespace Server.Mobiles
               }
             }
             */
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/EnslavedSatyr.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/EnslavedSatyr.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class EnslavedSatyr : Satyr
+    [SerializationGenerator(0, false)]
+    public partial class EnslavedSatyr : Satyr
     {
         [Constructible]
         public EnslavedSatyr()
@@ -18,26 +21,7 @@ namespace Server.Mobiles
         }
         */
 
-        public EnslavedSatyr(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an enslaved satyr corpse";
         public override string DefaultName => "an enslaved satyr";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Hydra.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Hydra.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Hydra : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Hydra : BaseCreature
     {
         [Constructible]
         public Hydra() : base(AIType.AI_Melee)
@@ -38,10 +40,6 @@ namespace Server.Mobiles
             // TODO: Fame/Karma
         }
 
-        public Hydra(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a hydra corpse";
         public override string DefaultName => "a hydra";
         public override int Hides => 40;
@@ -70,20 +68,6 @@ namespace Server.Mobiles
             if (Utility.RandomDouble() < 0.05)
               c.DropItem( new ThorvaldsMedallion() );
             */
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/InsaneDryad.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/InsaneDryad.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class InsaneDryad : MLDryad
+    [SerializationGenerator(0, false)]
+    public partial class InsaneDryad : MLDryad
     {
         [Constructible]
         public InsaneDryad()
@@ -19,28 +22,9 @@ namespace Server.Mobiles
         }
         */
 
-        public InsaneDryad(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an insane dryad corpse";
         public override bool InitialInnocent => false;
 
         public override string DefaultName => "an insane dryad";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Saliva.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Saliva.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Saliva : Harpy
+    [SerializationGenerator(0, false)]
+    public partial class Saliva : Harpy
     {
         [Constructible]
         public Saliva()
@@ -35,11 +37,6 @@ namespace Server.Mobiles
             // TODO: Fame/Karma?
         }
 
-        public Saliva(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Saliva corpse";
         public override string DefaultName => "Saliva";
 
@@ -57,20 +54,6 @@ namespace Server.Mobiles
             // TODO: uncomment once added
             // if (Utility.RandomDouble() < 0.1)
             // c.DropItem( new ParrotItem() );
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Tangle.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Tangle.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Tangle : BogThing
+    [SerializationGenerator(0, false)]
+    public partial class Tangle : BogThing
     {
         [Constructible]
         public Tangle()
@@ -37,11 +39,6 @@ namespace Server.Mobiles
             // TODO: Fame/Karma?
         }
 
-        public Tangle(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Tangle corpse";
         public override string DefaultName => "Tangle";
 
@@ -60,20 +57,6 @@ namespace Server.Mobiles
             {
                 c.DropItem(new TaintedSeeds());
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Thrasher.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Blighted Grove/Thrasher.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Thrasher : Alligator
+    [SerializationGenerator(0, false)]
+    public partial class Thrasher : Alligator
     {
         [Constructible]
         public Thrasher()
@@ -34,11 +36,6 @@ namespace Server.Mobiles
             // TODO: Fame/Karma
         }
 
-        public Thrasher(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Thrasher corpse";
         public override string DefaultName => "Thrasher";
 
@@ -58,20 +55,6 @@ namespace Server.Mobiles
             base.OnDeath(c);
 
             c.DropItem(new ThrashersTail());
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/FetidEssence.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/FetidEssence.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class FetidEssence : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class FetidEssence : BaseCreature
     {
         [Constructible]
         public FetidEssence() : base(AIType.AI_Mage)
@@ -37,10 +40,6 @@ namespace Server.Mobiles
             Karma = -3700; // Guessed
         }
 
-        public FetidEssence(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a fetid essence corpse";
         public override string DefaultName => "a fetid essence";
 
@@ -61,18 +60,6 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x56c;
 
         public override int GetDeathSound() => 0x56e;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
 
         /*private class InternalTimer : Timer
         {

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/InterredGrizzle .cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/InterredGrizzle .cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class InterredGrizzle : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class InterredGrizzle : BaseCreature
     {
         [Constructible]
         public InterredGrizzle() : base(AIType.AI_Mage)
@@ -45,10 +48,6 @@ namespace Server.Mobiles
           return base.OnBeforeDeath();
         }
         */
-
-        public InterredGrizzle(Serial serial) : base(serial)
-        {
-        }
 
         public override string CorpseName => "an interred grizzle corpse";
         public override string DefaultName => "a interred grizzle";
@@ -142,18 +141,6 @@ namespace Server.Mobiles
                     Combatant.SendLocalizedMessage(1072072); // A poisonous gas seeps out of your enemy's skin!
                 }
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/MLDryad.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/MLDryad.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 
 namespace Server.Mobiles
 {
-    public class MLDryad : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MLDryad : BaseCreature
     {
         private DateTime m_NextPeace;
 
@@ -52,10 +54,6 @@ namespace Server.Mobiles
             PackArcanceScroll(0.05);
         }
 
-        public MLDryad(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a dryad's corpse";
         public override bool InitialInnocent => true;
 
@@ -76,20 +74,6 @@ namespace Server.Mobiles
 
             AreaPeace();
             AreaUndress();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         public void AreaPeace()

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/Satyr.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/Satyr.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Mobiles
 {
-    public class Satyr : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Satyr : BaseCreature
     {
         private static readonly Dictionary<Mobile, Timer> m_Suppressed = new();
 
@@ -48,10 +50,6 @@ namespace Server.Mobiles
             PackArcanceScroll(0.05);
         }
 
-        public Satyr(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a satyr's corpse";
         public override string DefaultName => "a satyr";
 
@@ -72,20 +70,6 @@ namespace Server.Mobiles
             Undress(Combatant);
             Suppress(Combatant);
             Provoke(Combatant);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         public void Peace(Mobile target)

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/CorruptedSoul.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/CorruptedSoul.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CorruptedSoul : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CorruptedSoul : BaseCreature
     {
         [Constructible]
         public CorruptedSoul() : base(AIType.AI_Melee)
@@ -33,10 +36,6 @@ namespace Server.Mobiles
             Karma = -5000;
 
             // VirtualArmor = 6; Not sure
-        }
-
-        public CorruptedSoul(Serial serial) : base(serial)
-        {
         }
 
         public override bool DeleteCorpseOnDeath => true;
@@ -75,18 +74,6 @@ namespace Server.Mobiles
 
             Effects.SendLocationEffect(Location, Map, 0x376A, 10, 1);
             return true;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/FeralTreefellow.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/FeralTreefellow.cs
@@ -1,9 +1,12 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.FerelTreefellow")]
-    public class FeralTreefellow : BaseCreature
+
+    [SerializationGenerator(0, false)]
+    public partial class FeralTreefellow : BaseCreature
     {
         [Constructible]
         public FeralTreefellow() : base(AIType.AI_Melee, FightMode.Evil)
@@ -36,10 +39,6 @@ namespace Server.Mobiles
             PackItem(new Log(Utility.RandomMinMax(23, 34)));
         }
 
-        public FeralTreefellow(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a treefellow corpse";
 
         public override string DefaultName => "a feral treefellow";
@@ -59,18 +58,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average); // Unknown
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/Minotaur.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/Minotaur.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Minotaur : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Minotaur : BaseCreature
     {
         [Constructible]
         public Minotaur() : base(AIType.AI_Melee) // NEED TO CHECK
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 28; // Don't know what it should be
         }
 
-        public Minotaur(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a minotaur corpse";
 
         public override string DefaultName => "a minotaur";
@@ -65,17 +63,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x59a;
 
         public override int GetDeathSound() => 0x59c;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/MinotaurCaptain.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/MinotaurCaptain.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class MinotaurCaptain : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MinotaurCaptain : BaseCreature
     {
         [Constructible]
         public MinotaurCaptain() : base(AIType.AI_Melee) // NEED TO CHECK
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 28; // Don't know what it should be
         }
 
-        public MinotaurCaptain(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a minotaur corpse";
 
         public override string DefaultName => "a minotaur captain";
@@ -65,17 +63,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x59a;
 
         public override int GetDeathSound() => 0x59c;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/MinotaurScout.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/MinotaurScout.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class MinotaurScout : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MinotaurScout : BaseCreature
     {
         [Constructible]
         public MinotaurScout() : base(AIType.AI_Melee) // NEED TO CHECK
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 28; // Don't know what it should be
         }
 
-        public MinotaurScout(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a minotaur corpse";
 
         public override string DefaultName => "a minotaur scout";
@@ -65,17 +63,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x59a;
 
         public override int GetDeathSound() => 0x59c;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/PestilentBandage.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/PestilentBandage.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class PestilentBandage : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class PestilentBandage : BaseCreature
     {
         [Constructible]
         public PestilentBandage() : base(AIType.AI_Melee) // NEED TO CHECK
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             PackItem(new Bandage(5)); // How many?
         }
 
-        public PestilentBandage(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a pestilent bandage corpse";
         // Neither Stratics nor UOGuide have much description
         // beyond being a "Grey Mummy". Body, Sound and
@@ -63,18 +61,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Rich); // Need to verify
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/Tormented Minotaur.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/Tormented Minotaur.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class TormentedMinotaur : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class TormentedMinotaur : BaseCreature
     {
         [Constructible]
         public TormentedMinotaur() : base(AIType.AI_Melee)
@@ -33,17 +35,10 @@ namespace Server.Mobiles
             Karma = -20000;
         }
 
-        public TormentedMinotaur(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a tormented minotaur corpse";
-
         public override string DefaultName => "Tormented Minotaur";
-
         public override Poison PoisonImmune => Poison.Deadly;
         public override int TreasureMapLevel => 3;
-
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.Dismount;
 
         public override void GenerateLoot()
@@ -60,19 +55,5 @@ namespace Server.Mobiles
         public override int GetAngerSound() => 0x599;
 
         public override int GetHurtSound() => 0x59A;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/Troglodyte.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Melee/Troglodyte.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Troglodyte : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Troglodyte : BaseCreature
     {
         [Constructible]
         public Troglodyte() : base(AIType.AI_Melee) // NEED TO CHECK
@@ -41,13 +43,8 @@ namespace Server.Mobiles
             PackItem(new Ribs());
         }
 
-        public Troglodyte(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a troglodyte corpse";
         public override string DefaultName => "a troglodyte";
-
         public override bool CanHeal => true;
 
         public override void GenerateLoot()
@@ -63,18 +60,6 @@ namespace Server.Mobiles
             {
                 c.DropItem(new PrimitiveFetish());
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Labyrinth/Miasma.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Labyrinth/Miasma.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Miasma : Scorpion
+    [SerializationGenerator(0, false)]
+    public partial class Miasma : Scorpion
     {
         [Constructible]
         public Miasma()
@@ -70,11 +72,6 @@ namespace Server.Mobiles
         }
         */
 
-        public Miasma(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Miasma corpse";
         public override string DefaultName => "Miasma";
 
@@ -92,19 +89,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.MortalStrike;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Labyrinth/Pyre.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Labyrinth/Pyre.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Pyre : Phoenix
+    [SerializationGenerator(0, false)]
+    public partial class Pyre : Phoenix
     {
         [Constructible]
         public Pyre()
@@ -41,11 +43,6 @@ namespace Server.Mobiles
             Karma = -21000;
         }
 
-        public Pyre(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Pyre corpse";
         public override string DefaultName => "Pyre";
 
@@ -66,20 +63,6 @@ namespace Server.Mobiles
             }
 
             return WeaponAbility.BleedAttack;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Labyrinth/Rend.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Labyrinth/Rend.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Rend : Reptalon
+    [SerializationGenerator(0, false)]
+    public partial class Rend : Reptalon
     {
         [Constructible]
         public Rend()
@@ -38,11 +40,6 @@ namespace Server.Mobiles
             Karma = -21000;
         }
 
-        public Rend(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Rend corpse";
         public override string DefaultName => "Rend";
 
@@ -61,20 +58,6 @@ namespace Server.Mobiles
             }
 
             return WeaponAbility.BleedAttack;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Misc/Magic/GreaterDragon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Misc/Magic/GreaterDragon.cs
@@ -74,16 +74,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.BleedAttack;
-
-        [AfterDeserialization]
-        public void AfterDeserialization()
-        {
-            SetDamage(24, 33);
-                AnimalTaming.ScaleStats(this, 0.50);
-                AnimalTaming.ScaleSkills(this, 0.80, 0.90); // 90% * 80% = 72% of original skills trainable to 90%
-                Skills.Magery.Base =
-                    Skills.Magery
-                        .Cap; // Greater dragons have a 90% cap reduction and 90% skill reduction on magery
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Misc/Magic/GreaterDragon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Misc/Magic/GreaterDragon.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Items;
 using Server.SkillHandlers;
 
 namespace Server.Mobiles
 {
-    public class GreaterDragon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class GreaterDragon : BaseCreature
     {
         [Constructible]
         public GreaterDragon() : base(AIType.AI_Mage)
@@ -47,10 +49,6 @@ namespace Server.Mobiles
             MinTameSkill = 104.7;
         }
 
-        public GreaterDragon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a dragon corpse";
         public override bool StatLossAfterTame => true;
         public override string DefaultName => "a greater dragon";
@@ -77,27 +75,15 @@ namespace Server.Mobiles
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.BleedAttack;
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        public void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(1);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             SetDamage(24, 33);
-
-            if (version == 0)
-            {
                 AnimalTaming.ScaleStats(this, 0.50);
                 AnimalTaming.ScaleSkills(this, 0.80, 0.90); // 90% * 80% = 72% of original skills trainable to 90%
                 Skills.Magery.Base =
                     Skills.Magery
                         .Cap; // Greater dragons have a 90% cap reduction and 90% skill reduction on magery
-            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Misc/Melee/CorrosiveSlime.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Misc/Melee/CorrosiveSlime.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CorrosiveSlime : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CorrosiveSlime : BaseCreature
     {
         [Constructible]
         public CorrosiveSlime() : base(AIType.AI_Melee)
@@ -41,10 +44,6 @@ namespace Server.Mobiles
 
         // TODO: Damage weapon via acid
 
-        public CorrosiveSlime(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a slimey corpse";
         public override string DefaultName => "a corrosive slime";
 
@@ -56,18 +55,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Poor);
             AddLoot(LootPack.Gems);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Misc/Melee/Reptalon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Misc/Melee/Reptalon.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Reptalon : BaseMount
+    [SerializationGenerator(0, false)]
+    public partial class Reptalon : BaseMount
     {
         public override string DefaultName => "a reptalon";
 
@@ -39,12 +41,7 @@ namespace Server.Mobiles
             MinTameSkill = 101.1;
         }
 
-        public Reptalon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a reptalon corpse";
-
         public override int TreasureMapLevel => 5;
         public override int Meat => 5;
         public override int Hides => 10;
@@ -62,19 +59,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.ParalyzingBlow;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Painted Caves/Grobu.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Painted Caves/Grobu.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Grobu : BlackBear
+    [SerializationGenerator(0, false)]
+    public partial class Grobu : BlackBear
     {
         [Constructible]
         public Grobu()
@@ -40,11 +42,6 @@ namespace Server.Mobiles
             Karma = 1000;
         }
 
-        public Grobu(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Grobu corpse";
         public override string DefaultName => "Grobu";
 
@@ -60,20 +57,6 @@ namespace Server.Mobiles
             base.OnDeath(c);
 
             c.DropItem(new GrobusFur());
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Painted Caves/Lurg.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Painted Caves/Lurg.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Lurg : Troglodyte
+    [SerializationGenerator(0, false)]
+    public partial class Lurg : Troglodyte
     {
         [Constructible]
         public Lurg()
@@ -39,14 +41,8 @@ namespace Server.Mobiles
             Karma = -10000;
         }
 
-        public Lurg(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Lurg corpse";
         public override string DefaultName => "Lurg";
-
         public override bool GivesMLMinorArtifact => true;
         public override int TreasureMapLevel => 4;
 
@@ -56,19 +52,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.CrushingBlow;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Palace of Paroxysmus/Putrefier.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Palace of Paroxysmus/Putrefier.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Putrefier : Balron
+    [SerializationGenerator(0, false)]
+    public partial class Putrefier : Balron
     {
         [Constructible]
         public Putrefier()
@@ -44,11 +47,6 @@ namespace Server.Mobiles
             PackScroll(4, 7);
         }
 
-        public Putrefier(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Putrefier corpse";
         public override string DefaultName => "Putrefier";
 
@@ -72,20 +70,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.UltraRich, 3);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CorporealBrume.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CorporealBrume.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using System;
 
 namespace Server.Mobiles
 {
-    public class CorporealBrume : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CorporealBrume : BaseCreature
     {
         [Constructible]
         public CorporealBrume()
@@ -36,11 +38,6 @@ namespace Server.Mobiles
             Karma = -12000;
         }
 
-        public CorporealBrume(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a corporeal brume corpse";
         public override string DefaultName => "a corporeal brume";
 
@@ -63,20 +60,6 @@ namespace Server.Mobiles
         {
             m.FixedParticles(0x374A, 10, 15, 5038, 1181, 2, EffectLayer.Head);
             m.PlaySound(0x213);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalDaemon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalDaemon.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CrystalDaemon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CrystalDaemon : BaseCreature
     {
         [Constructible]
         public CrystalDaemon()
@@ -52,31 +55,12 @@ namespace Server.Mobiles
         }
         */
 
-        public CrystalDaemon(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a crystal daemon corpse";
         public override string DefaultName => "a crystal daemon";
 
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 3);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalLatticeSeeker.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalLatticeSeeker.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CrystalLatticeSeeker : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CrystalLatticeSeeker : BaseCreature
     {
         [Constructible]
         public CrystalLatticeSeeker()
@@ -37,11 +40,6 @@ namespace Server.Mobiles
             Karma = -17000;
 
             PackArcaneScroll(0, 2);
-        }
-
-        public CrystalLatticeSeeker(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a Crystal Lattice Seeker corpse";
@@ -140,19 +138,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x2F9;
 
         public override int GetIdleSound() => 0x2FA;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalSeaSerpent.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalSeaSerpent.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CrystalSeaSerpent : SeaSerpent
+    [SerializationGenerator(0, false)]
+    public partial class CrystalSeaSerpent : SeaSerpent
     {
         [Constructible]
         public CrystalSeaSerpent()
@@ -43,26 +46,7 @@ namespace Server.Mobiles
         }
         */
 
-        public CrystalSeaSerpent(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a crystal sea serpent corpse";
         public override string DefaultName => "a crystal sea serpent";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalVortex.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalVortex.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CrystalVortex : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class CrystalVortex : BaseCreature
     {
         [Constructible]
         public CrystalVortex()
@@ -39,11 +42,6 @@ namespace Server.Mobiles
             PackArcaneScroll(0, 2);
         }
 
-        public CrystalVortex(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a crystal vortex corpse";
         public override string DefaultName => "a crystal vortex";
 
@@ -71,19 +69,5 @@ namespace Server.Mobiles
         public override int GetAngerSound() => 0x15;
 
         public override int GetAttackSound() => 0x28;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalWisp.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/CrystalWisp.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class CrystalWisp : Wisp
+    [SerializationGenerator(0, false)]
+    public partial class CrystalWisp : Wisp
     {
         [Constructible]
         public CrystalWisp()
@@ -10,25 +13,6 @@ namespace Server.Mobiles
             PackArcaneScroll(0, 1);
         }
 
-        public CrystalWisp(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string DefaultName => "a crystal wisp";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/MantraEffervescence.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/MantraEffervescence.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class MantraEffervescence : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class MantraEffervescence : BaseCreature
     {
         [Constructible]
         public MantraEffervescence()
@@ -37,11 +40,6 @@ namespace Server.Mobiles
             Karma = -6500;
         }
 
-        public MantraEffervescence(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a mantra effervescence corpse";
         public override string DefaultName => "a mantra effervescence";
 
@@ -49,20 +47,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.FilthyRich);
             AddLoot(LootPack.Rich);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/Protector.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/Protector.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Protector : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Protector : BaseCreature
     {
         [Constructible]
         public Protector()
@@ -53,11 +55,6 @@ namespace Server.Mobiles
             AddItem(shroud);
         }
 
-        public Protector(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a human corpse";
         public override string DefaultName => "a Protector";
 
@@ -91,19 +88,5 @@ namespace Server.Mobiles
             c.DropItem( new ProtectorsEssence() );
         }
         */
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/UnfrozenMummy.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Prism of Light/UnfrozenMummy.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class UnfrozenMummy : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class UnfrozenMummy : BaseCreature
     {
         [Constructible]
         public UnfrozenMummy()
@@ -55,11 +58,6 @@ namespace Server.Mobiles
         }
         */
 
-        public UnfrozenMummy(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an unfrozen mummy corpse";
         public override string DefaultName => "an unfrozen mummy";
 
@@ -68,20 +66,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.UltraRich, 2);
             // TODO: uncomment once added
             // AddLoot( LootPack.Parrot );
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Sanctuary/Chiikkaha.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Sanctuary/Chiikkaha.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Chiikkaha : RatmanMage
+    [SerializationGenerator(0, false)]
+    public partial class Chiikkaha : RatmanMage
     {
         [Constructible]
         public Chiikkaha()
@@ -31,26 +34,7 @@ namespace Server.Mobiles
             Karma = -7500;
         }
 
-        public Chiikkaha(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Chiikkaha the Toothed corpse";
         public override string DefaultName => "Chiikkaha the Toothed";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Sanctuary/MougGuur.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Sanctuary/MougGuur.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class MougGuur : Ettin
+    [SerializationGenerator(0, false)]
+    public partial class MougGuur : Ettin
     {
         [Constructible]
         public MougGuur()
@@ -29,26 +32,7 @@ namespace Server.Mobiles
             Karma = -3000;
         }
 
-        public MougGuur(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Moug-Guur corpse";
         public override string DefaultName => "Moug-Guur";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Sanctuary/Szavetra.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Sanctuary/Szavetra.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Szavetra : Succubus
+    [SerializationGenerator(0, false)]
+    public partial class Szavetra : Succubus
     {
         [Constructible]
         public Szavetra()
@@ -33,26 +36,7 @@ namespace Server.Mobiles
             Karma = -24000;
         }
 
-        public Szavetra(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Szavetra corpse";
         public override string DefaultName => "Szavetra";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
@@ -282,6 +282,10 @@ namespace Server.Mobiles
     [SerializationGenerator(0, false)]
     public partial class StainedOoze : Item
     {
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [SerializableField(0)]
+        public bool _corrosive;
+
         private int m_Ticks;
         private TimerExecutionToken _timerToken;
 
@@ -295,10 +299,6 @@ namespace Server.Mobiles
             Timer.StartTimer(TimeSpan.Zero, TimeSpan.FromSeconds(1), OnTick, out _timerToken);
             m_Ticks = 0;
         }
-
-        [SerializedCommandProperty(AccessLevel.GameMaster)]
-        [SerializableField(0)]
-        public bool _corrosive;
 
         public override void OnAfterDelete()
         {
@@ -378,7 +378,7 @@ namespace Server.Mobiles
         }
 
         [AfterDeserialization]
-        public void AfterDeserialize()
+        private void AfterDeserialize()
         {
             Timer.StartTimer(TimeSpan.Zero, TimeSpan.FromSeconds(1), OnTick, out _timerToken);
             m_Ticks = ItemID == 0x122A ? 0 : 30;

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
@@ -291,14 +291,14 @@ namespace Server.Mobiles
             Movable = false;
             Hue = 0x95;
 
-            Corrosive = corrosive;
+            _corrosive = corrosive;
             Timer.StartTimer(TimeSpan.Zero, TimeSpan.FromSeconds(1), OnTick, out _timerToken);
             m_Ticks = 0;
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(0)]
-        public bool Corrosive { get; set; }
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [SerializableField(0)]
+        public bool _corrosive;
 
         public override void OnAfterDelete()
         {
@@ -349,7 +349,7 @@ namespace Server.Mobiles
 
         public void Damage(Mobile m)
         {
-            if (Corrosive)
+            if (_corrosive)
             {
                 var items = m.Items;
                 var damaged = false;

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 using Server.Engines.CannedEvil;
@@ -6,7 +7,8 @@ using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class Ilhenir : BaseChampion
+    [SerializationGenerator(0, false)]
+    public partial class Ilhenir : BaseChampion
     {
         private static readonly HashSet<Mobile> m_Table = new();
 
@@ -56,11 +58,6 @@ namespace Server.Mobiles
                 PackResources(8);
                 PackTalismans(5);
             }
-        }
-
-        public Ilhenir(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a corpse of Ilhenir";
@@ -202,20 +199,6 @@ namespace Server.Mobiles
 
         public override int GetDeathSound() => 0x584;
 
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
-
         public virtual void CacophonicAttack(Mobile to)
         {
             if (to.Alive && to.Player && !UnderCacophonicAttack(to))
@@ -296,7 +279,8 @@ namespace Server.Mobiles
         }
     }
 
-    public class StainedOoze : Item
+    [SerializationGenerator(0, false)]
+    public partial class StainedOoze : Item
     {
         private int m_Ticks;
         private TimerExecutionToken _timerToken;
@@ -312,12 +296,8 @@ namespace Server.Mobiles
             m_Ticks = 0;
         }
 
-        public StainedOoze(Serial serial)
-            : base(serial)
-        {
-        }
-
         [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(0)]
         public bool Corrosive { get; set; }
 
         public override void OnAfterDelete()
@@ -397,23 +377,9 @@ namespace Server.Mobiles
             AOS.Damage(m, 40, 0, 0, 0, 100, 0);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        public void AfterDeserialize()
         {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-
-            writer.Write(Corrosive);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
-            Corrosive = reader.ReadBool();
-
             Timer.StartTimer(TimeSpan.Zero, TimeSpan.FromSeconds(1), OnTick, out _timerToken);
             m_Ticks = ItemID == 0x122A ? 0 : 30;
         }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Meraktus.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Meraktus.cs
@@ -1,10 +1,12 @@
 using System;
 using Server.Engines.CannedEvil;
 using Server.Items;
+using ModernUO.Serialization;
 
 namespace Server.Mobiles
 {
-    public class Meraktus : BaseChampion
+    [SerializationGenerator(0, false)]
+    public partial class Meraktus : BaseChampion
     {
         [Constructible]
         public Meraktus()
@@ -52,10 +54,6 @@ namespace Server.Mobiles
             }
 
             Timer.StartTimer(TimeSpan.FromSeconds(1), SpawnTormented);
-        }
-
-        public Meraktus(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "the remains of Meraktus";
@@ -209,18 +207,6 @@ namespace Server.Mobiles
             }
 
             eable.Free();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
 
         public void SpawnTormented()

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Twaulo.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Twaulo.cs
@@ -1,108 +1,93 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.CannedEvil;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class Twaulo : BaseChampion
+namespace Server.Mobiles
 {
-    [Constructible]
-    public Twaulo()
-        : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class Twaulo : BaseChampion
     {
-        Title = "of the Glade";
-        Body = 101;
-        BaseSoundID = 679;
-        Hue = 0x455;
+        [Constructible]
+        public Twaulo()
+            : base(AIType.AI_Melee)
+        {
+            Title = "of the Glade";
+            Body = 101;
+            BaseSoundID = 679;
+            Hue = 0x455;
 
-        SetStr(1751, 1950);
-        SetDex(251, 450);
-        SetInt(801, 1000);
+            SetStr(1751, 1950);
+            SetDex(251, 450);
+            SetInt(801, 1000);
 
-        SetHits(7500);
+            SetHits(7500);
 
-        SetDamage(19, 24);
+            SetDamage(19, 24);
 
-        SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-        SetResistance(ResistanceType.Physical, 65, 75);
-        SetResistance(ResistanceType.Fire, 45, 55);
-        SetResistance(ResistanceType.Cold, 50, 60);
-        SetResistance(ResistanceType.Poison, 50, 60);
-        SetResistance(ResistanceType.Energy, 50, 60);
+            SetResistance(ResistanceType.Physical, 65, 75);
+            SetResistance(ResistanceType.Fire, 45, 55);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 50, 60);
+            SetResistance(ResistanceType.Energy, 50, 60);
 
-        SetSkill(SkillName.EvalInt, 0);    // Per Stratics?!?
-        SetSkill(SkillName.Magery, 0);     // Per Stratics?!?
-        SetSkill(SkillName.Meditation, 0); // Per Stratics?!?
-        SetSkill(SkillName.Anatomy, 95.1, 115.0);
-        SetSkill(SkillName.Archery, 95.1, 100.0);
-        SetSkill(SkillName.MagicResist, 50.3, 80.0);
-        SetSkill(SkillName.Tactics, 90.1, 100.0);
-        SetSkill(SkillName.Wrestling, 95.1, 100.0);
+            SetSkill(SkillName.EvalInt, 0);    // Per Stratics?!?
+            SetSkill(SkillName.Magery, 0);     // Per Stratics?!?
+            SetSkill(SkillName.Meditation, 0); // Per Stratics?!?
+            SetSkill(SkillName.Anatomy, 95.1, 115.0);
+            SetSkill(SkillName.Archery, 95.1, 100.0);
+            SetSkill(SkillName.MagicResist, 50.3, 80.0);
+            SetSkill(SkillName.Tactics, 90.1, 100.0);
+            SetSkill(SkillName.Wrestling, 95.1, 100.0);
 
-        Fame = 50000;
-        Karma = 50000;
+            Fame = 50000;
+            Karma = 50000;
 
-        VirtualArmor = 50;
+            VirtualArmor = 50;
 
-        AddItem(new Bow());
-        PackItem(new Arrow(Utility.RandomMinMax(500, 700)));
-    }
+            AddItem(new Bow());
+            PackItem(new Arrow(Utility.RandomMinMax(500, 700)));
+        }
 
-    public Twaulo(Serial serial)
-        : base(serial)
-    {
-    }
+        public override string CorpseName => "a corpse of Twaulo";
+        public override ChampionSkullType SkullType => ChampionSkullType.Pain;
 
-    public override string CorpseName => "a corpse of Twaulo";
-    public override ChampionSkullType SkullType => ChampionSkullType.Pain;
+        public override Type[] UniqueList => new[] { typeof(Quell) };
+        public override Type[] SharedList => new[] { typeof(TheMostKnowledgePerson), typeof(OblivionsNeedle) };
+        public override Type[] DecorativeList => new[] { typeof(Pier), typeof(MonsterStatuette) };
 
-    public override Type[] UniqueList => new[] { typeof(Quell) };
-    public override Type[] SharedList => new[] { typeof(TheMostKnowledgePerson), typeof(OblivionsNeedle) };
-    public override Type[] DecorativeList => new[] { typeof(Pier), typeof(MonsterStatuette) };
+        public override MonsterStatuetteType[] StatueTypes => new[] { MonsterStatuetteType.DreadHorn };
 
-    public override MonsterStatuetteType[] StatueTypes => new[] { MonsterStatuetteType.DreadHorn };
+        public override string DefaultName => "Twaulo";
 
-    public override string DefaultName => "Twaulo";
+        public override OppositionGroup OppositionGroup => OppositionGroup.FeyAndUndead;
 
-    public override OppositionGroup OppositionGroup => OppositionGroup.FeyAndUndead;
+        public override bool Unprovokable => true;
+        public override Poison PoisonImmune => Poison.Regular;
+        public override int TreasureMapLevel => 5;
+        public override int Meat => 1;
+        public override int Hides => 8;
+        public override HideType HideType => HideType.Spined;
 
-    public override bool Unprovokable => true;
-    public override Poison PoisonImmune => Poison.Regular;
-    public override int TreasureMapLevel => 5;
-    public override int Meat => 1;
-    public override int Hides => 8;
-    public override HideType HideType => HideType.Spined;
+        private static MonsterAbility[] _abilities = { MonsterAbilities.SummonPixiesCounter };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    private static MonsterAbility[] _abilities = { MonsterAbilities.SummonPixiesCounter };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.UltraRich, 2);
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Gems);
+        }
 
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.UltraRich, 2);
-        AddLoot(LootPack.Average);
-        AddLoot(LootPack.Gems);
-    }
+        public override void OnGaveMeleeAttack(Mobile defender, int damage)
+        {
+            base.OnGaveMeleeAttack(defender, damage);
 
-    public override void OnGaveMeleeAttack(Mobile defender, int damage)
-    {
-        base.OnGaveMeleeAttack(defender, damage);
-
-        defender.Damage(Utility.Random(20, 10), this);
-        defender.Stam -= Utility.Random(20, 10);
-        defender.Mana -= Utility.Random(20, 10);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
+            defender.Damage(Utility.Random(20, 10), this);
+            defender.Stam -= Utility.Random(20, 10);
+            defender.Mana -= Utility.Random(20, 10);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Changeling.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Changeling.cs
@@ -99,6 +99,7 @@ namespace Server.Mobiles
 
                     _morphedInto = value;
                     Delta(MobileDelta.Noto);
+                    this.MarkDirty();
                 }
             }
         }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Changeling.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Changeling.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 using Server.Spells;
 
 namespace Server.Mobiles
 {
-    public class Changeling : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Changeling : BaseCreature
     {
         private static readonly int[] m_FireNorth =
         {
@@ -21,8 +23,6 @@ namespace Server.Mobiles
         };
 
         private DateTime m_LastMorph;
-
-        private Mobile m_MorphedInto;
         private DateTime m_NextFireRing;
 
         [Constructible]
@@ -68,22 +68,18 @@ namespace Server.Mobiles
             PackArcaneScroll(0, 1);
         }
 
-        public Changeling(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a changeling corpse";
         public override string DefaultName => "a changeling";
         public virtual int DefaultHue => 0;
 
         public override bool ShowFameTitle => false;
-        public override bool InitialInnocent => m_MorphedInto != null;
+        public override bool InitialInnocent => _morphedInto != null;
 
         [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(0)]
         public Mobile MorphedInto
         {
-            get => m_MorphedInto;
+            get => _morphedInto;
             set
             {
                 if (value == this)
@@ -91,7 +87,7 @@ namespace Server.Mobiles
                     value = null;
                 }
 
-                if (m_MorphedInto != value)
+                if (_morphedInto != value)
                 {
                     Revert();
 
@@ -101,7 +97,7 @@ namespace Server.Mobiles
                         m_LastMorph = Core.Now;
                     }
 
-                    m_MorphedInto = value;
+                    _morphedInto = value;
                     Delta(MobileDelta.Noto);
                 }
             }
@@ -134,7 +130,7 @@ namespace Server.Mobiles
                     m_NextFireRing = Core.Now + TimeSpan.FromMinutes(2);
                 }
 
-                if (Combatant.Player && m_MorphedInto != Combatant && Utility.RandomDouble() < 0.05)
+                if (Combatant.Player && _morphedInto != Combatant && Utility.RandomDouble() < 0.05)
                 {
                     MorphedInto = Combatant;
                 }
@@ -145,7 +141,7 @@ namespace Server.Mobiles
         {
             var idle = base.CheckIdle();
 
-            if (idle && m_MorphedInto != null && Core.Now - m_LastMorph > TimeSpan.FromSeconds(30))
+            if (idle && _morphedInto != null && Core.Now - m_LastMorph > TimeSpan.FromSeconds(30))
             {
                 MorphedInto = null;
             }
@@ -260,21 +256,10 @@ namespace Server.Mobiles
         {
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        public void AfterDeserialize()
         {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-            writer.Write(m_MorphedInto != null);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
-            if (reader.ReadBool())
+            if (_morphedInto != null)
             {
                 ValidationQueue<Changeling>.Add(this);
             }
@@ -285,7 +270,8 @@ namespace Server.Mobiles
             Revert();
         }
 
-        private class ClonedItem : Item
+        [SerializationGenerator(0, false)]
+        public partial class ClonedItem : Item
         {
             public ClonedItem(Item item)
                 : base(item.ItemID)
@@ -295,25 +281,6 @@ namespace Server.Mobiles
                 Hue = item.Hue;
                 Layer = item.Layer;
                 Movable = false;
-            }
-
-            public ClonedItem(Serial serial)
-                : base(serial)
-            {
-            }
-
-            public override void Serialize(IGenericWriter writer)
-            {
-                base.Serialize(writer);
-
-                writer.Write(0); // version
-            }
-
-            public override void Deserialize(IGenericReader reader)
-            {
-                base.Deserialize(reader);
-
-                var version = reader.ReadInt();
             }
         }
     }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Changeling.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Changeling.cs
@@ -258,7 +258,7 @@ namespace Server.Mobiles
         }
 
         [AfterDeserialization]
-        public void AfterDeserialize()
+        private void AfterDeserialize()
         {
             if (_morphedInto != null)
             {

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Gnaw.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Gnaw.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Gnaw : DireWolf
+    [SerializationGenerator(0, false)]
+    public partial class Gnaw : DireWolf
     {
         [Constructible]
         public Gnaw()
@@ -46,14 +49,8 @@ namespace Server.Mobiles
         }
         */
 
-        public Gnaw(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Gnaw corpse";
         public override string DefaultName => "Gnaw";
-
         public override bool GivesMLMinorArtifact => true;
         public override int Hides => 28;
         public override int Meat => 4;
@@ -61,20 +58,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Guile.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Guile.cs
@@ -1,72 +1,57 @@
-namespace Server.Mobiles;
+using ModernUO.Serialization;
 
-public class Guile : Changeling
+namespace Server.Mobiles
 {
-    [Constructible]
-    public Guile()
+    [SerializationGenerator(0, false)]
+    public partial class Guile : Changeling
     {
-        IsParagon = true;
+        [Constructible]
+        public Guile()
+        {
+            IsParagon = true;
 
-        Hue = DefaultHue;
+            Hue = DefaultHue;
 
-        SetStr(53, 214);
-        SetDex(243, 367);
-        SetInt(369, 586);
+            SetStr(53, 214);
+            SetDex(243, 367);
+            SetInt(369, 586);
 
-        SetHits(1013, 1058);
-        SetStam(243, 367);
-        SetMana(369, 586);
+            SetHits(1013, 1058);
+            SetStam(243, 367);
+            SetMana(369, 586);
 
-        SetDamage(14, 20);
+            SetDamage(14, 20);
 
-        SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-        SetResistance(ResistanceType.Physical, 80, 90);
-        SetResistance(ResistanceType.Fire, 43, 46);
-        SetResistance(ResistanceType.Cold, 42, 44);
-        SetResistance(ResistanceType.Poison, 42, 50);
-        SetResistance(ResistanceType.Energy, 47, 50);
+            SetResistance(ResistanceType.Physical, 80, 90);
+            SetResistance(ResistanceType.Fire, 43, 46);
+            SetResistance(ResistanceType.Cold, 42, 44);
+            SetResistance(ResistanceType.Poison, 42, 50);
+            SetResistance(ResistanceType.Energy, 47, 50);
 
-        SetSkill(SkillName.Wrestling, 12.8, 16.7);
-        SetSkill(SkillName.Tactics, 102.6, 131.0);
-        SetSkill(SkillName.MagicResist, 141.2, 161.6);
-        SetSkill(SkillName.Magery, 108.4, 120.0);
-        SetSkill(SkillName.EvalInt, 108.4, 120.0);
-        SetSkill(SkillName.Meditation, 109.2, 120.0);
+            SetSkill(SkillName.Wrestling, 12.8, 16.7);
+            SetSkill(SkillName.Tactics, 102.6, 131.0);
+            SetSkill(SkillName.MagicResist, 141.2, 161.6);
+            SetSkill(SkillName.Magery, 108.4, 120.0);
+            SetSkill(SkillName.EvalInt, 108.4, 120.0);
+            SetSkill(SkillName.Meditation, 109.2, 120.0);
 
-        Fame = 21000;
-        Karma = -21000;
-    }
+            Fame = 21000;
+            Karma = -21000;
+        }
 
-    public Guile(Serial serial)
-        : base(serial)
-    {
-    }
+        public override string CorpseName => "a Guile corpse";
+        public override string DefaultName => "Guile";
+        public override int DefaultHue => 0x3F;
+        public override bool GivesMLMinorArtifact => true;
 
-    public override string CorpseName => "a Guile corpse";
-    public override string DefaultName => "Guile";
-    public override int DefaultHue => 0x3F;
-    public override bool GivesMLMinorArtifact => true;
+        private static MonsterAbility[] _abilities = { MonsterAbilities.DrainLifeAttack };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    private static MonsterAbility[] _abilities = { MonsterAbilities.DrainLifeAttack };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.UltraRich, 2);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-
-        writer.Write(0); // version
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.UltraRich, 2);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Irk.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Irk.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Irk : Changeling
+    [SerializationGenerator(0, false)]
+    public partial class Irk : Changeling
     {
         [Constructible]
         public Irk()
@@ -50,11 +53,6 @@ namespace Server.Mobiles
         }
         */
 
-        public Irk(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an Irk corpse";
         public override string DefaultName => "Irk";
         public override int DefaultHue => 0x489;
@@ -66,20 +64,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.UltraRich, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/LadyLissith.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/LadyLissith.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class LadyLissith : GiantBlackWidow
+    [SerializationGenerator(0, false)]
+    public partial class LadyLissith : GiantBlackWidow
     {
         [Constructible]
         public LadyLissith()
@@ -38,11 +40,6 @@ namespace Server.Mobiles
             Karma = -18900;
         }
 
-        public LadyLissith(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Lady Lissith corpse";
         public override string DefaultName => "Lady Lissith";
 
@@ -71,19 +68,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.BleedAttack;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/LadySabrix.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/LadySabrix.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class LadySabrix : GiantBlackWidow
+    [SerializationGenerator(0, false)]
+    public partial class LadySabrix : GiantBlackWidow
     {
         [Constructible]
         public LadySabrix()
@@ -36,11 +38,6 @@ namespace Server.Mobiles
 
             Fame = 18900;
             Karma = -18900;
-        }
-
-        public LadySabrix(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a Lady Sabrix corpse";
@@ -77,19 +74,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.ArmorIgnore;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Malefic.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Malefic.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Malefic : DreadSpider
+    [SerializationGenerator(0, false)]
+    public partial class Malefic : DreadSpider
     {
         [Constructible]
         public Malefic()
@@ -46,11 +48,6 @@ namespace Server.Mobiles
             */
         }
 
-        public Malefic(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Malefic corpse";
         public override string DefaultName => "Malefic";
 
@@ -62,19 +59,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.Dismount;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Silk.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Silk.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Silk : GiantBlackWidow
+    [SerializationGenerator(0, false)]
+    public partial class Silk : GiantBlackWidow
     {
         [Constructible]
         public Silk()
@@ -38,11 +40,6 @@ namespace Server.Mobiles
             Karma = -18900;
         }
 
-        public Silk(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Silk corpse";
         public override string DefaultName => "Silk";
 
@@ -54,19 +51,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.ParalyzingBlow;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Spite.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Spite.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Spite : Changeling
+    [SerializationGenerator(0, false)]
+    public partial class Spite : Changeling
     {
         [Constructible]
         public Spite()
@@ -38,11 +41,6 @@ namespace Server.Mobiles
             Karma = -21000;
         }
 
-        public Spite(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Spite corpse";
         public override string DefaultName => "Spite";
         public override int DefaultHue => 0x21;
@@ -52,20 +50,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.UltraRich, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Swoop.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Swoop.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Mobiles
 {
-    public class Swoop : Eagle
+    [SerializationGenerator(0, false)]
+    public partial class Swoop : Eagle
     {
         private static readonly Dictionary<Mobile, ExpireTimer> m_Table = new();
 
@@ -78,11 +80,6 @@ namespace Server.Mobiles
         }
         */
 
-        public Swoop(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Swoop corpse";
         public override string DefaultName => "Swoop";
 
@@ -126,20 +123,6 @@ namespace Server.Mobiles
             timer = new ExpireTimer(defender, mod, TimeSpan.FromSeconds(5.0));
             timer.Start();
             m_Table[defender] = timer;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         private class ExpireTimer : Timer

--- a/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Virulent.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Twisted Weald/Virulent.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Virulent : DreadSpider
+    [SerializationGenerator(0, false)]
+    public partial class Virulent : DreadSpider
     {
         [Constructible]
         public Virulent()
@@ -40,11 +42,6 @@ namespace Server.Mobiles
             Karma = -21000;
         }
 
-        public Virulent(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a Virulent corpse";
         public override string DefaultName => "Virulent";
 
@@ -76,19 +73,5 @@ namespace Server.Mobiles
         }
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.MortalStrike;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Mammal/Melee/HellHound.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Mammal/Melee/HellHound.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class HellHound : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class HellHound : BaseCreature
     {
         [Constructible]
         public HellHound() : base(AIType.AI_Melee)
@@ -38,10 +40,6 @@ namespace Server.Mobiles
             PackItem(new SulfurousAsh(5));
         }
 
-        public HellHound(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a hell hound corpse";
         public override string DefaultName => "a hell hound";
         public override int Meat => 1;
@@ -55,18 +53,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Mammal/Melee/VorpalBunny.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Mammal/Melee/VorpalBunny.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class VorpalBunny : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class VorpalBunny : BaseCreature
     {
         [Constructible]
         public VorpalBunny() : base(AIType.AI_Melee)
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             PackStatue();
 
             DelayBeginTunnel();
-        }
-
-        public VorpalBunny(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a vorpal bunny corpse";
@@ -89,23 +87,8 @@ namespace Server.Mobiles
 
         public override int GetDeathSound() => 0xCB;
 
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
-            DelayBeginTunnel();
-        }
-
-        public class BunnyHole : Item
+        [SerializationGenerator(0, false)]
+        public partial class BunnyHole : Item
         {
             public BunnyHole() : base(0x913)
             {
@@ -115,25 +98,11 @@ namespace Server.Mobiles
                 Timer.StartTimer(TimeSpan.FromSeconds(40.0), Delete);
             }
 
-            public BunnyHole(Serial serial) : base(serial)
-            {
-            }
-
             public override string DefaultName => "a mysterious rabbit hole";
 
-            public override void Serialize(IGenericWriter writer)
+            [AfterDeserialization]
+            private void AfterDeserialization()
             {
-                base.Serialize(writer);
-
-                writer.Write(0);
-            }
-
-            public override void Deserialize(IGenericReader reader)
-            {
-                base.Deserialize(reader);
-
-                var version = reader.ReadInt();
-
                 Delete();
             }
         }

--- a/Projects/UOContent/Mobiles/Monsters/Mammal/Melee/VorpalBunny.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Mammal/Melee/VorpalBunny.cs
@@ -100,7 +100,7 @@ namespace Server.Mobiles
 
             public override string DefaultName => "a mysterious rabbit hole";
 
-            [AfterDeserialization]
+            [AfterDeserialization(false)]
             private void AfterDeserialization()
             {
                 Delete();

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Magic/DarkWisp.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Magic/DarkWisp.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using Server.Ethics;
 using Server.Items;
@@ -5,7 +6,8 @@ using Server.Misc;
 
 namespace Server.Mobiles
 {
-    public class DarkWisp : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class DarkWisp : BaseCreature
     {
         [Constructible]
         public DarkWisp() : base(AIType.AI_Mage, FightMode.Aggressor)
@@ -44,11 +46,6 @@ namespace Server.Mobiles
             AddItem(new LightSource());
         }
 
-        public DarkWisp(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wisp corpse";
         public override InhumanSpeech SpeechType => InhumanSpeech.Wisp;
 
@@ -64,18 +61,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Magic/EtherealWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Magic/EtherealWarrior.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Gumps;
 
 namespace Server.Mobiles
 {
-    public class EtherealWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class EtherealWarrior : BaseCreature
     {
         private static readonly TimeSpan ResurrectDelay = TimeSpan.FromSeconds(2.0);
 
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             Karma = 7000;
 
             VirtualArmor = 120;
-        }
-
-        public EtherealWarrior(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "an ethereal warrior corpse";
@@ -113,18 +111,6 @@ namespace Server.Mobiles
             attacker.Damage(Utility.Random(10, 10), this);
             attacker.Stam -= Utility.Random(10, 10);
             attacker.Mana -= Utility.Random(10, 10);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Magic/Pixie.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Magic/Pixie.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Pixie : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Pixie : BaseCreature
     {
         [Constructible]
         public Pixie() : base(AIType.AI_Mage, FightMode.Evil)
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             }
         }
 
-        public Pixie(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a pixie corpse";
         public override bool InitialInnocent => true;
 
@@ -71,19 +69,6 @@ namespace Server.Mobiles
             {
                 c.DropItem(new PixieLeg());
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Magic/ShadowWisp.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Magic/ShadowWisp.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class ShadowWisp : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class ShadowWisp : BaseCreature
     {
         [Constructible]
         public ShadowWisp() : base(AIType.AI_Mage, FightMode.Aggressor)
@@ -52,25 +54,9 @@ namespace Server.Mobiles
             );
         }
 
-        public ShadowWisp(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wisp corpse";
         public override string DefaultName => "a shadow wisp";
 
         public override OppositionGroup OppositionGroup => OppositionGroup.FeyAndUndead;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Magic/Wisp.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Magic/Wisp.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Ethics;
@@ -7,7 +8,8 @@ using Server.Misc;
 
 namespace Server.Mobiles
 {
-    public class Wisp : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Wisp : BaseCreature
     {
         [Constructible]
         public Wisp() : base(AIType.AI_Mage, FightMode.Aggressor)
@@ -51,10 +53,6 @@ namespace Server.Mobiles
             AddItem(new LightSource());
         }
 
-        public Wisp(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wisp corpse";
         public override InhumanSpeech SpeechType => InhumanSpeech.Wisp;
 
@@ -71,18 +69,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/AnimatedWeapon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/AnimatedWeapon.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using ModernUO.Serialization;
+using System;
 
 namespace Server.Mobiles
 {
-    public class AnimatedWeapon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AnimatedWeapon : BaseCreature
     {
         [Constructible]
         public AnimatedWeapon(Mobile caster, int level) : base(AIType.AI_Melee)
@@ -71,11 +73,6 @@ namespace Server.Mobiles
             ControlSlots = 4;
         }
 
-        public AnimatedWeapon(Serial serial)
-            : base(serial)
-        {
-        }
-
         public override string CorpseName => "an animated weapon corpse";
         public override bool DeleteCorpseOnDeath => true;
         public override bool IsHouseSummonable => true;
@@ -96,20 +93,5 @@ namespace Server.Mobiles
         public override int GetAttackSound() => 0x3B8;
 
         public override int GetHurtSound() => 0x23A;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            /*int version = */
-            reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/BladeSpirits.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/BladeSpirits.cs
@@ -1,116 +1,101 @@
+using ModernUO.Serialization;
 using System;
 using Server.Buffers;
 using Server.Collections;
 
-namespace Server.Mobiles;
-
-public class BladeSpirits : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public BladeSpirits() : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class BladeSpirits : BaseCreature
     {
-        Body = 574;
-
-        SetStr(150);
-        SetDex(150);
-        SetInt(100);
-
-        SetHits(Core.SE ? 160 : 80);
-        SetStam(250);
-        SetMana(0);
-
-        SetDamage(10, 14);
-
-        SetDamageType(ResistanceType.Physical, 60);
-        SetDamageType(ResistanceType.Poison, 20);
-        SetDamageType(ResistanceType.Energy, 20);
-
-        SetResistance(ResistanceType.Physical, 30, 40);
-        SetResistance(ResistanceType.Fire, 40, 50);
-        SetResistance(ResistanceType.Cold, 30, 40);
-        SetResistance(ResistanceType.Poison, 100);
-        SetResistance(ResistanceType.Energy, 20, 30);
-
-        SetSkill(SkillName.MagicResist, 70.0);
-        SetSkill(SkillName.Tactics, 90.0);
-        SetSkill(SkillName.Wrestling, 90.0);
-
-        Fame = 0;
-        Karma = 0;
-
-        VirtualArmor = 40;
-        ControlSlots = Core.SE ? 2 : 1;
-    }
-
-    public BladeSpirits(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "a blade spirit corpse";
-    public override bool DeleteCorpseOnDeath => Core.AOS;
-    public override bool IsHouseSummonable => true;
-
-    public override double DispelDifficulty => 0.0;
-    public override double DispelFocus => 20.0;
-
-    public override string DefaultName => "a blade spirit";
-
-    public override bool BleedImmune => true;
-    public override Poison PoisonImmune => Poison.Lethal;
-
-    public override double GetFightModeRanking(Mobile m, FightMode acqType, bool bPlayerOnly) =>
-        (m.Str + m.Skills.Tactics.Value) / Math.Max(GetDistanceToSqrt(m), 1.0);
-
-    public override int GetAngerSound() => 0x23A;
-
-    public override int GetAttackSound() => 0x3B8;
-
-    public override int GetHurtSound() => 0x23A;
-
-    public override void OnThink()
-    {
-        if (Core.SE && Summoned)
+        [Constructible]
+        public BladeSpirits() : base(AIType.AI_Melee)
         {
-            var eable = GetMobilesInRange(5);
-            using var queue = PooledRefQueue<Mobile>.Create();
-            foreach (var m in eable)
-            {
-                if (m is EnergyVortex or BladeSpirits && ((BaseCreature)m).Summoned)
-                {
-                    queue.Enqueue(m);
-                }
-            }
-            eable.Free();
+            Body = 574;
 
-            var amount = queue.Count - 6;
-            if (amount > 0)
-            {
-                var mobs = queue.ToPooledArray();
-                mobs.Shuffle();
+            SetStr(150);
+            SetDex(150);
+            SetInt(100);
 
-                while (amount > 0)
-                {
-                    Dispel(mobs[amount--]);
-                }
+            SetHits(Core.SE ? 160 : 80);
+            SetStam(250);
+            SetMana(0);
 
-                STArrayPool<Mobile>.Shared.Return(mobs, true);
-            }
+            SetDamage(10, 14);
+
+            SetDamageType(ResistanceType.Physical, 60);
+            SetDamageType(ResistanceType.Poison, 20);
+            SetDamageType(ResistanceType.Energy, 20);
+
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 30, 40);
+            SetResistance(ResistanceType.Poison, 100);
+            SetResistance(ResistanceType.Energy, 20, 30);
+
+            SetSkill(SkillName.MagicResist, 70.0);
+            SetSkill(SkillName.Tactics, 90.0);
+            SetSkill(SkillName.Wrestling, 90.0);
+
+            Fame = 0;
+            Karma = 0;
+
+            VirtualArmor = 40;
+            ControlSlots = Core.SE ? 2 : 1;
         }
 
-        base.OnThink();
-    }
+        public override string CorpseName => "a blade spirit corpse";
+        public override bool DeleteCorpseOnDeath => Core.AOS;
+        public override bool IsHouseSummonable => true;
 
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
+        public override double DispelDifficulty => 0.0;
+        public override double DispelFocus => 20.0;
 
-        writer.Write(0); // version
-    }
+        public override string DefaultName => "a blade spirit";
 
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
+        public override bool BleedImmune => true;
+        public override Poison PoisonImmune => Poison.Lethal;
 
-        var version = reader.ReadInt();
+        public override double GetFightModeRanking(Mobile m, FightMode acqType, bool bPlayerOnly) =>
+            (m.Str + m.Skills.Tactics.Value) / Math.Max(GetDistanceToSqrt(m), 1.0);
+
+        public override int GetAngerSound() => 0x23A;
+
+        public override int GetAttackSound() => 0x3B8;
+
+        public override int GetHurtSound() => 0x23A;
+
+        public override void OnThink()
+        {
+            if (Core.SE && Summoned)
+            {
+                var eable = GetMobilesInRange(5);
+                using var queue = PooledRefQueue<Mobile>.Create();
+                foreach (var m in eable)
+                {
+                    if (m is EnergyVortex or BladeSpirits && ((BaseCreature)m).Summoned)
+                    {
+                        queue.Enqueue(m);
+                    }
+                }
+                eable.Free();
+
+                var amount = queue.Count - 6;
+                if (amount > 0)
+                {
+                    var mobs = queue.ToPooledArray();
+                    mobs.Shuffle();
+
+                    while (amount > 0)
+                    {
+                        Dispel(mobs[amount--]);
+                    }
+
+                    STArrayPool<Mobile>.Shared.Return(mobs, true);
+                }
+            }
+
+            base.OnThink();
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Centaur.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Centaur.cs
@@ -64,14 +64,5 @@ namespace Server.Mobiles
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Gems);
         }
-
-        [AfterDeserialization]
-        private void AfterDeserialization()
-        {
-            if (BaseSoundID == 678)
-            {
-                BaseSoundID = 679;
-            }
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Centaur.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Centaur.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Centaur : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Centaur : BaseCreature
     {
         [Constructible]
         public Centaur() : base(AIType.AI_Melee, FightMode.Aggressor)
@@ -48,10 +50,6 @@ namespace Server.Mobiles
             ); // OSI it is different: in a sub backpack, this is probably just a limitation of their engine
         }
 
-        public Centaur(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a centaur corpse";
 
         public override OppositionGroup OppositionGroup => OppositionGroup.FeyAndUndead;
@@ -67,17 +65,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Gems);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 678)
             {
                 BaseSoundID = 679;

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/EnergyVortex.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/EnergyVortex.cs
@@ -1,128 +1,116 @@
+using ModernUO.Serialization;
 using System;
 using Server.Buffers;
 using Server.Collections;
 
-namespace Server.Mobiles;
-
-public class EnergyVortex : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public EnergyVortex() : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class EnergyVortex : BaseCreature
     {
-        if (Core.SE && Utility.Random(500) == 0) // Per OSI FoF, it's a 1/500 chance.
+        [Constructible]
+        public EnergyVortex() : base(AIType.AI_Melee)
         {
-            // Llama vortex!
-            Body = 0xDC;
-            Hue = 0x76;
-        }
-        else
-        {
-            Body = 164;
-        }
-
-        SetStr(200);
-        SetDex(200);
-        SetInt(100);
-
-        SetHits(Core.SE ? 140 : 70);
-        SetStam(250);
-        SetMana(0);
-
-        SetDamage(14, 17);
-
-        SetDamageType(ResistanceType.Physical, 0);
-        SetDamageType(ResistanceType.Energy, 100);
-
-        SetResistance(ResistanceType.Physical, 60, 70);
-        SetResistance(ResistanceType.Fire, 40, 50);
-        SetResistance(ResistanceType.Cold, 40, 50);
-        SetResistance(ResistanceType.Poison, 40, 50);
-        SetResistance(ResistanceType.Energy, 90, 100);
-
-        SetSkill(SkillName.MagicResist, 99.9);
-        SetSkill(SkillName.Tactics, 100.0);
-        SetSkill(SkillName.Wrestling, 120.0);
-
-        Fame = 0;
-        Karma = 0;
-
-        VirtualArmor = 40;
-        ControlSlots = Core.SE ? 2 : 1;
-    }
-
-    public EnergyVortex(Serial serial)
-        : base(serial)
-    {
-    }
-
-    public override string CorpseName => "an energy vortex corpse";
-    public override bool DeleteCorpseOnDeath => Summoned;
-    public override bool AlwaysMurderer => true; // Or Llama vortices will appear gray.
-
-    public override double DispelDifficulty => 80.0;
-    public override double DispelFocus => 20.0;
-
-    public override string DefaultName => "an energy vortex";
-
-    public override bool BleedImmune => true;
-    public override Poison PoisonImmune => Poison.Lethal;
-
-    public override double GetFightModeRanking(Mobile m, FightMode acqType, bool bPlayerOnly) =>
-        (m.Int + m.Skills.Magery.Value) / Math.Max(GetDistanceToSqrt(m), 1.0);
-
-    public override int GetAngerSound() => 0x15;
-
-    public override int GetAttackSound() => 0x28;
-
-    public override void OnThink()
-    {
-        if (Core.SE && Summoned)
-        {
-            var eable = GetMobilesInRange(5);
-            using var queue = PooledRefQueue<Mobile>.Create();
-            foreach (var m in eable)
+            if (Core.SE && Utility.Random(500) == 0) // Per OSI FoF, it's a 1/500 chance.
             {
-                if (m is EnergyVortex or BladeSpirits && ((BaseCreature)m).Summoned)
+                // Llama vortex!
+                Body = 0xDC;
+                Hue = 0x76;
+            }
+            else
+            {
+                Body = 164;
+            }
+
+            SetStr(200);
+            SetDex(200);
+            SetInt(100);
+
+            SetHits(Core.SE ? 140 : 70);
+            SetStam(250);
+            SetMana(0);
+
+            SetDamage(14, 17);
+
+            SetDamageType(ResistanceType.Physical, 0);
+            SetDamageType(ResistanceType.Energy, 100);
+
+            SetResistance(ResistanceType.Physical, 60, 70);
+            SetResistance(ResistanceType.Fire, 40, 50);
+            SetResistance(ResistanceType.Cold, 40, 50);
+            SetResistance(ResistanceType.Poison, 40, 50);
+            SetResistance(ResistanceType.Energy, 90, 100);
+
+            SetSkill(SkillName.MagicResist, 99.9);
+            SetSkill(SkillName.Tactics, 100.0);
+            SetSkill(SkillName.Wrestling, 120.0);
+
+            Fame = 0;
+            Karma = 0;
+
+            VirtualArmor = 40;
+            ControlSlots = Core.SE ? 2 : 1;
+        }
+
+        public override string CorpseName => "an energy vortex corpse";
+        public override bool DeleteCorpseOnDeath => Summoned;
+        public override bool AlwaysMurderer => true; // Or Llama vortices will appear gray.
+
+        public override double DispelDifficulty => 80.0;
+        public override double DispelFocus => 20.0;
+
+        public override string DefaultName => "an energy vortex";
+
+        public override bool BleedImmune => true;
+        public override Poison PoisonImmune => Poison.Lethal;
+
+        public override double GetFightModeRanking(Mobile m, FightMode acqType, bool bPlayerOnly) =>
+            (m.Int + m.Skills.Magery.Value) / Math.Max(GetDistanceToSqrt(m), 1.0);
+
+        public override int GetAngerSound() => 0x15;
+
+        public override int GetAttackSound() => 0x28;
+
+        public override void OnThink()
+        {
+            if (Core.SE && Summoned)
+            {
+                var eable = GetMobilesInRange(5);
+                using var queue = PooledRefQueue<Mobile>.Create();
+                foreach (var m in eable)
                 {
-                    queue.Enqueue(m);
+                    if (m is EnergyVortex or BladeSpirits && ((BaseCreature)m).Summoned)
+                    {
+                        queue.Enqueue(m);
+                    }
+                }
+                eable.Free();
+
+                var amount = queue.Count - 6;
+                if (amount > 0)
+                {
+                    var mobs = queue.ToPooledArray();
+                    mobs.Shuffle();
+
+                    while (amount > 0)
+                    {
+                        Dispel(mobs[amount--]);
+                    }
+
+                    STArrayPool<Mobile>.Shared.Return(mobs, true);
                 }
             }
-            eable.Free();
 
-            var amount = queue.Count - 6;
-            if (amount > 0)
-            {
-                var mobs = queue.ToPooledArray();
-                mobs.Shuffle();
-
-                while (amount > 0)
-                {
-                    Dispel(mobs[amount--]);
-                }
-
-                STArrayPool<Mobile>.Shared.Return(mobs, true);
-            }
+            base.OnThink();
         }
 
-        base.OnThink();
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-
-        writer.Write(0); // version
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
-
-        if (BaseSoundID == 263)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            BaseSoundID = 0;
+            if (BaseSoundID == 263)
+            {
+                BaseSoundID = 0;
+            }
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/FrostOoze.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/FrostOoze.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class FrostOoze : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class FrostOoze : BaseCreature
     {
         [Constructible]
         public FrostOoze() : base(AIType.AI_Melee)
@@ -33,28 +36,12 @@ namespace Server.Mobiles
             VirtualArmor = 38;
         }
 
-        public FrostOoze(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a frost ooze corpse";
         public override string DefaultName => "a frost ooze";
 
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Gems, Utility.RandomMinMax(1, 2));
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Golem.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Golem.cs
@@ -1,182 +1,169 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class Golem : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public Golem(bool summoned = false, double scalar = 1.0) : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class Golem : BaseCreature
     {
-        Body = 752;
-
-        if (summoned)
+        [Constructible]
+        public Golem(bool summoned = false, double scalar = 1.0) : base(AIType.AI_Melee)
         {
-            Hue = 2101;
-        }
+            Body = 752;
 
-        SetStr((int)(251 * scalar), (int)(350 * scalar));
-        SetDex((int)(76 * scalar), (int)(100 * scalar));
-        SetInt((int)(101 * scalar), (int)(150 * scalar));
-
-        SetHits((int)(151 * scalar), (int)(210 * scalar));
-
-        SetDamage((int)(13 * scalar), (int)(24 * scalar));
-
-        SetDamageType(ResistanceType.Physical, 100);
-
-        SetResistance(ResistanceType.Physical, (int)(35 * scalar), (int)(55 * scalar));
-
-        if (summoned)
-        {
-            SetResistance(ResistanceType.Fire, (int)(50 * scalar), (int)(60 * scalar));
-        }
-        else
-        {
-            SetResistance(ResistanceType.Fire, (int)(100 * scalar));
-        }
-
-        SetResistance(ResistanceType.Cold, (int)(10 * scalar), (int)(30 * scalar));
-        SetResistance(ResistanceType.Poison, (int)(10 * scalar), (int)(25 * scalar));
-        SetResistance(ResistanceType.Energy, (int)(30 * scalar), (int)(40 * scalar));
-
-        SetSkill(SkillName.MagicResist, 150.1 * scalar, 190.0 * scalar);
-        SetSkill(SkillName.Tactics, 60.1 * scalar, 100.0 * scalar);
-        SetSkill(SkillName.Wrestling, 60.1 * scalar, 100.0 * scalar);
-
-        if (summoned)
-        {
-            Fame = 10;
-            Karma = 10;
-        }
-        else
-        {
-            Fame = 3500;
-            Karma = -3500;
-        }
-
-        if (!summoned)
-        {
-            PackItem(new IronIngot(Utility.RandomMinMax(13, 21)));
-
-            if (Utility.RandomDouble() < 0.1)
+            if (summoned)
             {
-                PackItem(new PowerCrystal());
+                Hue = 2101;
             }
 
-            if (Utility.RandomDouble() < 0.15)
+            SetStr((int)(251 * scalar), (int)(350 * scalar));
+            SetDex((int)(76 * scalar), (int)(100 * scalar));
+            SetInt((int)(101 * scalar), (int)(150 * scalar));
+
+            SetHits((int)(151 * scalar), (int)(210 * scalar));
+
+            SetDamage((int)(13 * scalar), (int)(24 * scalar));
+
+            SetDamageType(ResistanceType.Physical, 100);
+
+            SetResistance(ResistanceType.Physical, (int)(35 * scalar), (int)(55 * scalar));
+
+            if (summoned)
             {
-                PackItem(new ClockworkAssembly());
-            }
-
-            if (Utility.RandomDouble() < 0.2)
-            {
-                PackItem(new ArcaneGem());
-            }
-
-            if (Utility.RandomDouble() < 0.25)
-            {
-                PackItem(new Gears());
-            }
-        }
-
-        ControlSlots = 3;
-    }
-
-    public Golem(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "a golem corpse";
-
-    public override bool IsScaredOfScaryThings => false;
-    public override bool IsScaryToPets => true;
-
-    public override bool IsBondable => false;
-
-    public override FoodType FavoriteFood => FoodType.None;
-
-    public override bool CanBeDistracted => false;
-
-    public override string DefaultName => "a golem";
-
-    public override bool DeleteOnRelease => true;
-
-    public override bool AutoDispel => !Controlled;
-    public override bool BleedImmune => true;
-
-    public override bool BardImmune => !Core.AOS || Controlled;
-    public override Poison PoisonImmune => Poison.Lethal;
-
-    private static MonsterAbility[] _abilities = { MonsterAbilities.ColossalBlow };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void OnDeath(Container c)
-    {
-        base.OnDeath(c);
-
-        if (Utility.RandomDouble() < 0.05)
-        {
-            if (!IsParagon)
-            {
-                if (Utility.RandomDouble() < 0.75)
-                {
-                    c.DropItem(DawnsMusicGear.RandomCommon);
-                }
-                else
-                {
-                    c.DropItem(DawnsMusicGear.RandomUncommon);
-                }
+                SetResistance(ResistanceType.Fire, (int)(50 * scalar), (int)(60 * scalar));
             }
             else
             {
-                c.DropItem(DawnsMusicGear.RandomRare);
+                SetResistance(ResistanceType.Fire, (int)(100 * scalar));
             }
-        }
-    }
 
-    public override int GetAngerSound() => 541;
+            SetResistance(ResistanceType.Cold, (int)(10 * scalar), (int)(30 * scalar));
+            SetResistance(ResistanceType.Poison, (int)(10 * scalar), (int)(25 * scalar));
+            SetResistance(ResistanceType.Energy, (int)(30 * scalar), (int)(40 * scalar));
 
-    public override int GetIdleSound() => !Controlled ? 542 : base.GetIdleSound();
+            SetSkill(SkillName.MagicResist, 150.1 * scalar, 190.0 * scalar);
+            SetSkill(SkillName.Tactics, 60.1 * scalar, 100.0 * scalar);
+            SetSkill(SkillName.Wrestling, 60.1 * scalar, 100.0 * scalar);
 
-    public override int GetDeathSound() => !Controlled ? 545 : base.GetDeathSound();
-
-    public override int GetAttackSound() => 562;
-
-    public override int GetHurtSound() => Controlled ? 320 : base.GetHurtSound();
-
-    public override void OnDamage(int amount, Mobile from, bool willKill)
-    {
-        if (Controlled || Summoned)
-        {
-            var master = ControlMaster ?? SummonMaster;
-
-            if (master?.Player == true && master.Map == Map && master.InRange(Location, 20))
+            if (summoned)
             {
-                if (master.Mana >= amount)
+                Fame = 10;
+                Karma = 10;
+            }
+            else
+            {
+                Fame = 3500;
+                Karma = -3500;
+            }
+
+            if (!summoned)
+            {
+                PackItem(new IronIngot(Utility.RandomMinMax(13, 21)));
+
+                if (Utility.RandomDouble() < 0.1)
                 {
-                    master.Mana -= amount;
+                    PackItem(new PowerCrystal());
+                }
+
+                if (Utility.RandomDouble() < 0.15)
+                {
+                    PackItem(new ClockworkAssembly());
+                }
+
+                if (Utility.RandomDouble() < 0.2)
+                {
+                    PackItem(new ArcaneGem());
+                }
+
+                if (Utility.RandomDouble() < 0.25)
+                {
+                    PackItem(new Gears());
+                }
+            }
+
+            ControlSlots = 3;
+        }
+
+        public override string CorpseName => "a golem corpse";
+
+        public override bool IsScaredOfScaryThings => false;
+        public override bool IsScaryToPets => true;
+
+        public override bool IsBondable => false;
+
+        public override FoodType FavoriteFood => FoodType.None;
+
+        public override bool CanBeDistracted => false;
+
+        public override string DefaultName => "a golem";
+
+        public override bool DeleteOnRelease => true;
+
+        public override bool AutoDispel => !Controlled;
+        public override bool BleedImmune => true;
+
+        public override bool BardImmune => !Core.AOS || Controlled;
+        public override Poison PoisonImmune => Poison.Lethal;
+
+        private static MonsterAbility[] _abilities = { MonsterAbilities.ColossalBlow };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+
+        public override void OnDeath(Container c)
+        {
+            base.OnDeath(c);
+
+            if (Utility.RandomDouble() < 0.05)
+            {
+                if (!IsParagon)
+                {
+                    if (Utility.RandomDouble() < 0.75)
+                    {
+                        c.DropItem(DawnsMusicGear.RandomCommon);
+                    }
+                    else
+                    {
+                        c.DropItem(DawnsMusicGear.RandomUncommon);
+                    }
                 }
                 else
                 {
-                    amount -= master.Mana;
-                    master.Mana = 0;
-                    master.Damage(amount);
+                    c.DropItem(DawnsMusicGear.RandomRare);
                 }
             }
         }
 
-        base.OnDamage(amount, from, willKill);
-    }
+        public override int GetAngerSound() => 541;
 
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
+        public override int GetIdleSound() => !Controlled ? 542 : base.GetIdleSound();
 
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override int GetDeathSound() => !Controlled ? 545 : base.GetDeathSound();
+
+        public override int GetAttackSound() => 562;
+
+        public override int GetHurtSound() => Controlled ? 320 : base.GetHurtSound();
+
+        public override void OnDamage(int amount, Mobile from, bool willKill)
+        {
+            if (Controlled || Summoned)
+            {
+                var master = ControlMaster ?? SummonMaster;
+
+                if (master?.Player == true && master.Map == Map && master.InRange(Location, 20))
+                {
+                    if (master.Mana >= amount)
+                    {
+                        master.Mana -= amount;
+                    }
+                    else
+                    {
+                        amount -= master.Mana;
+                        master.Mana = 0;
+                        master.Damage(amount);
+                    }
+                }
+            }
+
+            base.OnDamage(amount, from, willKill);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
@@ -9,8 +9,21 @@ namespace Server.Mobiles
     [SerializationGenerator(0, false)]
     public partial class PlagueBeast : BaseCreature, IDevourer
     {
-        [SerializableField(0)]
-        private int _devourGoal;
+        [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(1)]
+        public int TotalDevoured { get; set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(2)]
+        public bool HasMetalChest { get; private set; }
+
+        [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(0)]
+        public int DevourGoal
+        {
+            get => IsParagon ? DevourGoal + 25 : DevourGoal;
+            set => DevourGoal = value;
+        }
 
         [Constructible]
         public PlagueBeast() : base(AIType.AI_Melee)
@@ -54,28 +67,11 @@ namespace Server.Mobiles
             }
 
             TotalDevoured = 0;
-            _devourGoal = Utility.RandomMinMax(15, 25); // How many corpses must be devoured before a metal chest is awarded
+            DevourGoal = Utility.RandomMinMax(15, 25); // How many corpses must be devoured before a metal chest is awarded
         }
 
         public override string CorpseName => "a plague beast corpse";
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(1)]
-        public int TotalDevoured { get; set; }
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int DevourGoal
-        {
-            get => IsParagon ? _devourGoal + 25 : _devourGoal;
-            set => _devourGoal = value;
-        }
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(2)]
-        public bool HasMetalChest { get; private set; }
-
         public override string DefaultName => "a plague beast";
-
         public override bool AutoDispel => true;
         public override Poison PoisonImmune => Poison.Lethal;
 

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
@@ -9,20 +9,20 @@ namespace Server.Mobiles
     [SerializationGenerator(0, false)]
     public partial class PlagueBeast : BaseCreature, IDevourer
     {
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(1)]
-        public int TotalDevoured { get; set; }
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [SerializableField(0, setter: "private")]
+        private bool _hasMetalChest;
+
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [SerializableField(1)]
+        private int _totalDevoured;
 
         [CommandProperty(AccessLevel.GameMaster)]
         [SerializableProperty(2)]
-        public bool HasMetalChest { get; private set; }
-
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(0)]
         public int DevourGoal
         {
-            get => IsParagon ? DevourGoal + 25 : DevourGoal;
-            set => DevourGoal = value;
+            get => IsParagon ? _devourGoal + 25 : _devourGoal;
+            set => _devourGoal = value;
         }
 
         [Constructible]
@@ -66,8 +66,8 @@ namespace Server.Mobiles
                 PackItem(Seed.RandomPeculiarSeed(4));
             }
 
-            TotalDevoured = 0;
-            DevourGoal = Utility.RandomMinMax(15, 25); // How many corpses must be devoured before a metal chest is awarded
+            _totalDevoured = 0;
+            _devourGoal = Utility.RandomMinMax(15, 25); // How many corpses must be devoured before a metal chest is awarded
         }
 
         public override string CorpseName => "a plague beast corpse";
@@ -88,7 +88,7 @@ namespace Server.Mobiles
             }
 
             IncreaseHits((int)Math.Ceiling(corpse.Owner.HitsMax * 0.75));
-            TotalDevoured++;
+            _totalDevoured++;
 
             PublicOverheadMessage(
                 MessageType.Emote,
@@ -96,10 +96,10 @@ namespace Server.Mobiles
                 1053033
             ); // * The plague beast absorbs the fleshy remains of the corpse *
 
-            if (!HasMetalChest && TotalDevoured >= DevourGoal)
+            if (!_hasMetalChest && _totalDevoured >= _devourGoal)
             {
                 PackItem(new MetalChest());
-                HasMetalChest = true;
+                _hasMetalChest = true;
             }
 
             return true;

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
@@ -5,9 +6,11 @@ using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class PlagueBeast : BaseCreature, IDevourer
+    [SerializationGenerator(0, false)]
+    public partial class PlagueBeast : BaseCreature, IDevourer
     {
-        private int m_DevourGoal;
+        [SerializableField(0)]
+        private int _devourGoal;
 
         [Constructible]
         public PlagueBeast() : base(AIType.AI_Melee)
@@ -51,26 +54,24 @@ namespace Server.Mobiles
             }
 
             TotalDevoured = 0;
-            m_DevourGoal = Utility.RandomMinMax(15, 25); // How many corpses must be devoured before a metal chest is awarded
-        }
-
-        public PlagueBeast(Serial serial) : base(serial)
-        {
+            _devourGoal = Utility.RandomMinMax(15, 25); // How many corpses must be devoured before a metal chest is awarded
         }
 
         public override string CorpseName => "a plague beast corpse";
 
         [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(1)]
         public int TotalDevoured { get; set; }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public int DevourGoal
         {
-            get => IsParagon ? m_DevourGoal + 25 : m_DevourGoal;
-            set => m_DevourGoal = value;
+            get => IsParagon ? _devourGoal + 25 : _devourGoal;
+            set => _devourGoal = value;
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(2)]
         public bool HasMetalChest { get; private set; }
 
         public override string DefaultName => "a plague beast";
@@ -163,33 +164,6 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 0x1C1;
 
         public override int GetDeathSound() => 0x1C2;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(1);
-
-            writer.Write(HasMetalChest);
-            writer.Write(TotalDevoured);
-            writer.Write(m_DevourGoal);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
-            switch (version)
-            {
-                case 1:
-                    {
-                        HasMetalChest = reader.ReadBool();
-                        TotalDevoured = reader.ReadInt();
-                        m_DevourGoal = reader.ReadInt();
-                        break;
-                    }
-            }
-        }
 
         public override void OnThink()
         {

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeastLord.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeastLord.cs
@@ -17,7 +17,7 @@ namespace Server.Mobiles
         private int _deadline;
 
         [SerializableProperty(2)]
-        private bool IsNotNullTimer { get => m_Timer != null; };
+        private bool IsNotNullTimer { get => m_Timer != null; }
 
         [Constructible]
         public PlagueBeastLord() : base(AIType.AI_Melee)

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeastLord.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeastLord.cs
@@ -1,12 +1,23 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 using Server.Network;
 
 namespace Server.Mobiles
 {
-    public class PlagueBeastLord : BaseCreature, ICarvable, IScissorable
+    [SerializationGenerator(0, false)]
+    public partial class PlagueBeastLord : BaseCreature, ICarvable, IScissorable
     {
         private DecayTimer m_Timer;
+
+        [SerializableField(0, getter: "private", setter: "private")]
+        private int _count;
+
+        [SerializableField(1, getter: "private", setter: "private")]
+        private int _deadline;
+
+        [SerializableProperty(2)]
+        private bool IsNotNullTimer { get => m_Timer != null; };
 
         [Constructible]
         public PlagueBeastLord() : base(AIType.AI_Melee)
@@ -42,15 +53,10 @@ namespace Server.Mobiles
             VirtualArmor = 50;
         }
 
-        public PlagueBeastLord(Serial serial) : base(serial)
-        {
-        }
-
-        public override string CorpseName => "a plague beast lord corpse";
-        public override Poison PoisonImmune => Poison.Lethal;
-
         [CommandProperty(AccessLevel.GameMaster)]
+        [SerializableProperty(3)]
         public Mobile OpenedBy { get; set; }
+
 
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsBleeding
@@ -73,6 +79,10 @@ namespace Server.Mobiles
                 return false;
             }
         }
+
+        public override string CorpseName => "a plague beast lord corpse";
+
+        public override Poison PoisonImmune => Poison.Lethal;
 
         public override string DefaultName => "a plague beast lord";
 
@@ -283,40 +293,12 @@ namespace Server.Mobiles
             }
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-
-            writer.WriteEncodedInt(0); // version
-
-            writer.Write(OpenedBy);
-
-            if (m_Timer != null)
+            if (IsNotNullTimer)
             {
-                writer.Write(true);
-                writer.Write(m_Timer.Count);
-                writer.Write(m_Timer.Deadline);
-            }
-            else
-            {
-                writer.Write(false);
-            }
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadEncodedInt();
-
-            OpenedBy = reader.ReadEntity<Mobile>();
-
-            if (reader.ReadBool())
-            {
-                var count = reader.ReadInt();
-                var deadline = reader.ReadInt();
-
-                m_Timer = new DecayTimer(this, count, deadline);
+                m_Timer = new DecayTimer(this, Count, Deadline);
                 m_Timer.Start();
             }
 
@@ -326,27 +308,25 @@ namespace Server.Mobiles
             }
         }
 
-        private class DecayTimer : Timer
+        public class DecayTimer : Timer
         {
-            private readonly PlagueBeastLord m_Lord;
+            private readonly PlagueBeastLord _lord;
 
             public DecayTimer(PlagueBeastLord lord, int count = 0, int deadline = 120) : base(
                 TimeSpan.Zero,
                 TimeSpan.FromSeconds(1)
             )
             {
-                m_Lord = lord;
+                _lord = lord;
                 Count = count;
                 Deadline = deadline;
             }
-
             public int Count { get; private set; }
-
             public int Deadline { get; private set; }
 
             protected override void OnTick()
             {
-                if (m_Lord?.Deleted != false)
+                if (_lord?.Deleted != false)
                 {
                     Stop();
                     return;
@@ -354,39 +334,39 @@ namespace Server.Mobiles
 
                 if (Count + 15 == Deadline)
                 {
-                    if (m_Lord.OpenedBy != null)
+                    if (_lord.OpenedBy != null)
                     {
-                        m_Lord.PublicOverheadMessage(
+                        _lord.PublicOverheadMessage(
                             MessageType.Regular,
                             0x3B2,
                             1071921
                         ); // * The plague beast begins to bubble and dissolve! *
                     }
 
-                    m_Lord.PlaySound(0x103);
+                    _lord.PlaySound(0x103);
                 }
                 else if (Count + 10 == Deadline)
                 {
-                    m_Lord.PlaySound(0x21);
+                    _lord.PlaySound(0x21);
                 }
                 else if (Count + 5 == Deadline)
                 {
-                    m_Lord.PlaySound(0x1C2);
+                    _lord.PlaySound(0x1C2);
                 }
                 else if (Count == Deadline)
                 {
-                    m_Lord.Unfreeze();
+                    _lord.Unfreeze();
 
-                    if (m_Lord.OpenedBy != null)
+                    if (_lord.OpenedBy != null)
                     {
-                        m_Lord.Kill();
+                        _lord.Kill();
                     }
 
                     Stop();
                 }
                 else if (Count % 15 == 0)
                 {
-                    m_Lord.PlaySound(0x1BF);
+                    _lord.PlaySound(0x1BF);
                 }
 
                 Count++;

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueSpawn.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueSpawn.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 using Server.ContextMenus;
 
 namespace Server.Mobiles
 {
-    public class PlagueSpawn : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class PlagueSpawn : BaseCreature
     {
         [Constructible]
         public PlagueSpawn(Mobile owner = null) : base(AIType.AI_Melee)
@@ -67,10 +69,6 @@ namespace Server.Mobiles
             VirtualArmor = 20;
         }
 
-        public PlagueSpawn(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a plague spawn corpse";
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -117,18 +115,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Poor);
             AddLoot(LootPack.Gems);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/SandVortex.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/SandVortex.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class SandVortex : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SandVortex : BaseCreature
     {
         private DateTime m_NextAttack;
 
@@ -41,10 +43,6 @@ namespace Server.Mobiles
             PackItem(new Bone());
         }
 
-        public SandVortex(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a sand vortex corpse";
         public override string DefaultName => "a sand vortex";
 
@@ -77,20 +75,6 @@ namespace Server.Mobiles
             m.FixedParticles(0x36B0, 10, 25, 9540, 2413, 0, EffectLayer.Waist);
 
             new InternalTimer(m, this).Start();
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         private class InternalTimer : Timer

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Slime.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Slime.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Slime : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Slime : BaseCreature
     {
         [Constructible]
         public Slime() : base(AIType.AI_Melee)
@@ -38,10 +41,6 @@ namespace Server.Mobiles
             MinTameSkill = 23.1;
         }
 
-        public Slime(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a slimey corpse";
         public override string DefaultName => "a slime";
 
@@ -55,18 +54,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Poor);
             AddLoot(LootPack.Gems);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/AgapiteElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/AgapiteElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class AgapiteElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AgapiteElemental : BaseCreature
     {
         [Constructible]
         public AgapiteElemental(int oreAmount = 2) : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             PackItem(ore);
         }
 
-        public AgapiteElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ore elemental corpse";
         public override string DefaultName => "an agapite elemental";
 
@@ -55,18 +53,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Gems, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/BronzeElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/BronzeElemental.cs
@@ -1,75 +1,62 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class BronzeElemental : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public BronzeElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class BronzeElemental : BaseCreature
     {
-        Body = 108;
-        BaseSoundID = 268;
+        [Constructible]
+        public BronzeElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+        {
+            Body = 108;
+            BaseSoundID = 268;
 
-        SetStr(226, 255);
-        SetDex(126, 145);
-        SetInt(71, 92);
+            SetStr(226, 255);
+            SetDex(126, 145);
+            SetInt(71, 92);
 
-        SetHits(136, 153);
+            SetHits(136, 153);
 
-        SetDamage(9, 16);
+            SetDamage(9, 16);
 
-        SetDamageType(ResistanceType.Physical, 30);
-        SetDamageType(ResistanceType.Fire, 70);
+            SetDamageType(ResistanceType.Physical, 30);
+            SetDamageType(ResistanceType.Fire, 70);
 
-        SetResistance(ResistanceType.Physical, 30, 40);
-        SetResistance(ResistanceType.Fire, 30, 40);
-        SetResistance(ResistanceType.Cold, 10, 20);
-        SetResistance(ResistanceType.Poison, 70, 80);
-        SetResistance(ResistanceType.Energy, 20, 30);
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 10, 20);
+            SetResistance(ResistanceType.Poison, 70, 80);
+            SetResistance(ResistanceType.Energy, 20, 30);
 
-        SetSkill(SkillName.MagicResist, 50.1, 95.0);
-        SetSkill(SkillName.Tactics, 60.1, 100.0);
-        SetSkill(SkillName.Wrestling, 60.1, 100.0);
+            SetSkill(SkillName.MagicResist, 50.1, 95.0);
+            SetSkill(SkillName.Tactics, 60.1, 100.0);
+            SetSkill(SkillName.Wrestling, 60.1, 100.0);
 
-        Fame = 5000;
-        Karma = -5000;
+            Fame = 5000;
+            Karma = -5000;
 
-        VirtualArmor = 29;
+            VirtualArmor = 29;
 
-        Item ore = new BronzeOre(oreAmount);
-        ore.ItemID = 0x19B9;
-        PackItem(ore);
-    }
+            Item ore = new BronzeOre(oreAmount);
+            ore.ItemID = 0x19B9;
+            PackItem(ore);
+        }
 
-    public BronzeElemental(Serial serial) : base(serial)
-    {
-    }
+        public override string CorpseName => "an ore elemental corpse";
+        public override string DefaultName => "a bronze elemental";
 
-    public override string CorpseName => "an ore elemental corpse";
-    public override string DefaultName => "a bronze elemental";
+        public override bool BleedImmune => true;
+        public override bool AutoDispel => true;
+        public override int TreasureMapLevel => 1;
 
-    public override bool BleedImmune => true;
-    public override bool AutoDispel => true;
-    public override int TreasureMapLevel => 1;
+        private static MonsterAbility[] _abilities = { MonsterAbilities.PoisonGasCounter };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    private static MonsterAbility[] _abilities = { MonsterAbilities.PoisonGasCounter };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Average);
-        AddLoot(LootPack.Gems, 2);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Gems, 2);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/CopperElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/CopperElemental.cs
@@ -1,83 +1,70 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class CopperElemental : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public CopperElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class CopperElemental : BaseCreature
     {
-        Body = 109;
-        BaseSoundID = 268;
+        [Constructible]
+        public CopperElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+        {
+            Body = 109;
+            BaseSoundID = 268;
 
-        SetStr(226, 255);
-        SetDex(126, 145);
-        SetInt(71, 92);
+            SetStr(226, 255);
+            SetDex(126, 145);
+            SetInt(71, 92);
 
-        SetHits(136, 153);
+            SetHits(136, 153);
 
-        SetDamage(9, 16);
+            SetDamage(9, 16);
 
-        SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-        SetResistance(ResistanceType.Physical, 30, 40);
-        SetResistance(ResistanceType.Fire, 30, 40);
-        SetResistance(ResistanceType.Cold, 30, 40);
-        SetResistance(ResistanceType.Poison, 20, 30);
-        SetResistance(ResistanceType.Energy, 10, 20);
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 30, 40);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 10, 20);
 
-        SetSkill(SkillName.MagicResist, 50.1, 95.0);
-        SetSkill(SkillName.Tactics, 60.1, 100.0);
-        SetSkill(SkillName.Wrestling, 60.1, 100.0);
+            SetSkill(SkillName.MagicResist, 50.1, 95.0);
+            SetSkill(SkillName.Tactics, 60.1, 100.0);
+            SetSkill(SkillName.Wrestling, 60.1, 100.0);
 
-        Fame = 4800;
-        Karma = -4800;
+            Fame = 4800;
+            Karma = -4800;
 
-        VirtualArmor = 26;
+            VirtualArmor = 26;
 
-        Item ore = new CopperOre(oreAmount);
-        ore.ItemID = 0x19B9;
-        PackItem(ore);
-    }
+            Item ore = new CopperOre(oreAmount);
+            ore.ItemID = 0x19B9;
+            PackItem(ore);
+        }
 
-    public CopperElemental(Serial serial) : base(serial)
-    {
-    }
+        public override string CorpseName => "an ore elemental corpse";
+        public override string DefaultName => "a copper elemental";
 
-    public override string CorpseName => "an ore elemental corpse";
-    public override string DefaultName => "a copper elemental";
+        public override bool BleedImmune => true;
+        public override bool AutoDispel => true;
+        public override int TreasureMapLevel => 1;
 
-    public override bool BleedImmune => true;
-    public override bool AutoDispel => true;
-    public override int TreasureMapLevel => 1;
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Gems, 2);
+        }
 
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Average);
-        AddLoot(LootPack.Gems, 2);
-    }
+        public override void AlterMeleeDamageFrom(Mobile from, ref int damage)
+        {
+            base.AlterMeleeDamageFrom(from, ref damage);
 
-    public override void AlterMeleeDamageFrom(Mobile from, ref int damage)
-    {
-        base.AlterMeleeDamageFrom(from, ref damage);
+            damage /= 2; // 50% melee damage
+        }
 
-        damage /= 2; // 50% melee damage
-    }
-
-    public override void CheckReflect(Mobile caster, ref bool reflect)
-    {
-        reflect = true; // Every spell is reflected back to the caster
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override void CheckReflect(Mobile caster, ref bool reflect)
+        {
+            reflect = true; // Every spell is reflected back to the caster
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/DullCopperElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/DullCopperElemental.cs
@@ -1,74 +1,61 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class DullCopperElemental : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public DullCopperElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class DullCopperElemental : BaseCreature
     {
-        Body = 110;
-        BaseSoundID = 268;
+        [Constructible]
+        public DullCopperElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+        {
+            Body = 110;
+            BaseSoundID = 268;
 
-        SetStr(226, 255);
-        SetDex(126, 145);
-        SetInt(71, 92);
+            SetStr(226, 255);
+            SetDex(126, 145);
+            SetInt(71, 92);
 
-        SetHits(136, 153);
+            SetHits(136, 153);
 
-        SetDamage(9, 16);
+            SetDamage(9, 16);
 
-        SetDamageType(ResistanceType.Physical, 100);
+            SetDamageType(ResistanceType.Physical, 100);
 
-        SetResistance(ResistanceType.Physical, 30, 40);
-        SetResistance(ResistanceType.Fire, 30, 40);
-        SetResistance(ResistanceType.Cold, 10, 20);
-        SetResistance(ResistanceType.Poison, 20, 30);
-        SetResistance(ResistanceType.Energy, 20, 30);
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 30, 40);
+            SetResistance(ResistanceType.Cold, 10, 20);
+            SetResistance(ResistanceType.Poison, 20, 30);
+            SetResistance(ResistanceType.Energy, 20, 30);
 
-        SetSkill(SkillName.MagicResist, 50.1, 95.0);
-        SetSkill(SkillName.Tactics, 60.1, 100.0);
-        SetSkill(SkillName.Wrestling, 60.1, 100.0);
+            SetSkill(SkillName.MagicResist, 50.1, 95.0);
+            SetSkill(SkillName.Tactics, 60.1, 100.0);
+            SetSkill(SkillName.Wrestling, 60.1, 100.0);
 
-        Fame = 3500;
-        Karma = -3500;
+            Fame = 3500;
+            Karma = -3500;
 
-        VirtualArmor = 20;
+            VirtualArmor = 20;
 
-        Item ore = new DullCopperOre(oreAmount);
-        ore.ItemID = 0x19B9;
-        PackItem(ore);
-    }
+            Item ore = new DullCopperOre(oreAmount);
+            ore.ItemID = 0x19B9;
+            PackItem(ore);
+        }
 
-    public DullCopperElemental(Serial serial) : base(serial)
-    {
-    }
+        public override string CorpseName => "an ore elemental corpse";
+        public override string DefaultName => "a dull copper elemental";
 
-    public override string CorpseName => "an ore elemental corpse";
-    public override string DefaultName => "a dull copper elemental";
+        public override bool AutoDispel => true;
+        public override bool BleedImmune => true;
+        public override int TreasureMapLevel => 1;
 
-    public override bool AutoDispel => true;
-    public override bool BleedImmune => true;
-    public override int TreasureMapLevel => 1;
+        private static MonsterAbility[] _abilities = { MonsterAbilities.DeathExplosion };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    private static MonsterAbility[] _abilities = { MonsterAbilities.DeathExplosion };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Average);
-        AddLoot(LootPack.Gems, 2);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Gems, 2);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/GoldenElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/GoldenElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class GoldenElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class GoldenElemental : BaseCreature
     {
         [Constructible]
         public GoldenElemental(int oreAmount = 2) : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             PackItem(ore);
         }
 
-        public GoldenElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ore elemental corpse";
         public override string DefaultName => "a golden elemental";
 
@@ -55,18 +53,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Gems, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/ShadowIronElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/ShadowIronElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class ShadowIronElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class ShadowIronElemental : BaseCreature
     {
         [Constructible]
         public ShadowIronElemental(int oreAmount = 2) : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             PackItem(ore);
         }
 
-        public ShadowIronElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ore elemental corpse";
         public override string DefaultName => "a shadow iron elemental";
 
@@ -75,18 +73,6 @@ namespace Server.Mobiles
         public override void AlterSpellDamageFrom(Mobile from, ref int damage)
         {
             damage = 0;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/ValoriteElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/ValoriteElemental.cs
@@ -1,94 +1,81 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class ValoriteElemental : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public ValoriteElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class ValoriteElemental : BaseCreature
     {
-        Body = 112;
-        BaseSoundID = 268;
-
-        SetStr(226, 255);
-        SetDex(126, 145);
-        SetInt(71, 92);
-
-        SetHits(136, 153);
-
-        SetDamage(28);
-
-        SetDamageType(ResistanceType.Physical, 25);
-        SetDamageType(ResistanceType.Fire, 25);
-        SetDamageType(ResistanceType.Cold, 25);
-        SetDamageType(ResistanceType.Energy, 25);
-
-        SetResistance(ResistanceType.Physical, 65, 75);
-        SetResistance(ResistanceType.Fire, 50, 60);
-        SetResistance(ResistanceType.Cold, 50, 60);
-        SetResistance(ResistanceType.Poison, 50, 60);
-        SetResistance(ResistanceType.Energy, 40, 50);
-
-        SetSkill(SkillName.MagicResist, 50.1, 95.0);
-        SetSkill(SkillName.Tactics, 60.1, 100.0);
-        SetSkill(SkillName.Wrestling, 60.1, 100.0);
-
-        Fame = 3500;
-        Karma = -3500;
-
-        VirtualArmor = 38;
-
-        Item ore = new ValoriteOre(oreAmount);
-        ore.ItemID = 0x19B9;
-        PackItem(ore);
-    }
-
-    public ValoriteElemental(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "an ore elemental corpse";
-    public override string DefaultName => "a valorite elemental";
-
-    public override bool AutoDispel => true;
-    public override bool BleedImmune => true;
-    public override int TreasureMapLevel => 1;
-
-    private static MonsterAbility[] _abilities = { MonsterAbilities.PoisonGasCounter, MonsterAbilities.DestroyEquipment };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.FilthyRich);
-        AddLoot(LootPack.Gems, 4);
-    }
-
-    public override void AlterMeleeDamageFrom(Mobile from, ref int damage)
-    {
-        if (from is BaseCreature bc && (bc.Controlled || bc.BardTarget == this))
+        [Constructible]
+        public ValoriteElemental(int oreAmount = 2) : base(AIType.AI_Melee)
         {
-            damage = 0; // Immune to pets and provoked creatures
+            Body = 112;
+            BaseSoundID = 268;
+
+            SetStr(226, 255);
+            SetDex(126, 145);
+            SetInt(71, 92);
+
+            SetHits(136, 153);
+
+            SetDamage(28);
+
+            SetDamageType(ResistanceType.Physical, 25);
+            SetDamageType(ResistanceType.Fire, 25);
+            SetDamageType(ResistanceType.Cold, 25);
+            SetDamageType(ResistanceType.Energy, 25);
+
+            SetResistance(ResistanceType.Physical, 65, 75);
+            SetResistance(ResistanceType.Fire, 50, 60);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 50, 60);
+            SetResistance(ResistanceType.Energy, 40, 50);
+
+            SetSkill(SkillName.MagicResist, 50.1, 95.0);
+            SetSkill(SkillName.Tactics, 60.1, 100.0);
+            SetSkill(SkillName.Wrestling, 60.1, 100.0);
+
+            Fame = 3500;
+            Karma = -3500;
+
+            VirtualArmor = 38;
+
+            Item ore = new ValoriteOre(oreAmount);
+            ore.ItemID = 0x19B9;
+            PackItem(ore);
         }
-        else
+
+        public override string CorpseName => "an ore elemental corpse";
+        public override string DefaultName => "a valorite elemental";
+
+        public override bool AutoDispel => true;
+        public override bool BleedImmune => true;
+        public override int TreasureMapLevel => 1;
+
+        private static MonsterAbility[] _abilities = { MonsterAbilities.PoisonGasCounter, MonsterAbilities.DestroyEquipment };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+
+        public override void GenerateLoot()
         {
-            damage /= 2; // 50% melee damage
+            AddLoot(LootPack.FilthyRich);
+            AddLoot(LootPack.Gems, 4);
         }
-    }
 
-    public override void CheckReflect(Mobile caster, ref bool reflect)
-    {
-        reflect = true; // Every spell is reflected back to the caster
-    }
+        public override void AlterMeleeDamageFrom(Mobile from, ref int damage)
+        {
+            if (from is BaseCreature bc && (bc.Controlled || bc.BardTarget == this))
+            {
+                damage = 0; // Immune to pets and provoked creatures
+            }
+            else
+            {
+                damage /= 2; // 50% melee damage
+            }
+        }
 
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override void CheckReflect(Mobile caster, ref bool reflect)
+        {
+            reflect = true; // Every spell is reflected back to the caster
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Ore Elementals/VeriteElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Ore Elementals/VeriteElemental.cs
@@ -1,75 +1,62 @@
+using ModernUO.Serialization;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class VeriteElemental : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public VeriteElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class VeriteElemental : BaseCreature
     {
-        Body = 113;
-        BaseSoundID = 268;
+        [Constructible]
+        public VeriteElemental(int oreAmount = 2) : base(AIType.AI_Melee)
+        {
+            Body = 113;
+            BaseSoundID = 268;
 
-        SetStr(226, 255);
-        SetDex(126, 145);
-        SetInt(71, 92);
+            SetStr(226, 255);
+            SetDex(126, 145);
+            SetInt(71, 92);
 
-        SetHits(136, 153);
+            SetHits(136, 153);
 
-        SetDamage(9, 16);
+            SetDamage(9, 16);
 
-        SetDamageType(ResistanceType.Physical, 50);
-        SetDamageType(ResistanceType.Energy, 50);
+            SetDamageType(ResistanceType.Physical, 50);
+            SetDamageType(ResistanceType.Energy, 50);
 
-        SetResistance(ResistanceType.Physical, 30, 40);
-        SetResistance(ResistanceType.Fire, 10, 20);
-        SetResistance(ResistanceType.Cold, 50, 60);
-        SetResistance(ResistanceType.Poison, 50, 60);
-        SetResistance(ResistanceType.Energy, 50, 60);
+            SetResistance(ResistanceType.Physical, 30, 40);
+            SetResistance(ResistanceType.Fire, 10, 20);
+            SetResistance(ResistanceType.Cold, 50, 60);
+            SetResistance(ResistanceType.Poison, 50, 60);
+            SetResistance(ResistanceType.Energy, 50, 60);
 
-        SetSkill(SkillName.MagicResist, 50.1, 95.0);
-        SetSkill(SkillName.Tactics, 60.1, 100.0);
-        SetSkill(SkillName.Wrestling, 60.1, 100.0);
+            SetSkill(SkillName.MagicResist, 50.1, 95.0);
+            SetSkill(SkillName.Tactics, 60.1, 100.0);
+            SetSkill(SkillName.Wrestling, 60.1, 100.0);
 
-        Fame = 3500;
-        Karma = -3500;
+            Fame = 3500;
+            Karma = -3500;
 
-        VirtualArmor = 35;
+            VirtualArmor = 35;
 
-        Item ore = new VeriteOre(oreAmount);
-        ore.ItemID = 0x19B9;
-        PackItem(ore);
-    }
+            Item ore = new VeriteOre(oreAmount);
+            ore.ItemID = 0x19B9;
+            PackItem(ore);
+        }
 
-    public VeriteElemental(Serial serial) : base(serial)
-    {
-    }
+        public override string CorpseName => "an ore elemental corpse";
+        public override string DefaultName => "a verite elemental";
 
-    public override string CorpseName => "an ore elemental corpse";
-    public override string DefaultName => "a verite elemental";
+        public override bool AutoDispel => true;
+        public override bool BleedImmune => true;
+        public override int TreasureMapLevel => 1;
 
-    public override bool AutoDispel => true;
-    public override bool BleedImmune => true;
-    public override int TreasureMapLevel => 1;
+        private static MonsterAbility[] _abilities = { MonsterAbilities.DestroyEquipment };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    private static MonsterAbility[] _abilities = { MonsterAbilities.DestroyEquipment };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Rich);
-        AddLoot(LootPack.Gems, 2);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Gems, 2);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Magic/Reaper.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Magic/Reaper.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Reaper : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Reaper : BaseCreature
     {
         [Constructible]
         public Reaper() : base(AIType.AI_Mage)
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             PackItem(new MandrakeRoot(5));
         }
 
-        public Reaper(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a reapers corpse";
         public override string DefaultName => "a reaper";
 
@@ -57,18 +55,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Melee/BogThing.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Melee/BogThing.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class BogThing : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BogThing : BaseCreature
     {
         [Constructible]
         public BogThing() : base(AIType.AI_Melee)
@@ -51,10 +53,6 @@ namespace Server.Mobiles
             PackItem(new Seed());
         }
 
-        public BogThing(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a plant corpse";
         public override string DefaultName => "a bog thing";
 
@@ -64,18 +62,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
 
         public void SpawnBogling(Mobile m)

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Melee/Bogling.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Melee/Bogling.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Bogling : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Bogling : BaseCreature
     {
         [Constructible]
         public Bogling() : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             PackItem(new Seed());
         }
 
-        public Bogling(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a plant corpse";
         public override string DefaultName => "a bogling";
 
@@ -53,18 +51,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Melee/Corpser.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Melee/Corpser.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Corpser : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Corpser : BaseCreature
     {
         [Constructible]
         public Corpser() : base(AIType.AI_Melee)
@@ -48,10 +50,6 @@ namespace Server.Mobiles
             PackItem(new MandrakeRoot(3));
         }
 
-        public Corpser(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a corpser corpse";
         public override string DefaultName => "a corpser";
 
@@ -63,17 +61,9 @@ namespace Server.Mobiles
             AddLoot(LootPack.Meager);
         }
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 352)
             {
                 BaseSoundID = 684;

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Melee/Quagmire.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Melee/Quagmire.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Quagmire : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Quagmire : BaseCreature
     {
         [Constructible]
         public Quagmire() : base(AIType.AI_Melee)
@@ -35,10 +38,6 @@ namespace Server.Mobiles
             VirtualArmor = 32;
         }
 
-        public Quagmire(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a quagmire corpse";
         public override string DefaultName => "a quagmire";
 
@@ -53,17 +52,9 @@ namespace Server.Mobiles
 
         public override int GetAngerSound() => 353;
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == -1)
             {
                 BaseSoundID = 352;

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Melee/SwampTentacle.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Melee/SwampTentacle.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SwampTentacle : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SwampTentacle : BaseCreature
     {
         [Constructible]
         public SwampTentacle() : base(AIType.AI_Melee)
@@ -38,10 +41,6 @@ namespace Server.Mobiles
             PackReg(3);
         }
 
-        public SwampTentacle(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a swamp tentacle corpse";
         public override string DefaultName => "a swamp tentacle";
 
@@ -50,18 +49,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Average);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Plant/Melee/WhippingVine.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Plant/Melee/WhippingVine.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class WhippingVine : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class WhippingVine : BaseCreature
     {
         [Constructible]
         public WhippingVine() : base(AIType.AI_Melee)
@@ -48,26 +50,10 @@ namespace Server.Mobiles
             PackItem(new Vines());
         }
 
-        public WhippingVine(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a whipping vine corpse";
         public override string DefaultName => "a whipping vine";
 
         public override bool BardImmune => !Core.AOS;
         public override Poison PoisonImmune => Poison.Lethal;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/AncientWyrm.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/AncientWyrm.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class AncientWyrm : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class AncientWyrm : BaseCreature
     {
         [Constructible]
         public AncientWyrm() : base(AIType.AI_Mage)
@@ -38,10 +41,6 @@ namespace Server.Mobiles
             VirtualArmor = 70;
         }
 
-        public AncientWyrm(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a dragon corpse";
         public override string DefaultName => "an ancient wyrm";
 
@@ -69,17 +68,5 @@ namespace Server.Mobiles
         public override int GetIdleSound() => 0x2D3;
 
         public override int GetHurtSound() => 0x2D1;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/DeepSeaSerpent.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/DeepSeaSerpent.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class DeepSeaSerpent : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class DeepSeaSerpent : BaseCreature
     {
         [Constructible]
         public DeepSeaSerpent() : base(AIType.AI_Mage)
@@ -51,10 +53,6 @@ namespace Server.Mobiles
             // PackItem( new SpecialFishingNet() );
         }
 
-        public DeepSeaSerpent(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a deep sea serpents corpse";
         public override string DefaultName => "a deep sea serpent";
         public override int Meat => 1;
@@ -67,18 +65,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/Dragon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/Dragon.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Dragon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Dragon : BaseCreature
     {
         [Constructible]
         public Dragon() : base(AIType.AI_Mage)
@@ -40,10 +43,6 @@ namespace Server.Mobiles
             MinTameSkill = 93.9;
         }
 
-        public Dragon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a dragon corpse";
         public override string DefaultName => "a dragon";
 
@@ -66,18 +65,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.FilthyRich, 2);
             AddLoot(LootPack.Gems, 8);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/Leviathan.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/Leviathan.cs
@@ -1,178 +1,163 @@
+using ModernUO.Serialization;
 using System;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class Leviathan : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public Leviathan(Mobile fisher = null) : base(AIType.AI_Mage)
+    [SerializationGenerator(0, false)]
+    public partial class Leviathan : BaseCreature
     {
-        Fisher = fisher;
-
-        // May not be OSI accurate; mostly copied from krakens
-        Body = 77;
-        BaseSoundID = 353;
-
-        Hue = 0x481;
-
-        SetStr(1000);
-        SetDex(501, 520);
-        SetInt(501, 515);
-
-        SetHits(1500);
-
-        SetDamage(25, 33);
-
-        SetDamageType(ResistanceType.Physical, 70);
-        SetDamageType(ResistanceType.Cold, 30);
-
-        SetResistance(ResistanceType.Physical, 55, 65);
-        SetResistance(ResistanceType.Fire, 45, 55);
-        SetResistance(ResistanceType.Cold, 45, 55);
-        SetResistance(ResistanceType.Poison, 35, 45);
-        SetResistance(ResistanceType.Energy, 25, 35);
-
-        SetSkill(SkillName.EvalInt, 97.6, 107.5);
-        SetSkill(SkillName.Magery, 97.6, 107.5);
-        SetSkill(SkillName.MagicResist, 97.6, 107.5);
-        SetSkill(SkillName.Meditation, 97.6, 107.5);
-        SetSkill(SkillName.Tactics, 97.6, 107.5);
-        SetSkill(SkillName.Wrestling, 97.6, 107.5);
-
-        Fame = 24000;
-        Karma = -24000;
-
-        VirtualArmor = 50;
-
-        CanSwim = true;
-        CantWalk = true;
-
-        PackItem(new MessageInABottle());
-        PackItem(new Rope { ItemID = 0x14F8 });
-        PackItem(new Rope { ItemID = 0x14FA });
-    }
-
-    public Leviathan(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "a leviathan corpse";
-
-    public Mobile Fisher { get; set; }
-
-    public override string DefaultName => "a leviathan";
-
-    public override int TreasureMapLevel => 5;
-
-    public static Type[] Artifacts { get; } =
-    {
-        // Decorations
-        typeof(CandelabraOfSouls),
-        typeof(GhostShipAnchor),
-        typeof(GoldBricks),
-        typeof(PhillipsWoodenSteed),
-        typeof(SeahorseStatuette),
-        typeof(ShipModelOfTheHMSCape),
-        typeof(AdmiralsHeartyRum),
-
-        // Equipment
-        typeof(AlchemistsBauble),
-        typeof(ArcticDeathDealer),
-        typeof(BlazeOfDeath),
-        typeof(BurglarsBandana),
-        typeof(CaptainQuacklebushsCutlass),
-        typeof(CavortingClub),
-        typeof(DreadPirateHat),
-        typeof(EnchantedTitanLegBone),
-        typeof(GwennosHarp),
-        typeof(IolosLute),
-        typeof(LunaLance),
-        typeof(NightsKiss),
-        typeof(NoxRangersHeavyCrossbow),
-        typeof(PolarBearMask),
-        typeof(VioletCourage)
-    };
-
-    private static MonsterAbility[] _abilities = { new LeviathanBreath() };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.FilthyRich, 5);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
-    }
-
-    public static void GiveArtifactTo(Mobile m)
-    {
-        var item = Loot.Construct(Artifacts);
-
-        if (item == null)
+        [Constructible]
+        public Leviathan(Mobile fisher = null) : base(AIType.AI_Mage)
         {
-            return;
+            Fisher = fisher;
+
+            // May not be OSI accurate; mostly copied from krakens
+            Body = 77;
+            BaseSoundID = 353;
+
+            Hue = 0x481;
+
+            SetStr(1000);
+            SetDex(501, 520);
+            SetInt(501, 515);
+
+            SetHits(1500);
+
+            SetDamage(25, 33);
+
+            SetDamageType(ResistanceType.Physical, 70);
+            SetDamageType(ResistanceType.Cold, 30);
+
+            SetResistance(ResistanceType.Physical, 55, 65);
+            SetResistance(ResistanceType.Fire, 45, 55);
+            SetResistance(ResistanceType.Cold, 45, 55);
+            SetResistance(ResistanceType.Poison, 35, 45);
+            SetResistance(ResistanceType.Energy, 25, 35);
+
+            SetSkill(SkillName.EvalInt, 97.6, 107.5);
+            SetSkill(SkillName.Magery, 97.6, 107.5);
+            SetSkill(SkillName.MagicResist, 97.6, 107.5);
+            SetSkill(SkillName.Meditation, 97.6, 107.5);
+            SetSkill(SkillName.Tactics, 97.6, 107.5);
+            SetSkill(SkillName.Wrestling, 97.6, 107.5);
+
+            Fame = 24000;
+            Karma = -24000;
+
+            VirtualArmor = 50;
+
+            CanSwim = true;
+            CantWalk = true;
+
+            PackItem(new MessageInABottle());
+            PackItem(new Rope { ItemID = 0x14F8 });
+            PackItem(new Rope { ItemID = 0x14FA });
         }
 
-        // TODO: Confirm messages
-        if (m.AddToBackpack(item))
+        public override string CorpseName => "a leviathan corpse";
+
+        public Mobile Fisher { get; set; }
+
+        public override string DefaultName => "a leviathan";
+
+        public override int TreasureMapLevel => 5;
+
+        public static Type[] Artifacts { get; } =
         {
-            m.SendMessage("As a reward for slaying the mighty leviathan, an artifact has been placed in your backpack.");
+            // Decorations
+            typeof(CandelabraOfSouls),
+            typeof(GhostShipAnchor),
+            typeof(GoldBricks),
+            typeof(PhillipsWoodenSteed),
+            typeof(SeahorseStatuette),
+            typeof(ShipModelOfTheHMSCape),
+            typeof(AdmiralsHeartyRum),
+
+            // Equipment
+            typeof(AlchemistsBauble),
+            typeof(ArcticDeathDealer),
+            typeof(BlazeOfDeath),
+            typeof(BurglarsBandana),
+            typeof(CaptainQuacklebushsCutlass),
+            typeof(CavortingClub),
+            typeof(DreadPirateHat),
+            typeof(EnchantedTitanLegBone),
+            typeof(GwennosHarp),
+            typeof(IolosLute),
+            typeof(LunaLance),
+            typeof(NightsKiss),
+            typeof(NoxRangersHeavyCrossbow),
+            typeof(PolarBearMask),
+            typeof(VioletCourage)
+        };
+
+        private static MonsterAbility[] _abilities = { new LeviathanBreath() };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.FilthyRich, 5);
         }
-        else
+
+        public static void GiveArtifactTo(Mobile m)
         {
-            m.SendMessage(
-                "As your backpack is full, your reward for destroying the legendary leviathan has been placed at your feet."
-            );
-        }
-    }
+            var item = Loot.Construct(Artifacts);
 
-    public override void OnKilledBy(Mobile mob)
-    {
-        base.OnKilledBy(mob);
-
-        if (Paragon.CheckArtifactChance(mob, this))
-        {
-            GiveArtifactTo(mob);
-
-            if (mob == Fisher)
+            if (item == null)
             {
-                Fisher = null;
+                return;
+            }
+
+            // TODO: Confirm messages
+            if (m.AddToBackpack(item))
+            {
+                m.SendMessage("As a reward for slaying the mighty leviathan, an artifact has been placed in your backpack.");
+            }
+            else
+            {
+                m.SendMessage(
+                    "As your backpack is full, your reward for destroying the legendary leviathan has been placed at your feet."
+                );
             }
         }
-    }
 
-    public override void OnDeath(Container c)
-    {
-        base.OnDeath(c);
-
-        if (Fisher != null && Utility.Random(100) < 25)
+        public override void OnKilledBy(Mobile mob)
         {
-            GiveArtifactTo(Fisher);
+            base.OnKilledBy(mob);
+
+            if (Paragon.CheckArtifactChance(mob, this))
+            {
+                GiveArtifactTo(mob);
+
+                if (mob == Fisher)
+                {
+                    Fisher = null;
+                }
+            }
         }
 
-        Fisher = null;
-    }
+        public override void OnDeath(Container c)
+        {
+            base.OnDeath(c);
 
-    private class LeviathanBreath : FireBreath
-    {
-        public override int PhysicalDamage => 70;
-        public override int ColdDamage => 30;
-        public override int FireDamage => 0;
-        public override int BreathEffectHue => 0x1ED;
-        public override double BreathDamageScalar => 0.05;
-        public override TimeSpan MinTriggerCooldown => TimeSpan.FromSeconds(5.0);
-        public override TimeSpan MaxTriggerCooldown => TimeSpan.FromSeconds(7.5);
+            if (Fisher != null && Utility.Random(100) < 25)
+            {
+                GiveArtifactTo(Fisher);
+            }
+
+            Fisher = null;
+        }
+
+        private class LeviathanBreath : FireBreath
+        {
+            public override int PhysicalDamage => 70;
+            public override int ColdDamage => 30;
+            public override int FireDamage => 0;
+            public override int BreathEffectHue => 0x1ED;
+            public override double BreathDamageScalar => 0.05;
+            public override TimeSpan MinTriggerCooldown => TimeSpan.FromSeconds(5.0);
+            public override TimeSpan MaxTriggerCooldown => TimeSpan.FromSeconds(7.5);
+        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/OphidianArchmage.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/OphidianArchmage.cs
@@ -1,7 +1,10 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.OphidianJusticar", "Server.Mobiles.OphidianZealot")]
-    public class OphidianArchmage : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class OphidianArchmage : BaseCreature
     {
         private static readonly string[] m_Names =
         {
@@ -48,10 +51,6 @@ namespace Server.Mobiles
             PackNecroReg(5, 15);
         }
 
-        public OphidianArchmage(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ophidian corpse";
 
         public override int Meat => 1;
@@ -62,18 +61,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.MedScrolls, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/OphidianMage.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/OphidianMage.cs
@@ -1,7 +1,10 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.OphidianShaman")]
-    public class OphidianMage : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class OphidianMage : BaseCreature
     {
         private static readonly string[] m_Names =
         {
@@ -46,10 +49,6 @@ namespace Server.Mobiles
             PackReg(10);
         }
 
-        public OphidianMage(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ophidian corpse";
 
         public override int Meat => 1;
@@ -63,18 +62,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.LowScrolls);
             AddLoot(LootPack.MedScrolls);
             AddLoot(LootPack.Potions);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/OphidianMatriarch.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/OphidianMatriarch.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class OphidianMatriarch : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class OphidianMatriarch : BaseCreature
     {
         [Constructible]
         public OphidianMatriarch() : base(AIType.AI_Mage)
@@ -37,10 +40,6 @@ namespace Server.Mobiles
             VirtualArmor = 50;
         }
 
-        public OphidianMatriarch(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ophidian corpse";
         public override string DefaultName => "an ophidian matriarch";
 
@@ -54,18 +53,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Average, 2);
             AddLoot(LootPack.MedScrolls, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SeaSerpent.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SeaSerpent.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.Seaserpant")]
-    public class SeaSerpent : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SeaSerpent : BaseCreature
     {
         [Constructible]
         public SeaSerpent() : base(AIType.AI_Mage)
@@ -54,10 +56,6 @@ namespace Server.Mobiles
             // PackItem( new SpecialFishingNet() );
         }
 
-        public SeaSerpent(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a sea serpents corpse";
         public override string DefaultName => "a sea serpent";
         public override int TreasureMapLevel => 2;
@@ -73,18 +71,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SerpentineDragon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SerpentineDragon.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 
 namespace Server.Mobiles
 {
-    public class SerpentineDragon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SerpentineDragon : BaseCreature
     {
         [Constructible]
         public SerpentineDragon() : base(AIType.AI_Mage, FightMode.Evil)
@@ -43,10 +45,6 @@ namespace Server.Mobiles
             {
                 PackItem(Seed.RandomPeculiarSeed(2));
             }
-        }
-
-        public SerpentineDragon(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a dragon corpse";
@@ -92,18 +90,6 @@ namespace Server.Mobiles
                 c.ControlOrder = OrderType.Attack;
                 c.Combatant = c.ControlMaster;
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/ShadowWyrm.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/ShadowWyrm.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class ShadowWyrm : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class ShadowWyrm : BaseCreature
     {
         [Constructible]
         public ShadowWyrm() : base(AIType.AI_Mage)
@@ -38,10 +41,6 @@ namespace Server.Mobiles
             VirtualArmor = 70;
         }
 
-        public ShadowWyrm(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a shadow wyrm corpse";
         public override string DefaultName => "a shadow wyrm";
         public override bool ReacquireOnMovement => true;
@@ -69,17 +68,5 @@ namespace Server.Mobiles
         public override int GetIdleSound() => 0x2D5;
 
         public override int GetHurtSound() => 0x2D1;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SkeletalDragon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/SkeletalDragon.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SkeletalDragon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SkeletalDragon : BaseCreature
     {
         [Constructible]
         public SkeletalDragon() : base(AIType.AI_Mage)
@@ -39,10 +42,6 @@ namespace Server.Mobiles
             VirtualArmor = 80;
         }
 
-        public SkeletalDragon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a skeletal dragon corpse";
         public override string DefaultName => "a skeletal dragon";
 
@@ -65,18 +64,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.FilthyRich, 4);
             AddLoot(LootPack.Gems, 5);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/WhiteWyrm.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Magic/WhiteWyrm.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class WhiteWyrm : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class WhiteWyrm : BaseCreature
     {
         [Constructible]
         public WhiteWyrm() : base(AIType.AI_Mage)
@@ -41,10 +44,6 @@ namespace Server.Mobiles
             MinTameSkill = 96.3;
         }
 
-        public WhiteWyrm(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a white wyrm corpse";
         public override string DefaultName => "a white wyrm";
 
@@ -64,18 +63,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.FilthyRich, 2);
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Gems, Utility.Random(1, 5));
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Drake.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Drake.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Drake : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Drake : BaseCreature
     {
         [Constructible]
         public Drake() : base(AIType.AI_Melee)
@@ -41,10 +44,6 @@ namespace Server.Mobiles
             PackReg(3);
         }
 
-        public Drake(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a drake corpse";
         public override string DefaultName => "a drake";
 
@@ -65,18 +64,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.MedScrolls, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Harpy.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Harpy.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class Harpy : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Harpy : BaseCreature
     {
         [Constructible]
         public Harpy() : base(AIType.AI_Melee)
@@ -34,10 +37,6 @@ namespace Server.Mobiles
             VirtualArmor = 28;
         }
 
-        public Harpy(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a harpy corpse";
         public override string DefaultName => "a harpy";
 
@@ -61,17 +60,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 919;
 
         public override int GetIdleSound() => 918;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Kraken.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Kraken.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Kraken : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Kraken : BaseCreature
     {
         [Constructible]
         public Kraken() : base(AIType.AI_Melee)
@@ -52,10 +54,6 @@ namespace Server.Mobiles
             PackItem(new SpecialFishingNet()); // Confirm?
         }
 
-        public Kraken(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a krakens corpse";
         public override string DefaultName => "a kraken";
 
@@ -64,18 +62,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Rich);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Lizardman.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Lizardman.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Misc;
 
 namespace Server.Mobiles
 {
-    public class Lizardman : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Lizardman : BaseCreature
     {
         [Constructible]
         public Lizardman() : base(AIType.AI_Melee)
@@ -36,10 +38,6 @@ namespace Server.Mobiles
             VirtualArmor = 28;
         }
 
-        public Lizardman(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a lizardman corpse";
         public override InhumanSpeech SpeechType => InhumanSpeech.Lizardman;
 
@@ -52,18 +50,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.Meager);
             // TODO: weapon
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/OphidianKnight.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/OphidianKnight.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.OphidianAvenger")]
-    public class OphidianKnight : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class OphidianKnight : BaseCreature
     {
         private static readonly string[] m_Names =
         {
@@ -48,10 +50,6 @@ namespace Server.Mobiles
             PackItem(new LesserPoisonPotion());
         }
 
-        public OphidianKnight(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ophidian corpse";
 
         public override int Meat => 2;
@@ -65,18 +63,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Rich, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/OphidianWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/OphidianWarrior.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class OphidianWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class OphidianWarrior : BaseCreature
     {
         private static readonly string[] m_Names =
         {
@@ -42,10 +45,6 @@ namespace Server.Mobiles
             VirtualArmor = 36;
         }
 
-        public OphidianWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an ophidian corpse";
 
         public override int Meat => 1;
@@ -58,18 +57,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.Meager);
             AddLoot(LootPack.Average);
             AddLoot(LootPack.Gems);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Scorpion.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Scorpion.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Scorpion : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Scorpion : BaseCreature
     {
         [Constructible]
         public Scorpion() : base(AIType.AI_Melee)
@@ -45,10 +47,6 @@ namespace Server.Mobiles
             PackItem(new LesserPoisonPotion());
         }
 
-        public Scorpion(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a scorpion corpse";
         public override string DefaultName => "a scorpion";
 
@@ -61,18 +59,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.Meager);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/StoneHarpy.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/StoneHarpy.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class StoneHarpy : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class StoneHarpy : BaseCreature
     {
         [Constructible]
         public StoneHarpy() : base(AIType.AI_Melee)
@@ -36,10 +39,6 @@ namespace Server.Mobiles
             VirtualArmor = 50;
         }
 
-        public StoneHarpy(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a stone harpy corpse";
         public override string DefaultName => "a stone harpy";
 
@@ -62,17 +61,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 919;
 
         public override int GetIdleSound() => 918;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Wyvern.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Reptile/Melee/Wyvern.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Wyvern : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Wyvern : BaseCreature
     {
         [Constructible]
         public Wyvern() : base(AIType.AI_Melee)
@@ -40,10 +42,6 @@ namespace Server.Mobiles
             PackItem(new LesserPoisonPotion());
         }
 
-        public Wyvern(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wyvern corpse";
         public override string DefaultName => "a wyvern";
 
@@ -74,17 +72,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 721;
 
         public override int GetIdleSound() => 725;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/BakeKitsune.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/BakeKitsune.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class BakeKitsune : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class BakeKitsune : BaseCreature
     {
         private TimerExecutionToken _disguiseTimerToken;
 
@@ -47,10 +49,6 @@ namespace Server.Mobiles
             {
                 PackItem(Seed.RandomBonsaiSeed());
             }
-        }
-
-        public BakeKitsune(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a bake kitsune corpse";
@@ -99,18 +97,10 @@ namespace Server.Mobiles
 
         public override int GetDeathSound() => 0x4DB;
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(1);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
-            if (version == 0 && PhysicalResistance > 60)
+            if (PhysicalResistance > 60)
             {
                 SetResistance(ResistanceType.Physical, 40, 60);
                 SetResistance(ResistanceType.Fire, 70, 90);

--- a/Projects/UOContent/Mobiles/Monsters/SE/DeathWatchBeetle.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/DeathWatchBeetle.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
+    [SerializationGenerator(0, false)]
     [TypeAlias("Server.Mobiles.DeathWatchBeetle")]
-    public class DeathwatchBeetle : BaseCreature
+    public partial class DeathwatchBeetle : BaseCreature
     {
         [Constructible]
         public DeathwatchBeetle() : base(AIType.AI_Melee, Core.ML ? FightMode.Aggressor : FightMode.Closest)
@@ -68,10 +70,6 @@ namespace Server.Mobiles
             ControlSlots = 1;
         }
 
-        public DeathwatchBeetle(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a deathwatchbeetle corpse";
 
         public override string DefaultName => "a deathwatch beetle";
@@ -132,18 +130,6 @@ namespace Server.Mobiles
             MovingParticles(m, 0x36D4, 1, 0, false, false, 0x3F, 0, 0x1F73, 1, 0, (EffectLayer)255, 0x100);
             m.ApplyPoison(this, Poison.Regular);
             m.SendLocalizedMessage(1070821, Name); // %s spits a poisonous substance at you!
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/DeathWatchBeetleHatchling.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/DeathWatchBeetleHatchling.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
+    [SerializationGenerator(0, false)]
     [TypeAlias("Server.Mobiles.DeathWatchBeetleHatchling")]
-    public class DeathwatchBeetleHatchling : BaseCreature
+    public partial class DeathwatchBeetleHatchling : BaseCreature
     {
         [Constructible]
         public DeathwatchBeetleHatchling() : base(AIType.AI_Melee, Core.ML ? FightMode.Aggressor : FightMode.Closest)
@@ -65,10 +67,6 @@ namespace Server.Mobiles
             }
         }
 
-        public DeathwatchBeetleHatchling(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a deathwatchbeetle hatchling corpse";
         public override string DefaultName => "a deathwatch beetle hatchling";
         public override int Hides => 8;
@@ -87,18 +85,6 @@ namespace Server.Mobiles
         {
             AddLoot(LootPack.LowScrolls, 1);
             AddLoot(LootPack.Potions, 1);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/EliteNinja.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/EliteNinja.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class EliteNinja : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class EliteNinja : BaseCreature
     {
         [Constructible]
         public EliteNinja() : base(AIType.AI_Melee)
@@ -80,10 +82,6 @@ namespace Server.Mobiles
             Utility.AssignRandomHair(this);
         }
 
-        public EliteNinja(Serial serial) : base(serial)
-        {
-        }
-
         public override bool ClickTitle => false;
         public override string DefaultName => "an elite ninja";
 
@@ -102,20 +100,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.FilthyRich);
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Gems, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/FanDancer.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/FanDancer.cs
@@ -1,91 +1,76 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class FanDancer : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public FanDancer() : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class FanDancer : BaseCreature
     {
-        Body = 247;
-        BaseSoundID = 0x372;
-
-        SetStr(301, 375);
-        SetDex(201, 255);
-        SetInt(21, 25);
-
-        SetHits(351, 430);
-
-        SetDamage(12, 17);
-
-        SetDamageType(ResistanceType.Physical, 70);
-        SetDamageType(ResistanceType.Fire, 10);
-        SetDamageType(ResistanceType.Cold, 10);
-        SetDamageType(ResistanceType.Poison, 10);
-
-        SetResistance(ResistanceType.Physical, 40, 60);
-        SetResistance(ResistanceType.Fire, 50, 70);
-        SetResistance(ResistanceType.Cold, 50, 70);
-        SetResistance(ResistanceType.Poison, 50, 70);
-        SetResistance(ResistanceType.Energy, 40, 60);
-
-        SetSkill(SkillName.MagicResist, 100.1, 110.0);
-        SetSkill(SkillName.Tactics, 85.1, 95.0);
-        SetSkill(SkillName.Wrestling, 85.1, 95.0);
-        SetSkill(SkillName.Anatomy, 85.1, 95.0);
-
-        Fame = 9000;
-        Karma = -9000;
-
-        if (Utility.RandomDouble() < .33)
+        [Constructible]
+        public FanDancer() : base(AIType.AI_Melee)
         {
-            PackItem(Seed.RandomBonsaiSeed());
+            Body = 247;
+            BaseSoundID = 0x372;
+
+            SetStr(301, 375);
+            SetDex(201, 255);
+            SetInt(21, 25);
+
+            SetHits(351, 430);
+
+            SetDamage(12, 17);
+
+            SetDamageType(ResistanceType.Physical, 70);
+            SetDamageType(ResistanceType.Fire, 10);
+            SetDamageType(ResistanceType.Cold, 10);
+            SetDamageType(ResistanceType.Poison, 10);
+
+            SetResistance(ResistanceType.Physical, 40, 60);
+            SetResistance(ResistanceType.Fire, 50, 70);
+            SetResistance(ResistanceType.Cold, 50, 70);
+            SetResistance(ResistanceType.Poison, 50, 70);
+            SetResistance(ResistanceType.Energy, 40, 60);
+
+            SetSkill(SkillName.MagicResist, 100.1, 110.0);
+            SetSkill(SkillName.Tactics, 85.1, 95.0);
+            SetSkill(SkillName.Wrestling, 85.1, 95.0);
+            SetSkill(SkillName.Anatomy, 85.1, 95.0);
+
+            Fame = 9000;
+            Karma = -9000;
+
+            if (Utility.RandomDouble() < .33)
+            {
+                PackItem(Seed.RandomBonsaiSeed());
+            }
+
+            AddItem(new Tessen());
+
+            if (Utility.RandomDouble() < 0.02)
+            {
+                PackItem(new OrigamiPaper());
+            }
         }
 
-        AddItem(new Tessen());
+        public override string CorpseName => "a fan dancer corpse";
+        public override string DefaultName => "a fan dancer";
 
-        if (Utility.RandomDouble() < 0.02)
+        public override bool Uncalmable => true;
+
+        private static MonsterAbility[] _abilities =
         {
-            PackItem(new OrigamiPaper());
+            MonsterAbilities.ReflectPhysicalDamage,
+            MonsterAbilities.FanningFire,
+            MonsterAbilities.FanThrowCounter
+        };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.FilthyRich);
+            AddLoot(LootPack.Rich);
+            AddLoot(LootPack.Gems, 2);
         }
-    }
-
-    public FanDancer(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "a fan dancer corpse";
-    public override string DefaultName => "a fan dancer";
-
-    public override bool Uncalmable => true;
-
-    private static MonsterAbility[] _abilities =
-    {
-        MonsterAbilities.ReflectPhysicalDamage,
-        MonsterAbilities.FanningFire,
-        MonsterAbilities.FanThrowCounter
-    };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.FilthyRich);
-        AddLoot(LootPack.Rich);
-        AddLoot(LootPack.Gems, 2);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-
-        writer.Write(0); // version
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/FireBeetle.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/FireBeetle.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using Server.Engines.Craft;
 using Server.Items;
 
 namespace Server.Mobiles
 {
     [Forge]
-    public class FireBeetle : BaseMount
+    [SerializationGenerator(0,false)]
+    public partial class FireBeetle : BaseMount
     {
         public override string DefaultName => "a fire beetle";
 
@@ -46,10 +48,6 @@ namespace Server.Mobiles
             Hue = 0x489;
         }
 
-        public FireBeetle(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a fire beetle corpse";
         public override bool SubdueBeforeTame => true; // Must be beaten into submission
         public override bool StatLossAfterTame => true;
@@ -89,23 +87,10 @@ namespace Server.Mobiles
 
         public override double GetControlChance(Mobile m, bool useBaseSkill = false) => 1.0;
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-
-            writer.Write(1); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-
-            if (version == 0)
-            {
-                Hue = 0x489;
-            }
+            Hue = 0x489;
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/Kappa.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/Kappa.cs
@@ -1,143 +1,130 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class Kappa : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public Kappa() : base(AIType.AI_Melee)
+    [SerializationGenerator(0, false)]
+    public partial class Kappa : BaseCreature
     {
-        Body = 240;
-
-        SetStr(186, 230);
-        SetDex(51, 75);
-        SetInt(41, 55);
-
-        SetMana(30);
-
-        SetHits(151, 180);
-
-        SetDamage(6, 12);
-
-        SetDamageType(ResistanceType.Physical, 100);
-
-        SetResistance(ResistanceType.Physical, 35, 50);
-        SetResistance(ResistanceType.Fire, 35, 50);
-        SetResistance(ResistanceType.Cold, 25, 50);
-        SetResistance(ResistanceType.Poison, 35, 50);
-        SetResistance(ResistanceType.Energy, 20, 30);
-
-        SetSkill(SkillName.MagicResist, 60.1, 70.0);
-        SetSkill(SkillName.Tactics, 79.1, 89.0);
-        SetSkill(SkillName.Wrestling, 60.1, 70.0);
-
-        Fame = 1700;
-        Karma = -1700;
-
-        PackItem(new RawFishSteak(3));
-        for (var i = 0; i < 2; i++)
+        [Constructible]
+        public Kappa() : base(AIType.AI_Melee)
         {
-            switch (Utility.Random(6))
+            Body = 240;
+
+            SetStr(186, 230);
+            SetDex(51, 75);
+            SetInt(41, 55);
+
+            SetMana(30);
+
+            SetHits(151, 180);
+
+            SetDamage(6, 12);
+
+            SetDamageType(ResistanceType.Physical, 100);
+
+            SetResistance(ResistanceType.Physical, 35, 50);
+            SetResistance(ResistanceType.Fire, 35, 50);
+            SetResistance(ResistanceType.Cold, 25, 50);
+            SetResistance(ResistanceType.Poison, 35, 50);
+            SetResistance(ResistanceType.Energy, 20, 30);
+
+            SetSkill(SkillName.MagicResist, 60.1, 70.0);
+            SetSkill(SkillName.Tactics, 79.1, 89.0);
+            SetSkill(SkillName.Wrestling, 60.1, 70.0);
+
+            Fame = 1700;
+            Karma = -1700;
+
+            PackItem(new RawFishSteak(3));
+            for (var i = 0; i < 2; i++)
             {
-                case 0:
-                    {
-                        PackItem(new Gears());
-                        break;
-                    }
-                case 1:
-                    {
-                        PackItem(new Hinge());
-                        break;
-                    }
-                case 2:
-                    {
-                        PackItem(new Axle());
-                        break;
-                    }
-            }
-        }
-
-        if (Core.ML && Utility.Random(3) == 0)
-        {
-            PackItem(Seed.RandomPeculiarSeed(4));
-        }
-    }
-
-    public Kappa(Serial serial) : base(serial)
-    {
-    }
-
-    public override string CorpseName => "a kappa corpse";
-    public override string DefaultName => "a kappa";
-
-    private static MonsterAbility[] _abilities = { MonsterAbilities.DrainLifeAttack };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Meager);
-        AddLoot(LootPack.Average);
-    }
-
-    public override int GetAngerSound() => 0x50B;
-
-    public override int GetIdleSound() => 0x50A;
-
-    public override int GetAttackSound() => 0x509;
-
-    public override int GetHurtSound() => 0x50C;
-
-    public override int GetDeathSound() => 0x508;
-
-    public override void OnDamage(int amount, Mobile from, bool willKill)
-    {
-        // Acid Blood ability
-        if (from?.Map != null)
-        {
-            var amt = 0;
-            Mobile target = this;
-            var rand = Utility.Random(1, 100);
-            if (willKill)
-            {
-                amt = ((rand % 5) >> 2) + 3;
-            }
-
-            if (Hits < 100 && rand < 21)
-            {
-                target = rand % 2 < 1 ? this : from;
-                amt++;
-            }
-
-            if (amt > 0)
-            {
-                SpillAcid(target, amt);
-                from.SendLocalizedMessage(1070820); // The creature spills a pool of acidic slime!
-                if (Mana > 14)
+                switch (Utility.Random(6))
                 {
-                    Mana -= 15;
+                    case 0:
+                        {
+                            PackItem(new Gears());
+                            break;
+                        }
+                    case 1:
+                        {
+                            PackItem(new Hinge());
+                            break;
+                        }
+                    case 2:
+                        {
+                            PackItem(new Axle());
+                            break;
+                        }
                 }
             }
+
+            if (Core.ML && Utility.Random(3) == 0)
+            {
+                PackItem(Seed.RandomPeculiarSeed(4));
+            }
         }
 
-        base.OnDamage(amount, from, willKill);
-    }
+        public override string CorpseName => "a kappa corpse";
+        public override string DefaultName => "a kappa";
 
-    public override Item NewHarmfulItem() => new PoolOfAcid(TimeSpan.FromSeconds(10), 5, 10)
-    {
-        Name = "slime"
-    };
+        private static MonsterAbility[] _abilities = { MonsterAbilities.DrainLifeAttack };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(0);
-    }
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Meager);
+            AddLoot(LootPack.Average);
+        }
 
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
+        public override int GetAngerSound() => 0x50B;
+
+        public override int GetIdleSound() => 0x50A;
+
+        public override int GetAttackSound() => 0x509;
+
+        public override int GetHurtSound() => 0x50C;
+
+        public override int GetDeathSound() => 0x508;
+
+        public override void OnDamage(int amount, Mobile from, bool willKill)
+        {
+            // Acid Blood ability
+            if (from?.Map != null)
+            {
+                var amt = 0;
+                Mobile target = this;
+                var rand = Utility.Random(1, 100);
+                if (willKill)
+                {
+                    amt = ((rand % 5) >> 2) + 3;
+                }
+
+                if (Hits < 100 && rand < 21)
+                {
+                    target = rand % 2 < 1 ? this : from;
+                    amt++;
+                }
+
+                if (amt > 0)
+                {
+                    SpillAcid(target, amt);
+                    from.SendLocalizedMessage(1070820); // The creature spills a pool of acidic slime!
+                    if (Mana > 14)
+                    {
+                        Mana -= 15;
+                    }
+                }
+            }
+
+            base.OnDamage(amount, from, willKill);
+        }
+
+        public override Item NewHarmfulItem() => new PoolOfAcid(TimeSpan.FromSeconds(10), 5, 10)
+        {
+            Name = "slime"
+        };
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/KazeKemono.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/KazeKemono.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Mobiles
 {
-    public class KazeKemono : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class KazeKemono : BaseCreature
     {
         private static readonly Dictionary<Mobile, ExpireTimer> m_FlurryOfTwigsTable = new();
 
@@ -42,11 +44,6 @@ namespace Server.Mobiles
 
             Fame = 8000;
             Karma = -8000;
-        }
-
-        public KazeKemono(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a kaze kemono corpse";
@@ -127,18 +124,6 @@ namespace Server.Mobiles
                 timer.Start();
                 m_ChlorophylBlastTable[defender] = timer;
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
 
         private class ExpireTimer : Timer

--- a/Projects/UOContent/Mobiles/Monsters/SE/LadyOfTheSnow.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/LadyOfTheSnow.cs
@@ -1,3 +1,4 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 using Server.Engines.Plants;
@@ -5,7 +6,8 @@ using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class LadyOfTheSnow : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class LadyOfTheSnow : BaseCreature
     {
         private static readonly Dictionary<Mobile, ExpireTimer> m_Table = new();
 
@@ -49,11 +51,6 @@ namespace Server.Mobiles
             {
                 PackItem(Seed.RandomBonsaiSeed());
             }
-        }
-
-        public LadyOfTheSnow(Serial serial)
-            : base(serial)
-        {
         }
 
         public override string CorpseName => "a lady of the snow corpse";
@@ -103,20 +100,6 @@ namespace Server.Mobiles
             timer = new ExpireTimer(defender, this);
             timer.Start();
             m_Table[defender] = timer;
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         private class ExpireTimer : Timer

--- a/Projects/UOContent/Mobiles/Monsters/SE/Oni.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/Oni.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 
 namespace Server.Mobiles
 {
-    public class Oni : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Oni : BaseCreature
     {
         [Constructible]
         public Oni() : base(AIType.AI_Mage)
@@ -54,10 +56,6 @@ namespace Server.Mobiles
          *  85: 51/17/17 -> 28 + 8 + 5 = 41
          */
 
-        public Oni(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an oni corpse";
         public override string DefaultName => "an oni";
 
@@ -77,20 +75,6 @@ namespace Server.Mobiles
         public override void GenerateLoot()
         {
             AddLoot(LootPack.FilthyRich, 3);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/RaiJu.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/RaiJu.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using System;
 using System.Collections.Generic;
 
 namespace Server.Mobiles
 {
-    public class RaiJu : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RaiJu : BaseCreature
     {
         private static readonly HashSet<Mobile> m_Table = new();
 
@@ -40,10 +42,6 @@ namespace Server.Mobiles
 
             Fame = 8000;
             Karma = -8000;
-        }
-
-        public RaiJu(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a rai-ju corpse";
@@ -84,20 +82,6 @@ namespace Server.Mobiles
             var timer = new ExpireTimer(defender, TimeSpan.FromSeconds(4.0));
             timer.Start();
             m_Table.Add(defender);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
 
         private class ExpireTimer : Timer

--- a/Projects/UOContent/Mobiles/Monsters/SE/RevenantLion.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/RevenantLion.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class RevenantLion : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class RevenantLion : BaseCreature
     {
         [Constructible]
         public RevenantLion() : base(AIType.AI_Mage)
@@ -53,10 +55,6 @@ namespace Server.Mobiles
             );
         }
 
-        public RevenantLion(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a revenant lion corpse";
         public override string DefaultName => "a Revenant Lion";
 
@@ -82,18 +80,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.MedScrolls, 2);
 
             // TODO: Bone Pile
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/Ronin.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/Ronin.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class Ronin : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Ronin : BaseCreature
     {
         [Constructible]
         public Ronin() : base(AIType.AI_Melee)
@@ -90,10 +92,6 @@ namespace Server.Mobiles
             Utility.AssignRandomHair(this);
         }
 
-        public Ronin(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a ronin corpse";
         public override bool ClickTitle => false;
         public override string DefaultName => "a ronin";
@@ -115,20 +113,6 @@ namespace Server.Mobiles
             AddLoot(LootPack.FilthyRich);
             AddLoot(LootPack.Rich);
             AddLoot(LootPack.Gems, 2);
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0); // version
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
         }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/RuneBeetle.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/RuneBeetle.cs
@@ -1,112 +1,100 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class RuneBeetle : BaseCreature
+namespace Server.Mobiles
 {
-    [Constructible]
-    public RuneBeetle() : base(AIType.AI_Mage)
+    [SerializationGenerator(0,false)]
+    public partial class RuneBeetle : BaseCreature
     {
-        Body = 244;
-
-        SetStr(401, 460);
-        SetDex(121, 170);
-        SetInt(376, 450);
-
-        SetHits(301, 360);
-
-        SetDamage(15, 22);
-
-        SetDamageType(ResistanceType.Physical, 20);
-        SetDamageType(ResistanceType.Poison, 10);
-        SetDamageType(ResistanceType.Energy, 70);
-
-        SetResistance(ResistanceType.Physical, 40, 65);
-        SetResistance(ResistanceType.Fire, 35, 50);
-        SetResistance(ResistanceType.Cold, 35, 50);
-        SetResistance(ResistanceType.Poison, 75, 95);
-        SetResistance(ResistanceType.Energy, 40, 60);
-
-        SetSkill(SkillName.EvalInt, 100.1, 125.0);
-        SetSkill(SkillName.Magery, 100.1, 110.0);
-        SetSkill(SkillName.Poisoning, 120.1, 140.0);
-        SetSkill(SkillName.MagicResist, 95.1, 110.0);
-        SetSkill(SkillName.Tactics, 78.1, 93.0);
-        SetSkill(SkillName.Wrestling, 70.1, 77.5);
-
-        Fame = 15000;
-        Karma = -15000;
-
-        if (Utility.RandomDouble() < .25)
+        [Constructible]
+        public RuneBeetle() : base(AIType.AI_Mage)
         {
-            PackItem(Seed.RandomBonsaiSeed());
+            Body = 244;
+
+            SetStr(401, 460);
+            SetDex(121, 170);
+            SetInt(376, 450);
+
+            SetHits(301, 360);
+
+            SetDamage(15, 22);
+
+            SetDamageType(ResistanceType.Physical, 20);
+            SetDamageType(ResistanceType.Poison, 10);
+            SetDamageType(ResistanceType.Energy, 70);
+
+            SetResistance(ResistanceType.Physical, 40, 65);
+            SetResistance(ResistanceType.Fire, 35, 50);
+            SetResistance(ResistanceType.Cold, 35, 50);
+            SetResistance(ResistanceType.Poison, 75, 95);
+            SetResistance(ResistanceType.Energy, 40, 60);
+
+            SetSkill(SkillName.EvalInt, 100.1, 125.0);
+            SetSkill(SkillName.Magery, 100.1, 110.0);
+            SetSkill(SkillName.Poisoning, 120.1, 140.0);
+            SetSkill(SkillName.MagicResist, 95.1, 110.0);
+            SetSkill(SkillName.Tactics, 78.1, 93.0);
+            SetSkill(SkillName.Wrestling, 70.1, 77.5);
+
+            Fame = 15000;
+            Karma = -15000;
+
+            if (Utility.RandomDouble() < .25)
+            {
+                PackItem(Seed.RandomBonsaiSeed());
+            }
+
+            PackItem(
+                Utility.Random(10) switch
+                {
+                    0 => new LeftArm(),
+                    1 => new RightArm(),
+                    2 => new Torso(),
+                    3 => new Bone(),
+                    4 => new RibCage(),
+                    5 => new RibCage(),
+                    _ => new BonePile() // 6-9
+                }
+            );
+
+            Tamable = true;
+            ControlSlots = 3;
+            MinTameSkill = 93.9;
         }
 
-        PackItem(
-            Utility.Random(10) switch
-            {
-                0 => new LeftArm(),
-                1 => new RightArm(),
-                2 => new Torso(),
-                3 => new Bone(),
-                4 => new RibCage(),
-                5 => new RibCage(),
-                _ => new BonePile() // 6-9
-            }
-        );
+        public override string CorpseName => "a rune beetle corpse";
+        public override string DefaultName => "a rune beetle";
 
-        Tamable = true;
-        ControlSlots = 3;
-        MinTameSkill = 93.9;
-    }
+        public override Poison PoisonImmune => Poison.Greater;
+        public override Poison HitPoison => Poison.Greater;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override bool CanAngerOnTame => true;
 
-    public RuneBeetle(Serial serial) : base(serial)
-    {
-    }
+        public override WeaponAbility GetWeaponAbility() => WeaponAbility.BleedAttack;
 
-    public override string CorpseName => "a rune beetle corpse";
-    public override string DefaultName => "a rune beetle";
+        public override int GetAngerSound() => 0x4E8;
 
-    public override Poison PoisonImmune => Poison.Greater;
-    public override Poison HitPoison => Poison.Greater;
-    public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
-    public override bool CanAngerOnTame => true;
+        public override int GetIdleSound() => 0x4E7;
 
-    public override WeaponAbility GetWeaponAbility() => WeaponAbility.BleedAttack;
+        public override int GetAttackSound() => 0x4E6;
 
-    public override int GetAngerSound() => 0x4E8;
+        public override int GetHurtSound() => 0x4E9;
 
-    public override int GetIdleSound() => 0x4E7;
+        public override int GetDeathSound() => 0x4E5;
 
-    public override int GetAttackSound() => 0x4E6;
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.FilthyRich, 2);
+            AddLoot(LootPack.MedScrolls, 1);
+        }
 
-    public override int GetHurtSound() => 0x4E9;
+        private static MonsterAbility[] _abilities = { MonsterAbilities.RuneCorruption };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
 
-    public override int GetDeathSound() => 0x4E5;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.FilthyRich, 2);
-        AddLoot(LootPack.MedScrolls, 1);
-    }
-
-    private static MonsterAbility[] _abilities = { MonsterAbilities.RuneCorruption };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-        writer.Write(1);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-        var version = reader.ReadInt();
-
-        if (version < 1)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
             for (var i = 0; i < Skills.Length; ++i)
             {
@@ -121,3 +109,4 @@ public class RuneBeetle : BaseCreature
         }
     }
 }
+

--- a/Projects/UOContent/Mobiles/Monsters/SE/TsukiWolf.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/TsukiWolf.cs
@@ -1,9 +1,11 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
-namespace Server.Mobiles;
-
-public class TsukiWolf : BaseCreature
+namespace Server.Mobiles
+{
+    [SerializationGenerator(0, false)]
+    public partial class TsukiWolf : BaseCreature
 {
     [Constructible]
     public TsukiWolf() : base(AIType.AI_Melee)
@@ -57,11 +59,6 @@ public class TsukiWolf : BaseCreature
         );
     }
 
-    public TsukiWolf(Serial serial)
-        : base(serial)
-    {
-    }
-
     public override string CorpseName => "a tsuki wolf corpse";
     public override string DefaultName => "a tsuki wolf";
     public override int Meat => 4;
@@ -75,20 +72,6 @@ public class TsukiWolf : BaseCreature
     {
         AddLoot(LootPack.Average);
         AddLoot(LootPack.Rich);
-    }
-
-    public override void Serialize(IGenericWriter writer)
-    {
-        base.Serialize(writer);
-
-        writer.Write(0);
-    }
-
-    public override void Deserialize(IGenericReader reader)
-    {
-        base.Deserialize(reader);
-
-        var version = reader.ReadInt();
     }
 
     public override int GetAngerSound() => 0x52D;

--- a/Projects/UOContent/Mobiles/Monsters/SE/TsukiWolf.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/TsukiWolf.cs
@@ -6,81 +6,82 @@ namespace Server.Mobiles
 {
     [SerializationGenerator(0, false)]
     public partial class TsukiWolf : BaseCreature
-{
-    [Constructible]
-    public TsukiWolf() : base(AIType.AI_Melee)
     {
-        Body = 250;
-        Hue = Utility.Random(3) == 0 ? Utility.RandomNeutralHue() : 0;
-
-        SetStr(401, 450);
-        SetDex(151, 200);
-        SetInt(66, 76);
-
-        SetHits(376, 450);
-        SetMana(40);
-
-        SetDamage(14, 18);
-
-        SetDamageType(ResistanceType.Physical, 90);
-        SetDamageType(ResistanceType.Cold, 5);
-        SetDamageType(ResistanceType.Energy, 5);
-
-        SetResistance(ResistanceType.Physical, 40, 60);
-        SetResistance(ResistanceType.Fire, 50, 70);
-        SetResistance(ResistanceType.Cold, 50, 70);
-        SetResistance(ResistanceType.Poison, 50, 70);
-        SetResistance(ResistanceType.Energy, 50, 70);
-
-        SetSkill(SkillName.Anatomy, 65.1, 72.0);
-        SetSkill(SkillName.MagicResist, 65.1, 70.0);
-        SetSkill(SkillName.Tactics, 95.1, 110.0);
-        SetSkill(SkillName.Wrestling, 97.6, 107.5);
-
-        Fame = 8500;
-        Karma = -8500;
-
-        if (Core.ML && Utility.RandomDouble() < .33)
+        [Constructible]
+        public TsukiWolf() : base(AIType.AI_Melee)
         {
-            PackItem(Seed.RandomPeculiarSeed(1));
+            Body = 250;
+            Hue = Utility.Random(3) == 0 ? Utility.RandomNeutralHue() : 0;
+
+            SetStr(401, 450);
+            SetDex(151, 200);
+            SetInt(66, 76);
+
+            SetHits(376, 450);
+            SetMana(40);
+
+            SetDamage(14, 18);
+
+            SetDamageType(ResistanceType.Physical, 90);
+            SetDamageType(ResistanceType.Cold, 5);
+            SetDamageType(ResistanceType.Energy, 5);
+
+            SetResistance(ResistanceType.Physical, 40, 60);
+            SetResistance(ResistanceType.Fire, 50, 70);
+            SetResistance(ResistanceType.Cold, 50, 70);
+            SetResistance(ResistanceType.Poison, 50, 70);
+            SetResistance(ResistanceType.Energy, 50, 70);
+
+            SetSkill(SkillName.Anatomy, 65.1, 72.0);
+            SetSkill(SkillName.MagicResist, 65.1, 70.0);
+            SetSkill(SkillName.Tactics, 95.1, 110.0);
+            SetSkill(SkillName.Wrestling, 97.6, 107.5);
+
+            Fame = 8500;
+            Karma = -8500;
+
+            if (Core.ML && Utility.RandomDouble() < .33)
+            {
+                PackItem(Seed.RandomPeculiarSeed(1));
+            }
+
+            PackItem(
+                Utility.Random(10) switch
+                {
+                    0 => new LeftArm(),
+                    1 => new RightArm(),
+                    2 => new Torso(),
+                    3 => new Bone(),
+                    4 => new RibCage(),
+                    5 => new RibCage(),
+                    _ => new BonePile() // 6-9
+                }
+            );
         }
 
-        PackItem(
-            Utility.Random(10) switch
-            {
-                0 => new LeftArm(),
-                1 => new RightArm(),
-                2 => new Torso(),
-                3 => new Bone(),
-                4 => new RibCage(),
-                5 => new RibCage(),
-                _ => new BonePile() // 6-9
-            }
-        );
+        public override string CorpseName => "a tsuki wolf corpse";
+        public override string DefaultName => "a tsuki wolf";
+        public override int Meat => 4;
+        public override int Hides => 25;
+        public override FoodType FavoriteFood => FoodType.Meat;
+
+        private static MonsterAbility[] _abilities = { MonsterAbilities.BloodBathAttack };
+        public override MonsterAbility[] GetMonsterAbilities() => _abilities;
+
+        public override void GenerateLoot()
+        {
+            AddLoot(LootPack.Average);
+            AddLoot(LootPack.Rich);
+        }
+
+        public override int GetAngerSound() => 0x52D;
+
+        public override int GetIdleSound() => 0x52C;
+
+        public override int GetAttackSound() => 0x52B;
+
+        public override int GetHurtSound() => 0x52E;
+
+        public override int GetDeathSound() => 0x52A;
     }
-
-    public override string CorpseName => "a tsuki wolf corpse";
-    public override string DefaultName => "a tsuki wolf";
-    public override int Meat => 4;
-    public override int Hides => 25;
-    public override FoodType FavoriteFood => FoodType.Meat;
-
-    private static MonsterAbility[] _abilities = { MonsterAbilities.BloodBathAttack };
-    public override MonsterAbility[] GetMonsterAbilities() => _abilities;
-
-    public override void GenerateLoot()
-    {
-        AddLoot(LootPack.Average);
-        AddLoot(LootPack.Rich);
-    }
-
-    public override int GetAngerSound() => 0x52D;
-
-    public override int GetIdleSound() => 0x52C;
-
-    public override int GetAttackSound() => 0x52B;
-
-    public override int GetHurtSound() => 0x52E;
-
-    public override int GetDeathSound() => 0x52A;
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/Yamandon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/Yamandon.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
     [TypeAlias("Server.Mobiles.Yamadon")]
-    public class Yamandon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class Yamandon : BaseCreature
     {
         [Constructible]
         public Yamandon() : base(AIType.AI_Melee)
@@ -44,10 +46,6 @@ namespace Server.Mobiles
             }
 
             PackItem(new Eggs(2));
-        }
-
-        public Yamandon(Serial serial) : base(serial)
-        {
         }
 
         public override string CorpseName => "a yamandon corpse";
@@ -157,19 +155,5 @@ namespace Server.Mobiles
         public override int GetHurtSound() => 1263;
 
         public override int GetIdleSound() => 1261;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/SE/YomotsuElder.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/YomotsuElder.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class YomotsuElder : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class YomotsuElder : BaseCreature
     {
         [Constructible]
         public YomotsuElder() : base(AIType.AI_Melee)
@@ -65,10 +67,6 @@ namespace Server.Mobiles
             }
         }
 
-        public YomotsuElder(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a wrinkly yomotsu corpse";
         public override string DefaultName => "a yomotsu elder";
 
@@ -106,18 +104,6 @@ namespace Server.Mobiles
 
                 defender.Paralyze(TimeSpan.FromSeconds(4.0));
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
 
         public override int GetIdleSound() => 0x42A;

--- a/Projects/UOContent/Mobiles/Monsters/SE/YomotsuPriest.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/YomotsuPriest.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class YomotsuPriest : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class YomotsuPriest : BaseCreature
     {
         [Constructible]
         public YomotsuPriest() : base(AIType.AI_Mage)
@@ -73,10 +75,6 @@ namespace Server.Mobiles
             }
         }
 
-        public YomotsuPriest(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a glowing yomotsu corpse";
         public override string DefaultName => "a yomotsu priest";
 
@@ -114,18 +112,6 @@ namespace Server.Mobiles
 
                 defender.Paralyze(TimeSpan.FromSeconds(4.0));
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
 
         public override int GetIdleSound() => 0x42A;

--- a/Projects/UOContent/Mobiles/Monsters/SE/YomotsuWarrior.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/YomotsuWarrior.cs
@@ -1,10 +1,12 @@
+using ModernUO.Serialization;
 using System;
 using Server.Engines.Plants;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class YomotsuWarrior : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class YomotsuWarrior : BaseCreature
     {
         [Constructible]
         public YomotsuWarrior() : base(AIType.AI_Melee)
@@ -71,10 +73,6 @@ namespace Server.Mobiles
             }
         }
 
-        public YomotsuWarrior(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a yomotsu corpse";
         public override string DefaultName => "a yomotsu warrior";
 
@@ -112,18 +110,6 @@ namespace Server.Mobiles
 
                 defender.Paralyze(TimeSpan.FromSeconds(4.0));
             }
-        }
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
         }
 
         public override int GetIdleSound() => 0x42A;

--- a/Projects/UOContent/Mobiles/Monsters/Summons/SummonedAirElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Summons/SummonedAirElemental.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SummonedAirElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SummonedAirElemental : BaseCreature
     {
         [Constructible]
         public SummonedAirElemental() : base(AIType.AI_Mage)
@@ -38,26 +41,14 @@ namespace Server.Mobiles
             ControlSlots = 2;
         }
 
-        public SummonedAirElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an air elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
         public override string DefaultName => "an air elemental";
 
-        public override void Serialize(IGenericWriter writer)
+        [AfterDeserialization]
+        private void AfterDeserialization()
         {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-
             if (BaseSoundID == 263)
             {
                 BaseSoundID = 655;

--- a/Projects/UOContent/Mobiles/Monsters/Summons/SummonedDaemon.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Summons/SummonedDaemon.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SummonedDaemon : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SummonedDaemon : BaseCreature
     {
         [Constructible]
         public SummonedDaemon() : base(AIType.AI_Mage)
@@ -35,27 +38,11 @@ namespace Server.Mobiles
             ControlSlots = Core.SE ? 4 : 5;
         }
 
-        public SummonedDaemon(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a daemon corpse";
         public override double DispelDifficulty => 125.0;
         public override double DispelFocus => 45.0;
 
         public override Poison PoisonImmune => Poison.Regular; // TODO: Immune to poison?
         public override bool CanFly => true;
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Summons/SummonedEarthElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Summons/SummonedEarthElemental.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SummonedEarthElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SummonedEarthElemental : BaseCreature
     {
         [Constructible]
         public SummonedEarthElemental() : base(AIType.AI_Melee)
@@ -32,25 +35,9 @@ namespace Server.Mobiles
             ControlSlots = 2;
         }
 
-        public SummonedEarthElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "an earth elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
         public override string DefaultName => "an earth elemental";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Summons/SummonedFireElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Summons/SummonedFireElemental.cs
@@ -1,8 +1,10 @@
+using ModernUO.Serialization;
 using Server.Items;
 
 namespace Server.Mobiles
 {
-    public class SummonedFireElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SummonedFireElemental : BaseCreature
     {
         [Constructible]
         public SummonedFireElemental() : base(AIType.AI_Mage)
@@ -37,25 +39,9 @@ namespace Server.Mobiles
             AddItem(new LightSource());
         }
 
-        public SummonedFireElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a fire elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
         public override string DefaultName => "a fire elemental";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Summons/SummonedWaterElemental.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Summons/SummonedWaterElemental.cs
@@ -1,6 +1,9 @@
+using ModernUO.Serialization;
+
 namespace Server.Mobiles
 {
-    public class SummonedWaterElemental : BaseCreature
+    [SerializationGenerator(0, false)]
+    public partial class SummonedWaterElemental : BaseCreature
     {
         [Constructible]
         public SummonedWaterElemental() : base(AIType.AI_Mage)
@@ -37,25 +40,9 @@ namespace Server.Mobiles
             CanSwim = true;
         }
 
-        public SummonedWaterElemental(Serial serial) : base(serial)
-        {
-        }
-
         public override string CorpseName => "a water elemental corpse";
         public override double DispelDifficulty => 117.5;
         public override double DispelFocus => 45.0;
         public override string DefaultName => "a water elemental";
-
-        public override void Serialize(IGenericWriter writer)
-        {
-            base.Serialize(writer);
-            writer.Write(0);
-        }
-
-        public override void Deserialize(IGenericReader reader)
-        {
-            base.Deserialize(reader);
-            var version = reader.ReadInt();
-        }
     }
 }


### PR DESCRIPTION
fix: Changes on Monsters to use code generation
Related Changes:
- Added namespace braces to keep similarity like all other classes.)
    - LBR
        - Exodus
            + ExodusMinion
            + ExodusOverseer
    - Misc
        - Melee
            + BladeSpirits
            + EnergyVortex
            + Golem
    - Ore Elementals
        + BronzeElemental
        + CopperElemental
        + DullCopperElemental
        + ValoriteElemental
        + VeriteElemental
    - Reptile
        - Magic
            + Leviathan
    - SE
        + FanDancer
        + Kappa
        + RuneBeetle
    - ML
        - Bedlam
            + LadyMarai
            + SirPatrick
        - Special
            + Twaulo
        - Twisted Weald
            + Guile

- Serialization variable adaptation:
    - Ants
        + BlackSolenQueen
        + BlackSolenWarrior
        + RedSolenQueen


- Deserialization adaptation:
    - AOS
        + AbysmalHorror
        + DarknightCreeper
        + FleshRenderer
        + Impaler
        + Revenant
        + ShadowKnight
        + Treefellow
    - Arachnid
        - Magic
            + DreadSpider
            + TerathanAvenger
        - Melee
            + FrostSpider
            + TerathanDrone
    - Elemental
        - Magic
            + AcidElemental
            + AirElemental
            + FireElemental
    - Mammal
        - Melee
            + VorpalBunny>BunnyHole
    - Misc
        - Melee
            + Centaur
            + EnergyVortex
    - ML
        - Animal
            + CuSidhe
        - Special
            + StainedOoze
        - Twisted Weald
            + Changeling (with adaptation property)
    - Plant
        - Melee
            + Corpser
            + Quagmire
    - Reptile
        - Melee
    - SE
        + BakeKitsume
        + FireBeetle
    - Summons
        + SummonedAirElemental