### PR TITLE
fix: FlippableAttribute with empty list will crash the client.

### DIFF
--- a/Projects/UOContent/Items/Misc/FlippableAttribute.cs
+++ b/Projects/UOContent/Items/Misc/FlippableAttribute.cs
@@ -59,7 +59,7 @@ public class FlippableAttribute : Attribute
 
     public virtual void Flip(Item item)
     {
-        if (ItemIDs == null)
+        if (ItemIDs == null || ItemIDs.Length == 0)
         {
             try
             {


### PR DESCRIPTION
Using a decorator tool on certain items (example: some Paragon Chests) will cause clients to crash, throwing a `IndexOutOfRangeException`.

It depends on the ItemIDs property, and we were only checking if it's null or not, not if it has any elements, which ended up causing it to set `item.ItemID = ItemIDs[index];` (or null).