### PR TITLE
fix: Fixes thread guard and cleans up incoming packet reader

### DIFF
--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -469,7 +469,9 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
                 Console.WriteLine("Attempting to get pipe buffer from wrong thread!");
                 Console.WriteLine(new StackTrace());
                 Utility.PopColor();
-                return;
+
+                buffer = Array.Empty<byte>();
+                return false;
             }
 #endif
         buffer = SendPipe.Writer.AvailableToWrite();

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -844,12 +844,16 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
         UpdatePacketCount(packetId);
 
+        var packetBuffer = packetReader.Buffer[..packetLength];
+
         if (PacketLogging)
         {
-            LogPacket(packetReader.Buffer[..packetLength], true);
+            LogPacket(packetBuffer, true);
         }
 
-        handler.OnReceive(this, packetReader, packetLength);
+        // Make a new SpanReader that is limited to the length of the packet.
+        // This allows us to use reader.Remaining for VendorBuyReply packet
+        handler.OnReceive(this, new SpanReader(packetBuffer));
 
         prof?.Finish(packetLength);
 

--- a/Projects/Server/Network/PacketHandler.cs
+++ b/Projects/Server/Network/PacketHandler.cs
@@ -21,7 +21,7 @@ public unsafe class PacketHandler
 {
     private readonly int _length;
 
-    public PacketHandler(int packetID, int length, bool ingame, delegate*<NetState, SpanReader, int, void> onReceive)
+    public PacketHandler(int packetID, int length, bool ingame, delegate*<NetState, SpanReader, void> onReceive)
     {
         _length = length;
         PacketID = packetID;
@@ -33,7 +33,7 @@ public unsafe class PacketHandler
 
     public virtual int GetLength(NetState ns) => _length;
 
-    public delegate*<NetState, SpanReader, int, void> OnReceive { get; }
+    public delegate*<NetState, SpanReader, void> OnReceive { get; }
 
     public delegate*<int, NetState, out bool, bool> ThrottleCallback { get; set; }
 

--- a/Projects/Server/Network/Packets/IncomingPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPackets.cs
@@ -26,7 +26,7 @@ public static class IncomingPackets
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void Register(int packetID, int length, bool ingame,
-        delegate*<NetState, SpanReader, int, void> onReceive) =>
+        delegate*<NetState, SpanReader, void> onReceive) =>
         Register(new PacketHandler(packetID, length, ingame, onReceive));
 
     public static void Register(PacketHandler packetHandler)

--- a/Projects/UOContent/Assistants/AssistantHandler.cs
+++ b/Projects/UOContent/Assistants/AssistantHandler.cs
@@ -76,7 +76,7 @@ public static class AssistantHandler
         _handshakes[m] = Timer.DelayCall(TimeSpan.FromSeconds(30), OnTimeout, m);
     }
 
-    public static void AssistVersion(NetState state, SpanReader reader, int packetLength)
+    public static void AssistVersion(NetState state, SpanReader reader)
     {
         // We are not supporting the old UOAssist protocol
         // var assistVersion = reader.ReadInt32();
@@ -87,7 +87,7 @@ public static class AssistantHandler
         state.Assistant = assistVersion.ContainsOrdinal(' ') ? assistVersion : $"RazorCE {assistVersion}";
     }
 
-    private static void HandshakeResponse(NetState state, SpanReader reader, int packetLength)
+    private static void HandshakeResponse(NetState state, SpanReader reader)
     {
         Mobile m = state.Mobile;
 

--- a/Projects/UOContent/Assistants/AssistantProtocol.cs
+++ b/Projects/UOContent/Assistants/AssistantProtocol.cs
@@ -12,7 +12,7 @@ public static class AssistantProtocol
         _handlers = ProtocolExtensions<AssistantsProtocolInfo>.Register(new AssistantsProtocolInfo());
     }
 
-    public static unsafe void Register(int cmd, bool ingame, delegate*<NetState, SpanReader, int, void> onReceive) =>
+    public static unsafe void Register(int cmd, bool ingame, delegate*<NetState, SpanReader, void> onReceive) =>
         _handlers[cmd] = new PacketHandler(cmd, 0, ingame, onReceive);
 
     private struct AssistantsProtocolInfo : IProtocolExtensionsInfo

--- a/Projects/UOContent/Engines/Chat/ChatPackets.cs
+++ b/Projects/UOContent/Engines/Chat/ChatPackets.cs
@@ -27,7 +27,7 @@ namespace Server.Engines.Chat
             IncomingPackets.Register(0xB3, 0, true, &ChatAction);
         }
 
-        public static void OpenChatWindowRequest(NetState state, SpanReader reader, int packetLength)
+        public static void OpenChatWindowRequest(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 
@@ -48,7 +48,7 @@ namespace Server.Engines.Chat
             ChatUser.AddChatUser(from, chatName);
         }
 
-        public static void ChatAction(NetState state, SpanReader reader, int packetLength)
+        public static void ChatAction(NetState state, SpanReader reader)
         {
             if (!ChatSystem.Enabled)
             {

--- a/Projects/UOContent/Engines/ML Quests/Gumps/RaceChangeGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/RaceChangeGump.cs
@@ -196,7 +196,7 @@ namespace Server.Engines.MLQuests.Gumps
             return false;
         }
 
-        private static void RaceChangeReply(NetState state, SpanReader reader, int packetLength)
+        private static void RaceChangeReply(NetState state, SpanReader reader)
         {
             if (!m_Pending.TryGetValue(state, out var raceChangeState))
             {

--- a/Projects/UOContent/Engines/UltimaStore/UltimaStorePackets.cs
+++ b/Projects/UOContent/Engines/UltimaStore/UltimaStorePackets.cs
@@ -10,7 +10,7 @@ namespace Server.Engines.UltimaStore
             IncomingPackets.Register(0xFA, 1, true, &UltimaStoreOpenRequest);
         }
 
-        public static void UltimaStoreOpenRequest(NetState state, SpanReader reader, int packetLength)
+        public static void UltimaStoreOpenRequest(NetState state, SpanReader reader)
         {
             state.Mobile.SendMessage("Ultima Store is not currently available.");
         }

--- a/Projects/UOContent/Items/Books/BookPackets.cs
+++ b/Projects/UOContent/Items/Books/BookPackets.cs
@@ -29,7 +29,7 @@ namespace Server.Items
             IncomingPackets.Register(0x93, 99, true, &OldHeaderChange);
         }
 
-        public static void OldHeaderChange(NetState state, SpanReader reader, int packetLength)
+        public static void OldHeaderChange(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 
@@ -48,7 +48,7 @@ namespace Server.Items
             book.Author = Utility.FixHtml(author);
         }
 
-        public static void HeaderChange(NetState state, SpanReader reader, int packetLength)
+        public static void HeaderChange(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 
@@ -84,7 +84,7 @@ namespace Server.Items
             book.Author = Utility.FixHtml(author);
         }
 
-        public static void ContentChange(NetState state, SpanReader reader, int packetLength)
+        public static void ContentChange(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Items/Bulletin Boards/BulletinBoardPackets.cs
+++ b/Projects/UOContent/Items/Bulletin Boards/BulletinBoardPackets.cs
@@ -47,7 +47,7 @@ namespace Server.Network
             return $"{seconds} second{(seconds == 1 ? "" : "s")}";
         }
 
-        public static void BBClientRequest(NetState state, SpanReader reader, int packetLength)
+        public static void BBClientRequest(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Items/Games/Mahjong/MahjongPackets.cs
+++ b/Projects/UOContent/Items/Games/Mahjong/MahjongPackets.cs
@@ -61,7 +61,7 @@ namespace Server.Engines.Mahjong
             RegisterSubCommand(0x18, MoveDealerIndicator);
         }
 
-        public static void OnPacket(NetState state, SpanReader reader, int packetLength)
+        public static void OnPacket(NetState state, SpanReader reader)
         {
             var game = World.FindItem((Serial)reader.ReadUInt32()) as MahjongGame;
 

--- a/Projects/UOContent/Items/Maps/MapItemPackets.cs
+++ b/Projects/UOContent/Items/Maps/MapItemPackets.cs
@@ -25,7 +25,7 @@ namespace Server.Network
             IncomingPackets.Register(0x56, 11, true, &OnMapCommand);
         }
 
-        private static void OnMapCommand(NetState state, SpanReader reader, int packetLength)
+        private static void OnMapCommand(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Misc/HardwareInfo.cs
+++ b/Projects/UOContent/Misc/HardwareInfo.cs
@@ -139,7 +139,7 @@ namespace Server
             }
         }
 
-        public static void OnReceive(NetState state, SpanReader reader, int packetLength)
+        public static void OnReceive(NetState state, SpanReader reader)
         {
             reader.ReadByte(); // 1: <4.0.1a, 2>=4.0.1a
 

--- a/Projects/UOContent/Multis/Houses/HouseFoundation.cs
+++ b/Projects/UOContent/Multis/Houses/HouseFoundation.cs
@@ -1812,7 +1812,7 @@ namespace Server.Multis
             context.Foundation.SendInfoTo(state);
         }
 
-        public static void QueryDesignDetails(NetState state, SpanReader reader, int packetLength)
+        public static void QueryDesignDetails(NetState state, SpanReader reader)
         {
             var from = state.Mobile;
 

--- a/Projects/UOContent/Network/ContainerGridPacketHandler.cs
+++ b/Projects/UOContent/Network/ContainerGridPacketHandler.cs
@@ -20,7 +20,7 @@ namespace Server.Network;
 public unsafe class ContainerGridPacketHandler : PacketHandler
 {
     public ContainerGridPacketHandler(int packetID, int length, bool ingame,
-        delegate*<NetState, SpanReader, int, void> onReceive)
+        delegate*<NetState, SpanReader, void> onReceive)
         : base(packetID, length, ingame, onReceive)
     {
     }

--- a/Projects/UOContent/Network/FreeshardProtocol.cs
+++ b/Projects/UOContent/Network/FreeshardProtocol.cs
@@ -27,7 +27,7 @@ namespace Server.Network
             _handlers = ProtocolExtensions<FreeshardProtocolInfo>.Register(new FreeshardProtocolInfo());
         }
 
-        public static unsafe void Register(int cmd, bool ingame, delegate*<NetState, SpanReader, int, void> onReceive) =>
+        public static unsafe void Register(int cmd, bool ingame, delegate*<NetState, SpanReader, void> onReceive) =>
             _handlers[cmd] = new PacketHandler(cmd, 0, ingame, onReceive);
 
         private struct FreeshardProtocolInfo : IProtocolExtensionsInfo

--- a/Projects/UOContent/Network/MapUO.cs
+++ b/Projects/UOContent/Network/MapUO.cs
@@ -29,14 +29,14 @@ public static class MapUO
         AssistantProtocol.Register(0x01, true, &QueryGuildMemberLocations);
     }
 
-    public static void QueryGuildMemberLocations(NetState state, SpanReader reader, int packetLength)
+    public static void QueryGuildMemberLocations(NetState state, SpanReader reader)
     {
         Mobile from = state.Mobile;
 
         state.SendGuildMemberLocations(from, from.Guild as Guild, reader.ReadBoolean());
     }
 
-    public static void QueryPartyMemberLocations(NetState state, SpanReader reader, int packetLength)
+    public static void QueryPartyMemberLocations(NetState state, SpanReader reader)
     {
         Mobile from = state.Mobile;
         var party = Party.Get(from);

--- a/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
@@ -55,7 +55,7 @@ public static class IncomingAccountPackets
         IncomingPackets.Register(0xF8, 106, false, &CreateCharacter);
     }
 
-    public static void CreateCharacter(NetState state, SpanReader reader, int packetLength)
+    public static void CreateCharacter(NetState state, SpanReader reader)
     {
         reader.Seek(9, SeekOrigin.Current);
         /*
@@ -185,7 +185,7 @@ public static class IncomingAccountPackets
         }
     }
 
-    public static void DeleteCharacter(NetState state, SpanReader reader, int packetLength)
+    public static void DeleteCharacter(NetState state, SpanReader reader)
     {
         reader.Seek(30, SeekOrigin.Current);
         var index = reader.ReadInt32();
@@ -193,18 +193,18 @@ public static class IncomingAccountPackets
         EventSink.InvokeDeleteRequest(state, index);
     }
 
-    public static void AccountID(NetState state, SpanReader reader, int packetLength)
+    public static void AccountID(NetState state, SpanReader reader)
     {
     }
 
-    public static void ClientVersion(NetState state, SpanReader reader, int packetLength)
+    public static void ClientVersion(NetState state, SpanReader reader)
     {
         var version = state.Version = new CV(reader.ReadAscii());
 
         EventSink.InvokeClientVersionReceived(state, version);
     }
 
-    public static void ClientType(NetState state, SpanReader reader, int packetLength)
+    public static void ClientType(NetState state, SpanReader reader)
     {
         reader.ReadUInt16();
 
@@ -214,7 +214,7 @@ public static class IncomingAccountPackets
         EventSink.InvokeClientVersionReceived(state, version);
     }
 
-    public static void PlayCharacter(NetState state, SpanReader reader, int packetLength)
+    public static void PlayCharacter(NetState state, SpanReader reader)
     {
         reader.Seek(36, SeekOrigin.Current); // 4 = 0xEDEDEDED, 30 = Name, 2 = unknown
         var flags = reader.ReadInt32();
@@ -346,7 +346,7 @@ public static class IncomingAccountPackets
         return authID;
     }
 
-    public static void GameLogin(NetState state, SpanReader reader, int packetLength)
+    public static void GameLogin(NetState state, SpanReader reader)
     {
         // TODO: Connection throttling
 
@@ -400,7 +400,7 @@ public static class IncomingAccountPackets
         }
     }
 
-    public static void PlayServer(NetState state, SpanReader reader, int packetLength)
+    public static void PlayServer(NetState state, SpanReader reader)
     {
         int index = reader.ReadInt16();
         var info = state.ServerInfo;
@@ -421,7 +421,7 @@ public static class IncomingAccountPackets
         }
     }
 
-    public static void LoginServerSeed(NetState state, SpanReader reader, int packetLength)
+    public static void LoginServerSeed(NetState state, SpanReader reader)
     {
         state.Seed = reader.ReadInt32();
         state.Seeded = true;
@@ -441,7 +441,7 @@ public static class IncomingAccountPackets
         state.Version = new ClientVersion(clientMaj, clientMin, clientRev, clientPat);
     }
 
-    public static void AccountLogin(NetState state, SpanReader reader, int packetLength)
+    public static void AccountLogin(NetState state, SpanReader reader)
     {
         // TODO: Throttle Connection
 

--- a/Projects/UOContent/Network/Packets/IncomingEntityPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingEntityPackets.cs
@@ -29,7 +29,7 @@ public static class IncomingEntityPackets
         IncomingPackets.Register(0xD6, 0, true, &BatchQueryProperties);
     }
 
-    public static void ObjectHelpRequest(NetState state, SpanReader reader, int packetLength)
+    public static void ObjectHelpRequest(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -58,7 +58,7 @@ public static class IncomingEntityPackets
         }
     }
 
-    public static void UseReq(NetState state, SpanReader reader, int packetLength)
+    public static void UseReq(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -102,7 +102,7 @@ public static class IncomingEntityPackets
         }
     }
 
-    public static void LookReq(NetState state, SpanReader reader, int packetLength)
+    public static void LookReq(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -151,7 +151,7 @@ public static class IncomingEntityPackets
         }
     }
 
-    public static void BatchQueryProperties(NetState state, SpanReader reader, int packetLength)
+    public static void BatchQueryProperties(NetState state, SpanReader reader)
     {
         if (!ObjectPropertyList.Enabled)
         {

--- a/Projects/UOContent/Network/Packets/IncomingExtendedCommandPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingExtendedCommandPackets.cs
@@ -60,16 +60,16 @@ public static class IncomingExtendedCommandPackets
         RegisterExtended(0x32, true, &ToggleFlying);
     }
 
-    private static void UnhandledBF(NetState state, SpanReader reader, int packetLength)
+    private static void UnhandledBF(NetState state, SpanReader reader)
     {
     }
 
-    public static void Empty(NetState state, SpanReader reader, int packetLength)
+    public static void Empty(NetState state, SpanReader reader)
     {
     }
 
     public static unsafe void RegisterExtended(int packetID, bool ingame,
-        delegate*<NetState, SpanReader, int, void> onReceive)
+        delegate*<NetState, SpanReader, void> onReceive)
     {
         if (packetID is >= 0 and < 0x100)
         {
@@ -88,7 +88,7 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static unsafe void ExtendedCommand(NetState state, SpanReader reader, int packetLength)
+    public static unsafe void ExtendedCommand(NetState state, SpanReader reader)
     {
         int packetId = reader.ReadUInt16();
 
@@ -113,17 +113,17 @@ public static class IncomingExtendedCommandPackets
         }
         else
         {
-            ph.OnReceive(state, reader, packetLength);
+            ph.OnReceive(state, reader);
         }
     }
 
-    public static void ScreenSize(NetState state, SpanReader reader, int packetLength)
+    public static void ScreenSize(NetState state, SpanReader reader)
     {
         var width = reader.ReadInt32();
         var unk = reader.ReadInt32();
     }
 
-    public static void PartyMessage(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage(NetState state, SpanReader reader)
     {
         if (state.Mobile == null)
         {
@@ -133,25 +133,25 @@ public static class IncomingExtendedCommandPackets
         switch (reader.ReadByte())
         {
             case 0x01:
-                PartyMessage_AddMember(state, reader, packetLength);
+                PartyMessage_AddMember(state, reader);
                 break;
             case 0x02:
-                PartyMessage_RemoveMember(state, reader, packetLength);
+                PartyMessage_RemoveMember(state, reader);
                 break;
             case 0x03:
-                PartyMessage_PrivateMessage(state, reader, packetLength);
+                PartyMessage_PrivateMessage(state, reader);
                 break;
             case 0x04:
-                PartyMessage_PublicMessage(state, reader, packetLength);
+                PartyMessage_PublicMessage(state, reader);
                 break;
             case 0x06:
-                PartyMessage_SetCanLoot(state, reader, packetLength);
+                PartyMessage_SetCanLoot(state, reader);
                 break;
             case 0x08:
-                PartyMessage_Accept(state, reader, packetLength);
+                PartyMessage_Accept(state, reader);
                 break;
             case 0x09:
-                PartyMessage_Decline(state, reader, packetLength);
+                PartyMessage_Decline(state, reader);
                 break;
             default:
                 state.Trace(reader.Buffer);
@@ -159,17 +159,17 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void PartyMessage_AddMember(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_AddMember(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnAdd(state.Mobile);
     }
 
-    public static void PartyMessage_RemoveMember(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_RemoveMember(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnRemove(state.Mobile, World.FindMobile((Serial)reader.ReadUInt32()));
     }
 
-    public static void PartyMessage_PrivateMessage(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_PrivateMessage(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnPrivateMessage(
             state.Mobile,
@@ -178,27 +178,27 @@ public static class IncomingExtendedCommandPackets
         );
     }
 
-    public static void PartyMessage_PublicMessage(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_PublicMessage(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnPublicMessage(state.Mobile, reader.ReadBigUniSafe());
     }
 
-    public static void PartyMessage_SetCanLoot(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_SetCanLoot(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnSetCanLoot(state.Mobile, reader.ReadBoolean());
     }
 
-    public static void PartyMessage_Accept(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_Accept(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnAccept(state.Mobile, World.FindMobile((Serial)reader.ReadUInt32()));
     }
 
-    public static void PartyMessage_Decline(NetState state, SpanReader reader, int packetLength)
+    public static void PartyMessage_Decline(NetState state, SpanReader reader)
     {
         PartyCommands.Handler?.OnDecline(state.Mobile, World.FindMobile((Serial)reader.ReadUInt32()));
     }
 
-    public static void Animate(NetState state, SpanReader reader, int packetLength)
+    public static void Animate(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -222,7 +222,7 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void CastSpell(NetState state, SpanReader reader, int packetLength)
+    public static void CastSpell(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -237,12 +237,12 @@ public static class IncomingExtendedCommandPackets
         EventSink.InvokeCastSpellRequest(from, spellID, spellbook);
     }
 
-    public static void ToggleFlying(NetState state, SpanReader reader, int packetLength)
+    public static void ToggleFlying(NetState state, SpanReader reader)
     {
         state.Mobile?.ToggleFlying();
     }
 
-    public static void StunRequest(NetState state, SpanReader reader, int packetLength)
+    public static void StunRequest(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -254,7 +254,7 @@ public static class IncomingExtendedCommandPackets
         EventSink.InvokeStunRequest(from);
     }
 
-    public static void DisarmRequest(NetState state, SpanReader reader, int packetLength)
+    public static void DisarmRequest(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -266,7 +266,7 @@ public static class IncomingExtendedCommandPackets
         EventSink.InvokeDisarmRequest(from);
     }
 
-    public static void StatLockChange(NetState state, SpanReader reader, int packetLength)
+    public static void StatLockChange(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -297,12 +297,12 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void CloseStatus(NetState state, SpanReader reader, int packetLength)
+    public static void CloseStatus(NetState state, SpanReader reader)
     {
         var serial = (Serial)reader.ReadUInt32();
     }
 
-    public static void Language(NetState state, SpanReader reader, int packetLength)
+    public static void Language(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -314,7 +314,7 @@ public static class IncomingExtendedCommandPackets
         from.Language = reader.ReadAscii(4);
     }
 
-    public static void QueryProperties(NetState state, SpanReader reader, int packetLength)
+    public static void QueryProperties(NetState state, SpanReader reader)
     {
         if (!ObjectPropertyList.Enabled)
         {
@@ -346,7 +346,7 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void ContextMenuResponse(NetState state, SpanReader reader, int packetLength)
+    public static void ContextMenuResponse(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -402,7 +402,7 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void ContextMenuRequest(NetState state, SpanReader reader, int packetLength)
+    public static void ContextMenuRequest(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
         var target = World.FindEntity((Serial)reader.ReadUInt32());
@@ -437,7 +437,7 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void BandageTarget(NetState state, SpanReader reader, int packetLength)
+    public static void BandageTarget(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -472,21 +472,21 @@ public static class IncomingExtendedCommandPackets
         }
     }
 
-    public static void TargetedSpell(NetState state, SpanReader reader, int packetLength)
+    public static void TargetedSpell(NetState state, SpanReader reader)
     {
         var spellId = (short)(reader.ReadInt16() - 1); // zero based;
 
         EventSink.InvokeTargetedSpell(state.Mobile, World.FindEntity((Serial)reader.ReadUInt32()), spellId);
     }
 
-    public static void TargetedSkillUse(NetState state, SpanReader reader, int packetLength)
+    public static void TargetedSkillUse(NetState state, SpanReader reader)
     {
         var skillId = reader.ReadInt16();
 
         EventSink.InvokeTargetedSkillUse(state.Mobile, World.FindEntity((Serial)reader.ReadUInt32()), skillId);
     }
 
-    public static void TargetByResourceMacro(NetState state, SpanReader reader, int packetLength)
+    public static void TargetByResourceMacro(NetState state, SpanReader reader)
     {
         var serial = (Serial)reader.ReadUInt32();
 

--- a/Projects/UOContent/Network/Packets/IncomingHousePackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingHousePackets.cs
@@ -24,7 +24,7 @@ public static class IncomingHousePackets
         IncomingPackets.Register(0xFB, 2, false, &ShowPublicHouseContent);
     }
 
-    public static void ShowPublicHouseContent(NetState state, SpanReader reader, int packetLength)
+    public static void ShowPublicHouseContent(NetState state, SpanReader reader)
     {
         var showPublicHouseContent = reader.ReadBoolean();
     }

--- a/Projects/UOContent/Network/Packets/IncomingItemPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingItemPackets.cs
@@ -31,7 +31,7 @@ public static class IncomingItemPackets
         IncomingPackets.Register(0xED, 0, false, &UnequipMacro);
     }
 
-    public static void LiftReq(NetState state, SpanReader reader, int packetLength)
+    public static void LiftReq(NetState state, SpanReader reader)
     {
         var serial = (Serial)reader.ReadUInt32();
         int amount = reader.ReadUInt16();
@@ -40,7 +40,7 @@ public static class IncomingItemPackets
         state.Mobile.Lift(item, amount, out _, out _);
     }
 
-    public static void EquipReq(NetState state, SpanReader reader, int packetLength)
+    public static void EquipReq(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
         var item = from.Holding;
@@ -65,7 +65,7 @@ public static class IncomingItemPackets
         item.ClearBounce();
     }
 
-    public static void DropReq(NetState state, SpanReader reader, int packetLength)
+    public static void DropReq(NetState state, SpanReader reader)
     {
         reader.ReadInt32(); // serial, ignored
         int x = reader.ReadInt16();
@@ -108,7 +108,7 @@ public static class IncomingItemPackets
         }
     }
 
-    public static void EquipMacro(NetState state, SpanReader reader, int packetLength)
+    public static void EquipMacro(NetState state, SpanReader reader)
     {
         int count = reader.ReadByte();
         var serialList = new List<Serial>(count);
@@ -120,7 +120,7 @@ public static class IncomingItemPackets
         EventSink.InvokeEquipMacro(state.Mobile, serialList);
     }
 
-    public static void UnequipMacro(NetState state, SpanReader reader, int packetLength)
+    public static void UnequipMacro(NetState state, SpanReader reader)
     {
         int count = reader.ReadByte();
         var layers = new List<Layer>(count);

--- a/Projects/UOContent/Network/Packets/IncomingMessagePackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingMessagePackets.cs
@@ -28,7 +28,7 @@ public static class IncomingMessagePackets
         IncomingPackets.Register(0xAD, 0, true, &UnicodeSpeech);
     }
 
-    public static void AsciiSpeech(NetState state, SpanReader reader, int packetLength)
+    public static void AsciiSpeech(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -55,7 +55,7 @@ public static class IncomingMessagePackets
         from.DoSpeech(text, Array.Empty<int>(), type, Utility.ClipDyedHue(hue));
     }
 
-    public static void UnicodeSpeech(NetState state, SpanReader reader, int packetLength)
+    public static void UnicodeSpeech(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 

--- a/Projects/UOContent/Network/Packets/IncomingMobilePackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingMobilePackets.cs
@@ -28,7 +28,7 @@ public static class IncomingMobilePackets
         IncomingPackets.Register(0x6F, 0, true, &SecureTrade);
     }
 
-    public static void RenameRequest(NetState state, SpanReader reader, int packetLength)
+    public static void RenameRequest(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
         var targ = World.FindMobile((Serial)reader.ReadUInt32());
@@ -39,7 +39,7 @@ public static class IncomingMobilePackets
         }
     }
 
-    public static void MobileNameRequest(NetState state, SpanReader reader, int packetLength)
+    public static void MobileNameRequest(NetState state, SpanReader reader)
     {
         var m = World.FindMobile((Serial)reader.ReadUInt32());
 
@@ -49,7 +49,7 @@ public static class IncomingMobilePackets
         }
     }
 
-    public static void ProfileReq(NetState state, SpanReader reader, int packetLength)
+    public static void ProfileReq(NetState state, SpanReader reader)
     {
         int type = reader.ReadByte();
         var serial = (Serial)reader.ReadUInt32();
@@ -89,7 +89,7 @@ public static class IncomingMobilePackets
         }
     }
 
-    public static void SecureTrade(NetState state, SpanReader reader, int packetLength)
+    public static void SecureTrade(NetState state, SpanReader reader)
     {
         switch (reader.ReadByte())
         {

--- a/Projects/UOContent/Network/Packets/IncomingMovementPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingMovementPackets.cs
@@ -80,7 +80,7 @@ public static class IncomingMovementPackets
         ns.SendTimeSyncResponse();
     }
 
-    public static void MovementReq(NetState state, SpanReader reader, int packetLength)
+    public static void MovementReq(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 

--- a/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
@@ -55,18 +55,18 @@ public static class IncomingPlayerPackets
         IncomingPackets.RegisterEncoded(0x32, true, &QuestGumpRequest);
     }
 
-    public static void DeathStatusResponse(NetState state, SpanReader reader, int packetLength)
+    public static void DeathStatusResponse(NetState state, SpanReader reader)
     {
         // Ignored
     }
 
-    public static void RequestScrollWindow(NetState state, SpanReader reader, int packetLength)
+    public static void RequestScrollWindow(NetState state, SpanReader reader)
     {
         int lastTip = reader.ReadInt16();
         int type = reader.ReadByte();
     }
 
-    public static void AttackReq(NetState state, SpanReader reader, int packetLength)
+    public static void AttackReq(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -83,7 +83,7 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void HuePickerResponse(NetState state, SpanReader reader, int packetLength)
+    public static void HuePickerResponse(NetState state, SpanReader reader)
     {
         var serial = reader.ReadUInt32();
         _ = reader.ReadInt16(); // Item ID
@@ -100,7 +100,7 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void SystemInfo(NetState state, SpanReader reader, int packetLength)
+    public static void SystemInfo(NetState state, SpanReader reader)
     {
         int v1 = reader.ReadByte();
         int v2 = reader.ReadUInt16();
@@ -116,7 +116,7 @@ public static class IncomingPlayerPackets
         var v8 = reader.ReadInt32();
     }
 
-    public static void TextCommand(NetState state, SpanReader reader, int packetLength)
+    public static void TextCommand(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -211,7 +211,7 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void AsciiPromptResponse(NetState state, SpanReader reader, int packetLength)
+    public static void AsciiPromptResponse(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -247,7 +247,7 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void UnicodePromptResponse(NetState state, SpanReader reader, int packetLength)
+    public static void UnicodePromptResponse(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -284,7 +284,7 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void MenuResponse(NetState state, SpanReader reader, int packetLength)
+    public static void MenuResponse(NetState state, SpanReader reader)
     {
         var serial = reader.ReadUInt32();
         int menuID = reader.ReadInt16(); // unused in our implementation
@@ -314,33 +314,33 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void Disconnect(NetState state, SpanReader reader, int packetLength)
+    public static void Disconnect(NetState state, SpanReader reader)
     {
         var minusOne = reader.ReadInt32();
     }
 
-    public static void ConfigurationFile(NetState state, SpanReader reader, int packetLength)
+    public static void ConfigurationFile(NetState state, SpanReader reader)
     {
     }
 
-    public static void LogoutReq(NetState state, SpanReader reader, int packetLength)
+    public static void LogoutReq(NetState state, SpanReader reader)
     {
         state.SendLogoutAck();
     }
 
-    public static void ChangeSkillLock(NetState state, SpanReader reader, int packetLength)
+    public static void ChangeSkillLock(NetState state, SpanReader reader)
     {
         var s = state.Mobile.Skills[reader.ReadInt16()];
 
         s?.SetLockNoRelay((SkillLock)reader.ReadByte());
     }
 
-    public static void HelpRequest(NetState state, SpanReader reader, int packetLength)
+    public static void HelpRequest(NetState state, SpanReader reader)
     {
         EventSink.InvokeHelpRequest(state.Mobile);
     }
 
-    public static void DisplayGumpResponse(NetState state, SpanReader reader, int packetLength)
+    public static void DisplayGumpResponse(NetState state, SpanReader reader)
     {
         var serial = (Serial)reader.ReadUInt32();
         var typeID = reader.ReadInt32();
@@ -482,13 +482,13 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void SetWarMode(NetState state, SpanReader reader, int packetLength)
+    public static void SetWarMode(NetState state, SpanReader reader)
     {
         state.Mobile?.DelayChangeWarmode(reader.ReadBoolean());
     }
 
     // TODO: Throttle/make this more safe
-    public static void Resynchronize(NetState state, SpanReader reader, int packetLength)
+    public static void Resynchronize(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
 
@@ -505,17 +505,17 @@ public static class IncomingPlayerPackets
         state.Sequence = 0;
     }
 
-    public static void PingReq(NetState state, SpanReader reader, int packetLength)
+    public static void PingReq(NetState state, SpanReader reader)
     {
         state.SendPingAck(reader.ReadByte());
     }
 
-    public static void SetUpdateRange(NetState state, SpanReader reader, int packetLength)
+    public static void SetUpdateRange(NetState state, SpanReader reader)
     {
         state.SendChangeUpdateRange(18);
     }
 
-    public static void MobileQuery(NetState state, SpanReader reader, int packetLength)
+    public static void MobileQuery(NetState state, SpanReader reader)
     {
         var from = state.Mobile;
         if (from == null)
@@ -552,7 +552,7 @@ public static class IncomingPlayerPackets
         }
     }
 
-    public static void CrashReport(NetState state, SpanReader reader, int packetLength)
+    public static void CrashReport(NetState state, SpanReader reader)
     {
         var clientMaj = reader.ReadByte();
         var clientMin = reader.ReadByte();
@@ -596,7 +596,7 @@ public static class IncomingPlayerPackets
         EventSink.InvokeQuestGumpRequest(state.Mobile);
     }
 
-    public static unsafe void EncodedCommand(NetState state, SpanReader reader, int packetLength)
+    public static unsafe void EncodedCommand(NetState state, SpanReader reader)
     {
         var e = World.FindEntity((Serial)reader.ReadUInt32());
         int packetId = reader.ReadUInt16();

--- a/Projects/UOContent/Network/Packets/IncomingTargetingPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingTargetingPackets.cs
@@ -26,7 +26,7 @@ public static class IncomingTargetingPackets
         IncomingPackets.Register(0x6C, 19, true, &TargetResponse);
     }
 
-    public static void TargetResponse(NetState state, SpanReader reader, int packetLength)
+    public static void TargetResponse(NetState state, SpanReader reader)
     {
         int type = reader.ReadByte();
         var targetID = reader.ReadInt32();

--- a/Projects/UOContent/Network/Packets/IncomingVendorPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingVendorPackets.cs
@@ -26,7 +26,7 @@ public static class IncomingVendorPackets
         IncomingPackets.Register(0x9F, 0, true, &VendorSellReply);
     }
 
-    public static void VendorBuyReply(NetState state, SpanReader reader, int packetLength)
+    public static void VendorBuyReply(NetState state, SpanReader reader)
     {
         var vendor = World.FindMobile((Serial)reader.ReadUInt32());
 
@@ -39,7 +39,7 @@ public static class IncomingVendorPackets
 
         if (!vendor.Deleted && Utility.InRange(vendor.Location, state.Mobile.Location, 10) && flag == 0x02)
         {
-            var msgSize = packetLength - 8; // Remaining bytes
+            var msgSize = reader.Remaining;
 
             if (msgSize / 7 > 100)
             {
@@ -66,7 +66,7 @@ public static class IncomingVendorPackets
         state.SendEndVendorBuy(vendor.Serial);
     }
 
-    public static void VendorSellReply(NetState state, SpanReader reader, int packetLength)
+    public static void VendorSellReply(NetState state, SpanReader reader)
     {
         var serial = (Serial)reader.ReadUInt32();
         var vendor = World.FindMobile(serial);

--- a/Projects/UOContent/Network/ProtocolExtensions.cs
+++ b/Projects/UOContent/Network/ProtocolExtensions.cs
@@ -35,7 +35,7 @@ namespace Server.Network
             return packetHandlers;
         }
 
-        private static unsafe void DecodeBundledPacket(NetState state, SpanReader reader, int packetLength)
+        private static unsafe void DecodeBundledPacket(NetState state, SpanReader reader)
         {
             int cmd = reader.ReadByte();
 
@@ -57,7 +57,7 @@ namespace Server.Network
             }
             else
             {
-                ph.OnReceive(state, reader, packetLength);
+                ph.OnReceive(state, reader);
             }
         }
     }

--- a/Projects/UOContent/Network/UOGateway.cs
+++ b/Projects/UOContent/Network/UOGateway.cs
@@ -33,7 +33,7 @@ namespace Server.Network
             }
         }
 
-        public static void QueryCompactShardStats(NetState state, SpanReader reader, int packetLength)
+        public static void QueryCompactShardStats(NetState state, SpanReader reader)
         {
             state.SendCompactShardStats(
                 (uint)(Core.Uptime / 1000),
@@ -44,7 +44,7 @@ namespace Server.Network
             );
         }
 
-        public static void QueryExtendedShardStats(NetState state, SpanReader reader, int packetLength)
+        public static void QueryExtendedShardStats(NetState state, SpanReader reader)
         {
             const long ticksInHour = 1000 * 60 * 60;
             state.SendExtendedShardStats(

--- a/Projects/UOContent/Skills/Tracking/Tracking.cs
+++ b/Projects/UOContent/Skills/Tracking/Tracking.cs
@@ -23,7 +23,7 @@ namespace Server.SkillHandlers
             SkillInfo.Table[(int)SkillName.Tracking].Callback = OnUse;
         }
 
-        public static void QuestArrow(NetState state, SpanReader reader, int packetLength)
+        public static void QuestArrow(NetState state, SpanReader reader)
         {
             if (state.Mobile is PlayerMobile from)
             {


### PR DESCRIPTION
### Summary
* Fixes syntax compile error when THREADGUARD is enabled.
* Removes `int packetLength` from incoming packet handles since they aren't needed.

### Developer Notes
Incoming packet handler `SpanReader` is now properly scoped to that packet by length.