### PR TITLE
fix: Fixes issue with duping items and serialization, and sector lists.

### DIFF
--- a/Projects/Server/Items/BaseMulti.cs
+++ b/Projects/Server/Items/BaseMulti.cs
@@ -32,13 +32,9 @@ public abstract partial class BaseMulti : Item
         {
             if (base.ItemID != value)
             {
-                var facet = Parent == null ? Map : null;
-
-                facet?.OnLeave(this);
-
+                Map?.OnLeave(this);
                 base.ItemID = value;
-
-                facet?.OnEnter(this);
+                Map?.OnEnter(this);
             }
         }
     }
@@ -68,21 +64,6 @@ public abstract partial class BaseMulti : Item
     public virtual bool AllowsRelativeDrop => false;
 
     public virtual MultiComponentList Components => MultiData.GetComponents(ItemID);
-
-    [Obsolete("Replace with calls to OnLeave and OnEnter surrounding component invalidation.", true)]
-    public virtual void RefreshComponents()
-    {
-        if (Parent == null)
-        {
-            var facet = Map;
-
-            if (facet != null)
-            {
-                facet.OnLeave(this);
-                facet.OnEnter(this);
-            }
-        }
-    }
 
     public override int GetMaxUpdateRange() => 22;
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -599,18 +599,16 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
 
             var oldParent = m_Parent;
 
+            if (m_Map != null && oldParent == null && value != null)
+            {
+                m_Map.OnLeave(this);
+            }
+
             m_Parent = value;
 
-            if (m_Map != null)
+            if (m_Map != null && oldParent != null && value == null)
             {
-                if (oldParent != null && m_Parent == null)
-                {
-                    m_Map.OnEnter(this);
-                }
-                else if (m_Parent != null)
-                {
-                    m_Map.OnLeave(this);
-                }
+                m_Map.OnEnter(this);
             }
         }
     }
@@ -1207,9 +1205,13 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
             {
                 var old = m_Map;
 
-                if (m_Map != null && m_Parent == null)
+                if (m_Map != null)
                 {
-                    m_Map.OnLeave(this);
+                    if (m_Parent == null)
+                    {
+                        m_Map.OnLeave(this);
+                    }
+
                     SendRemovePacket();
                 }
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -3330,13 +3330,14 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
         }
     }
 
-    private static readonly HashSet<string> _excludedProperties = new()
-    {
+    private static readonly HashSet<string> _excludedProperties =
+    [
+        "SaveBuffer",
         "Parent",
         "Next",
         "Previous",
         "OnLinkList"
-    };
+    ];
 
     public virtual bool DupeExcludedProperty(string propertyName) => _excludedProperties.Contains(propertyName);
 

--- a/Projects/Server/Maps/Map.cs
+++ b/Projects/Server/Maps/Map.cs
@@ -568,12 +568,12 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
         }
     }
 
-    public void OnEnter(Mobile m)
+    internal void OnEnter(Mobile m)
     {
         OnEnter(m.Location, m);
     }
 
-    public void OnEnter(Point3D p, Mobile m)
+    internal void OnEnter(Point3D p, Mobile m)
     {
         if (this != Internal)
         {
@@ -581,14 +581,14 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
         }
     }
 
-    public void OnEnter(Item item)
+    internal void OnEnter(Item item)
     {
         OnEnter(item.Location, item);
     }
 
-    public void OnEnter(Point3D p, Item item)
+    internal void OnEnter(Point3D p, Item item)
     {
-        if (this == Internal)
+        if (this == Internal || item.Parent != null)
         {
             return;
         }
@@ -606,12 +606,12 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
         }
     }
 
-    public void OnLeave(Mobile m)
+    internal void OnLeave(Mobile m)
     {
         OnLeave(m.Location, m);
     }
 
-    public void OnLeave(Point3D p, Mobile m)
+    internal void OnLeave(Point3D p, Mobile m)
     {
         if (this != Internal)
         {
@@ -619,14 +619,14 @@ public sealed partial class Map : IComparable<Map>, ISpanFormattable, ISpanParsa
         }
     }
 
-    public void OnLeave(Item item)
+    internal void OnLeave(Item item)
     {
         OnLeave(item.Location, item);
     }
 
-    public void OnLeave(Point3D p, Item item)
+    internal void OnLeave(Point3D p, Item item)
     {
-        if (this == Internal)
+        if (this == Internal || item.Parent != null)
         {
             return;
         }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -7272,6 +7272,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         }
 
         m_Location = newLocation;
+        m_Map?.OnMove(oldLocation, this);
         UpdateRegion();
 
         var box = FindBankNoCreate();
@@ -7282,8 +7283,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         }
 
         m_NetState?.ValidateAllTrades();
-
-        m_Map?.OnMove(oldLocation, this);
 
         if (isTeleport && m_NetState != null && (!m_NetState.HighSeas || !NoMoveHS))
         {

--- a/Projects/Server/World/EntityPersistence.cs
+++ b/Projects/Server/World/EntityPersistence.cs
@@ -246,7 +246,7 @@ public static class EntityPersistence
             }
             else
             {
-                Console.WriteLine($"***** Bad deserialize of {t.GetType()} *****");
+                Console.WriteLine($"***** Bad deserialize of {t.GetType()} ({t.Serial}) *****");
                 Console.WriteLine(error);
 
                 ConsoleKey pressedKey;

--- a/Projects/UOContent/World Saves/AutoSave.cs
+++ b/Projects/UOContent/World Saves/AutoSave.cs
@@ -40,11 +40,6 @@ namespace Server.Saves
             Warning = ServerConfiguration.GetOrUpdateSetting("autosave.warningDelay", TimeSpan.Zero);
         }
 
-        public static void Initialize()
-        {
-            SavesEnabled = true;
-        }
-
         public static void ResetAutoSave(TimeSpan saveDelay, TimeSpan warningDelay)
         {
             if (saveDelay != Delay || warningDelay != Warning)

--- a/Projects/UOContent/World Saves/AutoSave.cs
+++ b/Projects/UOContent/World Saves/AutoSave.cs
@@ -35,6 +35,7 @@ namespace Server.Saves
 
         public static void Configure()
         {
+            SavesEnabled = ServerConfiguration.GetOrUpdateSetting("autosave.enabled", true);
             Delay = ServerConfiguration.GetOrUpdateSetting("autosave.saveDelay", TimeSpan.FromMinutes(5.0));
             Warning = ServerConfiguration.GetOrUpdateSetting("autosave.warningDelay", TimeSpan.Zero);
         }


### PR DESCRIPTION
> [!Important]
> **This fixes a major issue with [dupe and serialization!**

### Summary

- Fixes [dupe sharing the same SaveBuffer, causing serialization clobbering.
- Fixes an issue with Mobile.SetLocation() -> UpdateRegion() -> OnRegionChange() -> having side effects that makes calling Map.OnMove(0 later in the SetLocation invalid.
- Fixes disabling AutoSave not working.