### PR TITLE
Fix for witch's apprentice quest - was not "beatable"

### DIFF
--- a/Projects/UOContent/Items/Food/Beverage.cs
+++ b/Projects/UOContent/Items/Food/Beverage.cs
@@ -479,7 +479,7 @@ public abstract partial class BaseBeverage : Item, IHasQuantity
 
                 var obj = qs.FindObjective<FindIngredientObjective>();
 
-                if (obj?.Completed == true && obj.Ingredient == Ingredient.SwampWater)
+                if (obj?.Completed == false && obj.Ingredient == Ingredient.SwampWater)
                 {
                     var contains = false;
 


### PR DESCRIPTION
The Witch's Apprentice quest was not beatable. The check would only allow players to fill up a pitcher with swamp water if the quest was completed, which made it unbeatable.