### PR TITLE
fix: Changes Map.Sector.Items to link list.

### DIFF
--- a/Projects/Server/Geometry/Rectangle2D.cs
+++ b/Projects/Server/Geometry/Rectangle2D.cs
@@ -22,6 +22,8 @@ namespace Server;
 [PropertyObject]
 public struct Rectangle2D : IEquatable<Rectangle2D>, ISpanFormattable, ISpanParsable<Rectangle2D>
 {
+    public static Rectangle2D Empty => new();
+
     private Point2D _start;
     private Point2D _end;
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2474,12 +2474,12 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Map.ItemEnumerator<Item> GetItemsInRange(int range) =>
-        m_Map == null ? Map.ItemEnumerator<Item>.Empty : m_Map.GetItemsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
+    public Map.ItemEnumerable<Item> GetItemsInRange(int range) =>
+        m_Map == null ? Map.ItemEnumerable<Item>.Empty : m_Map.GetItemsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Map.ItemEnumerator<T> GetItemsInRange<T>(int range) where T : Item =>
-        m_Map == null ? Map.ItemEnumerator<T>.Empty : m_Map.GetItemsInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
+    public Map.ItemEnumerable<T> GetItemsInRange<T>(int range) where T : Item =>
+        m_Map == null ? Map.ItemEnumerable<T>.Empty : m_Map.GetItemsInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     public IPooledEnumerable<Mobile> GetMobilesInRange(int range)
     {

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2473,13 +2473,13 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             : map.GetObjectsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
     }
 
-    public IPooledEnumerable<Item> GetItemsInRange(int range)
-    {
-        var map = m_Map;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ItemEnumerator<Item> GetItemsInRange(int range) =>
+        m_Map == null ? Map.ItemEnumerator<Item>.Empty : m_Map.GetItemsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
-        return map?.GetItemsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range)
-               ?? PooledEnumeration.NullEnumerable<Item>.Instance;
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ItemEnumerator<T> GetItemsInRange<T>(int range) where T : Item =>
+        m_Map == null ? Map.ItemEnumerator<T>.Empty : m_Map.GetItemsInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     public IPooledEnumerable<Mobile> GetMobilesInRange(int range)
     {
@@ -3547,10 +3547,8 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             z = top;
         }
 
-        var eable = map.GetItemsInRange(p, 0);
-
-        var items = new List<Item>();
-        foreach (var item in eable)
+        using var items = PooledRefList<Item>.Create();
+        foreach (var item in map.GetItemsInRange(p, 0))
         {
             if (item is BaseMulti || item.ItemID > TileData.MaxItemValue)
             {
@@ -3611,7 +3609,7 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             m_OpenSlots &= ~(((1 << bitCount) - 1) << zStart);
         }
 
-        for (var i = 0; i < items.Count; ++i)
+        for (var i = 0; i < items.Count; i++)
         {
             var item = items[i];
             var id = item.ItemData;

--- a/Projects/Server/Maps/Map.ItemEnumerator.cs
+++ b/Projects/Server/Maps/Map.ItemEnumerator.cs
@@ -1,0 +1,204 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2023 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: Map.Enumerators.cs                                              *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Server;
+
+public partial class Map
+{
+    private int _iteratingItems;
+    private List<(MapAction, Point3D, Item)> _delayedItemActions = new();
+
+    public bool IsIteratingItems
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _iteratingItems > 0;
+    }
+
+    public ItemEnumerator<Item> GetItemsInRange(Point3D p) => GetItemsInRange(p, Core.GlobalMaxUpdateRange);
+
+    public ItemEnumerator<Item> GetItemsInRange(Point3D p, int range) => GetItemsInRange<Item>(p, range);
+
+    public ItemEnumerator<T> GetItemsInRange<T>(Point3D p, int range) where T : Item =>
+        GetItemsInBounds<T>(new Rectangle2D(p.m_X - range, p.m_Y - range, range * 2 + 1, range * 2 + 1));
+
+    public ItemEnumerator<Item> GetItemsInBounds(Rectangle2D bounds) => GetItemsInBounds<Item>(bounds);
+
+    public ItemEnumerator<T> GetItemsInBounds<T>(Rectangle2D bounds, bool makeBoundsInclusive = false) where T : Item =>
+        new(this, bounds, makeBoundsInclusive);
+
+    private void BeginIteratingItems()
+    {
+#if THREADGUARD
+            if (Thread.CurrentThread != Core.Thread)
+            {
+                Utility.PushColor(ConsoleColor.Red);
+                Console.WriteLine($"Iterating through items on {this} from an invalid thread!");
+                Console.WriteLine(new StackTrace());
+                Utility.PopColor();
+                return;
+            }
+#endif
+
+        _iteratingItems++;
+    }
+
+    private void EndIteratingItems()
+    {
+#if THREADGUARD
+            if (Thread.CurrentThread != Core.Thread)
+            {
+                Utility.PushColor(ConsoleColor.Red);
+                Console.WriteLine($"Iterating through items on {this} from an invalid thread!");
+                Console.WriteLine(new StackTrace());
+                Utility.PopColor();
+                return;
+            }
+#endif
+
+        _iteratingItems--;
+
+        // Finished iterating, check for deferred actions
+        if (_iteratingItems == 0 && _delayedItemActions.Count > 0)
+        {
+            foreach (var (a, p, i) in _delayedItemActions)
+            {
+                switch (a)
+                {
+                    case MapAction.Enter:
+                        {
+                            OnEnter(p, i);
+                            break;
+                        }
+                    case MapAction.Leave:
+                        {
+                            OnLeave(p, i);
+                            break;
+                        }
+                    case MapAction.Move:
+                        {
+                            OnMove(p, i);
+                            break;
+                        }
+                }
+            }
+
+            _delayedItemActions.Clear();
+        }
+    }
+
+    public ref struct ItemEnumerator<T> where T : Item
+    {
+        private Map _map;
+        private int _sectorStartX;
+        private int _sectorStartY;
+        private int _sectorEndX;
+        private int _sectorEndY;
+        private Rectangle2D _bounds;
+
+        private int _currentSectorX;
+        private int _currentSectorY;
+        private T _current;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemEnumerator(Map map, Rectangle2D bounds, bool makeBoundsInclusive)
+        {
+            _map = map;
+            _bounds = bounds;
+
+            if (makeBoundsInclusive)
+            {
+                ++bounds.Width;
+                ++bounds.Height;
+            }
+
+            _bounds = bounds;
+
+            map.CalculateSectors(bounds, out _sectorStartX, out _sectorStartY, out _sectorEndX, out _sectorEndY);
+
+            // We start the X sector one short because it gets incremented immediately in MoveNext()
+            _currentSectorX = _sectorStartX - 1;
+            _currentSectorY = _sectorStartY;
+
+            _map.BeginIteratingItems();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            var map = _map;
+
+            if (map == null)
+            {
+                return false;
+            }
+
+            Item current = _current;
+            ref Rectangle2D bounds = ref _bounds;
+            var currentSectorX = _currentSectorX;
+            var currentSectorY = _currentSectorY;
+            var sectorEndX = _sectorEndX;
+            var sectorEndY = _sectorEndY;
+
+            while (true)
+            {
+                current = current?.Next;
+
+                while (current == null)
+                {
+                    // Move to next sector
+                    if (currentSectorX < sectorEndX)
+                    {
+                        _currentSectorX = ++currentSectorX;
+                    }
+                    else if (currentSectorY < sectorEndY)
+                    {
+                        _currentSectorX = currentSectorX = _sectorStartX;
+                        _currentSectorY = ++currentSectorY;
+                    }
+                    else
+                    {
+                        // Ran out of sectors
+                        return false;
+                    }
+
+                    current = map.GetRealSector(currentSectorX, currentSectorY).Items.First;
+                }
+
+                if (current is T { Deleted: false, Parent: null } o && bounds.Contains(o.Location))
+                {
+                    _current = o;
+                    return true;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose() => _map.EndIteratingItems();
+
+        public T Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _current;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemEnumerator<T> GetEnumerator() => this;
+
+        public static ItemEnumerator<T> Empty => new(null, Rectangle2D.Empty, false);
+    }
+}

--- a/Projects/Server/Maps/Map.ItemEnumerator.cs
+++ b/Projects/Server/Maps/Map.ItemEnumerator.cs
@@ -103,7 +103,6 @@ public partial class Map
 
     public ref struct ItemEnumerable<T> where T : Item
     {
-
         public static ItemEnumerable<T> Empty
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -121,6 +120,7 @@ public partial class Map
             _makeBoundsInclusive = makeBoundsInclusive;
         }
 
+        // The enumerator MUST be disposed. Not disposing it will damage the sector irreparably.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemEnumerator<T> GetEnumerator() => new(_map, _bounds, _makeBoundsInclusive);
     }

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -58,19 +58,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
     private TileMatrix m_Tiles;
 
-    public static void Configure()
-    {
-        for (var i = 0; i < AllMaps.Count; i++)
-        {
-            var map = AllMaps[i];
-            // Prepopulate the pool
-            for (var j = 0; j < 8; j++)
-            {
-                map._itemIterationOwners.Add(new ItemIterationOwner(map));
-            }
-        }
-    }
-
     public Map(int mapID, int mapIndex, int fileIndex, int width, int height, int season, string name, MapRules rules)
     {
         MapID = mapID;

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -58,6 +58,19 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
     private TileMatrix m_Tiles;
 
+    public static void Configure()
+    {
+        for (var i = 0; i < AllMaps.Count; i++)
+        {
+            var map = AllMaps[i];
+            // Prepopulate the pool
+            for (var j = 0; j < 8; j++)
+            {
+                map._itemIterationOwners.Add(new ItemIterationOwner(map));
+            }
+        }
+    }
+
     public Map(int mapID, int mapIndex, int fileIndex, int width, int height, int season, string name, MapRules rules)
     {
         MapID = mapID;

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -1498,7 +1498,7 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
         public List<NetState> Clients => _clients ?? m_DefaultClientList;
 
-        public bool Active => m_Active && Owner != Map.Internal;
+        public bool Active => m_Active && Owner != Internal;
 
         public Map Owner { get; }
 

--- a/Projects/Server/Maps/PooledEnumeration.cs
+++ b/Projects/Server/Maps/PooledEnumeration.cs
@@ -339,7 +339,7 @@ public static class PooledEnumeration
 
 #pragma warning disable CA1000 // Do not declare static members on generic types
         public static PooledEnumerable<T> Instantiate(
-            Map map, Rectangle2D bounds, PooledEnumeration.Selector<T> selector
+            Map map, Rectangle2D bounds, Selector<T> selector
         )
         {
             PooledEnumerable<T> e = null;
@@ -352,7 +352,7 @@ public static class PooledEnumeration
                 }
             }
 
-            var pool = PooledEnumeration.EnumerateSectors(map, bounds).SelectMany(s => selector(s, bounds));
+            var pool = EnumerateSectors(map, bounds).SelectMany(s => selector(s, bounds));
 
             if (e == null)
             {

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -8059,11 +8059,11 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Map.ItemEnumerator<Item> GetItemsInRange(int range) => GetItemsInRange<Item>(range);
+    public Map.ItemEnumerable<Item> GetItemsInRange(int range) => GetItemsInRange<Item>(range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Map.ItemEnumerator<T> GetItemsInRange<T>(int range) where T : Item =>
-        m_Map == null ? Map.ItemEnumerator<T>.Empty : m_Map.GetItemsInRange<T>(m_Location, range);
+    public Map.ItemEnumerable<T> GetItemsInRange<T>(int range) where T : Item =>
+        m_Map == null ? Map.ItemEnumerable<T>.Empty : m_Map.GetItemsInRange<T>(m_Location, range);
 
     public IPooledEnumerable<IEntity> GetObjectsInRange(int range) =>
         m_Map?.GetObjectsInRange(m_Location, range) ?? PooledEnumeration.NullEnumerable<IEntity>.Instance;

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -4165,10 +4165,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
                 }
             }
 
-            for (var i = 0; i < oldSector.Items.Count; ++i)
+            foreach (var item in oldSector.Items)
             {
-                var item = oldSector.Items[i];
-
                 if (item.AtWorldPoint(oldX, oldY) &&
                     (item.Z == oldZ || item.Z + item.ItemData.Height > oldZ && oldZ + 15 > item.Z) &&
                     !item.OnMoveOff(this))
@@ -4187,10 +4185,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
                 }
             }
 
-            for (var i = 0; i < newSector.Items.Count; ++i)
+            foreach (var item in newSector.Items)
             {
-                var item = newSector.Items[i];
-
                 if (item.AtWorldPoint(x, y) &&
                     (item.Z == newZ || item.Z + item.ItemData.Height > newZ && newZ + 15 > item.Z) &&
                     !item.OnMoveOver(this))
@@ -4217,10 +4213,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
                 }
             }
 
-            for (var i = 0; i < oldSector.Items.Count; ++i)
+            foreach (var item in oldSector.Items)
             {
-                var item = oldSector.Items[i];
-
                 if (item.AtWorldPoint(oldX, oldY) &&
                     (item.Z == oldZ || item.Z + item.ItemData.Height > oldZ && oldZ + 15 > item.Z) &&
                     !item.OnMoveOff(this))
@@ -8064,10 +8058,12 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         return -1;
     }
 
-    public IPooledEnumerable<Item> GetItemsInRange(int range) => GetItemsInRange<Item>(range);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ItemEnumerator<Item> GetItemsInRange(int range) => GetItemsInRange<Item>(range);
 
-    public IPooledEnumerable<T> GetItemsInRange<T>(int range) where T : Item =>
-        m_Map?.GetItemsInRange<T>(m_Location, range) ?? PooledEnumeration.NullEnumerable<T>.Instance;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ItemEnumerator<T> GetItemsInRange<T>(int range) where T : Item =>
+        m_Map == null ? Map.ItemEnumerator<T>.Empty : m_Map.GetItemsInRange<T>(m_Location, range);
 
     public IPooledEnumerable<IEntity> GetObjectsInRange(int range) =>
         m_Map?.GetObjectsInRange(m_Location, range) ?? PooledEnumeration.NullEnumerable<IEntity>.Instance;

--- a/Projects/Server/Regions/Region.cs
+++ b/Projects/Server/Regions/Region.cs
@@ -295,15 +295,15 @@ public class Region : IComparable<Region>, IValueLinkListNode<Region>
         }
 
         var sector = map.GetSector(p);
-        var list = sector.RegionRects;
+        var list = sector.Regions;
 
         for (var i = 0; i < list.Count; ++i)
         {
-            var regRect = list[i];
+            var region = list[i];
 
-            if (regRect.Contains(p))
+            if (region.Contains(p))
             {
-                return regRect.Region;
+                return region;
             }
         }
 

--- a/Projects/UOContent.Tests/Tests/Multis/Boats/BoatPacketTests.cs
+++ b/Projects/UOContent.Tests/Tests/Multis/Boats/BoatPacketTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Server;

--- a/Projects/UOContent/Commands/Object Creation/Decorate.cs
+++ b/Projects/UOContent/Commands/Object Creation/Decorate.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Toolkit.HighPerformance;
+using Server.Collections;
 using Server.Engines.Quests.Haven;
 using Server.Engines.Quests.Necro;
 using Server.Engines.Spawners;
@@ -77,8 +78,6 @@ namespace Server.Commands
         private static readonly Type typeofHintItem = typeof(HintItem);
         private static readonly Type typeofCannon = typeof(Cannon);
         private static readonly Type typeofSerpentPillar = typeof(SerpentPillar);
-
-        private static readonly Queue<Item> m_DeleteQueue = new();
 
         private static readonly string[] m_EmptyParams = Array.Empty<string>();
         private List<DecorationEntry> m_Entries;
@@ -1037,16 +1036,17 @@ namespace Server.Commands
         private static bool FindItem(int x, int y, int z, Map map, Item srcItem)
         {
             var itemID = srcItem.ItemID;
+            var lt = srcItem.Light;
+            var srcName = srcItem.ItemData.Name;
+            var type = srcItem.GetType();
 
             var res = false;
 
-            IPooledEnumerable<Item> eable;
+            using var queue = PooledRefQueue<Item>.Create();
 
-            if (srcItem is BaseDoor)
+            foreach (var item in map.GetItemsInRange(new Point3D(x, y, z), 1))
             {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 1);
-
-                foreach (var item in eable)
+                if (srcItem is BaseDoor)
                 {
                     if (!(item is BaseDoor))
                     {
@@ -1079,18 +1079,10 @@ namespace Server.Commands
                     }
                     else if ((item.Z - z).Abs() < 8)
                     {
-                        m_DeleteQueue.Enqueue(item);
+                        queue.Enqueue(item);
                     }
                 }
-            }
-            else if (TileData.ItemTable[itemID & TileData.MaxItemValue].LightSource)
-            {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 0);
-
-                var lt = srcItem.Light;
-                var srcName = srcItem.ItemData.Name;
-
-                foreach (var item in eable)
+                else if (TileData.ItemTable[itemID & TileData.MaxItemValue].LightSource)
                 {
                     if (item.Z == z)
                     {
@@ -1098,7 +1090,7 @@ namespace Server.Commands
                         {
                             if (item.Light != lt)
                             {
-                                m_DeleteQueue.Enqueue(item);
+                                queue.Enqueue(item);
                             }
                             else
                             {
@@ -1107,24 +1099,17 @@ namespace Server.Commands
                         }
                         else if (item.ItemData.LightSource && item.ItemData.Name == srcName)
                         {
-                            m_DeleteQueue.Enqueue(item);
+                            queue.Enqueue(item);
                         }
                     }
                 }
-            }
-            else if (srcItem is Teleporter or FillableContainer or BaseBook)
-            {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 0);
-
-                var type = srcItem.GetType();
-
-                foreach (var item in eable)
+                else if (srcItem is Teleporter or FillableContainer or BaseBook)
                 {
                     if (item.Z == z && item.ItemID == itemID)
                     {
                         if (item.GetType() != type)
                         {
-                            m_DeleteQueue.Enqueue(item);
+                            queue.Enqueue(item);
                         }
                         else
                         {
@@ -1132,12 +1117,7 @@ namespace Server.Commands
                         }
                     }
                 }
-            }
-            else
-            {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 0);
-
-                foreach (var item in eable)
+                else
                 {
                     if (item.Z == z && item.ItemID == itemID)
                     {
@@ -1146,9 +1126,9 @@ namespace Server.Commands
                 }
             }
 
-            while (m_DeleteQueue.Count > 0)
+            while (queue.Count > 0)
             {
-                m_DeleteQueue.Dequeue().Delete();
+                queue.Dequeue().Delete();
             }
 
             return res;
@@ -1195,11 +1175,9 @@ namespace Server.Commands
 
                         if (item is BaseDoor door)
                         {
-                            var eable = maps[j].GetItemsInRange<BaseDoor>(loc, 1);
-
                             var itemType = door.GetType();
 
-                            foreach (var link in eable)
+                            foreach (var link in maps[j].GetItemsInRange<BaseDoor>(loc, 1))
                             {
                                 if (link != item && link.Z == door.Z && link.GetType() == itemType)
                                 {

--- a/Projects/UOContent/Commands/Object Creation/Decorate.cs
+++ b/Projects/UOContent/Commands/Object Creation/Decorate.cs
@@ -1175,9 +1175,10 @@ namespace Server.Commands
 
                         if (item is BaseDoor door)
                         {
+                            var eable = maps[j].GetItemsInRange<BaseDoor>(loc, 1);
                             var itemType = door.GetType();
 
-                            foreach (var link in maps[j].GetItemsInRange<BaseDoor>(loc, 1))
+                            foreach (var link in eable)
                             {
                                 if (link != item && link.Z == door.Z && link.GetType() == itemType)
                                 {

--- a/Projects/UOContent/Commands/Object Creation/DecorateMag.cs
+++ b/Projects/UOContent/Commands/Object Creation/DecorateMag.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Toolkit.HighPerformance;
+using Server.Collections;
 using Server.Engines.Quests.Haven;
 using Server.Engines.Quests.Necro;
 using Server.Engines.Spawners;
@@ -73,8 +74,6 @@ namespace Server.Commands
         private static readonly Type typeofHintItem = typeof(HintItem);
         private static readonly Type typeofCannon = typeof(Cannon);
         private static readonly Type typeofSerpentPillar = typeof(SerpentPillar);
-
-        private static readonly Queue<Item> m_DeleteQueue = new();
 
         private static readonly string[] m_EmptyParams = Array.Empty<string>();
         private List<DecorationEntryMag> m_Entries;
@@ -1033,16 +1032,16 @@ namespace Server.Commands
         private static bool FindItem(int x, int y, int z, Map map, Item srcItem)
         {
             var itemID = srcItem.ItemID;
+            var lt = srcItem.Light;
+            var srcName = srcItem.ItemData.Name;
+            var type = srcItem.GetType();
 
             var res = false;
 
-            IPooledEnumerable<Item> eable;
-
-            if (srcItem is BaseDoor)
+            using var queue = PooledRefQueue<Item>.Create();
+            foreach (var item in map.GetItemsInRange(new Point3D(x, y, z), 1))
             {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 1);
-
-                foreach (var item in eable)
+                if (srcItem is BaseDoor)
                 {
                     if (!(item is BaseDoor))
                     {
@@ -1075,18 +1074,10 @@ namespace Server.Commands
                     }
                     else if ((item.Z - z).Abs() < 8)
                     {
-                        m_DeleteQueue.Enqueue(item);
+                        queue.Enqueue(item);
                     }
                 }
-            }
-            else if (TileData.ItemTable[itemID & TileData.MaxItemValue].LightSource)
-            {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 0);
-
-                var lt = srcItem.Light;
-                var srcName = srcItem.ItemData.Name;
-
-                foreach (var item in eable)
+                else if (TileData.ItemTable[itemID & TileData.MaxItemValue].LightSource)
                 {
                     if (item.Z == z)
                     {
@@ -1094,7 +1085,7 @@ namespace Server.Commands
                         {
                             if (item.Light != lt)
                             {
-                                m_DeleteQueue.Enqueue(item);
+                                queue.Enqueue(item);
                             }
                             else
                             {
@@ -1103,24 +1094,17 @@ namespace Server.Commands
                         }
                         else if (item.ItemData.LightSource && item.ItemData.Name == srcName)
                         {
-                            m_DeleteQueue.Enqueue(item);
+                            queue.Enqueue(item);
                         }
                     }
                 }
-            }
-            else if (srcItem is Teleporter or FillableContainer or BaseBook)
-            {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 0);
-
-                var type = srcItem.GetType();
-
-                foreach (var item in eable)
+                else if (srcItem is Teleporter or FillableContainer or BaseBook)
                 {
                     if (item.Z == z && item.ItemID == itemID)
                     {
                         if (item.GetType() != type)
                         {
-                            m_DeleteQueue.Enqueue(item);
+                            queue.Enqueue(item);
                         }
                         else
                         {
@@ -1128,12 +1112,7 @@ namespace Server.Commands
                         }
                     }
                 }
-            }
-            else
-            {
-                eable = map.GetItemsInRange(new Point3D(x, y, z), 0);
-
-                foreach (var item in eable)
+                else
                 {
                     if (item.Z == z && item.ItemID == itemID)
                     {
@@ -1142,9 +1121,9 @@ namespace Server.Commands
                 }
             }
 
-            while (m_DeleteQueue.Count > 0)
+            while (queue.Count > 0)
             {
-                m_DeleteQueue.Dequeue()?.Delete();
+                queue.Dequeue()?.Delete();
             }
 
             return res;
@@ -1181,11 +1160,9 @@ namespace Server.Commands
 
                         if (item is BaseDoor door)
                         {
-                            var eable = maps[j].GetItemsInRange<BaseDoor>(loc, 1);
-
                             var itemType = door.GetType();
 
-                            foreach (var link in eable)
+                            foreach (var link in maps[j].GetItemsInRange<BaseDoor>(loc, 1))
                             {
                                 if (link != item && link.Z == door.Z && link.GetType() == itemType)
                                 {

--- a/Projects/UOContent/Commands/Object Creation/GenTeleporter.cs
+++ b/Projects/UOContent/Commands/Object Creation/GenTeleporter.cs
@@ -121,17 +121,16 @@ namespace Server.Commands
 
             public static int DeleteTeleporters(WorldLocation worldLocation)
             {
-                var eable = worldLocation.Map.GetItemsInRange<Teleporter>(worldLocation, 0);
-
                 var count = 0;
-                foreach (var item in eable)
+                foreach (var item in worldLocation.Map.GetItemsInRange<Teleporter>(worldLocation, 0))
                 {
-                    if (!(item is KeywordTeleporter or SkillTeleporter) && IsWithinZ(item.Z - worldLocation.Z))
+                    if (item is not (KeywordTeleporter or SkillTeleporter) && IsWithinZ(item.Z - worldLocation.Z))
                     {
                         count++;
                         item.Delete();
                     }
                 }
+
                 return count;
             }
 

--- a/Projects/UOContent/Commands/SignParser.cs
+++ b/Projects/UOContent/Commands/SignParser.cs
@@ -91,9 +91,7 @@ namespace Server.Commands
 
         public static void Add_Static(int itemID, Point3D location, Map map, string name)
         {
-            var eable = map.GetItemsInRange(location, 0);
-
-            foreach (var item in eable)
+            foreach (var item in map.GetItemsInRange(location, 0))
             {
                 if (item is Sign && item.Z == location.Z && item.ItemID == itemID)
                 {

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -467,10 +467,8 @@ namespace Server.Engines.ConPVP
 
                     if (landTile.ID == 0x244 && statics.Length == 0) // 0x244 = invalid land tile
                     {
-                        var eable = Map.GetItemsInRange(point, 0);
-
                         var empty = true;
-                        foreach (var item in eable)
+                        foreach (var item in Map.GetItemsInRange(point, 0))
                         {
                             if (item != this)
                             {
@@ -513,8 +511,7 @@ namespace Server.Engines.ConPVP
 
                 var rect = new Rectangle2D(pTop.X, pTop.Y, pBottom.X - pTop.X + 1, pBottom.Y - pTop.Y + 1);
 
-                var area = Map.GetItemsInBounds(rect);
-                foreach (var i in area)
+                foreach (var i in Map.GetItemsInBounds(rect))
                 {
                     if (i == this || i.ItemID >= 0x4000)
                     {
@@ -567,6 +564,7 @@ namespace Server.Engines.ConPVP
                     {
                         continue;
                     }
+
                     if (i is BRGoal goal)
                     {
                         var oldLoc = new Point3D(GetWorldLocation());
@@ -662,8 +660,7 @@ namespace Server.Engines.ConPVP
                     }
                 }
 
-                var eable = GetItemsInRange(0);
-                foreach (var item in eable)
+                foreach (var item in GetItemsInRange(0))
                 {
                     if (item.Visible && item != this)
                     {

--- a/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
@@ -387,8 +387,7 @@ namespace Server.Engines.Craft
                 return false;
             }
 
-            var eable = map.GetItemsInRange(from.Location, 2);
-            foreach (var item in eable)
+            foreach (var item in map.GetItemsInRange(from.Location, 2))
             {
                 if (item.Z + 16 > item.Z && item.Z + 16 > item.Z && Find(item.ItemID, itemIDs))
                 {

--- a/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
+++ b/Projects/UOContent/Engines/Craft/DefBlacksmithy.cs
@@ -39,9 +39,7 @@ public class DefBlacksmithy : CraftSystem
             return;
         }
 
-        var eable = map.GetItemsInRange(from.Location, range);
-
-        foreach (var item in eable)
+        foreach (var item in map.GetItemsInRange(from.Location, range))
         {
             var type = item.GetType();
 

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
@@ -197,9 +197,7 @@ public partial class LeverPuzzleController : Item
     [Usage("GenLeverPuzzle"), Description("Generates lamp room and lever puzzle in doom.")]
     public static void GenLampPuzzle_OnCommand(CommandEventArgs e)
     {
-        var eable = Map.Malas.GetItemsInRange(lp_Center, 0);
-
-        foreach (var item in eable)
+        foreach (var item in Map.Malas.GetItemsInRange(lp_Center, 0))
         {
             if (item is LeverPuzzleController)
             {

--- a/Projects/UOContent/Engines/Ethics/Core/Ethic.cs
+++ b/Projects/UOContent/Engines/Ethics/Core/Ethic.cs
@@ -155,10 +155,9 @@ namespace Server.Ethics
                         continue;
                     }
 
-                    var eable = e.Mobile.GetItemsInRange(2);
                     var found = false;
 
-                    foreach (var item in eable)
+                    foreach (var item in e.Mobile.GetItemsInRange(2))
                     {
                         if (item is AnkhNorth or AnkhWest)
                         {

--- a/Projects/UOContent/Engines/Factions/Core/Generator.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Generator.cs
@@ -78,14 +78,14 @@ namespace Server.Factions
 
         private static bool CheckExistence(Point3D loc, Map facet, Type type)
         {
-            var eable = facet.GetItemsInRange(loc, 0);
-            foreach (var item in eable)
+            foreach (var item in facet.GetItemsInRange(loc, 0))
             {
                 if (type.IsInstanceOfType(item))
                 {
                     return true;
                 }
             }
+
             return false;
         }
     }

--- a/Projects/UOContent/Engines/Harvest/Core/HarvestSystem.cs
+++ b/Projects/UOContent/Engines/Harvest/Core/HarvestSystem.cs
@@ -307,8 +307,7 @@ namespace Server.Engines.Harvest
                 return false;
             }
 
-            var eable = m.GetItemsInRange(0);
-            foreach (var i in eable)
+            foreach (var i in m.GetItemsInRange(0))
             {
                 if (i.StackWith(m, i, false))
                 {

--- a/Projects/UOContent/Engines/Khaldun/KhaldunGen.cs
+++ b/Projects/UOContent/Engines/Khaldun/KhaldunGen.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Server.Items;
 
 namespace Server.Commands
@@ -15,10 +14,8 @@ namespace Server.Commands
 
         public static bool FindMorphItem(int x, int y, int z, int inactiveItemID, int activeItemID)
         {
-            var eable = Map.Felucca.GetItemsInRange(new Point3D(x, y, z), 0);
-
             var found = false;
-            foreach (var item in eable)
+            foreach (var item in Map.Felucca.GetItemsInRange(new Point3D(x, y, z), 0))
             {
                 if (item is MorphItem morphItem && morphItem.Z == z && morphItem.InactiveItemId == inactiveItemID && morphItem.ActiveItemId == activeItemID)
                 {
@@ -26,15 +23,14 @@ namespace Server.Commands
                     break;
                 }
             }
+
             return found;
         }
 
         public static bool FindEffectController(int x, int y, int z)
         {
-            var eable = Map.Felucca.GetItemsInRange(new Point3D(x, y, z), 0);
-
             var found = false;
-            foreach (var item in eable)
+            foreach (var item in Map.Felucca.GetItemsInRange(new Point3D(x, y, z), 0))
             {
                 if (item is EffectController && item.Z == z)
                 {
@@ -42,22 +38,20 @@ namespace Server.Commands
                     break;
                 }
             }
+
             return found;
         }
 
         public static T TryCreateItem<T>(int x, int y, int z, T srcItem) where T : Item
         {
-            var eable = Map.Felucca.GetItemsInBounds<T>(new Rectangle2D(x, y, 1, 1));
-            var t = eable.FirstOrDefault(item => item.GetType() == srcItem.GetType());
-            if (t != null)
+            foreach (var item in Map.Felucca.GetItemsInBounds<T>(new Rectangle2D(x, y, 1, 1)))
             {
                 srcItem.Delete();
-                return t;
+                return item;
             }
 
             srcItem.MoveToWorld(new Point3D(x, y, z), Map.Felucca);
             m_Count++;
-
             return srcItem;
         }
 

--- a/Projects/UOContent/Engines/Pathing/Movement.cs
+++ b/Projects/UOContent/Engines/Pathing/Movement.cs
@@ -98,10 +98,8 @@ namespace Server.Movement
 
                 foreach (var sector in _sectors)
                 {
-                    for (var j = 0; j < sector.Items.Count; ++j)
+                    foreach (var item in sector.Items)
                     {
-                        var item = sector.Items[j];
-
                         if (ignoreMovableImpassables && item.Movable && item.ItemData.ImpassableSurface)
                         {
                             continue;
@@ -167,10 +165,8 @@ namespace Server.Movement
 
                 if (!sectorStartIsForward)
                 {
-                    for (var i = 0; i < sectorForward.Items.Count; ++i)
+                    foreach (var item in sectorForward.Items)
                     {
-                        var item = sectorForward.Items[i];
-
                         if (ignoreMovableImpassables && item.Movable && item.ItemData.ImpassableSurface)
                         {
                             continue;
@@ -193,10 +189,8 @@ namespace Server.Movement
                     }
                 }
 
-                for (var i = 0; i < sectorStart.Items.Count; ++i)
+                foreach (var item in sectorStart.Items)
                 {
-                    var item = sectorStart.Items[i];
-
                     if (ignoreMovableImpassables && item.Movable && item.ItemData.ImpassableSurface)
                     {
                         continue;

--- a/Projects/UOContent/Engines/Spawners/Commands/GenerateSpawnersCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/GenerateSpawnersCommand.cs
@@ -147,8 +147,7 @@ namespace Server.Engines.Spawners
 
                 // Delete all spawners at this location.
                 // Probably shouldn't do this outside of migrations? Is there a better way to find/fix spawners?
-                var eable = map.GetItemsInRange<BaseSpawner>(location, 0);
-                foreach (var spawner in eable)
+                foreach (var spawner in map.GetItemsInRange<BaseSpawner>(location, 0))
                 {
                     if (spawner.GetType() == type)
                     {

--- a/Projects/UOContent/Holiday Stuff/Halloween/2009/Engines/PumpkinPatch.cs
+++ b/Projects/UOContent/Holiday Stuff/Halloween/2009/Engines/PumpkinPatch.cs
@@ -50,9 +50,8 @@ namespace Server.Engines.Events
                 var rect = m_PumpkinFields[i];
 
                 var spawncount = rect.Height * rect.Width / 20;
-                var eable = map.GetItemsInBounds<HalloweenPumpkin>(rect);
                 var pumpkins = 0;
-                foreach (var p in eable)
+                foreach (var _ in map.GetItemsInBounds<HalloweenPumpkin>(rect))
                 {
                     if (pumpkins++ >= spawncount)
                     {

--- a/Projects/UOContent/Items/Addons/SHTeleporter.cs
+++ b/Projects/UOContent/Items/Addons/SHTeleporter.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using ModernUO.Serialization;
 using Server.Mobiles;
 
@@ -268,9 +267,15 @@ namespace Server.Items
 
             public static SHTeleporter FindSHTeleporter(Map map, Point3D p)
             {
-                var eable = map.GetItemsInRange<SHTeleporter>(p, 0);
-                var teleporter = eable.FirstOrDefault(item => item.Z == p.Z);
-                return teleporter;
+                foreach (var teleporter in map.GetItemsInRange<SHTeleporter>(p, 0))
+                {
+                    if (teleporter.Z == p.Z)
+                    {
+                        return teleporter;
+                    }
+                }
+
+                return null;
             }
 
             public SHTeleporter AddSHT(Map map, bool ext, int x, int y, int z)

--- a/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
+++ b/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
@@ -332,13 +332,10 @@ public abstract partial class BaseDoor : Item, ILockable, ITelekinesisable
         var z = p.Z;
 
         var sector = map.GetSector(x, y);
-        var items = sector.Items;
         var mobs = sector.Mobiles;
 
-        for (var i = 0; i < items.Count; ++i)
+        foreach (var item in sector.Items)
         {
-            var item = items[i];
-
             if (item is not BaseMulti && item.ItemID <= TileData.MaxItemValue && item.AtWorldPoint(x, y) &&
                 item is not BaseDoor)
             {

--- a/Projects/UOContent/Items/Containers/MarkContainer.cs
+++ b/Projects/UOContent/Items/Containers/MarkContainer.cs
@@ -130,15 +130,14 @@ public partial class MarkContainer : LockableContainer
 
     private static bool FindMarkContainer(Point3D p, Map map)
     {
-        var eable = map.GetItemsInRange<MarkContainer>(p, 0);
-
-        foreach (var item in eable)
+        foreach (var item in map.GetItemsInRange<MarkContainer>(p, 0))
         {
             if (item.Z == p.Z)
             {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/Projects/UOContent/Items/Misc/OilFlask.cs
+++ b/Projects/UOContent/Items/Misc/OilFlask.cs
@@ -49,9 +49,8 @@ public partial class OilFlask : Item
             if (!from.PlaceInBackpack(emptyFlask))
             {
                 var didStack = false;
-                var eable = from.GetItemsInRange(0);
 
-                foreach (var i in eable)
+                foreach (var i in from.GetItemsInRange(0))
                 {
                     if (i.StackWith(from, this, false))
                     {

--- a/Projects/UOContent/Mobiles/AI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI.cs
@@ -2157,10 +2157,7 @@ public abstract class BaseAI
                 Movement.Movement.Offset(d, ref x, ref y);
 
                 var destroyables = 0;
-
-                var eable = map.GetItemsInRange(new Point3D(x, y, m_Mobile.Location.Z), 1);
-
-                foreach (var item in eable)
+                foreach (var item in map.GetItemsInRange(new Point3D(x, y, m_Mobile.Location.Z), 1))
                 {
                     if (canOpenDoors && item is BaseDoor door && door.Z + door.ItemData.Height > m_Mobile.Z &&
                         m_Mobile.Z + 16 > door.Z)

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -3638,9 +3638,8 @@ namespace Server.Mobiles
                 return false;
             }
 
-            var eable = GetItemsInRange<Corpse>(2);
             Corpse toRummage = null;
-            foreach (var c in eable)
+            foreach (var c in GetItemsInRange<Corpse>(2))
             {
                 if (c.Items.Count > 0)
                 {

--- a/Projects/UOContent/Mobiles/Familiars/HordeMinion.cs
+++ b/Projects/UOContent/Mobiles/Familiars/HordeMinion.cs
@@ -74,9 +74,8 @@ public partial class HordeMinionFamiliar : BaseFamiliar
             return;
         }
 
-        var eable = GetItemsInRange(2);
         using var queue = PooledRefQueue<Item>.Create();
-        foreach (var item in eable)
+        foreach (var item in GetItemsInRange(2))
         {
             if (item.Movable && item.Stackable)
             {

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/InterredGrizzle .cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/InterredGrizzle .cs
@@ -117,9 +117,13 @@ namespace Server.Mobiles
                 {
                     p = GetSpawnPosition(2);
 
-                    var eable = Map.GetItemsInRange<StainedOoze>(p, 0);
-                    using var enumerator = eable.GetEnumerator();
-                    bool atLocation = enumerator.MoveNext();
+                    var atLocation = false;
+                    foreach (var item in Map.GetItemsInRange<StainedOoze>(p, 0))
+                    {
+                        atLocation = true;
+                        break;
+                    }
+
                     if (!atLocation)
                     {
                         break;

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
@@ -234,9 +234,13 @@ namespace Server.Mobiles
                 {
                     p = GetSpawnPosition(2);
 
-                    var eable = Map.GetItemsInRange<StainedOoze>(p, 0);
-                    using var enumerator = eable.GetEnumerator();
-                    bool atLocation = enumerator.MoveNext();
+                    var atLocation = false;
+                    foreach (var item in Map.GetItemsInRange<StainedOoze>(p, 0))
+                    {
+                        atLocation = true;
+                        break;
+                    }
+
                     if (!atLocation)
                     {
                         break;

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/PlagueBeast.cs
@@ -165,18 +165,13 @@ namespace Server.Mobiles
             base.OnThink();
 
             // Check to see if we need to devour any corpses
-            var eable = GetItemsInRange<Corpse>(3); // Get all corpses in range
-
-            foreach (var item in eable)
-                // Ensure that the corpse was killed by us
+            foreach (var item in GetItemsInRange<Corpse>(3)) // Get all corpses in range
             {
+                // Ensure that the corpse was killed by us
                 if (item.Killer == this && item.Owner != null && !item.DevourCorpse() && !item.Devoured)
                 {
-                    PublicOverheadMessage(
-                        MessageType.Emote,
-                        0x3B2,
-                        1053032
-                    ); // * The plague beast attempts to absorb the remains, but cannot! *
+                    // * The plague beast attempts to absorb the remains, but cannot! *
+                    PublicOverheadMessage(MessageType.Emote, 0x3B2, 1053032);
                 }
             }
         }

--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Server.Engines.Spawners;
 using Server.Items;
@@ -1502,31 +1501,32 @@ namespace Server.Multis
                 }
             }
 
-            var eable = map.GetItemsInBounds(
-                new Rectangle2D(
-                    p.X + newComponents.Min.X,
-                    p.Y + newComponents.Min.Y,
-                    newComponents.Width,
-                    newComponents.Height
-                )
+            var bounds = new Rectangle2D(
+                p.X + newComponents.Min.X,
+                p.Y + newComponents.Min.Y,
+                newComponents.Width,
+                newComponents.Height
             );
 
-            var canFit = eable.All(
-                item =>
+            foreach (var item in map.GetItemsInBounds(bounds))
+            {
+                if (item is BaseMulti || item.ItemID > TileData.MaxItemValue || item.Z < p.Z || !item.Visible)
                 {
-                    if (item is BaseMulti || item.ItemID > TileData.MaxItemValue || item.Z < p.Z || !item.Visible)
-                    {
-                        return true;
-                    }
-
-                    var x = item.X - p.X + newComponents.Min.X;
-                    var y = item.Y - p.Y + newComponents.Min.Y;
-
-                    return x >= 0 && x < newComponents.Width && y >= 0 && y < newComponents.Height &&
-                        newComponents.Tiles[x][y].Length == 0 || Contains(item);
+                    continue;
                 }
-            );
-            return canFit;
+
+                var x = item.X - p.X + newComponents.Min.X;
+                var y = item.Y - p.Y + newComponents.Min.Y;
+
+                // Out of bounds, return false - cannot fit
+                if ((x < 0 || x >= newComponents.Width || y < 0 || y >= newComponents.Height ||
+                     newComponents.Tiles[x][y].Length != 0) && !Contains(item))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public Point3D Rotate(Point3D p, int count)

--- a/Projects/UOContent/Multis/Houses/BaseHouse.cs
+++ b/Projects/UOContent/Multis/Houses/BaseHouse.cs
@@ -1141,6 +1141,7 @@ namespace Server.Multis
             MovingCrate.DropItem(item);
         }
 
+        // TODO: Convert to a ref struct enumerator
         public List<Item> GetItems()
         {
             if (Map == null || Map == Map.Internal)
@@ -1152,8 +1153,14 @@ namespace Server.Multis
             var end = new Point2D(X + Components.Max.X + 1, Y + Components.Max.Y + 1);
             var rect = new Rectangle2D(start, end);
 
-            var eable = Map.GetItemsInBounds(rect);
-            var list = eable.Where(item => item.Movable && IsInside(item)).ToList();
+            var list = new List<Item>();
+            foreach (var item in Map.GetItemsInBounds(rect))
+            {
+                if (item.Movable && IsInside(item))
+                {
+                    list.Add(item);
+                }
+            }
 
             return list;
         }
@@ -3653,11 +3660,14 @@ namespace Server.Multis
             }
 
             var mcl = Components;
-            var eable =
-                map.GetItemsInBounds<Guildstone>(new Rectangle2D(X + mcl.Min.X, Y + mcl.Min.Y, mcl.Width, mcl.Height));
+            var bounds = new Rectangle2D(X + mcl.Min.X, Y + mcl.Min.Y, mcl.Width, mcl.Height);
 
-            var item = eable.FirstOrDefault(Contains);
-            return item;
+            foreach (var gs in map.GetItemsInBounds<Guildstone>(bounds))
+            {
+                return gs;
+            }
+
+            return null;
         }
 
         public void ResetDynamicDecay()

--- a/Projects/UOContent/Multis/Houses/HousePlacement.cs
+++ b/Projects/UOContent/Multis/Houses/HousePlacement.cs
@@ -142,10 +142,8 @@ namespace Server.Multis
 
                     items.Clear();
 
-                    for (var i = 0; i < sector.Items.Count; ++i)
+                    foreach (var item in sector.Items)
                     {
-                        var item = sector.Items[i];
-
                         if (item.Visible && item.X == tileX && item.Y == tileY)
                         {
                             items.Add(item);
@@ -366,12 +364,9 @@ namespace Server.Multis
                 }
 
                 var sector = map.GetSector(borderPoint.X, borderPoint.Y);
-                var sectorItems = sector.Items;
 
-                for (var j = 0; j < sectorItems.Count; ++j)
+                foreach (var item in sector.Items)
                 {
-                    var item = sectorItems[j];
-
                     if (item.X != borderPoint.X || item.Y != borderPoint.Y || item.Movable)
                     {
                         continue;

--- a/Projects/UOContent/Skills/DetectHidden.cs
+++ b/Projects/UOContent/Skills/DetectHidden.cs
@@ -83,17 +83,15 @@ namespace Server.SkillHandlers
 
                     if (Faction.Find(src) != null)
                     {
-                        var itemsInRange = src.Map.GetItemsInRange<BaseFactionTrap>(p, range);
-
-                        foreach (var trap in itemsInRange)
+                        foreach (var trap in src.Map.GetItemsInRange<BaseFactionTrap>(p, range))
                         {
                             if (src.CheckTargetSkill(SkillName.DetectHidden, trap, 80.0, 100.0))
                             {
                                 src.SendLocalizedMessage(
-                                    1042712,
+                                    1042712, // You reveal a trap placed by a faction:
                                     true,
                                     $" {(trap.Faction == null ? "" : trap.Faction.Definition.FriendlyName)}"
-                                ); // You reveal a trap placed by a faction:
+                                );
 
                                 trap.Visible = true;
                                 trap.BeginConceal();

--- a/Projects/UOContent/Skills/SpiritSpeak.cs
+++ b/Projects/UOContent/Skills/SpiritSpeak.cs
@@ -124,9 +124,8 @@ namespace Server.SkillHandlers
 
             public override void OnCast()
             {
-                var eable = Caster.GetItemsInRange<Corpse>(3);
                 Corpse toChannel = null;
-                foreach (var corpse in eable)
+                foreach (var corpse in Caster.GetItemsInRange<Corpse>(3))
                 {
                     if (!corpse.Channeled)
                     {

--- a/Projects/UOContent/Spells/Seventh/GateTravel.cs
+++ b/Projects/UOContent/Spells/Seventh/GateTravel.cs
@@ -141,9 +141,7 @@ namespace Server.Spells.Seventh
 
         private static bool GateExistsAt(Map map, Point3D loc)
         {
-            var eable = map.GetItemsInRange(loc, 0);
-
-            foreach (var item in eable)
+            foreach (var item in map.GetItemsInRange(loc, 0))
             {
                 if (item is Moongate or PublicMoongate)
                 {

--- a/Projects/UOContent/Spells/Spellweaving/ArcaneCircle.cs
+++ b/Projects/UOContent/Spells/Spellweaving/ArcaneCircle.cs
@@ -97,9 +97,7 @@ namespace Server.Spells.Spellweaving
                 }
             }
 
-            var eable = map.GetItemsInRange(location, 0);
-
-            foreach (var item in eable)
+            foreach (var item in map.GetItemsInRange(location, 0))
             {
                 if (item.Z + item.ItemData.CalcHeight == location.Z && IsValidTile(item.ItemID))
                 {

--- a/Projects/UOContent/Spells/Third/Teleport.cs
+++ b/Projects/UOContent/Spells/Third/Teleport.cs
@@ -96,9 +96,7 @@ namespace Server.Spells.Third
 
                 m.PlaySound(0x1FE);
 
-                var eable = m.GetItemsInRange(0);
-
-                foreach (var item in eable)
+                foreach (var item in m.GetItemsInRange(0))
                 {
                     if (item is ParalyzeFieldSpell.InternalItem or
                         PoisonFieldSpell.InternalItem or FireFieldSpell.FireFieldItem)


### PR DESCRIPTION
### Summary

Eliminates `IPooledEnumerable<T>` and `eable.Free()` from `Map` for items. This drastically simplifies code that iterates in range, for example:

```cs
foreach (var item in m.GetItemsInRange(5))
{
}
```
The code above no longer requires an eable and calling `Free()`.