### PR TITLE
fix: Fixes casting by sending ParalyzeFlag to client while animating

### DIFF
--- a/Projects/Server/Interfaces.cs
+++ b/Projects/Server/Interfaces.cs
@@ -33,6 +33,7 @@ public interface IHued
 
 public interface ISpell
 {
+    bool BlocksMovement { get; }
     bool IsCasting { get; }
     void OnCasterHurt();
     void OnCasterKilled();

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -6959,7 +6959,7 @@ public class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPropertyLis
     {
         var flags = 0x0;
 
-        if (m_Paralyzed || m_Frozen)
+        if (m_Paralyzed || m_Frozen || m_Spell?.BlocksMovement == true)
         {
             flags |= 0x01;
         }

--- a/Projects/UOContent/Items/Weapons/Ranged/BaseRanged.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/BaseRanged.cs
@@ -54,7 +54,8 @@ namespace Server.Items
 
                     if (canSwing)
                     {
-                        canSwing = attacker.Spell is not Spell sp || !sp.IsCasting || !sp.BlocksMovement;
+                        // On OSI you can swing + hold a cast at the same time
+                        canSwing = attacker.Spell is not Spell { IsCasting: true, BlocksMovement: true };
                     }
                 }
 


### PR DESCRIPTION
Hi @kamronbatman 

As we discussed together, on OSI they are sending Paralyze flag when a player casts a spell. This helps players with high ping as the client will not attempt to move whilst the paralyze flag is true. 

Previously the paralyze flag was not being sent, and when attempting to move the server would reject the move and therefore trigger a rubber band