### PR TITLE
Moved IncomingAccountPackets.cs to UOContent project

### DIFF
--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -30,6 +30,9 @@ using Server.Items;
 using Server.Logging;
 using Server.Menus;
 
+// This was added so UOContent project could access the _authId internal. Maybe we should make it public?
+[assembly: InternalsVisibleToAttribute("UOContent")]
+
 namespace Server.Network;
 
 public delegate void NetStateCreatedCallback(NetState ns);

--- a/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using CV = Server.ClientVersion;
 
 namespace Server.Network;


### PR DESCRIPTION
This is part of the effort to better separate the Core Server from actual UO code.