### PR TITLE
fix: Adds migration checks to CICD, updates dependencies, adds Fedora 37, alpine 3.17 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,6 @@ publish.cmd             text eol=lf
 /.github export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
+
+# Collapse in Github
+**/Migrations/*.v*.json linguist-generated=true

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -27,6 +27,8 @@ jobs:
         dotnet-version: 7.0.101
     - name: Build
       run: ./publish.cmd Release
+    - name: Migration Changes
+      run: git diff --exit-code ./**/Migrations/*.v*.json
     - name: Test
       run: dotnet test --no-restore
 
@@ -73,5 +75,7 @@ jobs:
           dotnet-version: 7.0.101
       - name: Build
         run: ./publish.sh Release
+      - name: Migration Changes
+        run: git diff --exit-code ./**/Migrations/*.v*.json
       - name: Test
         run: dotnet test --no-restore

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET 7
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.100
+        dotnet-version: 7.0.101
     - name: Build
       run: ./publish.cmd Release
     - name: Test
@@ -70,7 +70,7 @@ jobs:
       - name: Setup .NET 7
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.100
+          dotnet-version: 7.0.101
       - name: Build
         run: ./publish.sh Release
       - name: Test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -78,7 +78,5 @@ jobs:
           dotnet-version: 7.0.101
       - name: Build
         run: ./publish.sh Release
-      - name: Migration Changes
-        run: git diff --exit-code ./**/Migrations/*.v*.json
       - name: Test
         run: dotnet test --no-restore

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,6 +48,7 @@ jobs:
             packageManager: apt
           - container: fedora:37
             name: Fedora 37
+            packageManager: dnf
           - container: fedora:36
             name: Fedora 36
             packageManager: dnf

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,6 +46,8 @@ jobs:
           - container: debian:bullseye
             name: Debian 11
             packageManager: apt
+          - container: fedora:37
+            name: Fedora 37
           - container: fedora:36
             name: Fedora 36
             packageManager: dnf

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,8 +16,8 @@ jobs:
         token: ${{ secrets.WORKFLOW_TOKEN }}
     - name: Setup .NET 7
       uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 7.0.100
+      with
+        dotnet-version: 7.0.101
     - name: Install NGBV
       uses: dotnet/nbgv@master
       id: nbgv

--- a/Projects/Server.Tests/Server.Tests.csproj
+++ b/Projects/Server.Tests/Server.Tests.csproj
@@ -3,8 +3,8 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Moq" Version="4.18.3" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <ProjectReference Include="..\Server\Server.csproj" />

--- a/Projects/UOContent.Tests/UOContent.Tests.csproj
+++ b/Projects/UOContent.Tests/UOContent.Tests.csproj
@@ -3,8 +3,8 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Moq" Version="4.18.3" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
         <ProjectReference Include="..\Server\Server.csproj" />

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -30,7 +30,7 @@
         <ProjectReference Include="..\Server\Server.csproj" Private="false" PrivateAssets="All" IncludeAssets="None">
             <IncludeInPackage>false</IncludeInPackage>
         </ProjectReference>
-        <PackageReference Include="MailKit" Version="3.4.2" />
+        <PackageReference Include="MailKit" Version="3.4.3" />
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
         <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
         <PackageReference Include="Zlib.Bindings" Version="1.10.1" />

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ModernUO [![Discord](https://img.shields.io/discord/751317910504603701?logo=disc
 
 #### Development
 [![git](https://img.shields.io/badge/-git-F05032?logo=git&logoColor=F05032&labelColor=222222)](https://git-scm.com/downloads)
-[![.NET](https://img.shields.io/badge/-%207.0.100%20SDK-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
+[![.NET](https://img.shields.io/badge/-%207.0.101%20SDK-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
 
 #### Supported IDEs
 

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ ModernUO [![Discord](https://img.shields.io/discord/751317910504603701?logo=disc
 ## Requirements
 #### Supported Operating Systems
 [![Windows 10/11/2016/2019/2022](https://img.shields.io/badge/-server%202022-0078D6?logo=windows&logoColor=0078D6&labelColor=222222)](https://www.microsoft.com/en-US/evalcenter/evaluate-windows-server-2022)
-![MacOS 10.15/11/12/13](https://img.shields.io/badge/-ventura-222222?logo=apple&logoColor=white&labelColor=222222)
-[![Debian 10/11](https://img.shields.io/badge/-bullseye-A81D33?logo=debian&logoColor=A81D33&labelColor=222222)](https://www.debian.org/distrib/)
-[![Ubuntu 16/18/20/22 LTS](https://img.shields.io/badge/-22LTS-E95420?logo=ubuntu&logoColor=E95420&labelColor=222222)](https://ubuntu.com/download/server)
+![MacOS 10.15+](https://img.shields.io/badge/-ventura-222222?logo=apple&logoColor=white&labelColor=222222)
+[![Debian 10+](https://img.shields.io/badge/-bullseye-A81D33?logo=debian&logoColor=A81D33&labelColor=222222)](https://www.debian.org/distrib/)
+[![Ubuntu 16+ LTS](https://img.shields.io/badge/-22LTS-E95420?logo=ubuntu&logoColor=E95420&labelColor=222222)](https://ubuntu.com/download/server)
 <br />
-[![Alpine 3.15+](https://img.shields.io/badge/-3.16-0D597F?logo=alpinelinux&logoColor=0D597F&labelColor=222222)](https://alpinelinux.org/downloads/)
-[![Fedora 33/34/35/36](https://img.shields.io/badge/-36-51a2da?logo=fedora&logoColor=51a2da&labelColor=222222)](https://getfedora.org/en/server/download/)
+[![Alpine 3.15+](https://img.shields.io/badge/-3.17-0D597F?logo=alpinelinux&logoColor=0D597F&labelColor=222222)](https://alpinelinux.org/downloads/)
+[![Fedora 33+](https://img.shields.io/badge/-37-51a2da?logo=fedora&logoColor=51a2da&labelColor=222222)](https://getfedora.org/en/server/download/)
 [![RedHat 7/8](https://img.shields.io/badge/-8-BE0000?logo=redhat&logoColor=BE0000&labelColor=222222)](https://access.redhat.com/downloads)
 [![CentOS 7/8/9](https://img.shields.io/badge/-9-262577?logo=centos&logoColor=white&labelColor=222222)](https://www.centos.org/download/)
 [![openSUSE 15+](https://img.shields.io/badge/-15-73BA25?logo=openSUSE&logoColor=73BA25&labelColor=222222)](https://get.opensuse.org/)
 [![SUSE Enterprise 12 SP2+](https://img.shields.io/badge/-12%20SP2-0C322C?logo=suse&logoColor=30BA78&labelColor=222222)](https://www.suse.com/download/sles/)
-[![Linux Mint 17/18/19/20](https://img.shields.io/badge/-20-87CF3E?logo=linux%20mint&logoColor=87CF3E&labelColor=222222)](https://linuxmint.com/download.php)
+[![Linux Mint 17+](https://img.shields.io/badge/-20-87CF3E?logo=linux%20mint&logoColor=87CF3E&labelColor=222222)](https://linuxmint.com/download.php)
 [![Arch](https://img.shields.io/badge/-Arch-1793D1?logo=archlinux&logoColor=1793D1&labelColor=222222)](https://archlinux.org/download/)
 
 #### Running the server
-[![.NET](https://img.shields.io/badge/-7.0.0-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
+[![.NET](https://img.shields.io/badge/-7.0.1-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
 
 #### Development
 [![git](https://img.shields.io/badge/-git-F05032?logo=git&logoColor=F05032&labelColor=222222)](https://git-scm.com/downloads)
@@ -38,8 +38,8 @@ ModernUO [![Discord](https://img.shields.io/discord/751317910504603701?logo=disc
 
 #### Supported IDEs
 
-<p align="left"><a href="https://www.jetbrains.com/rider/download"><img height="64" title="Jetbrains Rider 2022.2.3+"
-      alt="Jetbrains Rider 2022.2.3+"
+<p align="left"><a href="https://www.jetbrains.com/rider/download"><img height="64" title="Jetbrains Rider 2022.3.1+"
+      alt="Jetbrains Rider 2022.3.1+"
       src="https://user-images.githubusercontent.com/3953314/133473479-734e425c-fbb6-433a-af2d-2cc8444398e8.png"></a><img
       alt="space" width="32" src="https://user-images.githubusercontent.com/3953314/200151935-3c1521ec-16cb-487b-85a2-7454d347c585.png"><a href="https://code.visualstudio.com/download"><img height="64" title="VSCode"
       alt="VSCode"
@@ -101,6 +101,6 @@ Thank you for supporting us! You can find out how by visiting the [sponsors](./S
 - [Karasho](https://github.com/andreakarasho), [Jaedan](https://github.com/jaedan) and the ClassicUO Community
 
 </br></br>
-<p align=center>Development Tools & Plugins provided with &hearts; by </br><a href="https://www.jetbrains.com/?from=ModernUO"><img align=middle src="https://user-images.githubusercontent.com/3953314/86882249-cfb2ea00-c0a4-11ea-9cec-bf3f3bcc6f28.png" height="64px" alt="JetBrains" title="JetBrains" /></a>
+<p align=center>Development Tools & Plugins provided with &hearts; by <br /><a href="https://www.jetbrains.com/?from=ModernUO"><img align=middle src="https://user-images.githubusercontent.com/3953314/86882249-cfb2ea00-c0a4-11ea-9cec-bf3f3bcc6f28.png" height="64px" alt="JetBrains" title="JetBrains" /></a>
 <a href="https://material-theme.com/"><img align=center src="https://material-theme.com/img/logo/material-oceanic.svg" width="64px" alt="Material Theme" title="Material Theme"></a>
 </p>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,5 +22,7 @@ jobs:
   - task: NuGetAuthenticate@1
   - script: ./publish.cmd Release
     displayName: 'Build'
+  - script: git diff --exit-code ./**/Migrations/*.v*.json
+    displayName: Migration Changes
   - script: dotnet test --no-restore
     displayName: 'Test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: 'Install .NET 7'
     inputs:
       packageType: sdk
-      version: 7.0.100
+      version: 7.0.101
   - task: NuGetAuthenticate@1
   - script: ./publish.cmd Release
     displayName: 'Build'


### PR DESCRIPTION
- [X] Automatically collapses migration files in github PRs.
- [X] CI/CD now checks to see if migrations are missing or modified.
- [X] Updates dependencies
- [X] Adds Fedora 37, Alpine 3.17 support