### PR TITLE
Fix mana drain debug build crash

### DIFF
--- a/Projects/UOContent/Spells/Fourth/ManaDrain.cs
+++ b/Projects/UOContent/Spells/Fourth/ManaDrain.cs
@@ -62,9 +62,9 @@ namespace Server.Spells.Fourth
                     {
                         m.SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
                     }
-                    else
+                    else if (m.Mana > 0)
                     {
-                        m.Mana -= Utility.Random(1, Math.Clamp(m.Mana, 1, 100));
+                        m.Mana -= Utility.Random(1, Math.Min(m.Mana, 100));
                     }
 
                     m.FixedParticles(0x374A, 10, 15, 5032, EffectLayer.Head);

--- a/Projects/UOContent/Spells/Fourth/ManaDrain.cs
+++ b/Projects/UOContent/Spells/Fourth/ManaDrain.cs
@@ -68,7 +68,7 @@ namespace Server.Spells.Fourth
                     }
                     else
                     {
-                        m.Mana -= Utility.Random(1, m.Mana);
+                        m.Mana -= Utility.Random(1, Math.Max(m.Mana, 1));
                     }
 
                     m.FixedParticles(0x374A, 10, 15, 5032, EffectLayer.Head);

--- a/Projects/UOContent/Spells/Fourth/ManaDrain.cs
+++ b/Projects/UOContent/Spells/Fourth/ManaDrain.cs
@@ -62,13 +62,9 @@ namespace Server.Spells.Fourth
                     {
                         m.SendLocalizedMessage(501783); // You feel yourself resisting magical energy.
                     }
-                    else if (m.Mana >= 100)
-                    {
-                        m.Mana -= Utility.Random(1, 100);
-                    }
                     else
                     {
-                        m.Mana -= Utility.Random(1, Math.Max(m.Mana, 1));
+                        m.Mana -= Utility.Random(1, Math.Clamp(m.Mana, 1, 100));
                     }
 
                     m.FixedParticles(0x374A, 10, 15, 5032, EffectLayer.Head);


### PR DESCRIPTION
Crashes on debug build when a player or mobile casts a mana drain on a player that has 0 mana and doesn't resist it. ManaDrain.cs line 71 uses Utility.Random(1, m.Mana), but there's a debug assert  in BaseRandomSource.cs that makes sure the count parameter (m.Mana in this case) is not 0.