### PR TITLE
fix: Adds GetClients to map iterators

### DIFF
--- a/Projects/Server/Effects.cs
+++ b/Projects/Server/Effects.cs
@@ -74,9 +74,7 @@ public static class Effects
         {
             Span<byte> buffer = stackalloc byte[OutgoingEffectPackets.SoundPacketLength].InitializePacket();
 
-            var eable = map.GetClientsInRange(new Point3D(p));
-
-            foreach (var state in eable)
+            foreach (var state in map.GetClientsInRange(p))
             {
                 state.Mobile.ProcessDelta();
                 OutgoingEffectPackets.CreateSoundEffect(buffer, soundID, p);
@@ -100,9 +98,7 @@ public static class Effects
         Span<byte> boltEffect = stackalloc byte[OutgoingEffectPackets.BoltEffectLength].InitializePacket();
         Span<byte> soundEffect = sound ? stackalloc byte[OutgoingEffectPackets.SoundPacketLength].InitializePacket() : null;
 
-        var eable = map.GetClientsInRange(e.Location);
-
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(e.Location))
         {
             if (state.Mobile.CanSee(e))
             {
@@ -169,9 +165,7 @@ public static class Effects
 
         Span<byte> regular = itemID != 0 ? stackalloc byte[OutgoingEffectPackets.HuedEffectLength].InitializePacket() : null;
 
-        var eable = map.GetClientsInRange(e.Location);
-
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(e.Location))
         {
             state.Mobile.ProcessDelta();
 
@@ -232,9 +226,7 @@ public static class Effects
         Span<byte> particles = stackalloc byte[OutgoingEffectPackets.ParticleEffectLength].InitializePacket();
         Span<byte> regular = itemID != 0 ? stackalloc byte[OutgoingEffectPackets.HuedEffectLength].InitializePacket() : null;
 
-        var eable = map.GetClientsInRange(target.Location);
-
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(target.Location))
         {
             state.Mobile.ProcessDelta();
 
@@ -446,9 +438,7 @@ public static class Effects
         Span<byte> particles = stackalloc byte[OutgoingEffectPackets.ParticleEffectLength].InitializePacket();
         Span<byte> regular = itemID != 0 ? stackalloc byte[OutgoingEffectPackets.HuedEffectLength].InitializePacket() : null;
 
-        var eable = map.GetClientsInRange(from.Location);
-
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(from.Location))
         {
             state.Mobile.ProcessDelta();
 
@@ -479,9 +469,7 @@ public static class Effects
             return;
         }
 
-        var eable = map.GetClientsInRange(new Point3D(origin));
-
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(origin))
         {
             state.Mobile.ProcessDelta();
             state.Send(effectBuffer);

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -332,11 +332,9 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
                 {
                     var worldLoc = GetWorldLocation();
 
-                    var eable = m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange());
-
                     Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-                    foreach (var state in eable)
+                    foreach (var state in m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange()))
                     {
                         var m = state.Mobile;
 
@@ -1106,9 +1104,7 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
                 Span<byte> saWorldItem = stackalloc byte[OutgoingEntityPackets.MaxWorldEntityPacketLength].InitializePacket();
                 Span<byte> hsWorldItem = stackalloc byte[OutgoingEntityPackets.MaxWorldEntityPacketLength].InitializePacket();
 
-                var eable = m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange());
-
-                foreach (var state in eable)
+                foreach (var state in m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange()))
                 {
                     var m = state.Mobile;
 
@@ -1157,15 +1153,11 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         }
         else if (m_Map != null)
         {
-            IPooledEnumerable<NetState> eable;
-
             if (oldLocation.m_X != 0)
             {
-                eable = m_Map.GetClientsInRange(oldLocation, GetMaxUpdateRange());
-
                 Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-                foreach (var state in eable)
+                foreach (var state in m_Map.GetClientsInRange(oldLocation, GetMaxUpdateRange()))
                 {
                     var m = state.Mobile;
 
@@ -1182,9 +1174,7 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             m_Location = location;
             OnLocationChange(oldRealLocation);
 
-            eable = m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange());
-
-            foreach (var state in eable)
+            foreach (var state in m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange()))
             {
                 var m = state.Mobile;
 
@@ -1352,9 +1342,7 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             return;
         }
 
-        var eable = map.GetClientsInRange(worldLoc, GetMaxUpdateRange());
-
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(worldLoc, GetMaxUpdateRange()))
         {
             var m = state.Mobile;
 
@@ -1488,15 +1476,11 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             {
                 if (m_Parent == null)
                 {
-                    IPooledEnumerable<NetState> eable;
-
                     if (m_Location.m_X != 0)
                     {
-                        eable = m_Map.GetClientsInRange(oldLocation, GetMaxUpdateRange());
-
                         Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-                        foreach (var state in eable)
+                        foreach (var state in m_Map.GetClientsInRange(oldLocation, GetMaxUpdateRange()))
                         {
                             var m = state.Mobile;
 
@@ -1513,9 +1497,7 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
 
                     SetLastMoved();
 
-                    eable = m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange());
-
-                    foreach (var state in eable)
+                    foreach (var state in m_Map.GetClientsInRange(m_Location, GetMaxUpdateRange()))
                     {
                         var m = state.Mobile;
 
@@ -2503,9 +2485,8 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         m_Map == null ? Map.MobileBoundsEnumerable<T>.Empty : m_Map.GetMobilesInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IPooledEnumerable<NetState> GetClientsInRange(int range) =>
-        m_Map.GetClientsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range)
-        ?? PooledEnumeration.NullEnumerable<NetState>.Instance;
+    public Map.ClientBoundsEnumerable GetClientsInRange(int range) =>
+        m_Map == null ? Map.ClientBoundsEnumerable.Empty : Map.GetClientsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     public bool GetTempFlag(int flag) => ((LookupCompactInfo()?.m_TempFlags ?? 0) & flag) != 0;
 
@@ -3276,11 +3257,10 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         }
 
         var worldLoc = GetWorldLocation();
-        var eable = m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange());
 
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLength(text)].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange()))
         {
             var m = state.Mobile;
 
@@ -3308,11 +3288,10 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         }
 
         var worldLoc = GetWorldLocation();
-        var eable = m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange());
 
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLocalizedLength(args)].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange()))
         {
             var m = state.Mobile;
 
@@ -3776,11 +3755,9 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             return;
         }
 
-        var eable = m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange());
-
         Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(worldLoc, GetMaxUpdateRange()))
         {
             var m = state.Mobile;
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2485,6 +2485,9 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         m_Map == null ? Map.MobileBoundsEnumerable<T>.Empty : m_Map.GetMobilesInRange<T>(m_Parent == null ? m_Location : GetWorldLocation(), range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ClientAtEnumerable GetClientsAt() => m_Map == null ? Map.ClientAtEnumerable.Empty : Map.GetClientsAt(m_Parent == null ? m_Location : GetWorldLocation());
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Map.ClientBoundsEnumerable GetClientsInRange(int range) =>
         m_Map == null ? Map.ClientBoundsEnumerable.Empty : Map.GetClientsInRange(m_Parent == null ? m_Location : GetWorldLocation(), range);
 

--- a/Projects/Server/Maps/Map.ClientEnumerator.cs
+++ b/Projects/Server/Maps/Map.ClientEnumerator.cs
@@ -2,7 +2,7 @@
  * ModernUO                                                              *
  * Copyright 2019-2023 - ModernUO Development Team                       *
  * Email: hi@modernuo.com                                                *
- * File: Map.MobileEnumerator.cs                                         *
+ * File: Map.ClientEnumerator.cs                                         *
  *                                                                       *
  * This program is free software: you can redistribute it and/or modify  *
  * it under the terms of the GNU General Public License as published by  *
@@ -16,69 +16,46 @@
 using System;
 using System.Runtime.CompilerServices;
 using Server.Collections;
+using Server.Network;
 
 namespace Server;
 
 public partial class Map
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileAtEnumerable<Mobile> GetMobilesAt(Point3D p) => GetMobilesAt<Mobile>(p);
+    public ClientAtEnumerable GetClientsAt(Point3D p) => GetClientsAt(new Point2D(p.X, p.Y));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileAtEnumerable<T> GetMobilesAt<T>(Point3D p) where T : Mobile => GetMobilesAt<T>(new Point2D(p.X, p.Y));
+    public ClientAtEnumerable GetClientsAt(int x, int y) => GetClientsAt(new Point2D(x, y));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileAtEnumerable<Mobile> GetMobilesAt(int x, int y) => GetMobilesAt<Mobile>(new Point2D(x, y));
+    public ClientAtEnumerable GetClientsAt(Point2D p) => new(this, p);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileAtEnumerable<T> GetMobilesAt<T>(int x, int y) where T : Mobile => GetMobilesAt<T>(new Point2D(x, y));
+    public ClientBoundsEnumerable GetClientsInRange(Point3D p) => GetClientsInRange(p, Core.GlobalMaxUpdateRange);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileAtEnumerable<Mobile> GetMobilesAt(Point2D p) => GetMobilesAt<Mobile>(p);
+    public ClientBoundsEnumerable GetClientsInRange(Point3D p, int range) =>
+        GetClientsInRange(p.m_X, p.m_Y, range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileAtEnumerable<T> GetMobilesAt<T>(Point2D p) where T : Mobile => new(this, p);
+    public ClientBoundsEnumerable GetClientsInRange(Point2D p) => GetClientsInRange(p, Core.GlobalMaxUpdateRange);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<Mobile> GetMobilesInRange(Point3D p) => GetMobilesInRange<Mobile>(p);
+    public ClientBoundsEnumerable GetClientsInRange(Point2D p, int range) =>
+        GetClientsInRange(p.m_X, p.m_Y, range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<Mobile> GetMobilesInRange(Point3D p, int range) => GetMobilesInRange<Mobile>(p, range);
+    public ClientBoundsEnumerable GetClientsInRange(int x, int y, int range) =>
+        GetClientsInBounds(new Rectangle2D(x - range, y - range, range * 2 + 1, range * 2 + 1));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<T> GetMobilesInRange<T>(Point3D p) where T : Mobile => GetMobilesInRange<T>(p, Core.GlobalMaxUpdateRange);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<T> GetMobilesInRange<T>(Point3D p, int range) where T : Mobile =>
-        GetMobilesInRange<T>(p.m_X, p.m_Y, range);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<Mobile> GetMobilesInRange(Point2D p) => GetMobilesInRange<Mobile>(p);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<Mobile> GetMobilesInRange(Point2D p, int range) => GetMobilesInRange<Mobile>(p, range);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<T> GetMobilesInRange<T>(Point2D p) where T : Mobile => GetMobilesInRange<T>(p, Core.GlobalMaxUpdateRange);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<T> GetMobilesInRange<T>(Point2D p, int range) where T : Mobile =>
-        GetMobilesInRange<T>(p.m_X, p.m_Y, range);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<T> GetMobilesInRange<T>(int x, int y, int range) where T : Mobile =>
-        GetMobilesInBounds<T>(new Rectangle2D(x - range, y - range, range * 2 + 1, range * 2 + 1));
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<Mobile> GetMobilesInBounds(Rectangle2D bounds) => GetMobilesInBounds<Mobile>(bounds);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public MobileBoundsEnumerable<T> GetMobilesInBounds<T>(Rectangle2D bounds, bool makeBoundsInclusive = false) where T : Mobile =>
+    public ClientBoundsEnumerable GetClientsInBounds(Rectangle2D bounds, bool makeBoundsInclusive = false) =>
         new(this, bounds, makeBoundsInclusive);
 
-    public ref struct MobileAtEnumerable<T> where T : Mobile
+    public ref struct ClientAtEnumerable
     {
-        public static MobileAtEnumerable<T> Empty
+        public static ClientAtEnumerable Empty
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => new();
@@ -87,30 +64,30 @@ public partial class Map
         private readonly Map _map;
         private readonly Point2D _location;
 
-        public MobileAtEnumerable(Map map, Point2D loc)
+        public ClientAtEnumerable(Map map, Point2D loc)
         {
             _map = map;
             _location = loc;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public MobileAtEnumerator<T> GetEnumerator() => new(_map, _location);
+        public ClientAtEnumerator GetEnumerator() => new(_map, _location);
     }
 
-    public ref struct MobileAtEnumerator<T> where T : Mobile
+    public ref struct ClientAtEnumerator
     {
         private bool _started;
         private Point2D _location;
-        private ref readonly ValueLinkList<Mobile> _linkList;
+        private ref readonly ValueLinkList<NetState> _linkList;
         private int _version;
-        private T _current;
+        private NetState _current;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public MobileAtEnumerator(Map map, Point2D loc)
+        public ClientAtEnumerator(Map map, Point2D loc)
         {
             _started = false;
             _location = loc;
-            _linkList = ref map.GetRealSector(loc.m_X, loc.m_Y).Mobiles;
+            _linkList = ref map.GetRealSector(loc.m_X, loc.m_Y).Clients;
             _version = 0;
             _current = null;
         }
@@ -119,7 +96,8 @@ public partial class Map
         public bool MoveNext()
         {
             ref var loc = ref _location;
-            Mobile current;
+            NetState current;
+            Mobile m;
 
             if (!_started)
             {
@@ -127,9 +105,10 @@ public partial class Map
                 _started = true;
                 _version = _linkList.Version;
 
-                if (current is T { Deleted: false } o && o.X == loc.m_X && o.Y == loc.m_Y)
+                m = current.Mobile;
+                if (m?.Deleted == false && m.X == loc.m_X && m.Y == loc.m_Y)
                 {
-                    _current = o;
+                    _current = current;
                     return true;
                 }
             }
@@ -146,9 +125,10 @@ public partial class Map
             {
                 current = current.Next;
 
-                if (current is T { Deleted: false } o && o.X == loc.m_X && o.Y == loc.m_Y)
+                m = current.Mobile;
+                if (m?.Deleted == false && m.X == loc.m_X && m.Y == loc.m_Y)
                 {
-                    _current = o;
+                    _current = current;
                     return true;
                 }
             }
@@ -156,26 +136,26 @@ public partial class Map
             return false;
         }
 
-        public T Current
+        public NetState Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _current;
         }
     }
 
-    public ref struct MobileBoundsEnumerable<T> where T : Mobile
+    public ref struct ClientBoundsEnumerable
     {
-        public static MobileBoundsEnumerable<T> Empty
+        public static ClientBoundsEnumerable Empty
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => new(null, Rectangle2D.Empty, false);
         }
 
-        private Map _map;
-        private Rectangle2D _bounds;
-        private bool _makeBoundsInclusive;
+        private readonly Map _map;
+        private readonly Rectangle2D _bounds;
+        private readonly bool _makeBoundsInclusive;
 
-        public MobileBoundsEnumerable(Map map, Rectangle2D bounds, bool makeBoundsInclusive)
+        public ClientBoundsEnumerable(Map map, Rectangle2D bounds, bool makeBoundsInclusive)
         {
             _map = map;
             _bounds = bounds;
@@ -183,23 +163,23 @@ public partial class Map
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public MobileEnumerator<T> GetEnumerator() => new(_map, _bounds, _makeBoundsInclusive);
+        public MobileEnumerator GetEnumerator() => new(_map, _bounds, _makeBoundsInclusive);
     }
 
-    public ref struct MobileEnumerator<T> where T : Mobile
+    public ref struct MobileEnumerator
     {
-        private Map _map;
-        private int _sectorStartX;
-        private int _sectorEndX;
-        private int _sectorEndY;
+        private readonly Map _map;
+        private readonly int _sectorStartX;
+        private readonly int _sectorEndX;
+        private readonly int _sectorEndY;
         private Rectangle2D _bounds;
 
         private int _currentSectorX;
         private int _currentSectorY;
 
-        private ref readonly ValueLinkList<Mobile> _linkList;
+        private ref readonly ValueLinkList<NetState> _linkList;
         private int _currentVersion;
-        private T _current;
+        private NetState _current;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public MobileEnumerator(Map map, Rectangle2D bounds, bool makeBoundsInclusive)
@@ -232,7 +212,8 @@ public partial class Map
                 return false;
             }
 
-            Mobile current = _current;
+            Mobile m;
+            NetState current = _current;
             ref Rectangle2D bounds = ref _bounds;
             var currentSectorX = _currentSectorX;
             var currentSectorY = _currentSectorY;
@@ -261,7 +242,7 @@ public partial class Map
                         return false;
                     }
 
-                    _linkList = ref map.GetRealSector(currentSectorX, currentSectorY).Mobiles;
+                    _linkList = ref map.GetRealSector(currentSectorX, currentSectorY).Clients;
                     _currentVersion = _linkList.Version;
                     current = _linkList._first;
                 }
@@ -271,15 +252,16 @@ public partial class Map
                     throw new InvalidOperationException(CollectionThrowStrings.InvalidOperation_EnumFailedVersion);
                 }
 
-                if (current is T { Deleted: false } o && bounds.Contains(o.Location))
+                m = current.Mobile;
+                if (m?.Deleted == false && bounds.Contains(m.Location))
                 {
-                    _current = o;
+                    _current = current;
                     return true;
                 }
             }
         }
 
-        public T Current
+        public NetState Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _current;

--- a/Projects/Server/Maps/Map.ItemEnumerator.cs
+++ b/Projects/Server/Maps/Map.ItemEnumerator.cs
@@ -84,8 +84,8 @@ public partial class Map
             get => new();
         }
 
-        private Map _map;
-        private Point2D _location;
+        private readonly Map _map;
+        private readonly Point2D _location;
 
         public ItemAtEnumerable(Map map, Point2D loc)
         {

--- a/Projects/Server/Maps/PooledEnumeration.cs
+++ b/Projects/Server/Maps/PooledEnumeration.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Server.Collections;
 using Server.Items;
-using Server.Network;
 
 namespace Server;
 
@@ -33,33 +32,15 @@ public static class PooledEnumeration
 
     static PooledEnumeration()
     {
-        ClientSelector = SelectClients;
         EntitySelector = SelectEntities;
         MultiSelector = SelectMultis;
         MultiTileSelector = SelectMultiTiles;
     }
 
-    public static Selector<NetState> ClientSelector { get; set; }
     public static Selector<IEntity> EntitySelector { get; set; }
     public static Selector<Mobile> MobileSelector { get; set; }
     public static Selector<BaseMulti> MultiSelector { get; set; }
     public static Selector<StaticTile[]> MultiTileSelector { get; set; }
-
-    public static IEnumerable<NetState> SelectClients(Map.Sector s, Rectangle2D bounds)
-    {
-        var clients = new List<NetState>(s.Clients.Count);
-        foreach (var client in s.Clients)
-        {
-            var m = client.Mobile;
-
-            if (m?.Deleted == false && bounds.Contains(m.Location))
-            {
-                clients.Add(client);
-            }
-        }
-
-        return clients;
-    }
 
     public static IEnumerable<IEntity> SelectEntities(Map.Sector s, Rectangle2D bounds)
     {
@@ -144,9 +125,6 @@ public static class PooledEnumeration
             }
         }
     }
-
-    public static PooledEnumerable<NetState> GetClients(Map map, Rectangle2D bounds) =>
-        PooledEnumerable<NetState>.Instantiate(map, bounds, ClientSelector ?? SelectClients);
 
     public static PooledEnumerable<IEntity> GetEntities(Map map, Rectangle2D bounds) =>
         PooledEnumerable<IEntity>.Instantiate(map, bounds, EntitySelector ?? SelectEntities);

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -8140,8 +8140,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         m_Map == null ? Map.MobileBoundsEnumerable<T>.Empty : m_Map.GetMobilesInRange<T>(m_Location, range);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IPooledEnumerable<NetState> GetClientsInRange(int range) =>
-        m_Map?.GetClientsInRange(m_Location, range) ?? PooledEnumeration.NullEnumerable<NetState>.Instance;
+    public Map.ClientBoundsEnumerable GetClientsInRange(int range) =>
+        m_Map == null ? Map.ClientBoundsEnumerable.Empty : Map.GetClientsInRange(m_Location, range);
 
     public void SayTo(Mobile to, bool ascii, string text) =>
         PrivateOverheadMessage(MessageType.Regular, SpeechHue, ascii, text, to.NetState);

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2864,8 +2864,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var eable = Map.GetClientsInRange(m_Location);
-
         Span<byte> statBufferTrue = stackalloc byte[OutgoingMobilePackets.MobileStatusCompactLength].InitializePacket();
         Span<byte> statBufferFalse = stackalloc byte[OutgoingMobilePackets.MobileStatusCompactLength].InitializePacket();
         Span<byte> hbpBuffer = stackalloc byte[OutgoingMobilePackets.MobileHealthbarPacketLength].InitializePacket();
@@ -2874,7 +2872,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
         Span<byte> hitsPacket = stackalloc byte[OutgoingMobilePackets.MobileAttributePacketLength].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in Map.GetClientsInRange(m_Location))
         {
             var beholder = state.Mobile;
 
@@ -4808,13 +4806,12 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         if (m_Map != null)
         {
-            var eable = m_Map.GetClientsInRange(m_Location);
             var corpseSerial = c?.Serial ?? Serial.Zero;
 
             Span<byte> deathAnimation = stackalloc byte[OutgoingMobilePackets.DeathAnimationPacketLength].InitializePacket();
             Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-            foreach (var state in eable)
+            foreach (var state in m_Map.GetClientsInRange(m_Location))
             {
                 if (state != m_NetState)
                 {
@@ -5104,12 +5101,11 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                         if (DragEffects && map != null && root is null or Item)
                         {
-                            var eable = map.GetClientsInRange(from.Location);
                             var rootItem = root as Item;
 
                             Span<byte> buffer = stackalloc byte[OutgoingPlayerPackets.DragEffectPacketLength].InitializePacket();
 
-                            foreach (var ns in eable)
+                            foreach (var ns in map.GetClientsInRange(from.Location))
                             {
                                 if (ns.Mobile != from && ns.Mobile.CanSee(from) && ns.Mobile.InLOS(from) &&
                                     ns.Mobile.CanSee(root))
@@ -5262,11 +5258,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var eable = map.GetClientsInRange(m_Location);
-
         Span<byte> buffer = stackalloc byte[OutgoingPlayerPackets.DragEffectPacketLength].InitializePacket();
 
-        foreach (var ns in eable)
+        foreach (var ns in map.GetClientsInRange(m_Location))
         {
             if (ns.StygianAbyss || ns.Mobile == this ||
                 !ns.Mobile.CanSee(this) || !ns.Mobile.InLOS(this) || !ns.Mobile.CanSee(root))
@@ -6004,9 +5998,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var eable = map.GetClientsInRange(m_Location);
-
-        foreach (var ns in eable)
+        foreach (var ns in map.GetClientsInRange(m_Location))
         {
             if (ns.Mobile.CanSee(this))
             {
@@ -6718,11 +6710,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         ProcessDelta();
 
-        var eable = map.GetClientsInRange(m_Location);
-
         Span<byte> buffer = stackalloc byte[OutgoingMobilePackets.MobileAnimationPacketLength].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in map.GetClientsInRange(m_Location))
         {
             if (!state.Mobile.CanSee(this))
             {
@@ -6799,9 +6789,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         Span<byte> buffer = stackalloc byte[OutgoingEffectPackets.SoundPacketLength].InitializePacket();
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (state.Mobile.CanSee(this))
             {
@@ -6849,11 +6837,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
         Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (state != m_NetState && (everyone || !state.Mobile.CanSee(this)))
             {
@@ -7080,11 +7066,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
         Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             var m = state.Mobile;
             if (!m.CanSee(this))
@@ -7309,12 +7293,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         if (map != null)
         {
             // First, send a remove message to everyone who can no longer see us. (inOldRange && !inNewRange)
-
-            var eable = map.GetClientsInRange(oldLocation);
-
             Span<byte> removeEntity = stackalloc byte[OutgoingEntityPackets.RemoveEntityLength].InitializePacket();
 
-            foreach (var ns in eable)
+            foreach (var ns in map.GetClientsInRange(oldLocation))
             {
                 if (ns != m_NetState && !Utility.InUpdateRange(newLocation, ns.Mobile.Location))
                 {
@@ -7395,10 +7376,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             }
             else
             {
-                eable = map.GetClientsInRange(newLocation);
-
                 // We're not attached to a client, so simply send an Incoming
-                foreach (var ns in eable)
+                foreach (var ns in map.GetClientsInRange(newLocation))
                 {
                     var m = ns.Mobile;
                     if ((isTeleport && (!ns.HighSeas || !NoMoveHS) || !Utility.InUpdateRange(oldLocation, m.Location)) &&
@@ -7478,9 +7457,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             var m = state.Mobile;
             if (m.CanSee(this))
@@ -8138,6 +8115,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Map.MobileBoundsEnumerable<T> GetMobilesInRange<T>(int range) where T : Mobile =>
         m_Map == null ? Map.MobileBoundsEnumerable<T>.Empty : m_Map.GetMobilesInRange<T>(m_Location, range);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Map.ClientAtEnumerable GetClientsAt() => m_Map == null ? Map.ClientAtEnumerable.Empty : Map.GetClientsAt(m_Location);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Map.ClientBoundsEnumerable GetClientsInRange(int range) =>
@@ -8960,9 +8940,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLength(text)].InitializePacket();
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (
                 state.Mobile.AccessLevel >= accessLevel &&
@@ -8993,9 +8971,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLocalizedLength(args)].InitializePacket();
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (state.Mobile.CanSee(this) && (noLineOfSight || state.Mobile.InLOS(this)))
             {
@@ -9027,9 +9003,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLocalizedAffixLength(affix, args)]
             .InitializePacket();
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (
                 state.Mobile.AccessLevel >= accessLevel &&
@@ -9077,9 +9051,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLocalizedLength(args)].InitializePacket();
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (state != m_NetState && state.Mobile.CanSee(this))
             {
@@ -9106,9 +9078,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLength(text)].InitializePacket();
 
-        var eable = m_Map.GetClientsInRange(m_Location);
-
-        foreach (var state in eable)
+        foreach (var state in m_Map.GetClientsInRange(m_Location))
         {
             if (state != m_NetState && state.Mobile.CanSee(this))
             {

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -140,8 +140,7 @@ namespace Server.Engines.ConPVP
                 return;
             }
 
-            var eable = GetClientsInRange(0);
-            foreach (var ns in eable)
+            foreach (var ns in GetClientsAt())
             {
                 var m = ns.Mobile;
 
@@ -585,8 +584,7 @@ namespace Server.Engines.ConPVP
                     return;
                 }
 
-                var clients = Map.GetClientsInBounds(rect);
-                foreach (var ns in clients)
+                foreach (var ns in Map.GetClientsInBounds(rect))
                 {
                     var m = ns.Mobile;
 

--- a/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
+++ b/Projects/UOContent/Engines/Doom/LeverPuzzle/LeverPuzzleController.cs
@@ -505,9 +505,7 @@ public partial class LeverPuzzleController : Item
     {
         Span<byte> buffer = stackalloc byte[OutgoingMessagePackets.GetMaxMessageLength(Msgs[index])].InitializePacket();
 
-        var eable = from.Map.GetClientsInRange(from.Location);
-
-        foreach (var state in eable)
+        foreach (var state in from.Map.GetClientsInRange(from.Location))
         {
             var length = OutgoingMessagePackets.CreateMessage(
                 buffer,

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
@@ -370,11 +370,9 @@ public partial class CharacterStatue : Mobile, IRewardItem
         }
 
         ProcessDelta();
-
-        var eable = Map.GetClientsInRange(Location);
         Span<byte> animPacket = stackalloc byte[CharacterStatuePackets.StatueAnimationPacketLength].InitializePacket();
 
-        foreach (var state in eable)
+        foreach (var state in Map.GetClientsInRange(Location))
         {
             state.Mobile.ProcessDelta();
             CharacterStatuePackets.CreateStatueAnimation(animPacket, Serial, 1, m_Animation, m_Frames);

--- a/Projects/UOContent/Items/Skill Items/Camping/Campfire.cs
+++ b/Projects/UOContent/Items/Skill Items/Camping/Campfire.cs
@@ -129,9 +129,7 @@ public partial class Campfire : Item
             }
         }
 
-        var eable = GetClientsInRange(SecureRange);
-
-        foreach (var state in eable)
+        foreach (var state in GetClientsInRange(SecureRange))
         {
             if (state.Mobile is PlayerMobile pm && GetEntry(pm) == null)
             {

--- a/Projects/UOContent/Skills/Snooping.cs
+++ b/Projects/UOContent/Skills/Snooping.cs
@@ -68,9 +68,7 @@ public static class Snooping
                 {
                     var message = $"You notice {from.Name} attempting to peek into {root.Name}'s belongings.";
 
-                    var eable = map.GetClientsInRange(from.Location, 8);
-
-                    foreach (var ns in eable)
+                    foreach (var ns in map.GetClientsInRange(from.Location, 8))
                     {
                         if (ns.Mobile != from)
                         {


### PR DESCRIPTION
### Summary

Eliminates `IPooledEnumerable<NetState>` and `eable.Free()` from `Map` for clients. This drastically simplifies code that iterates in range, for example:

```cs
foreach (var m in m.GetClientsInRange(5))
{
}
```
The code above no longer requires an eable and calling `Free()`.