### PR TITLE
fix: Fixes map iterators for Items

### DIFF
--- a/Projects/Server.Tests/Tests/Collections/ValueLinkListTests.cs
+++ b/Projects/Server.Tests/Tests/Collections/ValueLinkListTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Collections;
 using Xunit;
 
@@ -32,20 +33,35 @@ public class ValueLinkListTests
 
         Assert.True(entity1.OnLinkList);
         Assert.Equal(1, linkList.Count);
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity1, linkList.Last);
+
+        Assert.Collection(linkList.ToArray(), item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Null(item.Next);
+            }
+        );
 
         var entity2 = new TestEntity(2);
-
         linkList.AddFirst(entity2);
 
         Assert.True(entity2.OnLinkList);
         Assert.Equal(2, linkList.Count);
-        Assert.Equal(entity1, linkList.Last);
-        Assert.Equal(entity2, entity1.Previous);
 
-        Assert.Equal(entity2, linkList.First);
-        Assert.Equal(entity1, entity2.Next);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity1);
+            },
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Equal(item.Previous, entity2);
+                Assert.Null(item.Next);
+            }
+        );
     }
 
     [Fact]
@@ -58,8 +74,14 @@ public class ValueLinkListTests
 
         Assert.True(entity1.OnLinkList);
         Assert.Equal(1, linkList.Count);
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity1, linkList.Last);
+
+        Assert.Collection(linkList.ToArray(), item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Null(item.Next);
+            }
+        );
 
         var entity2 = new TestEntity(2);
 
@@ -67,11 +89,21 @@ public class ValueLinkListTests
 
         Assert.True(entity2.OnLinkList);
         Assert.Equal(2, linkList.Count);
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity2, entity1.Next);
 
-        Assert.Equal(entity2, linkList.Last);
-        Assert.Equal(entity1, entity2.Previous);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity2);
+            },
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Equal(item.Previous, entity1);
+                Assert.Null(item.Next);
+            }
+        );
     }
 
     [Fact]
@@ -87,20 +119,48 @@ public class ValueLinkListTests
         Assert.True(entity1.OnLinkList);
         Assert.True(entity2.OnLinkList);
         Assert.Equal(2, linkList.Count);
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity2, linkList.Last);
+
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity2);
+            },
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Equal(item.Previous, entity1);
+                Assert.Null(item.Next);
+            }
+        );
+
 
         var entity3 = new TestEntity(3);
         linkList.AddBefore(entity2, entity3);
         Assert.True(entity3.OnLinkList);
         Assert.Equal(3, linkList.Count);
 
-        Assert.Equal(entity1, entity3.Previous);
-        Assert.Equal(entity2, entity3.Next);
-
-        // First and Last should not have changed
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity2, linkList.Last);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity3);
+            },
+            item =>
+            {
+                Assert.Equal(entity3, item);
+                Assert.Equal(item.Previous, entity1);
+                Assert.Equal(item.Next, entity2);
+            },
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Equal(item.Previous, entity3);
+                Assert.Null(item.Next);
+            }
+        );
     }
 
     [Fact]
@@ -113,23 +173,31 @@ public class ValueLinkListTests
         linkList.AddFirst(entity1);
         linkList.AddLast(entity2);
 
-        Assert.True(entity1.OnLinkList);
-        Assert.True(entity2.OnLinkList);
-        Assert.Equal(2, linkList.Count);
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity2, linkList.Last);
-
         var entity3 = new TestEntity(3);
         linkList.AddAfter(entity1, entity3);
         Assert.True(entity3.OnLinkList);
         Assert.Equal(3, linkList.Count);
 
-        Assert.Equal(entity1, entity3.Previous);
-        Assert.Equal(entity2, entity3.Next);
-
-        // First and Last should not have changed
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity2, linkList.Last);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity3);
+            },
+            item =>
+            {
+                Assert.Equal(entity3, item);
+                Assert.Equal(item.Previous, entity1);
+                Assert.Equal(item.Next, entity2);
+            },
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Equal(item.Previous, entity3);
+                Assert.Null(item.Next);
+            }
+        );
     }
 
     [Fact]
@@ -157,12 +225,47 @@ public class ValueLinkListTests
         Assert.Equal(1, linkList.Count);
         Assert.Equal(5, linkList2.Count);
 
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity1, linkList.Last);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Null(item.Next);
+            }
+        );
 
-        Assert.Equal(entity2, entity6.Next);
-        Assert.Equal(entity6, entity2.Previous);
-        Assert.Equal(entity4, linkList2.Last);
+        Assert.Collection(linkList2.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity5, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity6);
+            },
+            item =>
+            {
+                Assert.Equal(entity6, item);
+                Assert.Equal(item.Previous, entity5);
+                Assert.Equal(item.Next, entity2);
+            },
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Equal(item.Previous, entity6);
+                Assert.Equal(item.Next, entity3);
+            },
+            item =>
+            {
+                Assert.Equal(entity3, item);
+                Assert.Equal(item.Previous, entity2);
+                Assert.Equal(item.Next, entity4);
+            },
+            item =>
+            {
+                Assert.Equal(entity4, item);
+                Assert.Equal(item.Previous, entity3);
+                Assert.Null(item.Next);
+            }
+        );
     }
 
     [Fact]
@@ -184,10 +287,20 @@ public class ValueLinkListTests
         linkList.RemoveAllBefore(entity4);
 
         Assert.Equal(2, linkList.Count);
-        Assert.Equal(entity4, linkList.First);
-        Assert.Equal(entity5, linkList.Last);
-        Assert.Null(entity4.Previous);
-        Assert.Null(entity5.Next);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity4, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity5);
+            },
+            item =>
+            {
+                Assert.Equal(entity5, item);
+                Assert.Equal(item.Previous, entity4);
+                Assert.Null(item.Next);
+            }
+        );
     }
 
     [Fact]
@@ -209,9 +322,104 @@ public class ValueLinkListTests
         linkList.RemoveAllAfter(entity2);
 
         Assert.Equal(2, linkList.Count);
-        Assert.Equal(entity1, linkList.First);
-        Assert.Equal(entity2, linkList.Last);
-        Assert.Null(entity1.Previous);
-        Assert.Null(entity2.Next);
+        Assert.Collection(linkList.ToArray(),
+            item =>
+            {
+                Assert.Equal(entity1, item);
+                Assert.Null(item.Previous);
+                Assert.Equal(item.Next, entity2);
+            },
+            item =>
+            {
+                Assert.Equal(entity2, item);
+                Assert.Equal(item.Previous, entity1);
+                Assert.Null(item.Next);
+            }
+        );
+    }
+
+    [Fact]
+    public void TestVersionIncrements()
+    {
+        var linkList = new ValueLinkList<TestEntity>();
+
+        var entity1 = new TestEntity(1);
+        var entity2 = new TestEntity(2);
+        var entity3 = new TestEntity(3);
+        var entity4 = new TestEntity(4);
+
+        var version = 0;
+        Assert.Equal(version, linkList.Version);
+
+        linkList.AddFirst(entity1); // 1
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.AddLast(entity2); // 1, 2
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.AddBefore(entity2, entity3); // 1, 3, 2
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.AddAfter(entity3, entity4); // 1, 3, 4, 2
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.Remove(entity1); // 3, 4, 2
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.RemoveAllAfter(entity4); // 3, 4
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.RemoveAllBefore(entity4); // 4
+        Assert.Equal(++version, linkList.Version);
+
+        linkList.RemoveAll(); // None
+        Assert.Equal(++version, linkList.Version);
+    }
+
+    [Fact]
+    public void TestThrowsIfModifiedWhileIterating()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () =>
+            {
+                var linkList = new ValueLinkList<TestEntity>();
+
+                var entity1 = new TestEntity(1);
+                var entity2 = new TestEntity(2);
+
+                linkList.AddFirst(entity1);
+                linkList.AddLast(entity2);
+
+                foreach (var item in linkList)
+                {
+                    linkList.Remove(item);
+                }
+            }
+        );
+    }
+
+    [Fact]
+    public void TestThrowsIfModifiedWhileIteratingNested()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () =>
+            {
+                var linkList = new ValueLinkList<TestEntity>();
+
+                var entity1 = new TestEntity(1);
+                var entity2 = new TestEntity(2);
+
+                linkList.AddFirst(entity1);
+                linkList.AddLast(entity2);
+
+                foreach (var item in linkList)
+                {
+                    foreach (var nestedItem in linkList)
+                    {
+                        linkList.Remove(nestedItem);
+                    }
+                }
+            }
+        );
     }
 }

--- a/Projects/Server/IEntity.cs
+++ b/Projects/Server/IEntity.cs
@@ -30,6 +30,12 @@ public interface IEntity : IPoint3D, ISerializable
     bool InRange(Point3D p, int range);
 
     void RemoveItem(Item item);
+
+    bool OnMoveOff(Mobile m);
+
+    bool OnMoveOver(Mobile m);
+
+    public void OnMovement(Mobile m, Point3D oldLocation);
 }
 
 public class Entity : IEntity
@@ -80,6 +86,14 @@ public class Entity : IEntity
     }
 
     public void RemoveItem(Item item)
+    {
+    }
+
+    public bool OnMoveOff(Mobile m) => true;
+
+    public bool OnMoveOver(Mobile m) => true;
+
+    public void OnMovement(Mobile m, Point3D oldLocation)
     {
     }
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2241,7 +2241,6 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
 
     public virtual bool CanDecay() => Decays && Parent == null && Map != Map.Internal;
 
-
     public virtual bool OnDecay() =>
         CanDecay() && Region.Find(Location, Map).OnDecay(this);
 
@@ -2474,12 +2473,20 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Map.ItemEnumerable<Item> GetItemsInRange(int range) =>
-        m_Map == null ? Map.ItemEnumerable<Item>.Empty : m_Map.GetItemsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
+    public Map.ItemAtEnumerable<Item> GetItemsAt() =>
+        m_Map == null ? Map.ItemAtEnumerable<Item>.Empty : m_Map.GetItemsAt(m_Parent == null ? m_Location : GetWorldLocation());
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Map.ItemEnumerable<T> GetItemsInRange<T>(int range) where T : Item =>
-        m_Map == null ? Map.ItemEnumerable<T>.Empty : m_Map.GetItemsInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
+    public Map.ItemAtEnumerable<T> GetItemsAt<T>() where T : Item =>
+        m_Map == null ? Map.ItemAtEnumerable<T>.Empty : m_Map.GetItemsAt<T>(m_Parent == null ? m_Location : GetWorldLocation());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ItemBoundsEnumerable<Item> GetItemsInRange(int range) =>
+        m_Map == null ? Map.ItemBoundsEnumerable<Item>.Empty : m_Map.GetItemsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ItemBoundsEnumerable<T> GetItemsInRange<T>(int range) where T : Item =>
+        m_Map == null ? Map.ItemBoundsEnumerable<T>.Empty : m_Map.GetItemsInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     public IPooledEnumerable<Mobile> GetMobilesInRange(int range)
     {

--- a/Projects/Server/Maps/Map.ItemEnumerator.cs
+++ b/Projects/Server/Maps/Map.ItemEnumerator.cs
@@ -13,140 +13,159 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using System.Collections.Generic;
+using System;
 using System.Runtime.CompilerServices;
+using Server.Collections;
 
 namespace Server;
 
 public partial class Map
 {
-    private int _iteratingItems;
-    private readonly List<(MapAction, Point3D, Item)> _delayedItemActions = new();
-
-    public bool IsIteratingItems
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _iteratingItems > 0;
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ItemAtEnumerable<Item> GetItemsAt(Point3D p) => GetItemsAt<Item>(p);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsAt(Point3D p) => GetItemsInRange(p, 0);
+    public ItemAtEnumerable<T> GetItemsAt<T>(Point3D p) where T : Item => GetItemsAt<T>(new Point2D(p.X, p.Y));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsAt<T>(Point3D p) where T : Item => GetItemsInRange<T>(p, 0);
+    public ItemAtEnumerable<Item> GetItemsAt(int x, int y) => GetItemsAt<Item>(new Point2D(x, y));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsInRange(Point3D p) => GetItemsInRange<Item>(p);
+    public ItemAtEnumerable<T> GetItemsAt<T>(int x, int y) where T : Item => GetItemsAt<T>(new Point2D(x, y));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsInRange(Point3D p, int range) => GetItemsInRange<Item>(p, range);
+    public ItemAtEnumerable<Item> GetItemsAt(Point2D p) => GetItemsAt<Item>(p);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsInRange<T>(Point3D p) where T : Item => GetItemsInRange<T>(p, Core.GlobalMaxUpdateRange);
+    public ItemAtEnumerable<T> GetItemsAt<T>(Point2D p) where T : Item => new(this, p);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsInRange<T>(Point3D p, int range) where T : Item =>
+    public ItemBoundsEnumerable<Item> GetItemsInRange(Point3D p) => GetItemsInRange<Item>(p);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ItemBoundsEnumerable<Item> GetItemsInRange(Point3D p, int range) => GetItemsInRange<Item>(p, range);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ItemBoundsEnumerable<T> GetItemsInRange<T>(Point3D p) where T : Item => GetItemsInRange<T>(p, Core.GlobalMaxUpdateRange);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ItemBoundsEnumerable<T> GetItemsInRange<T>(Point3D p, int range) where T : Item =>
         GetItemsInRange<T>(p.m_X, p.m_Y, range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsAt(Point2D p) => GetItemsInRange(p, 0);
+    public ItemBoundsEnumerable<Item> GetItemsInRange(Point2D p) => GetItemsInRange<Item>(p);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsAt<T>(Point2D p) where T : Item => GetItemsInRange<T>(p, 0);
+    public ItemBoundsEnumerable<Item> GetItemsInRange(Point2D p, int range) => GetItemsInRange<Item>(p, range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsInRange(Point2D p) => GetItemsInRange<Item>(p);
+    public ItemBoundsEnumerable<T> GetItemsInRange<T>(Point2D p) where T : Item => GetItemsInRange<T>(p, Core.GlobalMaxUpdateRange);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsInRange(Point2D p, int range) => GetItemsInRange<Item>(p, range);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsInRange<T>(Point2D p) where T : Item => GetItemsInRange<T>(p, Core.GlobalMaxUpdateRange);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsInRange<T>(Point2D p, int range) where T : Item =>
+    public ItemBoundsEnumerable<T> GetItemsInRange<T>(Point2D p, int range) where T : Item =>
         GetItemsInRange<T>(p.m_X, p.m_Y, range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsAt(int x, int y) => GetItemsAt<Item>(x, y);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsAt<T>(int x, int y) where T : Item => GetItemsInRange<T>(x, y, 0);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsInRange<T>(int x, int y, int range) where T : Item =>
+    public ItemBoundsEnumerable<T> GetItemsInRange<T>(int x, int y, int range) where T : Item =>
         GetItemsInBounds<T>(new Rectangle2D(x - range, y - range, range * 2 + 1, range * 2 + 1));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<Item> GetItemsInBounds(Rectangle2D bounds) => GetItemsInBounds<Item>(bounds);
+    public ItemBoundsEnumerable<Item> GetItemsInBounds(Rectangle2D bounds) => GetItemsInBounds<Item>(bounds);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ItemEnumerable<T> GetItemsInBounds<T>(Rectangle2D bounds, bool makeBoundsInclusive = false) where T : Item =>
+    public ItemBoundsEnumerable<T> GetItemsInBounds<T>(Rectangle2D bounds, bool makeBoundsInclusive = false) where T : Item =>
         new(this, bounds, makeBoundsInclusive);
 
-    private void BeginIteratingItems()
+    public ref struct ItemAtEnumerable<T> where T : Item
     {
-#if THREADGUARD
-            if (Thread.CurrentThread != Core.Thread)
-            {
-                Utility.PushColor(ConsoleColor.Red);
-                Console.WriteLine($"Iterating through items on {this} from an invalid thread!");
-                Console.WriteLine(new StackTrace());
-                Utility.PopColor();
-                return;
-            }
-#endif
+        public static ItemAtEnumerable<T> Empty
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => new();
+        }
 
-        _iteratingItems++;
+        private Map _map;
+        private Point2D _location;
+
+        public ItemAtEnumerable(Map map, Point2D loc)
+        {
+            _map = map;
+            _location = loc;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemAtEnumerator<T> GetEnumerator() => new(_map, _location);
     }
 
-    private void EndIteratingItems()
+    public ref struct ItemAtEnumerator<T> where T : Item
     {
-#if THREADGUARD
-            if (Thread.CurrentThread != Core.Thread)
-            {
-                Utility.PushColor(ConsoleColor.Red);
-                Console.WriteLine($"Iterating through items on {this} from an invalid thread!");
-                Console.WriteLine(new StackTrace());
-                Utility.PopColor();
-                return;
-            }
-#endif
+        private bool _started;
+        private Point2D _location;
+        private ref readonly ValueLinkList<Item> _linkList;
+        private int _version;
+        private T _current;
 
-        _iteratingItems--;
-
-        // Finished iterating, check for deferred actions
-        if (_iteratingItems == 0 && _delayedItemActions.Count > 0)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemAtEnumerator(Map map, Point2D loc)
         {
-            foreach (var (a, p, i) in _delayedItemActions)
+            _started = false;
+            _location = loc;
+            _linkList = ref map.GetRealSector(loc.m_X, loc.m_Y).Items;
+            _version = 0;
+            _current = null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            ref var loc = ref _location;
+            Item current;
+
+            if (!_started)
             {
-                switch (a)
+                current = _linkList._first;
+                _started = true;
+                _version = _linkList.Version;
+
+                if (current is T { Deleted: false, Parent: null } o && o.X == loc.m_X && o.Y == loc.m_Y)
                 {
-                    case MapAction.Enter:
-                        {
-                            OnEnter(p, i);
-                            break;
-                        }
-                    case MapAction.Leave:
-                        {
-                            OnLeave(p, i);
-                            break;
-                        }
-                    case MapAction.Move:
-                        {
-                            OnMove(p, i);
-                            break;
-                        }
+                    _current = o;
+                    return true;
+                }
+            }
+            else if (_linkList.Version != _version)
+            {
+                throw new InvalidOperationException(CollectionThrowStrings.InvalidOperation_EnumFailedVersion);
+            }
+            else
+            {
+                current = _current;
+            }
+
+            while (current != null)
+            {
+                current = current.Next;
+
+                if (current is T { Deleted: false, Parent: null } o && o.X == loc.m_X && o.Y == loc.m_Y)
+                {
+                    _current = o;
+                    return true;
                 }
             }
 
-            _delayedItemActions.Clear();
+            return false;
+        }
+
+        public T Current
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _current;
         }
     }
 
-    public ref struct ItemEnumerable<T> where T : Item
+    public ref struct ItemBoundsEnumerable<T> where T : Item
     {
-        public static ItemEnumerable<T> Empty
+        public static ItemBoundsEnumerable<T> Empty
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => new(null, Rectangle2D.Empty, false);
@@ -156,14 +175,13 @@ public partial class Map
         private Rectangle2D _bounds;
         private bool _makeBoundsInclusive;
 
-        public ItemEnumerable(Map map, Rectangle2D bounds, bool makeBoundsInclusive)
+        public ItemBoundsEnumerable(Map map, Rectangle2D bounds, bool makeBoundsInclusive)
         {
             _map = map;
             _bounds = bounds;
             _makeBoundsInclusive = makeBoundsInclusive;
         }
 
-        // The enumerator MUST be disposed. Not disposing it will damage the sector irreparably.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemEnumerator<T> GetEnumerator() => new(_map, _bounds, _makeBoundsInclusive);
     }
@@ -178,6 +196,9 @@ public partial class Map
 
         private int _currentSectorX;
         private int _currentSectorY;
+
+        private ref readonly ValueLinkList<Item> _linkList;
+        private int _currentVersion;
         private T _current;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -199,8 +220,6 @@ public partial class Map
             // We start the X sector one short because it gets incremented immediately in MoveNext()
             _currentSectorX = _sectorStartX - 1;
             _currentSectorY = _sectorStartY;
-
-            _map.BeginIteratingItems();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -242,7 +261,14 @@ public partial class Map
                         return false;
                     }
 
-                    current = map.GetRealSector(currentSectorX, currentSectorY).Items.First;
+                    _linkList = ref map.GetRealSector(currentSectorX, currentSectorY).Items;
+                    _currentVersion = _linkList.Version;
+                    current = _linkList._first;
+                }
+
+                if (_linkList.Version != _currentVersion)
+                {
+                    throw new InvalidOperationException(CollectionThrowStrings.InvalidOperation_EnumFailedVersion);
                 }
 
                 if (current is T { Deleted: false, Parent: null } o && bounds.Contains(o.Location))
@@ -252,9 +278,6 @@ public partial class Map
                 }
             }
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Dispose() => _map.EndIteratingItems();
 
         public T Current
         {

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -627,12 +627,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
     public void OnEnter(Item item)
     {
-        if (IsIteratingItems)
-        {
-            _delayedItemActions.Add((MapAction.Enter, item.Location, item));
-            return;
-        }
-
         OnEnter(item.Location, item);
     }
 
@@ -669,12 +663,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
     public void OnLeave(Item item)
     {
-        if (IsIteratingItems)
-        {
-            _delayedItemActions.Add((MapAction.Leave, item.Location, item));
-            return;
-        }
-
         OnLeave(item.Location, item);
     }
 
@@ -765,12 +753,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
         if (oldSector != newSector)
         {
-            if (IsIteratingItems)
-            {
-                _delayedItemActions.Add((MapAction.Move, item.Location, item));
-                return;
-            }
-
             oldSector.OnLeave(item);
             newSector.OnEnter(item);
         }
@@ -787,12 +769,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
             if (oldStart != start || oldEnd != end)
             {
-                if (IsIteratingItems)
-                {
-                    _delayedItemActions.Add((MapAction.Move, oldLocation, item));
-                    return;
-                }
-
                 RemoveMulti(m, oldStart, oldEnd);
                 AddMulti(m, start, end);
             }
@@ -1037,8 +1013,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
     public Sector GetSector(Point3D p) => InternalGetSector(p.m_X >> SectorShift, p.m_Y >> SectorShift);
 
     public Sector GetSector(Point2D p) => InternalGetSector(p.m_X >> SectorShift, p.m_Y >> SectorShift);
-
-    // public Sector GetSector(IPoint2D p) => InternalGetSector(p.X >> SectorShift, p.Y >> SectorShift);
 
     public Sector GetSector(int x, int y) => InternalGetSector(x >> SectorShift, y >> SectorShift);
 
@@ -1459,14 +1433,6 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
         return false;
     }
 
-    private enum MapAction
-    {
-        None,
-        Enter,
-        Leave,
-        Move
-    }
-
     public class Sector
     {
         // TODO: Can we avoid this?
@@ -1495,7 +1461,7 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
         public List<Mobile> Mobiles => _mobiles ?? m_DefaultMobileList;
 
-        public ref ValueLinkList<Item> Items => ref _items;
+        public ref readonly ValueLinkList<Item> Items => ref _items;
 
         public List<NetState> Clients => _clients ?? m_DefaultClientList;
 

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -1461,7 +1461,7 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
 
         public List<Mobile> Mobiles => _mobiles ?? m_DefaultMobileList;
 
-        public ref readonly ValueLinkList<Item> Items => ref _items;
+        internal ref readonly ValueLinkList<Item> Items => ref _items;
 
         public List<NetState> Clients => _clients ?? m_DefaultClientList;
 

--- a/Projects/Server/Maps/PooledEnumeration.cs
+++ b/Projects/Server/Maps/PooledEnumeration.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Server.Collections;
 using Server.Items;
 using Server.Network;
 

--- a/Projects/UOContent/Commands/SignParser.cs
+++ b/Projects/UOContent/Commands/SignParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Server.Collections;
 using Server.Items;
 using Server.Network;
 
@@ -8,8 +9,6 @@ namespace Server.Commands
 {
     public static class SignParser
     {
-        private static readonly Queue<Item> m_ToDelete = new();
-
         public static void Initialize()
         {
             CommandSystem.Register("SignGen", AccessLevel.Administrator, SignGen_OnCommand);
@@ -91,17 +90,18 @@ namespace Server.Commands
 
         public static void Add_Static(int itemID, Point3D location, Map map, string name)
         {
+            using var queue = PooledRefQueue<Item>.Create();
             foreach (var item in map.GetItemsInRange(location, 0))
             {
                 if (item is Sign && item.Z == location.Z && item.ItemID == itemID)
                 {
-                    m_ToDelete.Enqueue(item);
+                    queue.Enqueue(item);
                 }
             }
 
-            while (m_ToDelete.Count > 0)
+            while (queue.Count > 0)
             {
-                m_ToDelete.Dequeue().Delete();
+                queue.Dequeue().Delete();
             }
 
             Item sign;

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -468,7 +468,7 @@ namespace Server.Engines.ConPVP
                     if (landTile.ID == 0x244 && statics.Length == 0) // 0x244 = invalid land tile
                     {
                         var empty = true;
-                        foreach (var item in Map.GetItemsInRange(point, 0))
+                        foreach (var item in Map.GetItemsAt(point))
                         {
                             if (item != this)
                             {
@@ -660,7 +660,7 @@ namespace Server.Engines.ConPVP
                     }
                 }
 
-                foreach (var item in GetItemsInRange(0))
+                foreach (var item in GetItemsAt())
                 {
                     if (item.Visible && item != this)
                     {

--- a/Projects/UOContent/Engines/Doom/GenGauntlet.cs
+++ b/Projects/UOContent/Engines/Doom/GenGauntlet.cs
@@ -180,7 +180,7 @@ namespace Server.Engines.Doom
         public static void RemoveDoorSet(int x, int y)
         {
             var loc = new Point3D(x, y, -1);
-            foreach (var item in Map.Malas.GetItemsInRange(loc, 0))
+            foreach (var item in Map.Malas.GetItemsAt(loc))
             {
                 if (item is BaseDoor door)
                 {
@@ -226,9 +226,9 @@ namespace Server.Engines.Doom
 
         public static void RemoveItem<T>(int x, int y, int z = -1) where T : Item
         {
-            foreach (var item in Map.Malas.GetItemsInRange(new Point3D(x, y, z), 0))
+            foreach (var item in Map.Malas.GetItemsAt(x, y))
             {
-                if (item is T)
+                if (item is T && z == -1 || item.Z == z)
                 {
                     item.Delete();
                     break;

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
@@ -197,7 +197,7 @@ public partial class LeverPuzzleController : Item
     [Usage("GenLeverPuzzle"), Description("Generates lamp room and lever puzzle in doom.")]
     public static void GenLampPuzzle_OnCommand(CommandEventArgs e)
     {
-        foreach (var item in Map.Malas.GetItemsInRange(lp_Center, 0))
+        foreach (var item in Map.Malas.GetItemsAt(lp_Center))
         {
             if (item is LeverPuzzleController)
             {

--- a/Projects/UOContent/Engines/Factions/Core/Generator.cs
+++ b/Projects/UOContent/Engines/Factions/Core/Generator.cs
@@ -78,7 +78,7 @@ namespace Server.Factions
 
         private static bool CheckExistence(Point3D loc, Map facet, Type type)
         {
-            foreach (var item in facet.GetItemsInRange(loc, 0))
+            foreach (var item in facet.GetItemsAt(loc))
             {
                 if (type.IsInstanceOfType(item))
                 {

--- a/Projects/UOContent/Engines/Factions/Items/Traps/BaseFactionTrap.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Traps/BaseFactionTrap.cs
@@ -114,7 +114,7 @@ namespace Server.Factions
 
             if (Core.ML)
             {
-                foreach (var item in m.GetItemsInRange(p, 0))
+                foreach (var item in m.GetItemsAt(p))
                 {
                     if (item is BaseFactionTrap trap && trap.Faction == Faction)
                     {

--- a/Projects/UOContent/Engines/Harvest/Core/HarvestSystem.cs
+++ b/Projects/UOContent/Engines/Harvest/Core/HarvestSystem.cs
@@ -307,7 +307,7 @@ namespace Server.Engines.Harvest
                 return false;
             }
 
-            foreach (var i in m.GetItemsInRange(0))
+            foreach (var i in m.GetItemsAt())
             {
                 if (i.StackWith(m, i, false))
                 {

--- a/Projects/UOContent/Engines/Khaldun/KhaldunGen.cs
+++ b/Projects/UOContent/Engines/Khaldun/KhaldunGen.cs
@@ -15,9 +15,9 @@ namespace Server.Commands
         public static bool FindMorphItem(int x, int y, int z, int inactiveItemID, int activeItemID)
         {
             var found = false;
-            foreach (var item in Map.Felucca.GetItemsInRange(new Point3D(x, y, z), 0))
+            foreach (var morphItem in Map.Felucca.GetItemsAt<MorphItem>(x, y))
             {
-                if (item is MorphItem morphItem && morphItem.Z == z && morphItem.InactiveItemId == inactiveItemID && morphItem.ActiveItemId == activeItemID)
+                if (morphItem.Z == z && morphItem.InactiveItemId == inactiveItemID && morphItem.ActiveItemId == activeItemID)
                 {
                     found = true;
                     break;
@@ -30,9 +30,9 @@ namespace Server.Commands
         public static bool FindEffectController(int x, int y, int z)
         {
             var found = false;
-            foreach (var item in Map.Felucca.GetItemsInRange(new Point3D(x, y, z), 0))
+            foreach (var item in Map.Felucca.GetItemsAt<EffectController>(x, y))
             {
-                if (item is EffectController && item.Z == z)
+                if (item.Z == z)
                 {
                     found = true;
                     break;
@@ -44,7 +44,7 @@ namespace Server.Commands
 
         public static T TryCreateItem<T>(int x, int y, int z, T srcItem) where T : Item
         {
-            foreach (var item in Map.Felucca.GetItemsInBounds<T>(new Rectangle2D(x, y, 1, 1)))
+            foreach (var item in Map.Felucca.GetItemsAt<T>(x, y))
             {
                 srcItem.Delete();
                 return item;

--- a/Projects/UOContent/Engines/ML Quests/MLQuest.cs
+++ b/Projects/UOContent/Engines/ML Quests/MLQuest.cs
@@ -267,7 +267,7 @@ namespace Server.Engines.MLQuests
             var name = $"MLQS-{GetType().Name}";
 
             using var queue = PooledRefQueue<Item>.Create();
-            foreach (var item in map.GetItemsInRange(loc, 0))
+            foreach (var item in map.GetItemsAt(loc))
             {
                 // This predates GUIDs. Let's build these spawners and export them so we can delete this code!
                 if (item is BaseSpawner spawner && spawner.Name == name)
@@ -288,7 +288,7 @@ namespace Server.Engines.MLQuests
         public static void PutDeco(Item deco, Point3D loc, Map map)
         {
             using var queue = PooledRefQueue<Item>.Create();
-            foreach (var item in map.GetItemsInRange(loc, 0))
+            foreach (var item in map.GetItemsAt(loc))
             {
                 if (item.ItemID == deco.ItemID && item.Z == loc.Z)
                 {

--- a/Projects/UOContent/Engines/Quests/The Summoning/Mobiles/Victoria.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Mobiles/Victoria.cs
@@ -29,13 +29,9 @@ public partial class Victoria : BaseQuester
             if (_altar?.Deleted != false || _altar.Map != Map ||
                 !Utility.InRange(_altar.Location, Location, AltarRange))
             {
-                foreach (var item in GetItemsInRange(AltarRange))
+                foreach (var altar in GetItemsInRange<SummoningAltar>(AltarRange))
                 {
-                    if (item is SummoningAltar altar)
-                    {
-                        _altar = altar;
-                        break;
-                    }
+                    _altar = altar;
                 }
             }
 

--- a/Projects/UOContent/Engines/Spawners/Commands/GenerateSpawnersCommand.cs
+++ b/Projects/UOContent/Engines/Spawners/Commands/GenerateSpawnersCommand.cs
@@ -147,7 +147,7 @@ namespace Server.Engines.Spawners
 
                 // Delete all spawners at this location.
                 // Probably shouldn't do this outside of migrations? Is there a better way to find/fix spawners?
-                foreach (var spawner in map.GetItemsInRange<BaseSpawner>(location, 0))
+                foreach (var spawner in map.GetItemsAt<BaseSpawner>(location))
                 {
                     if (spawner.GetType() == type)
                     {

--- a/Projects/UOContent/Holiday Stuff/Christmas/2010/Addons/FireFliesDeed.cs
+++ b/Projects/UOContent/Holiday Stuff/Christmas/2010/Addons/FireFliesDeed.cs
@@ -199,9 +199,9 @@ namespace Server.Items
 
                                 bool isclear = true;
 
-                                foreach (Item item in Map.Malas.GetItemsInRange(p3d, 0))
+                                foreach (Fireflies fireflies in Map.Malas.GetItemsAt<Fireflies>(p3d))
                                 {
-                                    if (item is Fireflies)
+                                    if (fireflies.Z == p3d.Z)
                                     {
                                         isclear = false;
                                     }

--- a/Projects/UOContent/Items/Addons/SHTeleporter.cs
+++ b/Projects/UOContent/Items/Addons/SHTeleporter.cs
@@ -267,7 +267,7 @@ namespace Server.Items
 
             public static SHTeleporter FindSHTeleporter(Map map, Point3D p)
             {
-                foreach (var teleporter in map.GetItemsInRange<SHTeleporter>(p, 0))
+                foreach (var teleporter in map.GetItemsAt<SHTeleporter>(p))
                 {
                     if (teleporter.Z == p.Z)
                     {

--- a/Projects/UOContent/Items/Containers/MarkContainer.cs
+++ b/Projects/UOContent/Items/Containers/MarkContainer.cs
@@ -130,7 +130,7 @@ public partial class MarkContainer : LockableContainer
 
     private static bool FindMarkContainer(Point3D p, Map map)
     {
-        foreach (var item in map.GetItemsInRange<MarkContainer>(p, 0))
+        foreach (var item in map.GetItemsAt<MarkContainer>(p))
         {
             if (item.Z == p.Z)
             {

--- a/Projects/UOContent/Items/Misc/OilFlask.cs
+++ b/Projects/UOContent/Items/Misc/OilFlask.cs
@@ -50,7 +50,7 @@ public partial class OilFlask : Item
             {
                 var didStack = false;
 
-                foreach (var i in from.GetItemsInRange(0))
+                foreach (var i in from.GetItemsAt())
                 {
                     if (i.StackWith(from, this, false))
                     {

--- a/Projects/UOContent/Items/Misc/WarningItem.cs
+++ b/Projects/UOContent/Items/Misc/WarningItem.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using ModernUO.Serialization;
+using Server.Collections;
 
 namespace Server.Items;
 
@@ -83,19 +83,18 @@ public partial class WarningItem : Item
 
         if (NeighborRange >= 0)
         {
-            var list = new List<WarningItem>();
-
-            foreach (var item in GetItemsInRange(NeighborRange))
+            using var queue = PooledRefQueue<WarningItem>.Create();
+            foreach (var warningItem in GetItemsInRange<WarningItem>(NeighborRange))
             {
-                if (item != this && item is WarningItem warningItem)
+                if (warningItem != this)
                 {
-                    list.Add(warningItem);
+                    queue.Enqueue(warningItem);
                 }
             }
 
-            for (var i = 0; i < list.Count; i++)
+            while (queue.Count > 0)
             {
-                list[i].Broadcast(triggerer);
+                queue.Dequeue().Broadcast(triggerer);
             }
         }
 

--- a/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/InterredGrizzle .cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Humanoid/Magic/InterredGrizzle .cs
@@ -118,7 +118,7 @@ namespace Server.Mobiles
                     p = GetSpawnPosition(2);
 
                     var atLocation = false;
-                    foreach (var item in Map.GetItemsInRange<StainedOoze>(p, 0))
+                    foreach (var item in Map.GetItemsAt<StainedOoze>(p))
                     {
                         atLocation = true;
                         break;

--- a/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Special/Ilhenir.cs
@@ -235,7 +235,7 @@ namespace Server.Mobiles
                     p = GetSpawnPosition(2);
 
                     var atLocation = false;
-                    foreach (var item in Map.GetItemsInRange<StainedOoze>(p, 0))
+                    foreach (var item in Map.GetItemsAt<StainedOoze>(p))
                     {
                         atLocation = true;
                         break;

--- a/Projects/UOContent/Multis/Houses/HousePlacement.cs
+++ b/Projects/UOContent/Multis/Houses/HousePlacement.cs
@@ -358,11 +358,9 @@ namespace Server.Multis
                     }
                 }
 
-                var sector = map.GetSector(borderPoint.X, borderPoint.Y);
-
-                foreach (var item in sector.Items)
+                foreach (var item in map.GetItemsAt(borderPoint))
                 {
-                    if (item.X != borderPoint.X || item.Y != borderPoint.Y || item.Movable)
+                    if (item.Movable)
                     {
                         continue;
                     }

--- a/Projects/UOContent/Spells/Seventh/GateTravel.cs
+++ b/Projects/UOContent/Spells/Seventh/GateTravel.cs
@@ -141,7 +141,7 @@ namespace Server.Spells.Seventh
 
         private static bool GateExistsAt(Map map, Point3D loc)
         {
-            foreach (var item in map.GetItemsInRange(loc, 0))
+            foreach (var item in map.GetItemsAt(loc))
             {
                 if (item is Moongate or PublicMoongate)
                 {

--- a/Projects/UOContent/Spells/Spellweaving/ArcaneCircle.cs
+++ b/Projects/UOContent/Spells/Spellweaving/ArcaneCircle.cs
@@ -97,7 +97,7 @@ namespace Server.Spells.Spellweaving
                 }
             }
 
-            foreach (var item in map.GetItemsInRange(location, 0))
+            foreach (var item in map.GetItemsAt(location))
             {
                 if (item.Z + item.ItemData.CalcHeight == location.Z && IsValidTile(item.ItemID))
                 {

--- a/Projects/UOContent/Spells/Third/Teleport.cs
+++ b/Projects/UOContent/Spells/Third/Teleport.cs
@@ -1,3 +1,4 @@
+using Server.Collections;
 using Server.Factions;
 using Server.Items;
 using Server.Misc;
@@ -96,13 +97,20 @@ namespace Server.Spells.Third
 
                 m.PlaySound(0x1FE);
 
-                foreach (var item in m.GetItemsInRange(0))
+                using var queue = PooledRefQueue<Item>.Create();
+                foreach (var item in m.GetItemsAt())
                 {
                     if (item is ParalyzeFieldSpell.InternalItem or
                         PoisonFieldSpell.InternalItem or FireFieldSpell.FireFieldItem)
                     {
-                        item.OnMoveOver(m);
+                        // Use a queue just in case OnMoveOver changes the item's sector
+                        queue.Enqueue(item);
                     }
+                }
+
+                while (queue.Count > 0)
+                {
+                    queue.Dequeue().OnMoveOver(m);
                 }
             }
 


### PR DESCRIPTION
### Summary

Modifying a ValueLinkList using one of the methods will bump the "version". This field is used by iterators (foreach loops) to determine if the link list was modified while iterating. The sector.Items (and in the future other lists), will no longer be safe to modify while iterating. The server will _CRASH_ if the ValueLinkList is modified.

Thanks to @stefanomerotta for help!


### Screenshots
<img width="588" alt="image" src="https://github.com/modernuo/ModernUO/assets/3953314/83ee0b6e-ff4f-4768-9e29-84456e04b1ec">