### PR TITLE
fix: Fixes various mobile packets and setting serials

### DIFF
--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/PlayerPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/PlayerPacketTests.cs
@@ -45,7 +45,7 @@ namespace Server.Tests.Network
         [Fact]
         public void TestDeathStatus()
         {
-            var expected = new DeathStatus(true).Compile();
+            var expected = new DeathStatus(false).Compile();
 
             var ns = PacketTestUtilities.CreateTestNetState();
             ns.SendDeathStatus();

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/PlayerPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/PlayerPacketTests.cs
@@ -42,15 +42,13 @@ namespace Server.Tests.Network
             AssertThat.Equal(result, expected);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void TestDeathStatus(bool dead)
+        [Fact]
+        public void TestDeathStatus()
         {
-            var expected = new DeathStatus(dead).Compile();
+            var expected = new DeathStatus(true).Compile();
 
             var ns = PacketTestUtilities.CreateTestNetState();
-            ns.SendDeathStatus(dead);
+            ns.SendDeathStatus();
 
             var result = ns.SendPipe.Reader.AvailableToRead();
             AssertThat.Equal(result, expected);

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -585,7 +585,8 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         }
     }
 
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Developer)]
+    // Note: Setting the parent via command/props causes problems.
+    [CommandProperty(AccessLevel.GameMaster, readOnly: true)]
     public IEntity Parent
     {
         get => m_Parent;

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -6920,14 +6920,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                 if (ns.StygianAbyss)
                 {
-                    if (m.Blessed || m.YellowHealthbar)
-                    {
-                        ns.SendMobileHealthbar(m, Healthbar.Yellow);
-                    }
-                    else if (m.Poisoned)
-                    {
-                        ns.SendMobileHealthbar(m, Healthbar.Poison);
-                    }
+                    ns.SendMobileHealthbar(m, Healthbar.Yellow);
+                    ns.SendMobileHealthbar(m, Healthbar.Poison);
                 }
 
                 if (m.IsDeadBondedPet)
@@ -7334,14 +7328,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                         if (ns.StygianAbyss)
                         {
-                            if (Blessed || YellowHealthbar)
-                            {
-                                ns.SendMobileHealthbar(this, Healthbar.Yellow);
-                            }
-                            else if (Poisoned)
-                            {
-                                ns.SendMobileHealthbar(this, Healthbar.Poison);
-                            }
+                            ns.SendMobileHealthbar(this, Healthbar.Poison);
+                            ns.SendMobileHealthbar(this, Healthbar.Yellow);
                         }
 
                         if (IsDeadBondedPet)
@@ -7361,14 +7349,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                     if (ourState.StygianAbyss)
                     {
-                        if (m.Blessed || m.YellowHealthbar)
-                        {
-                            ourState.SendMobileHealthbar(m, Healthbar.Yellow);
-                        }
-                        else if (m.Poisoned)
-                        {
-                            ourState.SendMobileHealthbar(m, Healthbar.Poison);
-                        }
+                        ourState.SendMobileHealthbar(m, Healthbar.Poison);
+                        ourState.SendMobileHealthbar(m, Healthbar.Yellow);
                     }
 
                     if (m.IsDeadBondedPet)
@@ -7403,14 +7385,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                         if (ns.StygianAbyss)
                         {
-                            if (Blessed || YellowHealthbar)
-                            {
-                                ns.SendMobileHealthbar(this, Healthbar.Yellow);
-                            }
-                            else if (m.Poisoned)
-                            {
-                                ns.SendMobileHealthbar(this, Healthbar.Poison);
-                            }
+                            ns.SendMobileHealthbar(this, Healthbar.Poison);
+                            ns.SendMobileHealthbar(this, Healthbar.Yellow);
                         }
 
                         if (IsDeadBondedPet)
@@ -7488,14 +7464,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                 if (state.StygianAbyss)
                 {
-                    if (Blessed || YellowHealthbar)
-                    {
-                        state.SendMobileHealthbar(this, Healthbar.Yellow);
-                    }
-                    else if (m.Poisoned)
-                    {
-                        state.SendMobileHealthbar(this, Healthbar.Poison);
-                    }
+                    state.SendMobileHealthbar(this, Healthbar.Poison);
+                    state.SendMobileHealthbar(this, Healthbar.Yellow);
                 }
 
                 if (IsDeadBondedPet)

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -4565,7 +4565,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             }
 
             SendIncomingPacket();
-            SendIncomingPacket();
 
             OnAfterResurrect();
         }
@@ -4860,7 +4859,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         }
         else
         {
-            m_NetState.SendDeathStatus(true);
+            m_NetState.SendDeathStatus();
 
             Warmode = false;
 
@@ -4885,8 +4884,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             EventSink.InvokePlayerDeath(this);
 
             ProcessDelta();
-
-            m_NetState.SendDeathStatus(false);
 
             CheckStatTimers();
         }
@@ -7337,8 +7334,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                         if (ns.StygianAbyss)
                         {
-                            ns.SendMobileHealthbar(this, Healthbar.Poison);
-                            ns.SendMobileHealthbar(this, Healthbar.Yellow);
+                            if (Blessed || YellowHealthbar)
+                            {
+                                ns.SendMobileHealthbar(this, Healthbar.Yellow);
+                            }
+                            else if (Poisoned)
+                            {
+                                ns.SendMobileHealthbar(this, Healthbar.Poison);
+                            }
                         }
 
                         if (IsDeadBondedPet)
@@ -7358,8 +7361,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                     if (ourState.StygianAbyss)
                     {
-                        ourState.SendMobileHealthbar(m, Healthbar.Poison);
-                        ourState.SendMobileHealthbar(m, Healthbar.Yellow);
+                        if (m.Blessed || m.YellowHealthbar)
+                        {
+                            ourState.SendMobileHealthbar(m, Healthbar.Yellow);
+                        }
+                        else if (m.Poisoned)
+                        {
+                            ourState.SendMobileHealthbar(m, Healthbar.Poison);
+                        }
                     }
 
                     if (m.IsDeadBondedPet)
@@ -7394,8 +7403,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                         if (ns.StygianAbyss)
                         {
-                            ns.SendMobileHealthbar(this, Healthbar.Poison);
-                            ns.SendMobileHealthbar(this, Healthbar.Yellow);
+                            if (Blessed || YellowHealthbar)
+                            {
+                                ns.SendMobileHealthbar(this, Healthbar.Yellow);
+                            }
+                            else if (m.Poisoned)
+                            {
+                                ns.SendMobileHealthbar(this, Healthbar.Poison);
+                            }
                         }
 
                         if (IsDeadBondedPet)
@@ -7473,8 +7488,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                 if (state.StygianAbyss)
                 {
-                    state.SendMobileHealthbar(this, Healthbar.Poison);
-                    state.SendMobileHealthbar(this, Healthbar.Yellow);
+                    if (Blessed || YellowHealthbar)
+                    {
+                        state.SendMobileHealthbar(this, Healthbar.Yellow);
+                    }
+                    else if (m.Poisoned)
+                    {
+                        state.SendMobileHealthbar(this, Healthbar.Poison);
+                    }
                 }
 
                 if (IsDeadBondedPet)

--- a/Projects/Server/Network/Packets/OutgoingPlayerPackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingPlayerPackets.cs
@@ -60,8 +60,8 @@ public static class OutgoingPlayerPackets
         ns?.Send(stackalloc byte[] { 0xC8, range });
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void SendDeathStatus(this NetState ns, bool dead) =>
-        ns?.Send(stackalloc byte[] { 0x2C, dead ? (byte)0 : (byte)2 });
+    public static void SendDeathStatus(this NetState ns) =>
+        ns?.Send(stackalloc byte[] { 0x2C, 2 });
 
     public static void SendDisplayProfile(this NetState ns, Serial m, string header, string body, string footer)
     {

--- a/Projects/UOContent/Gumps/Props/PropsGump.cs
+++ b/Projects/UOContent/Gumps/Props/PropsGump.cs
@@ -303,7 +303,7 @@ namespace Server.Gumps
 
                         var type = prop.PropertyType;
 
-                        if (IsType(type, OfMobile) || IsType(type, OfItem))
+                        if (IsType(type, OfEntity))
                         {
                             from.SendGump(new SetObjectGump(prop, from, m_Object, type, this));
                         }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -3223,7 +3223,6 @@ namespace Server.Mobiles
 
                 ProcessDelta();
                 SendIncomingPacket();
-                SendIncomingPacket();
 
                 // TODO: This can be done in Parallel if there are lots of them.
                 var aggressors = Aggressors;
@@ -3841,7 +3840,6 @@ namespace Server.Mobiles
             OutgoingMobilePackets.CreateBondedStatus(buffer, Serial, false);
             Effects.SendPacket(Location, Map, buffer);
 
-            SendIncomingPacket();
             SendIncomingPacket();
 
             OnAfterResurrect();

--- a/Projects/UOContent/Utilities/Types.cs
+++ b/Projects/UOContent/Utilities/Types.cs
@@ -211,7 +211,7 @@ namespace Server
                         {
                             constructed = World.FindEntity((Serial)num);
                         }
-                        else if (isSerial) // mutate back
+                        else if (isSerial)
                         {
                             constructed = (Serial)num;
                         }

--- a/Projects/UOContent/Utilities/Types.cs
+++ b/Projects/UOContent/Utilities/Types.cs
@@ -137,8 +137,9 @@ namespace Server
         {
             constructed = null;
             var isSerial = IsType(type, OfSerial);
+            var isEntity = IsType(type, OfEntity);
 
-            if (isSerial) // mutate into int32
+            if (isSerial || isEntity) // mutate into int32
             {
                 type = OfInt;
             }
@@ -194,19 +195,33 @@ namespace Server
                     constructed = parsed;
                     return null;
                 }
-                
+
                 return "Not a valid boolean string.";
             }
 
-            if (value.StartsWithOrdinal("0x") && IsNumeric(type))
+            if (IsNumeric(type))
             {
                 try
                 {
-                    if (ulong.TryParse(value.AsSpan(2), NumberStyles.HexNumber, null, out var num))
+                    var isHex = value.StartsWithOrdinal("0x");
+                    var index = isHex ? 2 : 0;
+                    if (ulong.TryParse(value.AsSpan(index), isHex ? NumberStyles.HexNumber : NumberStyles.Integer, null, out var num))
                     {
-                        constructed = Convert.ChangeType(num, type);
+                        if (isEntity)
+                        {
+                            constructed = World.FindEntity((Serial)num);
+                        }
+                        else if (isSerial) // mutate back
+                        {
+                            constructed = (Serial)num;
+                        }
+                        else
+                        {
+                            constructed = Convert.ChangeType(num, type);
+                        }
+
+                        return null;
                     }
-                    return null;
                 }
                 catch
                 {
@@ -230,11 +245,6 @@ namespace Server
             try
             {
                 constructed = Convert.ChangeType(value, type);
-                if (isSerial) // mutate back
-                {
-                    constructed = (Serial)(constructed ?? Serial.MinusOne);
-                }
-
                 return null;
             }
             catch


### PR DESCRIPTION
### Summary
- Removes old death packet that isn't used. Doubtful this causes issues with clients that are v4+.
- Removes duplicate incoming packets. Again, probably to fix some old client issues, doubtful it affects clients v4+.
- Fixes setting serials and entities in props/commands. Note: Disabled setting `Parent` since the new sector code has issues. We shouldn't rely on it anyway!
- Reverts a recent change to healthbars that should not have been made. Oops!