### PR TITLE
fix: Optimizes FindItemsByType by removing allocations.

### DIFF
--- a/Projects/Server.Tests/Tests/Items/ContainerTests.cs
+++ b/Projects/Server.Tests/Tests/Items/ContainerTests.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using Server.Items;
+using Xunit;
+
+namespace Server.Tests;
+
+public class ContainerTests : IClassFixture<ServerFixture>
+{
+    [Fact]
+    public void TestFindItemsByType()
+    {
+        var staticSerial = (Serial)0x3;
+
+        var container = new Container((Serial)0x1);
+        container.AddItem(new Item((Serial)0x2));
+        container.AddItem(new Static(staticSerial));
+
+        Static staticItem = null;
+        foreach (var item in container.FindItemsByType<Static>())
+        {
+            staticItem = item;
+        }
+
+        Assert.NotNull(staticItem);
+        Assert.Equal(staticSerial, staticItem.Serial);
+    }
+
+    [Fact]
+    public void TestFindItemsByTypeNested()
+    {
+        var static1 = new Static((Serial)0x3);
+        var static2 = new Static((Serial)0x6);
+
+        var container = new Container((Serial)0x1);
+        container.AddItem(new Item((Serial)0x2));
+        var container2 = new Container((Serial)0x4);
+        container.AddItem(container2);
+
+        var container3 = new Container((Serial)0x5);
+        container2.AddItem(container3);
+        container3.AddItem(static2);
+
+        container2.AddItem(static1);
+
+        List<Static> statics = new List<Static>();
+        foreach (var item in container.FindItemsByType<Static>())
+        {
+            statics.Add(item);
+        }
+
+        Assert.Equal(2, statics.Count);
+        Assert.Equal(static1, statics[0]);
+        Assert.Equal(static2, statics[1]);
+    }
+
+    [Fact]
+    public void TestFindItemsByTypeNotMatching()
+    {
+        var container = new Container((Serial)0x1);
+        container.AddItem(new Item((Serial)0x2));
+        var container2 = new Container((Serial)0x4);
+        container.AddItem(container2);
+        container2.AddItem(new Item((Serial)0x5));
+
+        Static staticItem = null;
+        foreach (var item in container.FindItemsByType<Static>())
+        {
+            staticItem = item;
+        }
+
+        Assert.Null(staticItem);
+    }
+}

--- a/Projects/Server/Items/Container.Enumerable.cs
+++ b/Projects/Server/Items/Container.Enumerable.cs
@@ -36,7 +36,7 @@ public partial class Container
     /// <example>
     /// <code>
     ///     var total = 0;
-    ///     foreach (var gold in cont.FindItemsByType<Gold>())
+    ///     foreach (var gold in cont.FindItemsByType&lt;Gold&gt;())
     ///     {
     ///         total += gold.Amount;
     ///     }
@@ -74,7 +74,7 @@ public partial class Container
     /// </remarks>
     /// <example>
     /// <code>
-    ///     foreach (var item in cont.EnumerateItemsByType<Item>())
+    ///     foreach (var item in cont.EnumerateItemsByType&lt;Item&gt;())
     ///     {
     ///         if (item.LootType is not LootType.Blessed)
     ///         {

--- a/Projects/Server/Items/Container.Enumerable.cs
+++ b/Projects/Server/Items/Container.Enumerable.cs
@@ -1,0 +1,243 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2023 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: Container.Enumerable.cs                                         *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Server.Collections;
+
+namespace Server.Items;
+
+public partial class Container
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public FindItemsByTypeEnumerator<Item> FindItemsByType(bool recurse = true, Predicate<Item> predicate = null)
+        => FindItemsByType<Item>(recurse, predicate);
+
+    /// <summary>
+    ///     Performs a breadth-first search through all the <see cref="Item" />s and
+    ///     nested <see cref="Container" />s within this <see cref="Container" />.
+    /// </summary>
+    /// <remarks>
+    ///     DO NOT consume, delete, or move items while iterating
+    /// </remarks>
+    /// <example>
+    /// <code>
+    ///     var total = 0;
+    ///     foreach (var gold in cont.FindItemsByType<Gold>())
+    ///     {
+    ///         total += gold.Amount;
+    ///     }
+    /// </code>
+    /// </example>
+    /// <typeparam name="T">Type of objects being searched for</typeparam>
+    /// <param name="recurse">
+    ///     Optional: If true, the search will recursively
+    ///     check any nested <see cref="Container" />s; otherwise, nested
+    ///     <see cref="Container" />s will not be searched.
+    /// </param>
+    /// <param name="predicate">
+    ///     Optional: A predicate to check if the <see cref="Item" />
+    ///     of type <typeparamref name="T" /> is one of the targets of the search.
+    /// </param>
+    /// <returns>
+    ///     An enumerator for iterating through <see cref="Item" />s of type <typeparamref name="T" /> that match the optional
+    ///     <paramref name="predicate" />.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public FindItemsByTypeEnumerator<T> FindItemsByType<T>(bool recurse = true, Predicate<T> predicate = null)
+        where T : Item => new(this, recurse, predicate);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public QueuedItemsEnumerator<Item> EnumerateItemsByType(bool recurse = true, Predicate<Item> predicate = null)
+        => EnumerateItemsByType<Item>(recurse, predicate);
+
+    /// <summary>
+    ///     Safely enumerates items using a breadth-first search through all the <see cref="Item" />s and
+    ///     nested <see cref="Container" />s within this <see cref="Container" />.
+    /// </summary>
+    /// <remarks>
+    ///    Use EnumerateItemsByType for situations where the item might be manipulated, consumed, or moved.
+    ///    Note: This method scans through the container before returning the enumerator for iteration.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    ///     foreach (var item in cont.EnumerateItemsByType<Item>())
+    ///     {
+    ///         if (item.LootType is not LootType.Blessed)
+    ///         {
+    ///             item.Delete();
+    ///         }
+    ///     }
+    /// </code>
+    /// </example>
+    /// <typeparam name="T">Type of objects being searched for</typeparam>
+    /// <param name="recurse">
+    ///     Optional: If true, the search will recursively
+    ///     check any nested <see cref="Container" />s; otherwise, nested
+    ///     <see cref="Container" />s will not be searched.
+    /// </param>
+    /// <param name="predicate">
+    ///     Optional: A predicate to check if the <see cref="Item" />
+    ///     of type <typeparamref name="T" /> is one of the targets of the search.
+    /// </param>
+    /// <returns>
+    ///     An enumerator for iterating through <see cref="Item" />s of type <typeparamref name="T" /> that match the optional
+    ///     <paramref name="predicate" />.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public QueuedItemsEnumerator<T> EnumerateItemsByType<T>(bool recurse = true, Predicate<T> predicate = null)
+        where T : Item => new(QueueItemsByType(recurse, predicate));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public PooledRefQueue<Item> QueueItemsByType(bool recurse = true, Predicate<Item> predicate = null) =>
+        QueueItemsByType<Item>(recurse, predicate);
+
+    public PooledRefQueue<T> QueueItemsByType<T>(bool recurse = true, Predicate<T> predicate = null) where T : Item
+    {
+        var queue = PooledRefQueue<T>.Create();
+        foreach (var item in FindItemsByType(recurse, predicate))
+        {
+            queue.Enqueue(item);
+        }
+
+        return queue;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public PooledRefList<Item> ListItemsByType(bool recurse = true, Predicate<Item> predicate = null) =>
+        ListItemsByType<Item>(recurse, predicate);
+
+    public PooledRefList<T> ListItemsByType<T>(bool recurse = true, Predicate<T> predicate = null) where T : Item
+    {
+        var list = PooledRefList<T>.Create();
+        foreach (var item in FindItemsByType(recurse, predicate))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+    public ref struct FindItemsByTypeEnumerator<T> where T : Item
+    {
+        private PooledRefQueue<Container> _containers;
+        private Span<Item> _items;
+        private int _index;
+        private T _current;
+        private bool _recurse;
+        private Predicate<T> _predicate;
+
+        public FindItemsByTypeEnumerator(Container container, bool recurse, Predicate<T> predicate)
+        {
+            _containers = PooledRefQueue<Container>.Create();
+
+            if (container?.m_Items != null)
+            {
+                _items = CollectionsMarshal.AsSpan(container.m_Items);
+            }
+
+            _current = default;
+            _index = 0;
+            _recurse = recurse;
+            _predicate = predicate;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext() => SetNextItem() || _recurse && SetNextContainer();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool SetNextContainer()
+        {
+            if (!_containers.TryDequeue(out var c))
+            {
+                return false;
+            }
+
+            _items = CollectionsMarshal.AsSpan(c.m_Items);
+            _index = 0;
+            return SetNextItem();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool SetNextItem()
+        {
+            while (_index < _items.Length)
+            {
+                Item item = _items[_index++];
+                if (_recurse && item is Container { m_Items.Count: > 0 } c)
+                {
+                    _containers.Enqueue(c);
+                }
+
+                if (item is T t && _predicate?.Invoke(t) != false)
+                {
+                    _current = t;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public T Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _current;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() => _containers.Dispose();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public FindItemsByTypeEnumerator<T> GetEnumerator() => this;
+    }
+
+    public ref struct QueuedItemsEnumerator<T> where T : Item
+    {
+        private PooledRefQueue<T> _queue;
+        private T _current;
+
+        public QueuedItemsEnumerator(PooledRefQueue<T> queue)
+        {
+            _queue = queue;
+            _current = default;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            if (_queue.TryDequeue(out var item))
+            {
+                _current = item;
+                return true;
+            }
+
+            return false;
+        }
+
+        public T Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _current;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() => _queue.Dispose();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public QueuedItemsEnumerator<T> GetEnumerator() => this;
+    }
+}

--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -1565,7 +1565,7 @@ public partial class Container : Item
     public int GetAmount(Type type, bool recurse = true)
     {
         var total = 0;
-        foreach (var item in FindItemsByType<Item>(recurse))
+        foreach (var item in FindItemsByType(recurse))
         {
             if (type.IsInstanceOfType(item))
             {
@@ -1579,7 +1579,7 @@ public partial class Container : Item
     public int GetAmount(Type[] types, bool recurse = true)
     {
         var total = 0;
-        foreach (var item in FindItemsByType<Item>(recurse))
+        foreach (var item in FindItemsByType(recurse))
         {
             if (InTypeList(item, types))
             {
@@ -1593,11 +1593,11 @@ public partial class Container : Item
     public List<Item> FindItemsByType(Type type, bool recurse = true)
     {
         var items = new List<Item>();
-        foreach (var i in FindItemsByType<Item>(recurse))
+        foreach (var item in FindItemsByType(recurse))
         {
-            if (type.IsInstanceOfType(i))
+            if (type.IsInstanceOfType(item))
             {
-                items.Add(i);
+                items.Add(item);
             }
         }
 
@@ -1606,23 +1606,12 @@ public partial class Container : Item
 
     public List<Item> FindItemsByType(Type[] types, bool recurse = true)
     {
-        using var queue = PooledRefQueue<Container>.Create(128);
-        queue.Enqueue(this);
         var items = new List<Item>();
-        while (queue.Count > 0)
+        foreach (var item in FindItemsByType(recurse))
         {
-            var container = queue.Dequeue();
-            foreach (var item in container.Items)
+            if (InTypeList(item, types))
             {
-                if (InTypeList(item, types))
-                {
-                    items.Add(item);
-                }
-
-                if (recurse && item is Container itemContainer)
-                {
-                    queue.Enqueue(itemContainer);
-                }
+                items.Add(item);
             }
         }
 
@@ -1631,22 +1620,11 @@ public partial class Container : Item
 
     public Item FindItemByType(Type type, bool recurse = true)
     {
-        using var queue = PooledRefQueue<Container>.Create(128);
-        queue.Enqueue(this);
-        while (queue.Count > 0)
+        foreach (var item in FindItemsByType(recurse))
         {
-            var container = queue.Dequeue();
-            foreach (var item in container.Items)
+            if (type.IsInstanceOfType(item))
             {
-                if (type.IsInstanceOfType(item))
-                {
-                    return item;
-                }
-
-                if (recurse && item is Container itemContainer)
-                {
-                    queue.Enqueue(itemContainer);
-                }
+                return item;
             }
         }
 
@@ -1655,22 +1633,11 @@ public partial class Container : Item
 
     public Item FindItemByType(Type[] types, bool recurse = true)
     {
-        using var queue = PooledRefQueue<Container>.Create(128);
-        queue.Enqueue(this);
-        while (queue.Count > 0)
+        foreach (var item in FindItemsByType(recurse))
         {
-            var container = queue.Dequeue();
-            foreach (var item in container.Items)
+            if (InTypeList(item, types))
             {
-                if (InTypeList(item, types))
-                {
-                    return item;
-                }
-
-                if (recurse && item is Container itemContainer)
-                {
-                    queue.Enqueue(itemContainer);
-                }
+                return item;
             }
         }
 
@@ -1697,23 +1664,9 @@ public partial class Container : Item
     /// </returns>
     public T FindItemByType<T>(bool recurse = true, Predicate<T> predicate = null) where T : Item
     {
-        using var queue = PooledRefQueue<Container>.Create(128);
-        queue.Enqueue(this);
-        while (queue.Count > 0)
+        foreach (var item in FindItemsByType(recurse, predicate))
         {
-            var container = queue.Dequeue();
-            foreach (var item in container.Items)
-            {
-                if (item is T typedItem && predicate?.Invoke(typedItem) != false)
-                {
-                    return typedItem;
-                }
-
-                if (recurse && item is Container itemContainer)
-                {
-                    queue.Enqueue(itemContainer);
-                }
-            }
+            return item;
         }
 
         return null;

--- a/Projects/Server/Mobiles/IMount.cs
+++ b/Projects/Server/Mobiles/IMount.cs
@@ -13,8 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System;
-
 namespace Server.Mobiles;
 
 public interface IMount : IHasSteps

--- a/Projects/UOContent/Commands/Generic/Implementors/ContainedCommandImplementor.cs
+++ b/Projects/UOContent/Commands/Generic/Implementors/ContainedCommandImplementor.cs
@@ -67,7 +67,7 @@ namespace Server.Commands.Generic
 
                 var list = new List<object>();
 
-                foreach (var item in cont.FindItemsByType<Item>())
+                foreach (var item in cont.FindItemsByType())
                 {
                     if (ext.IsValid(item))
                     {

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -1737,23 +1737,20 @@ namespace Server.Engines.ConPVP
 
             var hadBomb = false;
 
-            corpse.FindItemsByType<BRBomb>(false)
-                .ForEach(
-                    bomb =>
-                    {
-                        hadBomb = true;
-                        bomb.DropTo(mob, killer);
-                    }
-                );
+            foreach (var bomb in corpse.EnumerateItemsByType<BRBomb>(false))
+            {
+                hadBomb = true;
+                bomb.DropTo(mob, killer);
+            }
 
-            mob.Backpack?.FindItemsByType<BRBomb>(false)
-                .ForEach(
-                    bomb =>
-                    {
-                        hadBomb = true;
-                        bomb.DropTo(mob, killer);
-                    }
-                );
+            if (mob.Backpack != null)
+            {
+                foreach (var bomb in mob.Backpack.EnumerateItemsByType<BRBomb>(false))
+                {
+                    hadBomb = true;
+                    bomb.DropTo(mob, killer);
+                }
+            }
 
             if (killer?.Player == true)
             {

--- a/Projects/UOContent/Engines/ConPVP/Games/CTF.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/CTF.cs
@@ -1018,23 +1018,20 @@ namespace Server.Engines.ConPVP
 
             var hadFlag = false;
 
-            corpse.FindItemsByType<CTFFlag>(false)
-                .ForEach(
-                    flag =>
-                    {
-                        hadFlag = true;
-                        flag.DropTo(mob, killer);
-                    }
-                );
+            foreach (var flag in corpse.EnumerateItemsByType<CTFFlag>(false))
+            {
+                hadFlag = true;
+                flag.DropTo(mob, killer);
+            }
 
-            mob.Backpack?.FindItemsByType<CTFFlag>(false)
-                .ForEach(
-                    flag =>
-                    {
-                        hadFlag = true;
-                        flag.DropTo(mob, killer);
-                    }
-                );
+            if (mob.Backpack != null)
+            {
+                foreach (var flag in mob.Backpack.EnumerateItemsByType<CTFFlag>(false))
+                {
+                    hadFlag = true;
+                    flag.DropTo(mob, killer);
+                }
+            }
 
             if (killer?.Player == true)
             {

--- a/Projects/UOContent/Engines/Craft/Core/CraftGump.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftGump.cs
@@ -141,11 +141,12 @@ namespace Server.Engines.Craft
 
                 if (from.Backpack != null)
                 {
-                    var items = from.Backpack.FindItemsByType(resourceType);
-
-                    for (var i = 0; i < items.Count; ++i)
+                    foreach (var item in from.Backpack.FindItemsByType())
                     {
-                        resourceCount += items[i].Amount;
+                        if (resourceType.IsInstanceOfType(item))
+                        {
+                            resourceCount += item.Amount;
+                        }
                     }
                 }
 
@@ -185,11 +186,12 @@ namespace Server.Engines.Craft
 
                 if (from.Backpack != null)
                 {
-                    var items = from.Backpack.FindItemsByType(resourceType);
-
-                    for (var i = 0; i < items.Count; ++i)
+                    foreach (var item in from.Backpack.FindItemsByType())
                     {
-                        resourceCount += items[i].Amount;
+                        if (resourceType.IsInstanceOfType(item))
+                        {
+                            resourceCount += item.Amount;
+                        }
                     }
                 }
 
@@ -263,11 +265,13 @@ namespace Server.Engines.Craft
 
                 if (from.Backpack != null)
                 {
-                    var items = from.Backpack.FindItemsByType(subResource.ItemType);
-
-                    for (var j = 0; j < items.Count; ++j)
+                    var type = subResource.ItemType;
+                    foreach (var item in from.Backpack.FindItemsByType())
                     {
-                        resourceCount += items[j].Amount;
+                        if (type.IsInstanceOfType(item))
+                        {
+                            resourceCount += item.Amount;
+                        }
                     }
                 }
 

--- a/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
@@ -685,7 +685,14 @@ namespace Server.Engines.Craft
             if (NameNumber == 1041267)
             {
                 // Runebooks are a special case, they need a blank recall rune
-                consumeExtra = ourPack.FindItemsByType<RecallRune>().Find(rune => !rune.Marked);
+                foreach (var rune in ourPack.FindItemsByType<RecallRune>())
+                {
+                    if (!rune.Marked)
+                    {
+                        consumeExtra = rune;
+                        break;
+                    }
+                }
 
                 if (consumeExtra == null)
                 {

--- a/Projects/UOContent/Engines/Factions/Core/Faction.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Faction.cs
@@ -385,7 +385,14 @@ namespace Server.Factions
 
             // Ordinarily, through normal faction removal, this will never find any sigils.
             // Only with a leave delay less than the ReturnPeriod or a Faction Kick/Ban, will this ever do anything
-            mob.Backpack?.FindItemsByType<Sigil>().ForEach(sigil => sigil.ReturnHome());
+
+            if (mob.Backpack != null)
+            {
+                foreach (var sigil in mob.Backpack.EnumerateItemsByType<Sigil>())
+                {
+                    sigil.ReturnHome();
+                }
+            }
 
             if (pl.RankIndex != -1)
             {
@@ -1039,35 +1046,36 @@ namespace Server.Factions
 
             var killerState = PlayerState.Find(killer);
             var killerPack = killer?.Backpack;
-            victim.Backpack?.FindItemsByType<Sigil>()
-                .ForEach(
-                    sigil =>
-                    {
-                        if (killerState == null || killerPack == null)
-                        {
-                            sigil.ReturnHome();
-                            return;
-                        }
 
-                        if (killer?.GetDistanceToSqrt(victim) > 64)
-                        {
-                            sigil.ReturnHome();
-                            killer.SendLocalizedMessage(1042230); // The sigil has gone back to its home location.
-                        }
-                        else if (Sigil.ExistsOn(killer))
-                        {
-                            sigil.ReturnHome();
-                            // The sigil has gone back to its home location because you already have a sigil.
-                            killer?.SendLocalizedMessage(1010258);
-                        }
-                        else if (!killerPack.TryDropItem(killer, sigil, false))
-                        {
-                            sigil.ReturnHome();
-                            // The sigil has gone home because your backpack is full.
-                            killer?.SendLocalizedMessage(1010259);
-                        }
+            if (victim.Backpack != null)
+            {
+                foreach (var sigil in victim.Backpack.EnumerateItemsByType<Sigil>())
+                {
+                    if (killerState == null || killerPack == null)
+                    {
+                        sigil.ReturnHome();
+                        continue;
                     }
-                );
+
+                    if (killer?.GetDistanceToSqrt(victim) > 64)
+                    {
+                        sigil.ReturnHome();
+                        killer.SendLocalizedMessage(1042230); // The sigil has gone back to its home location.
+                    }
+                    else if (Sigil.ExistsOn(killer))
+                    {
+                        sigil.ReturnHome();
+                        // The sigil has gone back to its home location because you already have a sigil.
+                        killer?.SendLocalizedMessage(1010258);
+                    }
+                    else if (!killerPack.TryDropItem(killer, sigil, false))
+                    {
+                        sigil.ReturnHome();
+                        // The sigil has gone home because your backpack is full.
+                        killer?.SendLocalizedMessage(1010259);
+                    }
+                }
+            }
 
             if (killerState == null)
             {
@@ -1227,7 +1235,13 @@ namespace Server.Factions
 
         private static void EventSink_Logout(Mobile m)
         {
-            m.Backpack?.FindItemsByType<Sigil>().ForEach(sigil => sigil.ReturnHome());
+            if (m.Backpack != null)
+            {
+                foreach (var sigil in m.Backpack.EnumerateItemsByType<Sigil>())
+                {
+                    sigil.ReturnHome();
+                }
+            }
         }
 
         private static void EventSink_Login(Mobile m) => CheckLeaveTimer(m);

--- a/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
@@ -1,5 +1,4 @@
 using System;
-using ModernUO.Serialization;
 using Server.Factions.AI;
 using Server.Items;
 using Server.Mobiles;

--- a/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Server.Gumps;
 
 namespace Server.Engines.MLQuests.Objectives
@@ -110,8 +109,16 @@ namespace Server.Engines.MLQuests.Objectives
                 return 0;
             }
 
-            var items = pack.FindItemsByType(Objective.AcceptedType, false); // Note: subclasses are included
-            return items.Where(item => item.QuestItem && Objective.CheckItem(item)).Sum(item => item.Amount);
+            var total = 0;
+            foreach (var item in pack.FindItemsByType(false))
+            {
+                if (ClaimTypePredicate(item) && item.QuestItem && Objective.CheckItem(item))
+                {
+                    total += item.Amount;
+                }
+            }
+
+            return total;
         }
 
         public override bool AllowsQuestItem(Item item, Type type) => Objective.CheckType(type) && Objective.CheckItem(item);
@@ -128,18 +135,19 @@ namespace Server.Engines.MLQuests.Objectives
                 return;
             }
 
-            var checkType = Objective.AcceptedType;
-            var items = pack.FindItemsByType(checkType, false);
-
-            foreach (var item in items)
+            foreach (var item in pack.FindItemsByType(false))
             {
-                if (item.QuestItem && !MLQuestSystem.CanMarkQuestItem(pm, item, checkType)
-                ) // does another quest still need this item? (OSI just unmarks everything)
+                // does another quest still need this item? (OSI just unmarks everything)
+                if (ClaimTypePredicate(item) &&
+                    item.QuestItem && !MLQuestSystem.CanMarkQuestItem(pm, item, Objective.AcceptedType))
                 {
                     item.QuestItem = false;
                 }
             }
         }
+
+        // Note: subclasses are included
+        private bool ClaimTypePredicate(Item item) => Objective.AcceptedType.IsInstanceOfType(item);
 
         // Should only be called after IsComplete() is checked to be true
         public override void OnClaimReward()
@@ -153,10 +161,9 @@ namespace Server.Engines.MLQuests.Objectives
 
             // TODO: OSI also counts the item in the cursor?
 
-            var items = pack.FindItemsByType(Objective.AcceptedType, false);
             var left = Objective.DesiredAmount;
 
-            foreach (var item in items)
+            foreach (var item in pack.EnumerateItemsByType<Item>(false, ClaimTypePredicate))
             {
                 if (item.QuestItem && Objective.CheckItem(item))
                 {

--- a/Projects/UOContent/Engines/ML Quests/Objectives/DeliverObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/DeliverObjective.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Server.Gumps;
 using Server.Items;
 using Server.Logging;
@@ -150,8 +149,16 @@ namespace Server.Engines.MLQuests.Objectives
                 return 0;
             }
 
-            var items = pack.FindItemsByType(Objective.Delivery, false); // Note: subclasses are included
-            return items.Sum(item => item.Amount);
+            var total = 0;
+            foreach (var item in pack.FindItemsByType(false))
+            {
+                if (ClaimTypePredicate(item))
+                {
+                    total += item.Amount;
+                }
+            }
+
+            return total;
         }
 
         public override bool OnBeforeClaimReward()
@@ -171,6 +178,9 @@ namespace Server.Engines.MLQuests.Objectives
             return true;
         }
 
+        // Note: subclasses are included
+        private bool ClaimTypePredicate(Item item) => Objective.Delivery.IsInstanceOfType(item);
+
         // TODO: This is VERY similar to CollectObjective.OnClaimReward
         public override void OnClaimReward()
         {
@@ -181,10 +191,9 @@ namespace Server.Engines.MLQuests.Objectives
                 return;
             }
 
-            var items = pack.FindItemsByType(Objective.Delivery, false);
             var left = Objective.Amount;
 
-            foreach (var item in items)
+            foreach (var item in pack.EnumerateItemsByType<Item>(false, ClaimTypePredicate))
             {
                 if (left == 0)
                 {

--- a/Projects/UOContent/Engines/Plants/MainPlantGump.cs
+++ b/Projects/UOContent/Engines/Plants/MainPlantGump.cs
@@ -327,11 +327,16 @@ namespace Server.Engines.Plants
                     }
                 case 6: // Water
                     {
-                        var bev = from.Backpack.FindItemsByType<BaseBeverage>()
-                            .Find(
-                                beverage =>
-                                    beverage.IsEmpty && beverage.Pourable && beverage.Content == BeverageType.Water
-                            );
+                        BaseBeverage bev = null;
+
+                        foreach (var beverage in from.Backpack.FindItemsByType<BaseBeverage>())
+                        {
+                            if (beverage.IsEmpty && beverage.Pourable && beverage.Content == BeverageType.Water)
+                            {
+                                bev = beverage;
+                                break;
+                            }
+                        }
 
                         if (bev == null)
                         {

--- a/Projects/UOContent/Engines/Plants/PlantSystem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using ModernUO.Serialization;
+using Server.Items;
 using Server.Misc;
 
 namespace Server.Engines.Plants
@@ -402,28 +403,29 @@ namespace Server.Engines.Plants
 
         private static void EventSink_Login(Mobile from)
         {
-            from.Backpack?.FindItemsByType<PlantItem>()
-                .ForEach(
-                    plant =>
+            Container cont = from.Backpack;
+            if (cont != null)
+            {
+                foreach (var plant in cont.FindItemsByType<PlantItem>())
+                {
+                    if (plant.IsGrowable)
                     {
-                        if (plant.IsGrowable)
-                        {
-                            plant.PlantSystem.DoGrowthCheck();
-                        }
+                        plant.PlantSystem.DoGrowthCheck();
                     }
-                );
+                }
+            }
 
-            from.FindBankNoCreate()
-                ?.FindItemsByType<PlantItem>()
-                .ForEach(
-                    plant =>
+            cont = from.FindBankNoCreate();
+            if (cont != null)
+            {
+                foreach (var plant in cont.FindItemsByType<PlantItem>())
+                {
+                    if (plant.IsGrowable)
                     {
-                        if (plant.IsGrowable)
-                        {
-                            plant.PlantSystem.DoGrowthCheck();
-                        }
+                        plant.PlantSystem.DoGrowthCheck();
                     }
-                );
+                }
+            }
         }
 
         public static void GrowAll()

--- a/Projects/UOContent/Items/Aquarium/Aquarium.cs
+++ b/Projects/UOContent/Items/Aquarium/Aquarium.cs
@@ -921,7 +921,20 @@ namespace Server.Items
 
         public static FishBowl GetEmptyBowl(Mobile from)
         {
-            return from?.Backpack?.FindItemsByType<FishBowl>().Find(bowl => bowl.Empty);
+            if (from.Backpack == null)
+            {
+                return null;
+            }
+
+            foreach (var bowl in from.Backpack.FindItemsByType<FishBowl>())
+            {
+                if (bowl.Empty)
+                {
+                    return bowl;
+                }
+            }
+
+            return null;
         }
 
         public static bool Accepts(Item item)

--- a/Projects/UOContent/Items/Containers/SalvageBag.cs
+++ b/Projects/UOContent/Items/Containers/SalvageBag.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using ModernUO.Serialization;
 using Server.ContextMenus;
 using Server.Engines.Craft;
@@ -173,7 +172,20 @@ public partial class SalvageBag : Bag
 
     private void SalvageIngots(Mobile from)
     {
-        if (from.Backpack.FindItemsByType<BaseTool>().All(tool => tool.CraftSystem != DefBlacksmithy.CraftSystem))
+        var hasTool = false;
+        if (from.Backpack != null)
+        {
+            foreach (var tool in from.Backpack.FindItemsByType<BaseTool>())
+            {
+                if (tool.CraftSystem == DefBlacksmithy.CraftSystem)
+                {
+                    hasTool = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasTool)
         {
             from.SendLocalizedMessage(1079822); // You need a blacksmithing tool in order to salvage ingots.
             return;
@@ -190,11 +202,7 @@ public partial class SalvageBag : Bag
         var salvaged = 0;
         var notSalvaged = 0;
 
-        Container sBag = this;
-
-        var smeltables = sBag.FindItemsByType<Item>();
-
-        foreach (var item in smeltables)
+        foreach (var item in FindItemsByType())
         {
             if (item?.Deleted != false)
             {
@@ -220,10 +228,8 @@ public partial class SalvageBag : Bag
         }
         else
         {
-            from.SendLocalizedMessage(
-                1079973,
-                $"{salvaged}\t{salvaged + notSalvaged}"
-            ); // Salvaged: ~1_COUNT~/~2_NUM~ blacksmithed items
+            // Salvaged: ~1_COUNT~/~2_NUM~ blacksmithed items
+            from.SendLocalizedMessage(1079973, $"{salvaged}\t{salvaged + notSalvaged}");
         }
     }
 
@@ -245,14 +251,8 @@ public partial class SalvageBag : Bag
         var salvaged = 0;
         var notSalvaged = 0;
 
-        Container sBag = this;
-
-        var scissorables = sBag.FindItemsByType<Item>();
-
-        for (var i = scissorables.Count - 1; i >= 0; --i)
+        foreach (var item in EnumerateItemsByType<Item>())
         {
-            var item = scissorables[i];
-
             if (item is not IScissorable scissorable)
             {
                 continue;

--- a/Projects/UOContent/Items/Skill Items/Magical/Potions/BasePotion.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Potions/BasePotion.cs
@@ -83,12 +83,8 @@ public abstract partial class BasePotion : Item, ICraftable, ICommodity
                     return 1;
                 }
 
-                var kegs = pack.FindItemsByType<PotionKeg>();
-
-                for (var i = 0; i < kegs.Count; ++i)
+                foreach (var keg in pack.EnumerateItemsByType<PotionKeg>())
                 {
-                    var keg = kegs[i];
-
                     if (keg.Held is <= 0 or >= 100)
                     {
                         continue;

--- a/Projects/UOContent/Mobiles/Townfolk/Banker.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/Banker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Server.Accounting;
 using Server.ContextMenus;
 using Server.Items;
@@ -47,24 +46,24 @@ namespace Server.Mobiles
 
             if (bank != null)
             {
-                var gold = bank.FindItemsByType<Gold>();
-                var checks = bank.FindItemsByType<BankCheck>();
-
-                balance += gold.Aggregate(0L, (c, t) => c + t.Amount);
-                if (balance >= int.MaxValue)
+                foreach (var gold in bank.FindItemsByType<Gold>())
                 {
-                    return int.MaxValue;
+                    balance += gold.Amount;
                 }
 
-                balance += checks.Aggregate(0L, (c, t) => c + t.Worth);
+                foreach (var check in bank.FindItemsByType<BankCheck>())
+                {
+                    balance += check.Worth;
+                }
             }
 
-            return Math.Max(0, (int)Math.Min(int.MaxValue, balance));
+            return (int)Math.Clamp(balance, 0, int.MaxValue);
         }
 
         public static int GetBalance(Mobile m, out List<Item> gold, out List<Item> checks)
         {
             long balance = 0;
+            gold = checks = new List<Item>();
 
             if (AccountGold.Enabled && m.Account != null)
             {
@@ -72,7 +71,6 @@ namespace Server.Mobiles
 
                 if (balance > int.MaxValue)
                 {
-                    gold = checks = new List<Item>();
                     return int.MaxValue;
                 }
             }
@@ -81,23 +79,25 @@ namespace Server.Mobiles
 
             if (bank != null)
             {
-                gold = bank.FindItemsByType(typeof(Gold));
-                checks = bank.FindItemsByType(typeof(BankCheck));
+                foreach (var g in bank.FindItemsByType<Gold>())
+                {
+                    balance += g.Amount;
+                    gold.Add(g);
+                }
 
-                balance += gold.OfType<Gold>().Aggregate(0L, (c, t) => c + t.Amount);
-                if (balance >= int.MaxValue)
+                if (balance > int.MaxValue)
                 {
                     return int.MaxValue;
                 }
 
-                balance += checks.OfType<BankCheck>().Aggregate(0L, (c, t) => c + t.Worth);
-            }
-            else
-            {
-                gold = checks = new List<Item>();
+                foreach (var bc in bank.FindItemsByType<BankCheck>())
+                {
+                    balance += bc.Worth;
+                    checks.Add(bc);
+                }
             }
 
-            return Math.Max(0, (int)Math.Min(int.MaxValue, balance));
+            return (int)Math.Clamp(balance, 0, int.MaxValue);
         }
 
         public static bool Withdraw(Mobile from, int amount)

--- a/Projects/UOContent/Mobiles/Townfolk/Banker.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/Banker.cs
@@ -51,6 +51,11 @@ namespace Server.Mobiles
                     balance += gold.Amount;
                 }
 
+                if (balance >= int.MaxValue)
+                {
+                    return int.MaxValue;
+                }
+
                 foreach (var check in bank.FindItemsByType<BankCheck>())
                 {
                     balance += check.Worth;
@@ -69,7 +74,7 @@ namespace Server.Mobiles
             {
                 balance = m.Account.GetTotalGold();
 
-                if (balance > int.MaxValue)
+                if (balance >= int.MaxValue)
                 {
                     return int.MaxValue;
                 }
@@ -85,7 +90,7 @@ namespace Server.Mobiles
                     gold.Add(g);
                 }
 
-                if (balance > int.MaxValue)
+                if (balance >= int.MaxValue)
                 {
                     return int.MaxValue;
                 }

--- a/Projects/UOContent/Spells/Seventh/GateTravel.cs
+++ b/Projects/UOContent/Spells/Seventh/GateTravel.cs
@@ -4,7 +4,6 @@ using Server.Factions;
 using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
-using Server.Multis;
 
 namespace Server.Spells.Seventh
 {


### PR DESCRIPTION
### Summary
Container enumeration is in dire need of optimization. Thanks to @stefanomerotta for initiating this work with PR #1443. This PR handles a small part of what Stefan started. Also included are some bug fixes.

### Method Signatures

```cs
// Use with foreach without moving/deleting items
FindItemsByTypeEnumerator<T> FindItemsByType<T>(bool recurse = true, Predicate<T> predicate = null)

// Use with foreach when moving/deleting items
QueuedItemsEnumerator<T> EnumerateItemsByType<T>(bool recurse = true, Predicate<T> predicate = null)

// Use when iterating multiple times or queuing
PooledRefQueue<T> QueueItemsByType<T>(bool recurse = true, Predicate<T> predicate = null)

// Use when iterating multiples times or manipulating elements without traversing
PooledRefList<T> ListItemsByType<T>(bool recurse = true, Predicate<T> predicate = null)
```

* `FindItemsByType<T>` has changed from returning `List<T>` to `FindItemsByTypeEnumerator<T>` - This method is not safe to use in situations where an item may get consumed, deleted, or moved.

* `EnumerateItemsByType<T>` was added as a safe way to iterate and manipulate items.
  * **Note**: EnumerateItemsByType will _completely traverse the container_ before iteration starts because it uses `QueueItemsByType` under the hood.

* `QueueItemsByType<T>`  and `ListItemsByType<T>` was added to return a queue or list of items to iterate multiple times and manipulate the items. This isn't the most efficient since it uses a predicate and can result in 2 or 3 total iterations unnecessarily.

### Bug Fixes
- [X] Fishing had an error in the random check that may have caused slight bias.