### PR TITLE
fix: Fixes crashing while trying to detect old clients

### DIFF
--- a/Projects/Server/Client/ClientVersion.cs
+++ b/Projects/Server/Client/ClientVersion.cs
@@ -85,7 +85,7 @@ public class ClientVersion : IComparable<ClientVersion>, IComparer<ClientVersion
                 {
                     if (!char.IsWhiteSpace(fmt, br3))
                     {
-                        Patch = fmt[br3] - 'a' + 1;
+                        Patch = fmt[br3] - 'a';
                     }
                 }
                 else

--- a/Projects/Server/Client/UOClient.cs
+++ b/Projects/Server/Client/UOClient.cs
@@ -105,19 +105,17 @@ public static class UOClient
                 0x4E, 0x00, 0x46, 0x00, 0x4F, 0x00
             };
 
-            for (var i = 0; i < buffer.Length; i++)
+            var versionIndex = buffer.AsSpan().IndexOf(vsVersionInfo);
+            if (versionIndex > -1)
             {
-                if (vsVersionInfo.SequenceEqual(buffer.AsSpan(i, 30)))
-                {
-                    var offset = i + 42; // 30 + 12
+                var offset = versionIndex + 42; // 30 + 12
 
-                    var minorPart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset));
-                    var majorPart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset + 2));
-                    var privatePart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset + 4));
-                    var buildPart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset + 6));
+                var minorPart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset));
+                var majorPart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset + 2));
+                var privatePart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset + 4));
+                var buildPart = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset + 6));
 
-                    return new ClientVersion(majorPart, minorPart, buildPart, privatePart);
-                }
+                return new ClientVersion(majorPart, minorPart, buildPart, privatePart);
             }
         }
 


### PR DESCRIPTION
### Summary

Since we can't detect the version of a client older than v5.0.4d, we should return null. This fixes a bug where it was crashing.
Also fixes detecting the proper patch version.

Closes #1455 
Closes #1456