### PR TITLE
fix: Fixes default GumpID and DropSound serialization for containers

### DIFF
--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -118,6 +118,9 @@ public partial class Container : Item
     [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeDropSound() => _dropSound != -1;
 
+    [SerializableFieldDefault(2)]
+    private int DropSoundDefaultValue() => -1;
+
     [CommandProperty(AccessLevel.GameMaster)]
     public virtual int MaxWeight => Parent is Container { MaxWeight: 0 } ? 0 : DefaultMaxWeight;
 

--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -99,6 +99,9 @@ public partial class Container : Item
     [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeGumpId() => _gumpID != -1;
 
+    [SerializableFieldDefault(1)]
+    private int GumpIDDefaultValue() => -1;
+
     [EncodedInt]
     [SerializableProperty(2)]
     [CommandProperty(AccessLevel.GameMaster)]


### PR DESCRIPTION
Fixes GumpID and DropSound default value for containers that will be set as -1.
Fixes for already saved containers can be done with following commands:

```
[global set gumpid -1 where container gumpid == 0
```

```
[global set dropsound -1 where container dropsound == 0
```