### PR TITLE
fix: Fixes LOS house bug

### DIFF
--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -1057,8 +1057,15 @@ public sealed class Map : IComparable<Map>, ISpanFormattable, ISpanParsable<Map>
         }
         else if (o is Item item)
         {
-            p = item.GetWorldLocation();
-            p.Z += item.ItemData.Height / 2 + 1;
+            if (item.RootParent != null)
+            {
+                p = GetPoint(item.RootParent, eye);
+            }
+            else
+            {
+                p = item.GetWorldLocation();
+                p.Z += item.ItemData.Height / 2 + 1;
+            }
         }
         else if (o is Point3D point3D)
         {


### PR DESCRIPTION
Fixes a bug where items that are large (big ItemData.CalcHeight), like harps (10), will cause an LOS error because the calculation uses the target item's height instead of the container it's in. In this edge case, the harp's height was 27 + 10, and the roof tile was 28 + 3.