### PR TITLE
fix: Fixes JSON TypeConverter so that it can deserialize full name types

### DIFF
--- a/Projects/Server.Tests/Fixtures/ServerFixture.cs
+++ b/Projects/Server.Tests/Fixtures/ServerFixture.cs
@@ -1,35 +1,39 @@
 using System;
 using System.Reflection;
 
-namespace Server.Tests
+namespace Server.Tests;
+
+internal class ServerFixture : IDisposable
 {
-    internal class ServerFixture : IDisposable
+    // Global setup
+    static ServerFixture()
     {
-        // Global setup
-        static ServerFixture()
-        {
-            Core.Assembly = Assembly.GetExecutingAssembly();
-            Core.LoopContext = new EventLoopContext();
-            Core.Expansion = Expansion.EJ;
+        Core.Assembly = Assembly.GetExecutingAssembly(); // Server.Tests.dll
 
-            // Load Configurations
-            ServerConfiguration.Load(true);
+        // Load Configurations
+        ServerConfiguration.Load(true);
 
-            // Configure / Initialize
-            TestMapDefinitions.ConfigureTestMapDefinitions();
+        // Load an empty assembly list into the resolver
+        ServerConfiguration.AssemblyDirectories.Add(Core.BaseDirectory);
+        AssemblyHandler.LoadAssemblies(new[]{ "ModernUO.dll" });
 
-            // Configure the world
-            World.Configure();
+        Core.LoopContext = new EventLoopContext();
+        Core.Expansion = Expansion.EJ;
 
-            Timer.Init(0);
+        // Configure / Initialize
+        TestMapDefinitions.ConfigureTestMapDefinitions();
 
-            // Load the world
-            World.Load();
-        }
+        // Configure the world
+        World.Configure();
 
-        public void Dispose()
-        {
-            Timer.Init(0);
-        }
+        Timer.Init(0);
+
+        // Load the world
+        World.Load();
+    }
+
+    public void Dispose()
+    {
+        Timer.Init(0);
     }
 }

--- a/Projects/Server.Tests/Tests/Serialization/TypeConverterTests.cs
+++ b/Projects/Server.Tests/Tests/Serialization/TypeConverterTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Xunit;
+
+using System.Buffers;
+using Server.Json;
+using System.Text.Json;
+using System.IO;
+using Microsoft.Toolkit.HighPerformance;
+using System.Text;
+using Server.Engines.Plants;
+
+namespace Server.Tests;
+
+public class TypeConverterTests
+{
+    [Fact]
+    public void TestReadAfterWrite()
+    {
+        // Given
+        Type itemType = typeof(Item);
+        Core.Assembly = itemType.Assembly;
+        ServerConfiguration.Load(true);
+        string assemblyLocation = itemType.Assembly.Location;
+        AssemblyHandler.LoadAssemblies(new string[] { assemblyLocation });
+
+        TypeConverter converter = new TypeConverter();
+        var bufferWriter = new ArrayBufferWriter<byte>();
+        Utf8JsonWriter jsonWriter = new Utf8JsonWriter(bufferWriter);
+        converter.Write(jsonWriter, itemType, new JsonSerializerOptions());
+
+        // When
+        jsonWriter.Flush();
+        var jsonData = bufferWriter.WrittenSpan;
+        var writtenString = Encoding.UTF8.GetString(jsonData.ToArray());
+        Utf8JsonReader jsonReader = new Utf8JsonReader(jsonData);
+        jsonReader.Read();
+
+        // Then
+        Type readType = converter.Read(ref jsonReader, null, new JsonSerializerOptions());
+        Assert.Equal(typeof(Item), readType);
+    }
+}

--- a/Projects/Server/Json/Converters/TypeConverter.cs
+++ b/Projects/Server/Json/Converters/TypeConverter.cs
@@ -32,14 +32,10 @@ public class TypeConverter : JsonConverter<Type>
         }
 
         var typeName = reader.GetString();
-        var type = AssemblyHandler.FindTypeByName(typeName);
+        var type = AssemblyHandler.FindTypeByName(typeName) ?? AssemblyHandler.FindTypeByName(typeName, true);
         if (type == null)
         {
-            type = AssemblyHandler.FindTypeByName(typeName, true);
-            if (type == null)
-            {
-                logger.Warning("Attempted to deserialize type {Type} which does not exist.", typeName);
-            }
+            logger.Warning("Attempted to deserialize type {Type} which does not exist.", typeName);
         }
 
         return type;

--- a/Projects/Server/Json/Converters/TypeConverter.cs
+++ b/Projects/Server/Json/Converters/TypeConverter.cs
@@ -35,7 +35,11 @@ public class TypeConverter : JsonConverter<Type>
         var type = AssemblyHandler.FindTypeByName(typeName);
         if (type == null)
         {
-            logger.Warning("Attempted to deserialize type {Type} which does not exist.", typeName);
+            type = AssemblyHandler.FindTypeByName(typeName, true);
+            if (type == null)
+            {
+                logger.Warning("Attempted to deserialize type {Type} which does not exist.", typeName);
+            }
         }
 
         return type;

--- a/Projects/UOContent.Tests/Fixtures/ServerFixture.cs
+++ b/Projects/UOContent.Tests/Fixtures/ServerFixture.cs
@@ -18,7 +18,7 @@ namespace Server.Tests
 
             // Load UOContent.dll into the type resolver
             ServerConfiguration.AssemblyDirectories.Add(Core.BaseDirectory);
-            var assembles = new [] { "UOContent.dll" };
+            var assembles = new [] { "ModernUO.dll", "UOContent.dll" };
             AssemblyHandler.LoadAssemblies(assembles);
 
             // Load Skills


### PR DESCRIPTION
TypeConverter wasn't checking for fully qualified type names, which meant it couldn't convert type names into types that have been serialized by it.

Fixed this and added a test. Would be possible to expand this test into a full suite of conversion tests... 