### PR TITLE
Fix Server.TryParse so it works for Boolean types

### DIFF
--- a/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
+++ b/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
@@ -1,0 +1,21 @@
+using Server;
+using System;
+using Xunit;
+
+namespace Server.Tests.Utility;
+
+public class TryParseTests
+{
+    [Theory]
+    [InlineData("True", null, true)]
+    [InlineData("False", null, false)]
+    [InlineData("Alakazam", "Bool parse failed", true)]
+    public void TestTryParseBool(string value, string returned, bool parsedAs)
+    {
+        string actualReturned = Server.Types.TryParse(typeof(bool), value, out object constructed);
+        Assert.Equal(returned, actualReturned);
+
+        if (returned == null)
+            Assert.Equal(parsedAs, constructed);
+    }
+}

--- a/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
+++ b/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
@@ -16,6 +16,8 @@ public class TryParseTests
         Assert.Equal(returned, actualReturned);
 
         if (returned == null)
+        {
             Assert.Equal(parsedAs, constructed);
+        }
     }
 }

--- a/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
+++ b/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
@@ -9,7 +9,7 @@ public class TryParseTests
     [Theory]
     [InlineData("True", null, true)]
     [InlineData("False", null, false)]
-    [InlineData("Alakazam", "Bool parse failed", true)]
+    [InlineData("Alakazam", "Not a valid boolean string.", true)]
     public void TestTryParseBool(string value, string returned, bool parsedAs)
     {
         string actualReturned = Server.Types.TryParse(typeof(bool), value, out object constructed);

--- a/Projects/UOContent/Utilities/Types.cs
+++ b/Projects/UOContent/Utilities/Types.cs
@@ -189,14 +189,13 @@ namespace Server
 
             if (IsType(type, OfBool))
             {
-                bool parsed;
-                bool parseSuccessful = bool.TryParse(value, out parsed);
-                if (!parseSuccessful)
+                if (bool.TryParse(value, out bool parsed))
                 {
-                    return "Not a valid boolean string.";
+                    constructed = parsed;
+                    return null;
                 }
-                constructed = parsed;
-                return null;
+                
+                return "Not a valid boolean string.";
             }
 
             if (value.StartsWithOrdinal("0x") && IsNumeric(type))

--- a/Projects/UOContent/Utilities/Types.cs
+++ b/Projects/UOContent/Utilities/Types.cs
@@ -187,6 +187,18 @@ namespace Server
                 return null;
             }
 
+            if (IsType(type, OfBool))
+            {
+                bool parsed;
+                bool parseSuccessful = bool.TryParse(value, out parsed);
+                if (!parseSuccessful)
+                {
+                    return "Not a valid boolean string.";
+                }
+                constructed = parsed;
+                return null;
+            }
+
             if (value.StartsWithOrdinal("0x") && IsNumeric(type))
             {
                 try


### PR DESCRIPTION
Server.TryParse() function was failing to parse "True" or "False" as bools. I've fixed this and added tests.