### PR TITLE
fix: Fixes character starting cities.

### DIFF
--- a/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
+++ b/Projects/UOContent.Tests/Tests/Utilities/TryParseTests.cs
@@ -1,5 +1,3 @@
-using Server;
-using System;
 using Xunit;
 
 namespace Server.Tests.Utility;

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -412,7 +412,7 @@ public static class AccountHandler
             logger.Information("Login: {NetState} Account '{Username}' at character list", e.State, un);
             e.State.Account = acct;
             e.Accepted = true;
-            e.CityInfo = CharacterCreation.GetStartingCities(acct.AccessLevel == AccessLevel.Player && acct.Young);
+            e.CityInfo = CharacterCreation.GetStartingCities(acct.Young);
         }
 
         if (!e.Accepted)

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -5,6 +5,7 @@ using System.Net;
 using Server.Accounting;
 using Server.Engines.Help;
 using Server.Logging;
+using Server.Maps;
 using Server.Network;
 using Server.Regions;
 
@@ -19,33 +20,6 @@ public static class AccountHandler
     private static bool RestrictDeletion = !TestCenter.Enabled;
     private static TimeSpan DeleteDelay = TimeSpan.FromDays(7.0);
     private static bool PasswordCommandEnabled;
-
-    private static CityInfo[] OldHavenStartingCities =
-    {
-        new("Yew", "The Empath Abbey", 633, 858, 0),
-        new("Minoc", "The Barnacle", 2476, 413, 15),
-        new("Britain", "Sweet Dreams Inn", 1496, 1628, 10),
-        new("Moonglow", "The Scholars Inn", 4408, 1168, 0),
-        new("Trinsic", "The Traveler's Inn", 1845, 2745, 0),
-        new("Magincia", "The Great Horns Tavern", 3734, 2222, 20),
-        new("Jhelom", "The Mercenary Inn", 1374, 3826, 0),
-        new("Skara Brae", "The Falconer's Inn", 618, 2234, 0),
-        new("Vesper", "The Ironwood Inn", 2771, 976, 0),
-        new("Haven", "Buckler's Hideaway", 3667, 2625, 0)
-    };
-
-    private static CityInfo[] StartingCities =
-    {
-        new("New Haven", "New Haven Bank", 1150168, 3667, 2625, 0),
-        new("Yew", "The Empath Abbey", 1075072, 633, 858, 0),
-        new("Minoc", "The Barnacle", 1075073, 2476, 413, 15),
-        new("Britain", "The Wayfarer's Inn", 1075074, 1602, 1591, 20),
-        new("Moonglow", "The Scholars Inn", 1075075, 4408, 1168, 0),
-        new("Trinsic", "The Traveler's Inn", 1075076, 1845, 2745, 0),
-        new("Jhelom", "The Mercenary Inn", 1075078, 1374, 3826, 0),
-        new("Skara Brae", "The Falconer's Inn", 1075079, 618, 2234, 0),
-        new("Vesper", "The Ironwood Inn", 1075080, 2771, 976, 0)
-    };
 
     private static Dictionary<IPAddress, int> m_IPTable;
 
@@ -439,7 +413,7 @@ public static class AccountHandler
             logger.Information("Login: {NetState} Account '{Username}' at character list", e.State, un);
             e.State.Account = acct;
             e.Accepted = true;
-            e.CityInfo = TileMatrix.Pre6000ClientSupport ? OldHavenStartingCities : StartingCities;
+            e.CityInfo = CharacterCreation.GetStartingCities(acct.AccessLevel == AccessLevel.Player && acct.Young);
         }
 
         if (!e.Accepted)

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -412,7 +412,7 @@ public static class AccountHandler
             logger.Information("Login: {NetState} Account '{Username}' at character list", e.State, un);
             e.State.Account = acct;
             e.Accepted = true;
-            e.CityInfo = CharacterCreation.GetStartingCities(acct.Young);
+            e.CityInfo = CharacterCreation.GetStartingCities(acct);
         }
 
         if (!e.Accepted)

--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -5,7 +5,6 @@ using System.Net;
 using Server.Accounting;
 using Server.Engines.Help;
 using Server.Logging;
-using Server.Maps;
 using Server.Network;
 using Server.Regions;
 

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -181,6 +181,13 @@ public static class CharacterCreation
             Array.Copy(FeluccaStartingCities, 0, cities, index, FeluccaStartingCities.Length);
         }
 
+        // TODO: Add Royal City for gargoyles
+
+        if (cities.Length == 0)
+        {
+            logger.Warning("Both Felucca and Trammel are unavailable maps, therefore no starting cities are available.");
+        }
+
         return cities;
     }
 

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -136,19 +136,9 @@ public static class CharacterCreation
 
     public static CityInfo[] GetStartingCities(bool isYoung)
     {
-        if (isYoung)
+        if (isYoung && ExpansionInfo.CoreExpansion.MapSelectionFlags.Includes(MapSelectionFlags.Trammel))
         {
-            var availableMaps = ExpansionInfo.CoreExpansion.MapSelectionFlags;
-
-            if (availableMaps.Includes(MapSelectionFlags.Trammel))
-            {
-                return NewHavenInn;
-            }
-
-            if (availableMaps.Includes(MapSelectionFlags.Felucca))
-            {
-                return OldHavenBank;
-            }
+            return TileMatrix.Pre6000ClientSupport ? OldHavenBank : NewHavenInn;
         }
 
         return _availableStartingCities ??= ConstructAvailableStartingCities();

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -398,16 +398,6 @@ public static class CharacterCreation
                 }
         }
 
-        if (args.City.Map == Map.Trammel && !availableMaps.Includes(MapSelectionFlags.Trammel))
-        {
-            args.City.Map = Map.Felucca;
-        }
-
-        if (args.City.Map == Map.Felucca && !availableMaps.Includes(MapSelectionFlags.Felucca))
-        {
-            args.City.Map = Map.Trammel;
-        }
-
         return args.City;
     }
 

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -132,12 +132,11 @@ public static class CharacterCreation
         new("Vesper", "The Ironwood Inn", 1075080, 2771, 976, 0, Map.Trammel)
     };
 
-
     private static CityInfo[] _availableStartingCities;
 
-    public static CityInfo[] GetStartingCities(bool isYoung)
+    public static CityInfo[] GetStartingCities(Account acct)
     {
-        if (isYoung && ExpansionInfo.CoreExpansion.MapSelectionFlags.Includes(MapSelectionFlags.Trammel))
+        if (acct.Young && ExpansionInfo.CoreExpansion.MapSelectionFlags.Includes(MapSelectionFlags.Trammel))
         {
             return TileMatrix.Pre6000ClientSupport ? OldHavenBank : NewHavenInn;
         }

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -132,6 +132,7 @@ public static class CharacterCreation
         new("Vesper", "The Ironwood Inn", 1075080, 2771, 976, 0, Map.Trammel)
     };
 
+
     private static CityInfo[] _availableStartingCities;
 
     public static CityInfo[] GetStartingCities(bool isYoung)
@@ -321,10 +322,18 @@ public static class CharacterCreation
     private static CityInfo GetStartLocation(CharacterCreatedEventArgs args)
     {
         var availableMaps = ExpansionInfo.CoreExpansion.MapSelectionFlags;
-
-        var flags = args.State?.Flags ?? ClientFlags.None;
         var m = args.Mobile;
 
+        if (m.AccessLevel > AccessLevel.Player)
+        {
+            var map = availableMaps.Includes(MapSelectionFlags.Felucca) ? Map.Felucca : Map.Trammel;
+            if (availableMaps.Includes(MapSelectionFlags.Felucca))
+            {
+                return new CityInfo("Green Acres", "Green Acres", 5445, 1153, 0, map);
+            }
+        }
+
+        var flags = args.State?.Flags ?? ClientFlags.None;
         var profession = ProfessionInfo.Professions[args.Profession];
 
         switch (profession?.Name.ToLowerInvariant())

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -159,6 +159,12 @@ public static class CharacterCreation
         var length = (trammelAvailable ? TrammelStartingCities.Length : 0) +
                      (feluccaAvailable ? FeluccaStartingCities.Length : 0);
 
+        if (length == 0)
+        {
+            logger.Error("Both Felucca and Trammel are unavailable maps, therefore no starting cities are available.");
+            return Array.Empty<CityInfo>();
+        }
+
         var cities = new CityInfo[length];
         var index = 0;
         if (trammelAvailable)
@@ -173,11 +179,6 @@ public static class CharacterCreation
         }
 
         // TODO: Add Royal City for gargoyles
-
-        if (cities.Length == 0)
-        {
-            logger.Warning("Both Felucca and Trammel are unavailable maps, therefore no starting cities are available.");
-        }
 
         return cities;
     }


### PR DESCRIPTION
### Summary

- Moves starting city info from AccountHandler to CharacterCreation
- Simplifies the logic of determining the starting cities
- Adds support for Trammel & Felucca for non-young accounts
- Fixes fall through starting city for v6+ in UOR era.
- All staff are force-sent to GA.

### TODOS

- Move the starting cities to JSON files
- Add in New Magincia (`1075077`) to the client versions/eras that support it.

Closes #1408 