### PR TITLE
Fix for vendors not actually selling anything (except via Buy Agent)

### DIFF
--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -1263,6 +1263,7 @@ public partial class Container : Item
             if (type.IsInstanceOfType(item))
             {
                 items.Enqueue(item);
+
                 total += item.Amount;
                 if (total >= amount)
                 {

--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -1262,7 +1262,7 @@ public partial class Container : Item
         {
             if (type.IsInstanceOfType(item))
             {
-                Items.Add(item);
+                items.Enqueue(item);
                 total += item.Amount;
                 if (total >= amount)
                 {


### PR DESCRIPTION
Issue:
* The Items queue was never actually getting populated with any items, so the `ConsumeTotal` call was always returning false, causing the vendor to always say the user doesn't have enough gold.

Changes:
* Removed the `Item.add()` call and added an `items.Enqueue()` call to items.