### PR TITLE
fix: Bumps PollGroup to fix arm support

### DIFF
--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -33,7 +33,7 @@
     </Target>
     <ItemGroup>
         <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
-        <PackageReference Include="PollGroup" Version="1.3.1" />
+        <PackageReference Include="PollGroup" Version="1.4.1" />
         <PackageReference Include="Standart.Hash.xxHash.Signed" Version="4.0.5" />
         <PackageReference Include="Zlib.Bindings" Version="1.11.0" />
 


### PR DESCRIPTION
### Summary

Fixes an issue with linux arm support where the epoll struct is not supposed to be packed.