### PR TITLE
fix: Fixes pooled ref collections dispose on defaults

### DIFF
--- a/Projects/Server/Collections/PooledRefList.cs
+++ b/Projects/Server/Collections/PooledRefList.cs
@@ -1143,7 +1143,7 @@ public ref struct PooledRefList<T>
     {
         var array = _items;
 
-        if (array is { Length: > 0 })
+        if (array?.Length > 0)
         {
             Clear();
             ArrayPool.Return(_items);

--- a/Projects/Server/Collections/PooledRefList.cs
+++ b/Projects/Server/Collections/PooledRefList.cs
@@ -55,8 +55,8 @@ public ref struct PooledRefList<T>
         _items = capacity switch
         {
             < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
-            0   => Array.Empty<T>(),
-            _   => (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
+            0 => Array.Empty<T>(),
+            _ => (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
         };
 
     }
@@ -1143,7 +1143,7 @@ public ref struct PooledRefList<T>
     {
         var array = _items;
 
-        if (array.Length > 0)
+        if (array is { Length: > 0 })
         {
             Clear();
             ArrayPool.Return(_items);

--- a/Projects/Server/Collections/PooledRefList.cs
+++ b/Projects/Server/Collections/PooledRefList.cs
@@ -55,8 +55,8 @@ public ref struct PooledRefList<T>
         _items = capacity switch
         {
             < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
-            0 => Array.Empty<T>(),
-            _ => (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
+            0  => Array.Empty<T>(),
+            _  => (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
         };
 
     }

--- a/Projects/Server/Collections/PooledRefList.cs
+++ b/Projects/Server/Collections/PooledRefList.cs
@@ -55,8 +55,8 @@ public ref struct PooledRefList<T>
         _items = capacity switch
         {
             < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
-            0  => Array.Empty<T>(),
-            _  => (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
+            0   => Array.Empty<T>(),
+            _   => (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
         };
 
     }

--- a/Projects/Server/Collections/PooledRefQueue.cs
+++ b/Projects/Server/Collections/PooledRefQueue.cs
@@ -40,8 +40,8 @@ public ref struct PooledRefQueue<T>
         _array = capacity switch
         {
             < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
-            0  => s_emptyArray,
-            _  => (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
+            0   => s_emptyArray,
+            _   => (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
         };
 
         _head = 0;

--- a/Projects/Server/Collections/PooledRefQueue.cs
+++ b/Projects/Server/Collections/PooledRefQueue.cs
@@ -40,8 +40,8 @@ public ref struct PooledRefQueue<T>
         _array = capacity switch
         {
             < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
-            0 => s_emptyArray,
-            _ => (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
+            0  => s_emptyArray,
+            _  => (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
         };
 
         _head = 0;

--- a/Projects/Server/Collections/PooledRefQueue.cs
+++ b/Projects/Server/Collections/PooledRefQueue.cs
@@ -40,8 +40,8 @@ public ref struct PooledRefQueue<T>
         _array = capacity switch
         {
             < 0 => throw new ArgumentOutOfRangeException(nameof(capacity), capacity, CollectionThrowStrings.ArgumentOutOfRange_NeedNonNegNum),
-            0   => s_emptyArray,
-            _   => (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
+            0 => s_emptyArray,
+            _ => (mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Rent(capacity)
         };
 
         _head = 0;
@@ -385,7 +385,7 @@ public ref struct PooledRefQueue<T>
     public void Dispose()
     {
         var array = _array;
-        if (array.Length > 0)
+        if (array is { Length: > 0 })
         {
             Clear();
             (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Return(array);

--- a/Projects/Server/Collections/PooledRefQueue.cs
+++ b/Projects/Server/Collections/PooledRefQueue.cs
@@ -385,7 +385,7 @@ public ref struct PooledRefQueue<T>
     public void Dispose()
     {
         var array = _array;
-        if (array is { Length: > 0 })
+        if (array?.Length > 0)
         {
             Clear();
             (_mt ? ArrayPool<T>.Shared : STArrayPool<T>.Shared).Return(array);


### PR DESCRIPTION
Added an additional check to pooled collection dispose method so it can be used also against defaults