### PR TITLE
fix: Fixes untamed creatures not entering houses

### DIFF
--- a/Projects/UOContent/Engines/Spawners/SpawnerEntry.cs
+++ b/Projects/UOContent/Engines/Spawners/SpawnerEntry.cs
@@ -46,11 +46,6 @@ namespace Server.Engines.Spawners
                 {
                     e.Spawner = parent;
 
-                    if (e is BaseCreature creature)
-                    {
-                        creature.RemoveIfUntamed = true;
-                    }
-
                     Spawned.Add(e);
                     parent.Spawned.TryAdd(e, this);
                 }

--- a/Projects/UOContent/Items/Weapons/Staves/ShepherdsCrook.cs
+++ b/Projects/UOContent/Items/Weapons/Staves/ShepherdsCrook.cs
@@ -81,7 +81,7 @@ namespace Server.Items
                 }
             }
 
-            private bool IsHerdable(BaseCreature bc)
+            private static bool IsHerdable(BaseCreature bc)
             {
                 if (bc.IsParagon)
                 {

--- a/Projects/UOContent/Regions/HouseRegion.cs
+++ b/Projects/UOContent/Regions/HouseRegion.cs
@@ -150,7 +150,8 @@ public class HouseRegion : BaseRegion
                 return false;
             }
 
-            if (bc?.Controlled == false && House.IsAosRules && !House.Public) // Untamed creatures cannot enter public houses
+            // Untamed creatures cannot enter private houses
+            if (House.IsAosRules && !House.Public && bc?.Controlled == false)
             {
                 return false;
             }

--- a/Projects/UOContent/Regions/HouseRegion.cs
+++ b/Projects/UOContent/Regions/HouseRegion.cs
@@ -144,18 +144,13 @@ public class HouseRegion : BaseRegion
 
         if (bc?.NoHouseRestrictions != true)
         {
-            if (bc?.Controlled == false) // Untamed creatures cannot enter public houses
-            {
-                return false;
-            }
-
             if (bc?.IsHouseSummonable == true &&
                 !(BaseCreature.Summoning || House.IsInside(oldLocation, 16)))
             {
                 return false;
             }
 
-            if (bc?.Controlled == false && House.IsAosRules && !House.Public)
+            if (bc?.Controlled == false && House.IsAosRules && !House.Public) // Untamed creatures cannot enter public houses
             {
                 return false;
             }


### PR DESCRIPTION
On Dark Factions, untamed creatures were unable to move into houses (e.g., if attacked and lured). I noticed 2 places where the Controlled flag was checked in HouseRegion.cs OnMoveInto(). They both seem to be doing the same thing except one checks if AoSRules and if it's public. I'm guessing the latter is the one wanted. This removes the first check.