### PR TITLE
fix: Client crash when banker tries to use checks & gold for a purchase

### DIFF
--- a/Projects/UOContent/Mobiles/Townfolk/Banker.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/Banker.cs
@@ -66,7 +66,8 @@ public partial class Banker : BaseVendor
     public static int GetBalance(Mobile m, out List<Item> gold, out List<Item> checks)
     {
         long balance = 0;
-        gold = checks = new List<Item>();
+        var gold = new List<Item>();
+        var checks = new List<Item>();
 
         if (AccountGold.Enabled && m.Account != null)
         {
@@ -82,7 +83,7 @@ public partial class Banker : BaseVendor
 
         if (bank != null)
         {
-            foreach (var g in bank.FindItemsByType<Gold>())
+            foreach (var g in bank.FindItemsByType<Gold>(true))
             {
                 balance += g.Amount;
                 gold.Add(g);
@@ -93,7 +94,7 @@ public partial class Banker : BaseVendor
                 return int.MaxValue;
             }
 
-            foreach (var bc in bank.FindItemsByType<BankCheck>())
+            foreach (var bc in bank.FindItemsByType<BankCheck>(true))
             {
                 balance += bc.Worth;
                 checks.Add(bc);

--- a/Projects/UOContent/Mobiles/Townfolk/Banker.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/Banker.cs
@@ -126,7 +126,7 @@ public partial class Banker : BaseVendor
         gold = PooledRefList<Gold>.Create();
         checks = PooledRefList<BankCheck>.Create();
 
-        foreach (var g in bank.FindItemsByType<Gold>(true))
+        foreach (var g in bank.FindItemsByType<Gold>())
         {
             balance += g.Amount;
             gold.Add(g);
@@ -137,7 +137,7 @@ public partial class Banker : BaseVendor
             }
         }
 
-        foreach (var bc in bank.FindItemsByType<BankCheck>(true))
+        foreach (var bc in bank.FindItemsByType<BankCheck>())
         {
             balance += bc.Worth;
             checks.Add(bc);

--- a/Projects/UOContent/Mobiles/Townfolk/Banker.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/Banker.cs
@@ -124,8 +124,6 @@ public partial class Banker : BaseVendor
         long balance = 0;
 
         gold = PooledRefList<Gold>.Create();
-        checks = PooledRefList<BankCheck>.Create();
-
         foreach (var g in bank.FindItemsByType<Gold>())
         {
             balance += g.Amount;
@@ -133,10 +131,13 @@ public partial class Banker : BaseVendor
 
             if (balance >= requiredBalance)
             {
+                checks = default;
                 return true;
             }
         }
 
+        checks = PooledRefList<BankCheck>.Create();
+ 
         foreach (var bc in bank.FindItemsByType<BankCheck>())
         {
             balance += bc.Worth;

--- a/Projects/UOContent/Mobiles/Townfolk/Banker.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/Banker.cs
@@ -86,7 +86,7 @@ public partial class Banker : BaseVendor
         {
             gold = new List<Gold>();
 
-            foreach (var g in bank.FindItemsByType<Gold>(true))
+            foreach (var g in bank.FindItemsByType<Gold>())
             {
                 balance += g.Amount;
                 gold.Add(g);
@@ -99,7 +99,7 @@ public partial class Banker : BaseVendor
 
             checks = new List<BankCheck>();
 
-            foreach (var bc in bank.FindItemsByType<BankCheck>(true))
+            foreach (var bc in bank.FindItemsByType<BankCheck>())
             {
                 balance += bc.Worth;
                 checks.Add(bc);


### PR DESCRIPTION
Discovered when players would use a House Placement Tool to make a large purchase. When this code would check their bank box:
1. It wouldn't recursively check containers in the bank box for gold/checks.
2. It would crash when players had check(s) and gold in their bank box. Full Disclaimer: I'm by no means a .NET expert. I don't know how the code works that I removed (Feel free to explain!). It seemed to act like the two variables were references to one another. When my test character had 2 piles of gold and 2 checks in their main bank box, it would return both `gold` AND `checks` as lists with FOUR objects each. This caused a client crash in Banker.cs line 138, when it was attempting to cast a `Gold` object into a `BankCheck` object. It most likely caused issues on line 122, as well, since the `gold` variable was being looped through (I didn't test that, but it's a pretty good guess 😄 ).