### PR TITLE
fix: Adds generic entity persistence support and BOBEntry as entities

### DIFF
--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -50,9 +50,6 @@ public abstract class BaseGuild : ISerializable
     [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public DateTime Created { get; set; } = Core.Now;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    DateTime ISerializable.LastSerialized { get; set; } = Core.Now;
-
     long ISerializable.SavePosition { get; set; } = -1;
 
     BufferWriter ISerializable.SaveBuffer { get; set; }

--- a/Projects/Server/IEntity.cs
+++ b/Projects/Server/IEntity.cs
@@ -45,8 +45,6 @@ public class Entity : IEntity
 
     DateTime ISerializable.Created { get; set; } = Core.Now;
 
-    DateTime ISerializable.LastSerialized { get; set; } = DateTime.MaxValue;
-
     long ISerializable.SavePosition { get; set; } = -1;
 
     BufferWriter ISerializable.SaveBuffer { get; set; }

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -760,9 +760,6 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
     [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public DateTime Created { get; set; } = Core.Now;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    DateTime ISerializable.LastSerialized { get; set; } = Core.Now;
-
     long ISerializable.SavePosition { get; set; } = -1;
 
     BufferWriter ISerializable.SaveBuffer { get; set; }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2258,9 +2258,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public DateTime Created { get; set; } = Core.Now;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    DateTime ISerializable.LastSerialized { get; set; } = Core.Now;
-
     long ISerializable.SavePosition { get; set; } = -1;
 
     BufferWriter ISerializable.SaveBuffer { get; set; }

--- a/Projects/Server/Serialization/GenericEntitySerialization.cs
+++ b/Projects/Server/Serialization/GenericEntitySerialization.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Server.Logging;
@@ -19,22 +18,9 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
     private static readonly Dictionary<Serial, T> _pendingDelete = new();
     private static Dictionary<Serial, T> _entitiesBySerial = new();
 
-    static GenericEntitySerialization()
+    public static void Configure(string systemName)
     {
-        var classType = typeof(GenericEntitySerialization<T>);
-        var serializationSystemAttribute = classType.GetCustomAttribute<SerializationSystemAttribute>();
-        if (serializationSystemAttribute == null)
-        {
-            throw new Exception(
-                $"{classType.FullName} is missing the \"[SerializationSystem]\" attribute on its class declaration."
-            );
-        }
-
-        _systemName = serializationSystemAttribute.SystemName;
-    }
-
-    public static void Configure()
-    {
+        _systemName = systemName;
         typeof(T).RegisterFindEntity(FindEntity);
         Persistence.Register(_systemName, Serialize, WriteSnapshot, Deserialize);
     }

--- a/Projects/Server/Serialization/GenericEntitySerialization.cs
+++ b/Projects/Server/Serialization/GenericEntitySerialization.cs
@@ -21,7 +21,7 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
     public static void Configure(string systemName)
     {
         _systemName = systemName;
-        typeof(T).RegisterFindEntity(FindEntity);
+        typeof(T).RegisterFindEntity(FindEntity<T>);
         Persistence.Register(_systemName, Serialize, WriteSnapshot, Deserialize);
     }
 

--- a/Projects/Server/Serialization/GenericEntitySerialization.cs
+++ b/Projects/Server/Serialization/GenericEntitySerialization.cs
@@ -72,7 +72,7 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
             {
                 last++;
 
-                if (FindEntity(last) == null)
+                if (FindEntity<T>(last) == null)
                 {
                     return _lastEntitySerial = last;
                 }
@@ -164,9 +164,9 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
         }
     }
 
-    public static T FindEntity(Serial serial) => FindEntity(serial, false);
+    public static R FindEntity<R>(Serial serial) where R : class, T => FindEntity<R>(serial, false);
 
-    public static T FindEntity(Serial serial, bool returnDeleted)
+    public static R FindEntity<R>(Serial serial, bool returnDeleted) where R : class, T
     {
         switch (World.WorldState)
         {
@@ -177,7 +177,7 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
                 {
                     if (returnDeleted && _pendingDelete.TryGetValue(serial, out var entity))
                     {
-                        return entity;
+                        return entity as R;
                     }
 
                     if (!_pendingAdd.TryGetValue(serial, out entity) && !_entitiesBySerial.TryGetValue(serial, out entity))
@@ -185,12 +185,12 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
                         return null;
                     }
 
-                    return !entity.Deleted || returnDeleted ? entity : null;
+                    return !entity.Deleted || returnDeleted ? entity as R : null;
                 }
             case WorldState.Running:
                 {
                     return _entitiesBySerial.TryGetValue(serial, out var entity)
-                           && (!entity.Deleted || returnDeleted) ? entity : null;
+                           && (!entity.Deleted || returnDeleted) ? entity as R : null;
                 }
         }
     }

--- a/Projects/Server/Serialization/GenericEntitySerialization.cs
+++ b/Projects/Server/Serialization/GenericEntitySerialization.cs
@@ -21,7 +21,7 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
     public static void Configure(string systemName)
     {
         _systemName = systemName;
-        typeof(T).RegisterFindEntity(FindEntity<T>);
+        typeof(T).RegisterFindEntity(Find);
         Persistence.Register(_systemName, Serialize, WriteSnapshot, Deserialize);
     }
 
@@ -163,6 +163,12 @@ public class GenericEntitySerialization<T> where T : class, ISerializable
                 }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Find(Serial serial) => FindEntity<T>(serial, false);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T Find(Serial serial, bool returnDeleted) => FindEntity<T>(serial, returnDeleted);
 
     public static R FindEntity<R>(Serial serial) where R : class, T => FindEntity<R>(serial, false);
 

--- a/Projects/Server/Serialization/GenericEntitySerialization.cs
+++ b/Projects/Server/Serialization/GenericEntitySerialization.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Server.Logging;
+
+namespace Server;
+
+public class GenericEntitySerialization<T> where T : class, ISerializable
+{
+    private static readonly ILogger logger = LogFactory.GetLogger(typeof(GenericEntitySerialization<T>));
+
+    private static string _systemName;
+    private static Serial _lastEntitySerial;
+    private static readonly Dictionary<Serial, T> _pendingAdd = new();
+    private static readonly Dictionary<Serial, T> _pendingDelete = new();
+    private static Dictionary<Serial, T> _entitiesBySerial = new();
+
+    static GenericEntitySerialization()
+    {
+        var classType = typeof(GenericEntitySerialization<T>);
+        var serializationSystemAttribute = classType.GetCustomAttribute<SerializationSystemAttribute>();
+        if (serializationSystemAttribute == null)
+        {
+            throw new Exception(
+                $"{classType.FullName} is missing the \"[SerializationSystem]\" attribute on its class declaration."
+            );
+        }
+
+        _systemName = serializationSystemAttribute.SystemName;
+    }
+
+    public static void Configure()
+    {
+        typeof(T).RegisterFindEntity(FindEntity);
+        Persistence.Register(_systemName, Serialize, WriteSnapshot, Deserialize);
+    }
+
+    internal static void Serialize()
+    {
+        EntityPersistence.SaveEntities(
+            _entitiesBySerial.Values,
+            entity => entity.Serialize(World.SerializedTypes)
+        );
+    }
+
+    internal static void WriteSnapshot(string basePath)
+    {
+        IIndexInfo<Serial> indexInfo = new EntityTypeIndex(_systemName);
+        EntityPersistence.WriteEntities(indexInfo, _entitiesBySerial, basePath,World.SerializedTypes, out _);
+    }
+
+    internal static void Deserialize(string path, Dictionary<ulong, string> typesDb)
+    {
+        IIndexInfo<Serial> indexInfo = new EntityTypeIndex(_systemName);
+
+        _entitiesBySerial = EntityPersistence.LoadIndex(path, indexInfo, typesDb, out List<EntitySpan<T>> entities);
+
+        if (_entitiesBySerial.Count > 0)
+        {
+            _lastEntitySerial = _entitiesBySerial.Keys.Max();
+        }
+
+        EntityPersistence.LoadData(path, indexInfo, typesDb, entities);
+    }
+
+    public static Serial NewEntity
+    {
+        get
+        {
+#if THREADGUARD
+            if (Thread.CurrentThread != Core.Thread)
+            {
+                logger.Error(
+                    "Attempted to get a new entity serial from the wrong thread!\n{StackTrace}",
+                    new StackTrace()
+                );
+            }
+#endif
+            var last = _lastEntitySerial;
+
+            for (uint i = 0; i < uint.MaxValue; i++)
+            {
+                last++;
+
+                if (FindEntity(last) == null)
+                {
+                    return _lastEntitySerial = last;
+                }
+            }
+
+            OutOfMemory("No serials left to allocate for BOBEntries");
+            return Serial.MinusOne;
+        }
+    }
+
+    public static void AddEntity(T entity)
+    {
+        var worldState = World.WorldState;
+        switch (worldState)
+        {
+            default: // Not Running
+                {
+                    throw new Exception($"Added {entity.GetType().Name} before world load.");
+                }
+            case WorldState.Saving:
+            case WorldState.Loading:
+            case WorldState.WritingSave:
+                {
+                    if (_pendingDelete.Remove(entity.Serial))
+                    {
+                        logger.Warning("Deleted then added {Entity} during {WorldState} state.", entity.GetType().Name, worldState.ToString());
+                    }
+
+                    _pendingAdd[entity.Serial] = entity;
+                    break;
+                }
+            case WorldState.Running:
+                {
+                    ref var entityEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(_entitiesBySerial, entity.Serial, out bool exists);
+                    if (exists)
+                    {
+                        if (entityEntry == entity)
+                        {
+                            logger.Error(
+                                $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Items but it already exists in the collection.{Environment.NewLine}{{StackTrace}}",
+                                entity.GetType().FullName,
+                                entity.Serial,
+                                new StackTrace()
+                            );
+                        }
+                        else
+                        {
+                            logger.Error(
+                                $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Items but found '{{ExistingEntity}}' ({{ExistingSerial}}).{Environment.NewLine}{{StackTrace}}",
+                                entity.GetType().FullName,
+                                entity.Serial,
+                                entityEntry.GetType().FullName,
+                                entityEntry.Serial,
+                                new StackTrace()
+                            );
+                        }
+                    }
+                    else
+                    {
+                        entityEntry = entity;
+                    }
+                    break;
+                }
+        }
+    }
+
+    public static void RemoveEntity(T entity)
+    {
+        var worldState = World.WorldState;
+        switch (worldState)
+        {
+            default: // Not Running
+                {
+                    throw new Exception($"Removed {entity.GetType().Name} before world load.");
+                }
+            case WorldState.Saving:
+            case WorldState.Loading:
+            case WorldState.WritingSave:
+                {
+                    _pendingAdd.Remove(entity.Serial);
+                    _pendingDelete[entity.Serial] = entity;
+                    break;
+                }
+            case WorldState.Running:
+                {
+                    _entitiesBySerial.Remove(entity.Serial);
+                    break;
+                }
+        }
+    }
+
+    public static T FindEntity(Serial serial) => FindEntity(serial, false);
+
+    public static T FindEntity(Serial serial, bool returnDeleted)
+    {
+        switch (World.WorldState)
+        {
+            default: return null;
+            case WorldState.Loading:
+            case WorldState.Saving:
+            case WorldState.WritingSave:
+                {
+                    if (returnDeleted && _pendingDelete.TryGetValue(serial, out var entity))
+                    {
+                        return entity;
+                    }
+
+                    if (!_pendingAdd.TryGetValue(serial, out entity) && !_entitiesBySerial.TryGetValue(serial, out entity))
+                    {
+                        return null;
+                    }
+
+                    return !entity.Deleted || returnDeleted ? entity : null;
+                }
+            case WorldState.Running:
+                {
+                    return _entitiesBySerial.TryGetValue(serial, out var entity)
+                           && (!entity.Deleted || returnDeleted) ? entity : null;
+                }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void OutOfMemory(string message) => throw new OutOfMemoryException(message);
+}

--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -19,14 +19,6 @@ using System.IO;
 
 namespace Server;
 
-[AttributeUsage(AttributeTargets.Class)]
-public class SerializationSystemAttribute : Attribute
-{
-    public string SystemName { get; }
-
-    public SerializationSystemAttribute(string systemName) => SystemName = systemName;
-}
-
 public static class GenericPersistence
 {
     public static void Register(

--- a/Projects/Server/Serialization/GenericPersistence.cs
+++ b/Projects/Server/Serialization/GenericPersistence.cs
@@ -19,6 +19,14 @@ using System.IO;
 
 namespace Server;
 
+[AttributeUsage(AttributeTargets.Class)]
+public class SerializationSystemAttribute : Attribute
+{
+    public string SystemName { get; }
+
+    public SerializationSystemAttribute(string systemName) => SystemName = systemName;
+}
+
 public static class GenericPersistence
 {
     public static void Register(

--- a/Projects/Server/Serialization/ISerializable.cs
+++ b/Projects/Server/Serialization/ISerializable.cs
@@ -24,8 +24,6 @@ public interface ISerializable
     // Should be serialized/deserialized with the index so it can be referenced by IGenericReader
     DateTime Created { get; set; }
 
-    // Should be serialized/deserialized with the index so it can be referenced by IGenericReader
-    DateTime LastSerialized { get; protected internal set; }
     long SavePosition { get; protected internal set; }
     BufferWriter SaveBuffer { get; protected internal set; }
 
@@ -61,7 +59,6 @@ public interface ISerializable
             return;
         }
 
-        LastSerialized = Core.Now;
         SaveBuffer.Seek(0, SeekOrigin.Begin);
         Serialize(SaveBuffer);
 

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Server.Guilds;
 using Server.Logging;
@@ -684,11 +685,10 @@ public static class World
                 {
                     if (entity.Serial.IsItem)
                     {
-                        if (!Items.TryAdd(entity.Serial, entity as Item))
+                        ref var item = ref CollectionsMarshal.GetValueRefOrAddDefault(Items, entity.Serial, out bool exists);
+                        if (exists)
                         {
-                            var existing = Items[entity.Serial];
-
-                            if (existing == entity)
+                            if (item == entity)
                             {
                                 logger.Error(
                                     $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Items but it already exists in the collection.{Environment.NewLine}{{StackTrace}}",
@@ -703,21 +703,24 @@ public static class World
                                     $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Items but found '{{ExistingEntity}}' ({{ExistingSerial}}).{Environment.NewLine}{{StackTrace}}",
                                     entity.GetType().FullName,
                                     entity.Serial,
-                                    existing.GetType().FullName,
-                                    existing.Serial,
+                                    item.GetType().FullName,
+                                    item.Serial,
                                     new StackTrace()
                                 );
                             }
+                        }
+                        else
+                        {
+                            item = entity as Item;
                         }
                     }
 
                     if (entity.Serial.IsMobile)
                     {
-                        if (!Mobiles.TryAdd(entity.Serial, entity as Mobile))
+                        ref var mob = ref CollectionsMarshal.GetValueRefOrAddDefault(Mobiles, entity.Serial, out bool exists);
+                        if (exists)
                         {
-                            var existing = Mobiles[entity.Serial];
-
-                            if (existing == entity)
+                            if (mob == entity)
                             {
                                 logger.Error(
                                     $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Mobiles but it already exists in the collection.{Environment.NewLine}{{StackTrace}}",
@@ -732,11 +735,15 @@ public static class World
                                     $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Mobiles but found '{{ExistingEntity}}' ({{ExistingSerial}}).{Environment.NewLine}{{StackTrace}}",
                                     entity.GetType().FullName,
                                     entity.Serial,
-                                    existing.GetType().FullName,
-                                    existing.Serial,
+                                    mob.GetType().FullName,
+                                    mob.Serial,
                                     new StackTrace()
                                 );
                             }
+                        }
+                        else
+                        {
+                            mob = entity as Mobile;
                         }
                     }
                     break;
@@ -744,18 +751,17 @@ public static class World
         }
     }
 
-    public static void AddGuild(BaseGuild guild)
+    public static void AddGuild(BaseGuild entity)
     {
-        if (!Guilds.TryAdd(guild.Serial, guild))
+        ref var guild = ref CollectionsMarshal.GetValueRefOrAddDefault(Guilds, entity.Serial, out bool exists);
+        if (exists)
         {
-            var existing = Guilds[guild.Serial];
-
-            if (existing == guild)
+            if (guild == entity)
             {
                 logger.Error(
                     $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Guilds but it already exists in the collection.{Environment.NewLine}{{StackTrace}}",
-                    guild.GetType().FullName,
-                    guild.Serial,
+                    entity.GetType().FullName,
+                    entity.Serial,
                     new StackTrace()
                 );
             }
@@ -763,13 +769,17 @@ public static class World
             {
                 logger.Error(
                     $"Attempted to add '{{Entity}}' ({{Serial}}) to World.Guilds but found '{{ExistingEntity}}' ({{ExistingSerial}}).{Environment.NewLine}{{StackTrace}}",
+                    entity.GetType().FullName,
+                    entity.Serial,
                     guild.GetType().FullName,
                     guild.Serial,
-                    existing.GetType().FullName,
-                    existing.Serial,
                     new StackTrace()
                 );
             }
+        }
+        else
+        {
+            guild = entity;
         }
     }
 

--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -290,9 +290,6 @@ namespace Server.Accounting
         [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
         public DateTime Created { get; set; } = Core.Now;
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        DateTime ISerializable.LastSerialized { get; set; } = Core.Now;
-
         public Serial Serial { get; set; }
 
         [AfterDeserialization(false)]

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BOBEntries.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BOBEntries.cs
@@ -1,0 +1,6 @@
+namespace Server.Engines.BulkOrders;
+
+[SerializationSystem("BOBEntries")]
+public class BOBEntries : GenericEntitySerialization<IBOBEntry>
+{
+}

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BOBEntries.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BOBEntries.cs
@@ -1,6 +1,9 @@
 namespace Server.Engines.BulkOrders;
 
-[SerializationSystem("BOBEntries")]
 public class BOBEntries : GenericEntitySerialization<IBOBEntry>
 {
+    public static void Configure()
+    {
+        Configure("BOBEntries");
+    }
 }

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BOBLargeSubEntry.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BOBLargeSubEntry.cs
@@ -1,58 +1,35 @@
 using System;
+using ModernUO.Serialization;
 
-namespace Server.Engines.BulkOrders
+namespace Server.Engines.BulkOrders;
+
+[SerializationGenerator(0)]
+public partial class BOBLargeSubEntry
 {
-    public class BOBLargeSubEntry
+    [SerializableField(0, setter: "private")]
+    private Type _itemType;
+
+    [EncodedInt]
+    [SerializableField(1, setter: "private")]
+    private int _amountCur;
+
+    [EncodedInt]
+    [SerializableField(2, setter: "private")]
+    private int _number;
+
+    [EncodedInt]
+    [SerializableField(3, setter: "private")]
+    private int _graphic;
+
+    public BOBLargeSubEntry()
     {
-        public BOBLargeSubEntry(LargeBulkEntry lbe)
-        {
-            ItemType = lbe.Details.Type;
-            AmountCur = lbe.Amount;
-            Number = lbe.Details.Number;
-            Graphic = lbe.Details.Graphic;
-        }
+    }
 
-        public BOBLargeSubEntry(IGenericReader reader)
-        {
-            var version = reader.ReadEncodedInt();
-
-            switch (version)
-            {
-                case 0:
-                    {
-                        var type = reader.ReadString();
-
-                        if (type != null)
-                        {
-                            ItemType = AssemblyHandler.FindTypeByFullName(type);
-                        }
-
-                        AmountCur = reader.ReadEncodedInt();
-                        Number = reader.ReadEncodedInt();
-                        Graphic = reader.ReadEncodedInt();
-
-                        break;
-                    }
-            }
-        }
-
-        public Type ItemType { get; }
-
-        public int AmountCur { get; }
-
-        public int Number { get; }
-
-        public int Graphic { get; }
-
-        public void Serialize(IGenericWriter writer)
-        {
-            writer.WriteEncodedInt(0); // version
-
-            writer.Write(ItemType?.FullName);
-
-            writer.WriteEncodedInt(AmountCur);
-            writer.WriteEncodedInt(Number);
-            writer.WriteEncodedInt(Graphic);
-        }
+    public BOBLargeSubEntry(LargeBulkEntry lbe)
+    {
+        _itemType = lbe.Details.Type;
+        _amountCur = lbe.Amount;
+        _number = lbe.Details.Number;
+        _graphic = lbe.Details.Graphic;
     }
 }

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BOBSmallEntry.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BOBSmallEntry.cs
@@ -1,110 +1,76 @@
 using System;
+using ModernUO.Serialization;
 
-namespace Server.Engines.BulkOrders
+namespace Server.Engines.BulkOrders;
+
+[SerializationGenerator(1)]
+public partial class BOBSmallEntry : BaseBOBEntry
 {
-    public class BOBSmallEntry : IBOBEntry
+    [SerializableField(0, setter: "private")]
+    private Type _itemType;
+
+    [EncodedInt]
+    [SerializableField(1, setter: "private")]
+    private int _amountCur;
+
+    [EncodedInt]
+    [SerializableField(2, setter: "private")]
+    private int _number;
+
+    [EncodedInt]
+    [SerializableField(3, setter: "private")]
+    private int _graphic;
+
+    public BOBSmallEntry(SmallBOD bod)
     {
-        public BOBSmallEntry(SmallBOD bod)
+        _itemType = bod.Type;
+        RequireExceptional = bod.RequireExceptional;
+
+        if (bod is SmallTailorBOD)
         {
-            ItemType = bod.Type;
-            RequireExceptional = bod.RequireExceptional;
-
-            if (bod is SmallTailorBOD)
-            {
-                DeedType = BODType.Tailor;
-            }
-            else if (bod is SmallSmithBOD)
-            {
-                DeedType = BODType.Smith;
-            }
-
-            Material = bod.Material;
-            AmountCur = bod.AmountCur;
-            AmountMax = bod.AmountMax;
-            Number = bod.Number;
-            Graphic = bod.Graphic;
+            DeedType = BODType.Tailor;
+        }
+        else if (bod is SmallSmithBOD)
+        {
+            DeedType = BODType.Smith;
         }
 
-        public BOBSmallEntry(IGenericReader reader)
+        Material = bod.Material;
+        _amountCur = bod.AmountCur;
+        AmountMax = bod.AmountMax;
+        _number = bod.Number;
+        _graphic = bod.Graphic;
+    }
+
+    public override Item Reconstruct()
+    {
+        SmallBOD bod = null;
+
+        if (DeedType == BODType.Smith)
         {
-            var version = reader.ReadEncodedInt();
-
-            switch (version)
-            {
-                case 0:
-                    {
-                        var type = reader.ReadString();
-
-                        if (type != null)
-                        {
-                            ItemType = AssemblyHandler.FindTypeByFullName(type);
-                        }
-
-                        RequireExceptional = reader.ReadBool();
-
-                        DeedType = (BODType)reader.ReadEncodedInt();
-
-                        Material = (BulkMaterialType)reader.ReadEncodedInt();
-                        AmountCur = reader.ReadEncodedInt();
-                        AmountMax = reader.ReadEncodedInt();
-                        Number = reader.ReadEncodedInt();
-                        Graphic = reader.ReadEncodedInt();
-                        Price = reader.ReadEncodedInt();
-
-                        break;
-                    }
-            }
+            bod = new SmallSmithBOD(AmountCur, AmountMax, ItemType, Number, Graphic, RequireExceptional, Material);
+        }
+        else if (DeedType == BODType.Tailor)
+        {
+            bod = new SmallTailorBOD(AmountCur, AmountMax, ItemType, Number, Graphic, RequireExceptional, Material);
         }
 
-        public Type ItemType { get; }
+        return bod;
+    }
 
-        public int AmountCur { get; }
+    private void Deserialize(IGenericReader reader, int version)
+    {
+        _itemType = reader.ReadType();
 
-        public int Number { get; }
+        RequireExceptional = reader.ReadBool();
 
-        public int Graphic { get; }
+        DeedType = (BODType)reader.ReadEncodedInt();
 
-        public bool RequireExceptional { get; }
-
-        public BODType DeedType { get; }
-
-        public BulkMaterialType Material { get; }
-
-        public int AmountMax { get; }
-
-        public int Price { get; set; }
-
-        public Item Reconstruct()
-        {
-            SmallBOD bod = null;
-
-            if (DeedType == BODType.Smith)
-            {
-                bod = new SmallSmithBOD(AmountCur, AmountMax, ItemType, Number, Graphic, RequireExceptional, Material);
-            }
-            else if (DeedType == BODType.Tailor)
-            {
-                bod = new SmallTailorBOD(AmountCur, AmountMax, ItemType, Number, Graphic, RequireExceptional, Material);
-            }
-
-            return bod;
-        }
-
-        public void Serialize(IGenericWriter writer)
-        {
-            writer.WriteEncodedInt(0); // version
-
-            writer.Write(ItemType?.FullName);
-
-            writer.Write(RequireExceptional);
-
-            writer.WriteEncodedInt((int)DeedType);
-            writer.WriteEncodedInt((int)Material);
-            writer.WriteEncodedInt(AmountCur);
-            writer.WriteEncodedInt(AmountMax);
-            writer.WriteEncodedInt(Number);
-            writer.WriteEncodedInt(Graphic);
-            writer.WriteEncodedInt(Price);
-        }
+        Material = (BulkMaterialType)reader.ReadEncodedInt();
+        AmountCur = reader.ReadEncodedInt();
+        AmountMax = reader.ReadEncodedInt();
+        Number = reader.ReadEncodedInt();
+        Graphic = reader.ReadEncodedInt();
+        Price = reader.ReadEncodedInt();
     }
 }

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BaseBOBEntry.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BaseBOBEntry.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using ModernUO.Serialization;
+
+namespace Server.Engines.BulkOrders;
+
+[SerializationGenerator(1)]
+public abstract partial class BaseBOBEntry : IBOBEntry
+{
+    [SerializableField(0, setter: "protected")]
+    private bool _requireExceptional;
+
+    [SerializableField(1, setter: "protected")]
+    private BODType _deedType;
+
+    [SerializableField(2, setter: "protected")]
+    private BulkMaterialType _material;
+
+    [SerializableField(3, setter: "protected")]
+    private int _amountMax;
+
+    [SerializableField(4)]
+    private int _price;
+
+    public DateTime Created { get; set; } = Core.Now;
+
+    public DateTime LastSerialized { get; set; } = Core.Now;
+
+    public Serial Serial { get; }
+
+    public bool Deleted { get; private set; }
+
+    public BaseBOBEntry()
+    {
+        Serial = BOBEntries.NewEntity;
+        BOBEntries.AddEntity(this);
+    }
+
+    public virtual void Delete()
+    {
+        Deleted = true;
+        BOBEntries.RemoveEntity(this);
+    }
+
+    public abstract Item Reconstruct();
+
+    private void Deserialize(IGenericReader reader, int version)
+    {
+        if (version == 0)
+        {
+            // version 0 - This class didn't exist, so we are going to skip deserializing
+            // Seek back 1 byte because encoded int of 0 is 1 byte
+            reader.Seek(-1, SeekOrigin.Current);
+        }
+        else
+        {
+            throw new Exception("Unknown deserialization error in presource generated BOB Entries");
+        }
+    }
+}

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BulkOrderBook.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BulkOrderBook.cs
@@ -244,11 +244,20 @@ namespace Server.Engines.BulkOrders
                             switch (v)
                             {
                                 case 0:
-                                    Entries.Add(new BOBLargeEntry(reader));
-                                    break;
+                                    {
+                                        var largeEntry = new BOBLargeEntry(BOBEntries.NewEntity);
+                                        largeEntry.Deserialize(reader);
+
+                                        Entries.Add(largeEntry);
+                                        break;
+                                    }
                                 case 1:
-                                    Entries.Add(new BOBSmallEntry(reader));
-                                    break;
+                                    {
+                                        var smallEntry = new BOBSmallEntry(BOBEntries.NewEntity);
+                                        smallEntry.Deserialize(reader);
+                                        Entries.Add(smallEntry);
+                                        break;
+                                    }
                             }
                         }
 

--- a/Projects/UOContent/Engines/Bulk Orders/Books/IBOBEntry.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/IBOBEntry.cs
@@ -1,6 +1,6 @@
 namespace Server.Engines.BulkOrders
 {
-    public interface IBOBEntry
+    public interface IBOBEntry : ISerializable
     {
         bool RequireExceptional { get; }
         BODType DeedType { get; }

--- a/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BOBLargeEntry.v1.json
+++ b/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BOBLargeEntry.v1.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "type": "Server.Engines.BulkOrders.BOBLargeEntry",
+  "properties": [
+    {
+      "name": "Entries",
+      "type": "Server.Engines.BulkOrders.BOBLargeSubEntry[]",
+      "rule": "ArrayMigrationRule",
+      "ruleArguments": [
+        "Server.Engines.BulkOrders.BOBLargeSubEntry",
+        "RawSerializableMigrationRule",
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BOBLargeSubEntry.v0.json
+++ b/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BOBLargeSubEntry.v0.json
@@ -1,0 +1,35 @@
+{
+  "version": 0,
+  "type": "Server.Engines.BulkOrders.BOBLargeSubEntry",
+  "properties": [
+    {
+      "name": "ItemType",
+      "type": "System.Type",
+      "rule": "PrimitiveTypeMigrationRule"
+    },
+    {
+      "name": "AmountCur",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Number",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Graphic",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BOBSmallEntry.v1.json
+++ b/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BOBSmallEntry.v1.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "type": "Server.Engines.BulkOrders.BOBSmallEntry",
+  "properties": [
+    {
+      "name": "ItemType",
+      "type": "System.Type",
+      "rule": "PrimitiveTypeMigrationRule"
+    },
+    {
+      "name": "AmountCur",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Number",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Graphic",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BaseBOBEntry.v1.json
+++ b/Projects/UOContent/Migrations/Server.Engines.BulkOrders.BaseBOBEntry.v1.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "type": "Server.Engines.BulkOrders.BaseBOBEntry",
+  "properties": [
+    {
+      "name": "RequireExceptional",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "DeedType",
+      "type": "Server.Engines.BulkOrders.BODType",
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Material",
+      "type": "Server.Engines.BulkOrders.BulkMaterialType",
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "AmountMax",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Price",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Mobiles/Healers/BaseHealer.cs
+++ b/Projects/UOContent/Mobiles/Healers/BaseHealer.cs
@@ -136,7 +136,7 @@ public abstract partial class BaseHealer : BaseVendor
 
     private void Deserialize(IGenericReader reader, int version)
     {
-        // NOTE: This is to fix a previous RunUO serialiation issue with this class:
+        // NOTE: This is to fix a previous RunUO serialization issue with this class:
         // This would be a breaking change if there is a derived class that is version 2 or higher
         // If that is the case, change the SerializationGenerator to a version higher than that before merging this change
         reader.Seek(-4, SeekOrigin.Current);


### PR DESCRIPTION
### Summary
Adds a generic entity persistence. This can be used to create new entity types that have a `Serial`.

Here is an example:

```cs
public class BOBEntries : GenericEntitySerialization<IBOBEntry>
{
    public static void Configure()
    {
        Configure("BOBEntries");
    }
}
```

The annotation tells the system what folder to serialize the entries to. The class/interface (`IBOBEntry`) is the root type that implements `ISerializable`.