### PR TITLE
fix: An empty array of tiles is not the same as no water tiles being present

### DIFF
--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -1480,6 +1480,14 @@ namespace Server.Multis
                     // if (!landTile.Ignored && top > landZ && landTop > z)
                     // return false;
 
+
+                    // This appears to be required for older game data
+                    // An empty array of tiles != non-water
+                    if (tiles?.Length == 0)
+                    {
+                        continue;
+                    }
+
                     for (var i = 0; i < tiles.Length; ++i)
                     {
                         var tile = tiles[i];


### PR DESCRIPTION
Boats were completely broken. My server and client are based on 5.0.9.1.

Tracked it down to an empty list erroneously invalidating the sea water check.