### PR TITLE
Fix explosion sometimes keeps mobiles alive in memory indefinitely if the attacker fails the harmful check against the target e.g. if the caster/target dies

### DIFF
--- a/Projects/UOContent/Spells/Sixth/Explosion.cs
+++ b/Projects/UOContent/Spells/Sixth/Explosion.cs
@@ -96,9 +96,9 @@ namespace Server.Spells.Sixth
                     _target.PlaySound(0x307);
 
                     SpellHelper.Damage(_spell, _target, damage, 0, 100, 0, 0, 0);
-
-                    _spell?.RemoveDelayedDamageContext(_attacker);
                 }
+
+                _spell?.RemoveDelayedDamageContext(_attacker);
             }
         }
     }


### PR DESCRIPTION
Hi @kamronbatman,

I noticed that mobiles are being held in memory until the server restarts when the mobile casted explosion, but either the target or caster dies before the spell has landed

![image](https://github.com/modernuo/ModernUO/assets/15312181/98d21913-4395-4cc4-abfe-04cb158d263a)
![image](https://github.com/modernuo/ModernUO/assets/15312181/f78971c2-753a-4bdc-89ba-9a003cd01a39)
![image](https://github.com/modernuo/ModernUO/assets/15312181/59eec9d2-8d49-4233-bf9e-8370d45f4199)
![image](https://github.com/modernuo/ModernUO/assets/15312181/b769d8e6-3ae5-4976-90f3-476a4a94830e)
