### PR TITLE
Fix hues for Bags of Sending

### DIFF
--- a/Projects/UOContent/Items/Special/Solen Items/BagOfSending.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BagOfSending.cs
@@ -30,7 +30,7 @@ public partial class BagOfSending : Item, TranslocationItem
     {
         Weight = 2.0;
 
-        _bagOfSendingHue = hue;
+        BagOfSendingHue = hue;
         _charges = Utility.RandomMinMax(3, 9);
     }
 


### PR DESCRIPTION
You couldn't actually set the hue (randomly/automatically or manually) on item creation.