### PR TITLE
fix: Fixes stabled, abilities targeting self, and unsummon memory leak

### DIFF
--- a/Projects/Server/Mobiles/Mobile.Migrations.cs
+++ b/Projects/Server/Mobiles/Mobile.Migrations.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Server;
+
+public partial class Mobile
+{
+    // Migrating Stabled property to PlayerMobile
+    public static Dictionary<Mobile, HashSet<Mobile>> StableMigrations { get; private set; }
+
+    public static void AddToStabledMigration(Mobile m, HashSet<Mobile> stabled)
+    {
+        if (stabled?.Count > 0)
+        {
+            StableMigrations ??= new Dictionary<Mobile, HashSet<Mobile>>();
+            StableMigrations[m] = stabled;
+        }
+    }
+}

--- a/Projects/Server/Serialization/SerializationExtensions.cs
+++ b/Projects/Server/Serialization/SerializationExtensions.cs
@@ -48,9 +48,17 @@ public static class SerializationExtensions
         return entity?.Created <= reader.LastSerialized ? entity : null;
     }
 
-    public static List<T> ReadEntityList<T>(this IGenericReader reader) where T : class, ISerializable
+    public static List<T> ReadEntityList<T>(
+        this IGenericReader reader,
+        bool nullIfEmpty = false
+    ) where T : class, ISerializable
     {
         var count = reader.ReadInt();
+
+        if (count == 0 && nullIfEmpty)
+        {
+            return null;
+        }
 
         var list = new List<T>(count);
 
@@ -66,9 +74,17 @@ public static class SerializationExtensions
         return list;
     }
 
-    public static HashSet<T> ReadEntitySet<T>(this IGenericReader reader) where T : class, ISerializable
+    public static HashSet<T> ReadEntitySet<T>(
+        this IGenericReader reader,
+        bool nullIfEmpty = false
+    ) where T : class, ISerializable
     {
         var count = reader.ReadInt();
+
+        if (count == 0 && nullIfEmpty)
+        {
+            return null;
+        }
 
         var set = new HashSet<T>(count);
 

--- a/Projects/UOContent/Commands/Handlers.cs
+++ b/Projects/UOContent/Commands/Handlers.cs
@@ -287,37 +287,34 @@ namespace Server.Commands
             {
                 var pets = pm.AllFollowers;
 
-                if (pets.Count > 0)
+                if (!(pets?.Count > 0))
                 {
-                    CommandLogging.WriteLine(
-                        from,
-                        $"{from.AccessLevel} {CommandLogging.Format(from)} getting all followers of {CommandLogging.Format(pm)}"
-                    );
+                    from.SendMessage("There were no pets found for that player.");
+                    return;
+                }
 
-                    if (pets.Count == 1)
-                    {
-                        from.SendMessage($"That player has {pets.Count} pet.");
-                    }
-                    else
-                    {
-                        from.SendMessage($"That player has {pets.Count} pets.");
-                    }
+                CommandLogging.WriteLine(
+                    from,
+                    $"{from.AccessLevel} {CommandLogging.Format(from)} getting all followers of {CommandLogging.Format(pm)}"
+                );
 
-                    for (var i = 0; i < pets.Count; ++i)
-                    {
-                        var pet = pets[i];
-
-                        if (pet is IMount mount)
-                        {
-                            mount.Rider = null; // make sure it's dismounted
-                        }
-
-                        pet.MoveToWorld(from.Location, from.Map);
-                    }
+                if (pets.Count == 1)
+                {
+                    from.SendMessage($"That player has {pets.Count} pet.");
                 }
                 else
                 {
-                    from.SendMessage("There were no pets found for that player.");
+                    from.SendMessage($"That player has {pets.Count} pets.");
+                }
+
+                foreach (var pet in pets)
+                {
+                    if (pet is IMount mount)
+                    {
+                        mount.Rider = null; // make sure it's dismounted
+                    }
+
+                    pet.MoveToWorld(from.Location, from.Map);
                 }
             }
             else if (obj is Mobile master && master.Player)

--- a/Projects/UOContent/Items/Misc/Teleporter.cs
+++ b/Projects/UOContent/Items/Misc/Teleporter.cs
@@ -867,7 +867,7 @@ public partial class ConditionTeleporter : Teleporter
         }
 
         if (GetFlag(ConditionFlag.DenyFollowers) &&
-            (m.Followers != 0 || m is PlayerMobile mobile && mobile.AutoStabled.Count != 0))
+            (m.Followers != 0 || m is PlayerMobile mobile && mobile.AutoStabled?.Count != 0))
         {
             m.SendLocalizedMessage(1077250); // No pets permitted beyond this point.
             return false;

--- a/Projects/UOContent/Items/Special/Solen Items/BallOfSummoning.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BallOfSummoning.cs
@@ -166,7 +166,7 @@ public partial class BallOfSummoning : Item, TranslocationItem
     {
         var pet = Pet;
 
-        if (Deleted || pet == null || RootParent != from)
+        if (Deleted || pet == null || RootParent != from || from is not PlayerMobile pm)
         {
             return;
         }
@@ -186,7 +186,7 @@ public partial class BallOfSummoning : Item, TranslocationItem
             // The Crystal Ball fills with a blue mist. Your pet is not responding to the summons.
             this.SendLocalizedMessageTo(from, 1054125, 0x5);
         }
-        else if ((!pet.Controlled || pet.ControlMaster != from) && !from.Stabled.Contains(pet))
+        else if ((!pet.Controlled || pet.ControlMaster != from) && pm.Stabled?.Contains(pet) != true)
         {
             // The Crystal Ball fills with a grey mist. You are not the owner of the pet you are attempting to summon.
             this.SendLocalizedMessageTo(from, 1054126, 0x8FD);
@@ -221,7 +221,7 @@ public partial class BallOfSummoning : Item, TranslocationItem
     {
         var pet = Pet;
 
-        if (pet == null)
+        if (pet == null || from is not PlayerMobile pm)
         {
             return;
         }
@@ -242,12 +242,8 @@ public partial class BallOfSummoning : Item, TranslocationItem
 
             pet.IsStabled = false;
             pet.StabledBy = null;
-            from.Stabled.Remove(pet);
-
-            if (from is PlayerMobile mobile)
-            {
-                mobile.AutoStabled.Remove(pet);
-            }
+            pm.RemoveStabled(pet);
+            pm.AutoStabled?.Remove(pet);
         }
 
         pet.MoveToWorld(from.Location, from.Map);

--- a/Projects/UOContent/Mobiles/Abilities/MonsterAbility.cs
+++ b/Projects/UOContent/Mobiles/Abilities/MonsterAbility.cs
@@ -18,6 +18,9 @@ public abstract partial class MonsterAbility
     public virtual TimeSpan MinTriggerCooldown => TimeSpan.Zero;
     public virtual TimeSpan MaxTriggerCooldown => TimeSpan.Zero;
 
+    // To prevent reflect from harming the monster
+    public virtual bool CanTriggerAgainstSelf => false;
+
     public bool WillTrigger(MonsterAbilityTrigger trigger) => (AbilityTrigger & trigger) != 0;
 
     /// <summary>
@@ -54,7 +57,8 @@ public abstract partial class MonsterAbility
     /// </summary>
     public virtual void Trigger(MonsterAbilityTrigger trigger, BaseCreature source, Mobile target)
     {
-        if (MinTriggerCooldown <= TimeSpan.Zero && MaxTriggerCooldown <= TimeSpan.Zero)
+        if (!CanTriggerAgainstSelf && target == source ||
+            MinTriggerCooldown <= TimeSpan.Zero && MaxTriggerCooldown <= TimeSpan.Zero)
         {
             return;
         }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -2380,6 +2380,8 @@ namespace Server.Mobiles
                 MLQuestSystem.HandleDeletion(this);
             }
 
+            UnsummonTimer.StopTimer(this);
+
             base.OnAfterDelete();
         }
 
@@ -3430,7 +3432,6 @@ namespace Server.Mobiles
 
             SummonMaster = null;
             ReceivedHonorContext?.Cancel();
-            UnsummonTimer.StopTimer(this);
 
             base.OnDelete();
             m?.InvalidateProperties();

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -2280,17 +2280,17 @@ namespace Server.Mobiles
             if (m_ControlMaster != null)
             {
                 m_ControlMaster.Followers += ControlSlots;
-                if (m_ControlMaster is PlayerMobile mobile)
+                if (m_ControlMaster is PlayerMobile pm)
                 {
-                    mobile.AddFollower(this);
+                    pm.AddFollower(this);
                 }
             }
             else if (m_SummonMaster != null)
             {
                 m_SummonMaster.Followers += ControlSlots;
-                if (m_SummonMaster is PlayerMobile mobile)
+                if (m_SummonMaster is PlayerMobile pm)
                 {
-                    mobile.AddFollower(this);
+                    pm.AddFollower(this);
                 }
             }
         }

--- a/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
+++ b/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
@@ -113,7 +113,7 @@ namespace Server.Mobiles
 
             var list = new List<BaseCreature>();
 
-            if (pm.Stabled != null)
+            if (pm.Stabled?.Count > 0)
             {
                 using var queue = PooledRefQueue<Mobile>.Create();
 
@@ -288,7 +288,7 @@ namespace Server.Mobiles
 
             var claimByName = petName != null;
 
-            if (pm.Stabled != null)
+            if (pm.Stabled?.Count > 0)
             {
                 using var queue = PooledRefQueue<Mobile>.Create();
 

--- a/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
+++ b/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
@@ -1,5 +1,6 @@
 using ModernUO.Serialization;
 using System.Collections.Generic;
+using Server.Collections;
 using Server.ContextMenus;
 using Server.Gumps;
 using Server.Items;
@@ -41,11 +42,11 @@ namespace Server.Mobiles
 
         public override void AddCustomContextEntries(Mobile from, List<ContextMenuEntry> list)
         {
-            if (from.Alive)
+            if (from is PlayerMobile { Alive: true } pm)
             {
                 list.Add(new StableEntry(this, from));
 
-                if (from.Stabled.Count > 0)
+                if (pm.Stabled?.Count > 0)
                 {
                     list.Add(new ClaimAllEntry(this, from));
                 }
@@ -105,31 +106,38 @@ namespace Server.Mobiles
 
         public void BeginClaimList(Mobile from)
         {
-            if (Deleted || !from.CheckAlive())
+            if (Deleted || !from.CheckAlive() || from is not PlayerMobile pm)
             {
                 return;
             }
 
             var list = new List<BaseCreature>();
 
-            for (var i = 0; i < from.Stabled.Count; ++i)
+            if (pm.Stabled != null)
             {
-                var pet = from.Stabled[i] as BaseCreature;
+                using var queue = PooledRefQueue<Mobile>.Create();
 
-                if (pet?.Deleted != false)
+                foreach (var m in pm.Stabled)
                 {
-                    if (pet != null)
+                    if (m is BaseCreature pet)
                     {
+                        if (!pet.Deleted)
+                        {
+                            list.Add(pet);
+                            break;
+                        }
+
                         pet.IsStabled = false;
                         pet.StabledBy = null;
                     }
 
-                    from.Stabled.RemoveAt(i);
-                    --i;
-                    continue;
+                    queue.Enqueue(m);
                 }
 
-                list.Add(pet);
+                while (queue.Count > 0)
+                {
+                    pm.RemoveStabled(queue.Dequeue());
+                }
             }
 
             if (list.Count > 0)
@@ -144,7 +152,7 @@ namespace Server.Mobiles
 
         public void EndClaimList(Mobile from, BaseCreature pet)
         {
-            if (pet?.Deleted != false || from.Map != Map || !from.Stabled.Contains(pet) || !from.CheckAlive())
+            if (pet?.Deleted != false || from.Map != Map || from is not PlayerMobile pm || pm.Stabled?.Contains(pet) != true || !from.CheckAlive())
             {
                 return;
             }
@@ -159,9 +167,8 @@ namespace Server.Mobiles
             {
                 DoClaim(from, pet);
 
-                from.Stabled.Remove(pet);
-
-                (from as PlayerMobile)?.AutoStabled.Remove(pet);
+                pm.RemoveStabled(pet);
+                pm.AutoStabled?.Remove(pet);
             }
             else
             {
@@ -175,8 +182,6 @@ namespace Server.Mobiles
             {
                 return;
             }
-
-            Container bank = from.FindBankNoCreate();
 
             if (!(from.Backpack?.GetAmount(typeof(Gold)) >= 30) &&
                 !(Banker.GetBalance(from) >= 30))
@@ -197,7 +202,7 @@ namespace Server.Mobiles
 
         public void EndStable(Mobile from, BaseCreature pet)
         {
-            if (Deleted || !from.CheckAlive())
+            if (Deleted || !from.CheckAlive() || from is not PlayerMobile pm)
             {
                 return;
             }
@@ -236,14 +241,12 @@ namespace Server.Mobiles
             {
                 SayTo(from, 1042564); // I'm sorry.  Your pet seems to be busy.
             }
-            else if (from.Stabled.Count >= GetMaxStabled(from))
+            else if (pm.Stabled?.Count >= GetMaxStabled(from))
             {
                 SayTo(from, 1042565); // You have too many pets in the stables!
             }
             else
             {
-                Container bank = from.FindBankNoCreate();
-
                 if (from.Backpack?.ConsumeTotal(typeof(Gold), 30) == true || Banker.Withdraw(from, 30))
                 {
                     pet.ControlTarget = null;
@@ -261,14 +264,10 @@ namespace Server.Mobiles
                         pet.Loyalty = MaxLoyalty; // Wonderfully happy
                     }
 
-                    from.Stabled.Add(pet);
+                    pm.AddStabled(pet);
 
-                    SayTo(
-                        from,
-                        Core.AOS
-                            ? 1049677
-                            : 502679
-                    ); // [AOS: Your pet has been stabled.] Very well, thy pet is stabled. Thou mayst recover it by saying 'claim' to me. In one real world week, I shall sell it off if it is not claimed!
+                    // [AOS: Your pet has been stabled.] Very well, thy pet is stabled. Thou mayst recover it by saying 'claim' to me. In one real world week, I shall sell it off if it is not claimed!
+                    SayTo(from, Core.AOS ? 1049677 : 502679);
                 }
                 else
                 {
@@ -279,7 +278,7 @@ namespace Server.Mobiles
 
         public void Claim(Mobile from, string petName = null)
         {
-            if (Deleted || !from.CheckAlive())
+            if (Deleted || !from.CheckAlive() || from is not PlayerMobile pm)
             {
                 return;
             }
@@ -289,44 +288,51 @@ namespace Server.Mobiles
 
             var claimByName = petName != null;
 
-            for (var i = 0; i < from.Stabled.Count; ++i)
+            if (pm.Stabled != null)
             {
-                var pet = from.Stabled[i] as BaseCreature;
+                using var queue = PooledRefQueue<Mobile>.Create();
 
-                if (pet?.Deleted != false)
+                foreach (var m in pm.Stabled)
                 {
-                    if (pet != null)
+                    var pet = m as BaseCreature;
+
+                    if (pet?.Deleted != false)
                     {
-                        pet.IsStabled = false;
-                        pet.StabledBy = null;
+                        if (pet != null)
+                        {
+                            pet.IsStabled = false;
+                            pet.StabledBy = null;
+                        }
+
+                        queue.Enqueue(pet);
+                        continue;
                     }
-                    from.Stabled.RemoveAt(i);
-                    --i;
-                    continue;
+
+                    ++stabled;
+
+                    if (claimByName && !pet.Name.InsensitiveEquals(petName))
+                    {
+                        continue;
+                    }
+
+                    if (CanClaim(from, pet))
+                    {
+                        DoClaim(from, pet);
+
+                        queue.Enqueue(pet);
+
+                        claimed = true;
+                        pm.AutoStabled.Remove(pet);
+                    }
+                    else
+                    {
+                        SayTo(from, 1049612, pet.Name); // ~1_NAME~ remained in the stables because you have too many followers.
+                    }
                 }
 
-                ++stabled;
-
-                if (claimByName && !pet.Name.InsensitiveEquals(petName))
+                while (queue.Count > 0)
                 {
-                    continue;
-                }
-
-                if (CanClaim(from, pet))
-                {
-                    DoClaim(from, pet);
-
-                    from.Stabled.RemoveAt(i);
-
-                    (from as PlayerMobile)?.AutoStabled.Remove(pet);
-
-                    --i;
-
-                    claimed = true;
-                }
-                else
-                {
-                    SayTo(from, 1049612, pet.Name); // ~1_NAME~ remained in the stables because you have too many followers.
+                    pm.RemoveStabled(queue.Dequeue());
                 }
             }
 

--- a/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
+++ b/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
@@ -322,7 +322,7 @@ namespace Server.Mobiles
                         queue.Enqueue(pet);
 
                         claimed = true;
-                        pm.AutoStabled.Remove(pet);
+                        pm.AutoStabled?.Remove(pet);
                     }
                     else
                     {

--- a/Projects/UOContent/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Projects/UOContent/Spells/Necromancy/AnimateDeadSpell.cs
@@ -281,7 +281,12 @@ namespace Server.Spells.Necromancy
                 Timer.StartTimer(list[0].Kill);
             }
 
-            Timer.StartTimer(TimeSpan.FromSeconds(2.0), TimeSpan.FromSeconds(2.0), () => Summoned_Damage(summoned));
+            Timer.DelayCall(
+                TimeSpan.FromMilliseconds(1650),
+                TimeSpan.FromMilliseconds(1650),
+                Summoned_Damage,
+                summoned
+            );
         }
 
         private static void Summoned_Damage(Mobile mob)

--- a/Projects/UOContent/Spells/Necromancy/AnimateDeadSpell.cs
+++ b/Projects/UOContent/Spells/Necromancy/AnimateDeadSpell.cs
@@ -239,9 +239,7 @@ namespace Server.Spells.Necromancy
                 return;
             }
 
-            list.Remove(summoned);
-
-            if (list.Count == 0)
+            if (list.Remove(summoned) && list.Count == 0)
             {
                 _table.Remove(master);
             }
@@ -278,7 +276,9 @@ namespace Server.Spells.Necromancy
 
             if (list.Count > 3)
             {
-                Timer.StartTimer(list[0].Kill);
+                var toKill = list[0];
+                Unregister(master, toKill);
+                toKill.Kill();
             }
 
             Timer.DelayCall(

--- a/Projects/UOContent/Spells/Ninjitsu/MirrorImage.cs
+++ b/Projects/UOContent/Spells/Ninjitsu/MirrorImage.cs
@@ -161,7 +161,7 @@ namespace Server.Mobiles
             ControlOrder = OrderType.Follow;
             ControlTarget = caster;
 
-            var duration = TimeSpan.FromSeconds(30 + caster.Skills.Ninjitsu.Fixed / 40);
+            var duration = TimeSpan.FromSeconds(30.0 + caster.Skills.Ninjitsu.Value / 4.0);
 
             new UnsummonTimer(this, duration).Start();
             SummonEnd = Core.Now + duration;

--- a/Projects/UOContent/Spells/UnsummonTimer.cs
+++ b/Projects/UOContent/Spells/UnsummonTimer.cs
@@ -34,6 +34,7 @@ public class UnsummonTimer : Timer
 
     protected override void OnTick()
     {
+        // BaseCreature.OnAfterDelete will remove the creature from the timers table
         _creature?.Delete();
     }
 }

--- a/Projects/UOContent/Spells/UnsummonTimer.cs
+++ b/Projects/UOContent/Spells/UnsummonTimer.cs
@@ -1,23 +1,39 @@
 using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Server.Mobiles;
 
-namespace Server.Spells
+namespace Server.Spells;
+
+public class UnsummonTimer : Timer
 {
-    internal class UnsummonTimer : Timer
+    // Track timers since some of them are really long and might hold references to long dead/deleted mobs
+    private static readonly Dictionary<BaseCreature, UnsummonTimer> _timers = new();
+    private BaseCreature _creature;
+
+    public static void StopTimer(BaseCreature creature)
     {
-        private readonly BaseCreature m_Creature;
-
-        public UnsummonTimer(BaseCreature creature, TimeSpan delay) : base(delay)
+        if (_timers.Remove(creature, out var timer))
         {
-            m_Creature = creature;
+            timer.Stop();
+        }
+    }
+
+    public UnsummonTimer(BaseCreature creature, TimeSpan delay) : base(delay)
+    {
+        _creature = creature;
+
+        ref var timer = ref CollectionsMarshal.GetValueRefOrAddDefault(_timers, creature, out bool exists);
+        if (exists)
+        {
+            timer.Stop();
         }
 
-        protected override void OnTick()
-        {
-            if (!m_Creature.Deleted)
-            {
-                m_Creature.Delete();
-            }
-        }
+        timer = this;
+    }
+
+    protected override void OnTick()
+    {
+        _creature?.Delete();
     }
 }


### PR DESCRIPTION
## **MAJOR CHANGE**
* `Stabled` has been moved to `PlayerMobile`.
* New methods added, `PlayerMobile.AddStabled` and `PlayerMobile.RemoveStabled`.
* Added `PlayerMobile.AddFollower` and `PlayerMobile.RemoveFollower`.
* `Stabled`, `AutoStabled`, and `AllFollowers` are now `HashSet` and **_CAN BE NULL_**.

### Summary
* Fixes monster abilities causing harm to the monster through reflect
* Adds `CanTriggerAgainstSelf` to override this for healing or some other self-affecting ability
* Fixes a major memory leak where `UnsummonTimer` from animated dead spell lasts up-to 24hrs and therefore holds onto references of dead/deleted mobs.
* Fixes another minor leak where a mob is not unregistered from the animated dead spell list until the next spell cast.