### PR TITLE
Fix for missing ethereal horse label

### DIFF
--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
@@ -421,6 +421,8 @@ namespace Server.Mobiles
             : base(0x20DD, 0x3EAA)
         {
         }
+
+        public override int LabelNumber => 1041298; // Ethereal Horse Statuette
     }
 
     [SerializationGenerator(0, false)]


### PR DESCRIPTION
![image](https://github.com/modernuo/ModernUO/assets/1682329/09111ee3-fbf7-4098-a421-d138799a66c3)

Fixed missing label for ethereal horse statues.  Issue can be seen in screen shot.