### PR TITLE
fix: Fix animal trainer pet list only showing first pet.

### DIFF
--- a/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
+++ b/Projects/UOContent/Mobiles/Vendors/NPC/AnimalTrainer.cs
@@ -124,7 +124,7 @@ namespace Server.Mobiles
                         if (!pet.Deleted)
                         {
                             list.Add(pet);
-                            break;
+                            continue;
                         }
 
                         pet.IsStabled = false;


### PR DESCRIPTION
Changes:
* Changed the `break` to `continue` so the foreach loop will continue looping in order to list out all pets. 
   * Previously, the `break` would cause it to always list the first stabled pet and stop there.

Screenshot:
Shows the new implementation (using `claim l`) in action and the regular `claim` command's text output (after claiming and restabling).
![image](https://github.com/modernuo/ModernUO/assets/1682329/ae63ce86-6d10-48e5-b11e-549b5ecde2d2)
