### PR TITLE
Fix drydocking when EffectItem type items are onboard (teleporting of…

### DIFF
--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -1941,7 +1941,7 @@ namespace Server.Multis
                         continue;
                     }
 
-                    if (current is Item item)
+                    if (current is Item item || item is EffectItem)
                     {
                         if (item == _boat)
                         {


### PR DESCRIPTION
Found an issue with drydocking a boat on DarkFactions UO, but replicated on a vanilla ModernUO local server as well. Reported by xombie on DarkFactions UO,

When teleporting off a boat either using the spell or GM powers, the particle effect seems to remain for a few seconds, causing a "cluttered deck" message. In CheckDryDock() in BaseBoat.cs, I checked and printed the item and it's ID, which was 1, and traced it back to MovingEntitiesEnumerator.MoveNext() and printed the Item type, which was "EffectItem," which seems to deal with particle effects, which explains why the message only happens for a few seconds of double clicking the tillerman. Added a check in MoveNext() that skips the item if it's an EffectItem.