### PR TITLE
fix: Fixes serialization threading, moves world save to end of loop, and eliminates Parallel.ForEach.

### DIFF
--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -50,9 +50,9 @@ public abstract class BaseGuild : ISerializable
     [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public DateTime Created { get; set; } = Core.Now;
 
-    long ISerializable.SavePosition { get; set; } = -1;
+    public long SavePosition { get; set; } = -1;
 
-    BufferWriter ISerializable.SaveBuffer { get; set; }
+    public BufferWriter SaveBuffer { get; set; }
 
     public int TypeRef { get; private set; }
 

--- a/Projects/Server/IEntity.cs
+++ b/Projects/Server/IEntity.cs
@@ -43,11 +43,11 @@ public class Entity : IEntity
 
     public Entity(Serial serial) => Serial = serial;
 
-    DateTime ISerializable.Created { get; set; } = Core.Now;
+    public DateTime Created { get; set; } = Core.Now;
 
-    long ISerializable.SavePosition { get; set; } = -1;
+    public long SavePosition { get; set; } = -1;
 
-    BufferWriter ISerializable.SaveBuffer { get; set; }
+    public BufferWriter SaveBuffer { get; set; }
 
     public int TypeRef => -1;
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -760,9 +760,9 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
     [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public DateTime Created { get; set; } = Core.Now;
 
-    long ISerializable.SavePosition { get; set; } = -1;
+    public long SavePosition { get; set; } = -1;
 
-    BufferWriter ISerializable.SaveBuffer { get; set; }
+    public BufferWriter SaveBuffer { get; set; }
 
     [CommandProperty(AccessLevel.Counselor)]
     public Serial Serial { get; }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2258,9 +2258,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public DateTime Created { get; set; } = Core.Now;
 
-    long ISerializable.SavePosition { get; set; } = -1;
+    public long SavePosition { get; set; } = -1;
 
-    BufferWriter ISerializable.SaveBuffer { get; set; }
+    public BufferWriter SaveBuffer { get; set; }
 
     [CommandProperty(AccessLevel.Counselor)]
     public Serial Serial { get; }

--- a/Projects/Server/Network/PingServer.cs
+++ b/Projects/Server/Network/PingServer.cs
@@ -75,7 +75,7 @@ public static class PingServer
 
     public static void Slice()
     {
-        if (!Enabled || Core.Closing)
+        if (!Enabled)
         {
             return;
         }

--- a/Projects/Server/Serialization/ISerializable.cs
+++ b/Projects/Server/Serialization/ISerializable.cs
@@ -19,7 +19,7 @@ using System.IO;
 
 namespace Server;
 
-public interface ISerializable
+public interface ISerializable : IGenericSerializable
 {
     // Should be serialized/deserialized with the index so it can be referenced by IGenericReader
     DateTime Created { get; set; }
@@ -48,7 +48,7 @@ public interface ISerializable
         }
     }
 
-    public void Serialize(ConcurrentQueue<Type> types)
+    void IGenericSerializable.Serialize(ConcurrentQueue<Type> types)
     {
         SaveBuffer ??= new BufferWriter(true, types);
 

--- a/Projects/Server/Serialization/Persistence.cs
+++ b/Projects/Server/Serialization/Persistence.cs
@@ -81,8 +81,10 @@ public abstract class Persistence
 
     internal static void SerializeAll()
     {
-        // TODO: Hand off to a scheduler
-        Parallel.ForEach(_registry, p => p.Serialize());
+        foreach (var p in _registry)
+        {
+            p.Serialize();
+        }
     }
 
     internal static void PostSerializeAll()

--- a/Projects/Server/World/IGenericSerializable.cs
+++ b/Projects/Server/World/IGenericSerializable.cs
@@ -1,0 +1,24 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2023 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: IWorldSerializable.cs                                           *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Collections.Concurrent;
+
+namespace Server;
+
+public interface IGenericSerializable
+{
+    void Serialize(ConcurrentQueue<Type> types);
+}


### PR DESCRIPTION
### Summary
- [X] Eliminates Parallel.ForEach to speed up serializing to memory.
- [X] Adds GenericPersistence as single entities so they are properly serialized in parallel with the new logic.
- [X] Moves saves to the end of the world tick so that way packets/timers/context have all executed.

