### PR TITLE
fix: Removes run flag from NPC movement

### DIFF
--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -8881,9 +8881,13 @@ public class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPropertyLis
         return ret | (run ? Direction.Running : 0);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Direction GetDirectionTo(Point2D p, bool run = false) => GetDirectionTo(p.m_X, p.m_Y, run);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Direction GetDirectionTo(Point3D p, bool run = false) => GetDirectionTo(p.m_X, p.m_Y, run);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Direction GetDirectionTo(IPoint2D p, bool run = false) =>
         p == null ? Direction.North | (run ? Direction.Running : 0) : GetDirectionTo(p.X, p.Y, run);
 

--- a/Projects/UOContent/Engines/Pathing/PathFollower.cs
+++ b/Projects/UOContent/Engines/Pathing/PathFollower.cs
@@ -102,14 +102,14 @@ namespace Server
 
             if (!(Enabled && m_Path.Success))
             {
-                d = m_From.GetDirectionTo(goal, run);
+                d = m_From.GetDirectionTo(goal);
                 m_From.SetDirection(d);
                 Move(d);
 
                 return Check(m_From.Location, goal, range);
             }
 
-            d = m_From.GetDirectionTo(m_Next, run);
+            d = m_From.GetDirectionTo(m_Next);
             m_From.SetDirection(d);
             var res = Move(d);
 
@@ -123,16 +123,16 @@ namespace Server
                 m_Path = null;
                 CheckPath();
 
-                if (!m_Path.Success)
+                if (!m_Path!.Success)
                 {
-                    d = m_From.GetDirectionTo(goal, run);
+                    d = m_From.GetDirectionTo(goal);
                     m_From.SetDirection(d);
                     Move(d);
 
                     return Check(m_From.Location, goal, range);
                 }
 
-                d = m_From.GetDirectionTo(m_Next, run);
+                d = m_From.GetDirectionTo(m_Next);
                 m_From.SetDirection(d);
 
                 if (Move(d) == MoveResult.Blocked)

--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -2041,14 +2041,16 @@ public abstract class BaseAI
 
     public double TransformMoveDelay(double thinkingSpeed)
     {
+        var isControlled = m_Mobile.Controlled || m_Mobile.Summoned;
+
         // Monster is passive
-        if (m_Mobile is { Controlled: false, Summoned: false } && Math.Abs(thinkingSpeed - m_Mobile.PassiveSpeed) < 0.0001)
+        if (!isControlled && Math.Abs(thinkingSpeed - m_Mobile.PassiveSpeed) < 0.0001)
         {
-            thinkingSpeed *= 3;
+            thinkingSpeed *= 3; // Monster passive is 3x slower than thinking
         }
-        else // Movement speed is twice as slow as "thinking"
+        else if (!isControlled || m_Mobile.ControlOrder != OrderType.Follow || m_Mobile.ControlTarget != m_Mobile.ControlMaster)
         {
-            thinkingSpeed *= 2;
+            thinkingSpeed *= 2; // Monster active speed is 2x slower than thinking
         }
 
         if (!m_Mobile.IsDeadPet && (m_Mobile.ReduceSpeedWithDamage || m_Mobile.IsSubdued))

--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -2414,7 +2414,7 @@ public abstract class BaseAI
                 return true;
             }
         }
-        else if (!DoMove(m_Mobile.GetDirectionTo(m, run), true))
+        else if (!DoMove(m_Mobile.GetDirectionTo(m), true))
         {
             m_Path = new PathFollower(m_Mobile, m) { Mover = DoMoveImpl };
 


### PR DESCRIPTION
### Summary
Fixes an issue with monsters where they "run" "stop" "run" "stop" because the running flag is used.
While we could have monsters properly run when necessary, it would have to work in conjunction with their animation cadence (200ms for humanoid, 100ms for other monsters).
The use-case and game logic for this feature is out of scope and nobody has asked for it so I am not inclined to bother.