### PR TITLE
fix: Updates BufferWriter with more streamlined code

### DIFF
--- a/Projects/Server/Serialization/BufferWriter.cs
+++ b/Projects/Server/Serialization/BufferWriter.cs
@@ -314,8 +314,7 @@ public class BufferWriter : IGenericWriter
             Flush();
         }
 
-        // We use bytes written in case it is smaller than length due to 3rd party overrides.
-        // We don't loop since that may not get us the result we want in this edge case.
-        Index += _encoding.GetBytes(value, _buffer.AsSpan((int)_index));
+        // We don't use spans here since that incurs extra allocations for safety.
+        Index += _encoding.GetBytes(value, 0, value.Length, _buffer, (int)_index);
     }
 }


### PR DESCRIPTION
### Summary
Updates BufferWriter with more standard ways of writing primitives. Eliminates looping to write a string per @jaedan's suggestion.

Note: This change assumes we don't have crazy large strings.