### PR TITLE
fix: Removes scoped for gump AppendTo

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET 7
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.202
+        dotnet-version: 7.0.302
     - name: Build
       run: ./publish.cmd Release
     - name: Migration Changes
@@ -75,7 +75,7 @@ jobs:
       - name: Setup .NET 7
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.202
+          dotnet-version: 7.0.302
       - name: Build
         run: ./publish.sh Release
       - name: Test

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET 7
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.202
+        dotnet-version: 7.0.302
     - name: Install NGBV
       uses: dotnet/nbgv@master
       id: nbgv

--- a/Projects/Server/Gumps/GumpAlphaRegion.cs
+++ b/Projects/Server/Gumps/GumpAlphaRegion.cs
@@ -36,7 +36,7 @@ public class GumpAlphaRegion : GumpEntry
 
     public int Height { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ checkertrans {X} {Y} {Width} {Height} }}");
     }

--- a/Projects/Server/Gumps/GumpBackground.cs
+++ b/Projects/Server/Gumps/GumpBackground.cs
@@ -39,7 +39,7 @@ public class GumpBackground : GumpEntry
 
     public int GumpID { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ resizepic {X} {Y} {GumpID} {Width} {Height} }}");
     }

--- a/Projects/Server/Gumps/GumpButton.cs
+++ b/Projects/Server/Gumps/GumpButton.cs
@@ -54,7 +54,7 @@ public class GumpButton : GumpEntry
 
     public int Param { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ button {X} {Y} {NormalID} {PressedID} {(int)Type} {Param} {ButtonID} }}");
     }

--- a/Projects/Server/Gumps/GumpCheck.cs
+++ b/Projects/Server/Gumps/GumpCheck.cs
@@ -42,7 +42,7 @@ public class GumpCheck : GumpEntry
 
     public int SwitchID { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var initialState = InitialState ? "1" : "0";
         writer.WriteAscii($"{{ checkbox {X} {Y} {InactiveID} {ActiveID} {initialState} {SwitchID} }}");

--- a/Projects/Server/Gumps/GumpECHandleInput.cs
+++ b/Projects/Server/Gumps/GumpECHandleInput.cs
@@ -22,7 +22,7 @@ public class GumpECHandleInput : GumpEntry
 {
     private static byte[] _layout = Gump.StringToBuffer("{ echandleinput }");
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.Write(_layout);
     }

--- a/Projects/Server/Gumps/GumpEntry.cs
+++ b/Projects/Server/Gumps/GumpEntry.cs
@@ -25,5 +25,5 @@ public abstract class GumpEntry
 
     // TODO: Replace OrderedHashSet with InsertOnlyHashSet, a copy of HashSet that is ReadOnly compatible, but includes
     // a public AddIfNotPresent function that returns the index of the element
-    public abstract void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches);
+    public abstract void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches);
 }

--- a/Projects/Server/Gumps/GumpGroup.cs
+++ b/Projects/Server/Gumps/GumpGroup.cs
@@ -26,7 +26,7 @@ public class GumpGroup : GumpEntry
 
     public int Group { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         if (Group == 1)
         {

--- a/Projects/Server/Gumps/GumpHtml.cs
+++ b/Projects/Server/Gumps/GumpHtml.cs
@@ -45,7 +45,7 @@ public class GumpHtml : GumpEntry
 
     public bool Scrollbar { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var textIndex = strings.GetOrAdd(Text ?? "");
         var background = Background ? "1" : "0";

--- a/Projects/Server/Gumps/GumpHtmlLocalized.cs
+++ b/Projects/Server/Gumps/GumpHtmlLocalized.cs
@@ -101,7 +101,7 @@ public class GumpHtmlLocalized : GumpEntry
     public GumpHtmlLocalizedType Type { get; set; }
 
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var background = Background ? "1" : "0";
         var scrollbar = Scrollbar ? "1" : "0";

--- a/Projects/Server/Gumps/GumpImage.cs
+++ b/Projects/Server/Gumps/GumpImage.cs
@@ -39,7 +39,7 @@ public class GumpImage : GumpEntry
 
     public string Class { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var hasHue = Hue != 0;
         var hasClass = !string.IsNullOrEmpty(Class);

--- a/Projects/Server/Gumps/GumpImageTileButton.cs
+++ b/Projects/Server/Gumps/GumpImageTileButton.cs
@@ -61,7 +61,7 @@ public class GumpImageTileButton : GumpEntry
 
     public int Height { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii(
             $"{{ buttontileart {X} {Y} {NormalID} {PressedID} {(int)Type} {Param} {ButtonID} {ItemID} {Hue} {Width} {Height} }}"

--- a/Projects/Server/Gumps/GumpImageTiled.cs
+++ b/Projects/Server/Gumps/GumpImageTiled.cs
@@ -39,7 +39,7 @@ public class GumpImageTiled : GumpEntry
 
     public int GumpID { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ gumppictiled {X} {Y} {Width} {Height} {GumpID} }}");
     }

--- a/Projects/Server/Gumps/GumpItem.cs
+++ b/Projects/Server/Gumps/GumpItem.cs
@@ -36,7 +36,7 @@ public class GumpItem : GumpEntry
 
     public int Hue { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii(Hue == 0 ? $"{{ tilepic {X} {Y} {ItemID} }}" : $"{{ tilepichue {X} {Y} {ItemID} {Hue} }}");
     }

--- a/Projects/Server/Gumps/GumpItemProperty.cs
+++ b/Projects/Server/Gumps/GumpItemProperty.cs
@@ -24,7 +24,7 @@ public class GumpItemProperty : GumpEntry
 
     public Serial Serial { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ itemproperty {Serial.Value} }}");
     }

--- a/Projects/Server/Gumps/GumpLabel.cs
+++ b/Projects/Server/Gumps/GumpLabel.cs
@@ -36,7 +36,7 @@ public class GumpLabel : GumpEntry
 
     public string Text { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var textIndex = strings.GetOrAdd(Text ?? "");
         writer.WriteAscii($"{{ text {X} {Y} {Hue} {textIndex} }}");

--- a/Projects/Server/Gumps/GumpLabelCropped.cs
+++ b/Projects/Server/Gumps/GumpLabelCropped.cs
@@ -42,7 +42,7 @@ public class GumpLabelCropped : GumpEntry
 
     public string Text { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var textIndex = strings.GetOrAdd(Text ?? "");
         writer.WriteAscii($"{{ croppedtext {X} {Y} {Width} {Height} {Hue} {textIndex} }}");

--- a/Projects/Server/Gumps/GumpMasterGump.cs
+++ b/Projects/Server/Gumps/GumpMasterGump.cs
@@ -24,7 +24,7 @@ public class GumpMasterGump : GumpEntry
 
     public int GumpID { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ mastergump {GumpID} }}");
     }

--- a/Projects/Server/Gumps/GumpPage.cs
+++ b/Projects/Server/Gumps/GumpPage.cs
@@ -26,7 +26,7 @@ public class GumpPage : GumpEntry
 
     public int Page { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         if (Page == 0)
         {

--- a/Projects/Server/Gumps/GumpRadio.cs
+++ b/Projects/Server/Gumps/GumpRadio.cs
@@ -42,7 +42,7 @@ public class GumpRadio : GumpEntry
 
     public int SwitchID { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var initialState = InitialState ? "1" : "0";
         writer.WriteAscii($"{{ radio {X} {Y} {InactiveID} {ActiveID} {initialState} {SwitchID} }}");

--- a/Projects/Server/Gumps/GumpSpriteImage.cs
+++ b/Projects/Server/Gumps/GumpSpriteImage.cs
@@ -45,7 +45,7 @@ public class GumpSpriteImage : GumpEntry
 
     public int SY { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii($"{{ picinpic {X} {Y} {GumpID} {Width} {Height} {SX} {SY} }}");
     }

--- a/Projects/Server/Gumps/GumpTextEntry.cs
+++ b/Projects/Server/Gumps/GumpTextEntry.cs
@@ -45,7 +45,7 @@ public class GumpTextEntry : GumpEntry
 
     public string InitialText { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var textIndex = strings.GetOrAdd(InitialText ?? "");
         writer.WriteAscii($"{{ textentry {X} {Y} {Width} {Height} {Hue} {EntryID} {textIndex} }}");

--- a/Projects/Server/Gumps/GumpTextEntryLimited.cs
+++ b/Projects/Server/Gumps/GumpTextEntryLimited.cs
@@ -50,7 +50,7 @@ public class GumpTextEntryLimited : GumpEntry
 
     public int Size { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         var textIndex = strings.GetOrAdd(InitialText ?? "");
         writer.WriteAscii($"{{ textentrylimited {X} {Y} {Width} {Height} {Hue} {EntryID} {textIndex} {Size} }}");

--- a/Projects/Server/Gumps/GumpTooltip.cs
+++ b/Projects/Server/Gumps/GumpTooltip.cs
@@ -32,7 +32,7 @@ public class GumpTooltip : GumpEntry
 
     public string Args { get; set; }
 
-    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, scoped ref int entries, scoped ref int switches)
+    public override void AppendTo(ref SpanWriter writer, OrderedHashSet<string> strings, ref int entries, ref int switches)
     {
         writer.WriteAscii(string.IsNullOrEmpty(Args) ? $"{{ tooltip {Number} }}" : $"{{ tooltip {Number} @{Args}@ }}");
     }

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ ModernUO [![Discord](https://img.shields.io/discord/751317910504603701?logo=disc
 [![Arch](https://img.shields.io/badge/-Arch-1793D1?logo=archlinux&logoColor=1793D1&labelColor=222222)](https://archlinux.org/download/)
 
 #### Running the server
-[![.NET](https://img.shields.io/badge/-7.0.4-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
+[![.NET](https://img.shields.io/badge/-7.0.5-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
 
 #### Development
 [![git](https://img.shields.io/badge/-git-F05032?logo=git&logoColor=F05032&labelColor=222222)](https://git-scm.com/downloads)
-[![.NET](https://img.shields.io/badge/-%207.0.202%20SDK-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
+[![.NET](https://img.shields.io/badge/-%207.0.302%20SDK-5C2D91?logo=.NET&logoColor=white&labelColor=222222)](https://dotnet.microsoft.com/download/dotnet/7.0)
 
 #### Supported IDEs
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: 'Install .NET 7'
     inputs:
       packageType: sdk
-      version: 7.0.202
+      version: 7.0.302
   - task: NuGetAuthenticate@1
   - script: ./publish.cmd Release
     displayName: 'Build'


### PR DESCRIPTION
### Summary
.NET 6 had a bug that required the `scoped` keyword for the gump AppendTo. It looks like this was fixed since then.