### PR TITLE
fix: Fixes loot with zero amount

### DIFF
--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -655,6 +655,17 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
 
                 m_Amount = value;
 
+                if (m_Amount <= 0)
+                {
+                    logger.Error(
+                        new Exception("Item.Amount <= 0 error"),
+                        "Item {Type} ({Serial}) was changed to amount of {Amount}, but must be at least 1",
+                        GetType(),
+                        Serial,
+                        m_Amount
+                    );
+                }
+
                 var newPileWeight = PileWeight;
 
                 UpdateTotal(this, TotalType.Weight, newPileWeight - oldPileWeight);

--- a/Projects/UOContent/Engines/Treasures of Tokuno/LesserArtifacts.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/LesserArtifacts.cs
@@ -479,7 +479,7 @@ public partial class ChestOfHeirlooms : LockableContainer
 
         for (var i = 0; i < 10; ++i)
         {
-            var item = Loot.ChestOfHeirloomsContains();
+            var item = Loot.RandomChestOfHeirloomsContent();
 
             var attributeCount = Utility.RandomMinMax(1, 5);
             var min = 20;

--- a/Projects/UOContent/Misc/Loot.cs
+++ b/Projects/UOContent/Misc/Loot.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Server.Items;
 using Server.Utilities;
 
@@ -332,358 +333,342 @@ namespace Server
             typeof(VirtueBook)
         };
 
+        private static readonly Type[][] _wandTypes = [WandTypes, NewWandTypes];
+        private static readonly Type[][] _oldWandTypes = [OldWandTypes, WandTypes, NewWandTypes];
+
         public static BaseWand RandomWand()
         {
             if (Core.ML)
             {
-                return Construct(NewWandTypes) as BaseWand;
+                return Construct<BaseWand>(NewWandTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(WandTypes, NewWandTypes) as BaseWand;
+                return Construct<BaseWand>(_wandTypes);
             }
 
-            return Construct(OldWandTypes, WandTypes, NewWandTypes) as BaseWand;
+            return Construct<BaseWand>(_oldWandTypes);
         }
 
-        public static BaseClothing RandomClothing() => RandomClothing(false, false);
+        private static readonly Type[][] _mlClothingTypes = [MLClothingTypes, AosClothingTypes, ClothingTypes];
+        private static readonly Type[][] _seClothingTypes = [SEClothingTypes, AosClothingTypes, ClothingTypes];
+        private static readonly Type[][] _aosClothingTypes = [AosClothingTypes, ClothingTypes];
 
-        public static BaseClothing RandomClothing(bool inTokuno, bool isMondain)
+        public static BaseClothing RandomClothing(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLClothingTypes, AosClothingTypes, ClothingTypes) as BaseClothing;
+                return Construct<BaseClothing>(_mlClothingTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SEClothingTypes, AosClothingTypes, ClothingTypes) as BaseClothing;
+                return Construct<BaseClothing>(_seClothingTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(AosClothingTypes, ClothingTypes) as BaseClothing;
+                return Construct<BaseClothing>(_aosClothingTypes);
             }
 
-            return Construct(ClothingTypes) as BaseClothing;
+            return Construct<BaseClothing>(ClothingTypes);
         }
 
-        public static BaseWeapon RandomRangedWeapon() => RandomRangedWeapon(false, false);
+        private static readonly Type[][] _mlRangedWeaponTypes = [MLRangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes];
+        private static readonly Type[][] _seRangedWeaponTypes = [SERangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes];
+        private static readonly Type[][] _aosRangedWeaponTypes = [AosRangedWeaponTypes, RangedWeaponTypes];
 
-        public static BaseWeapon RandomRangedWeapon(bool inTokuno, bool isMondain)
+        public static BaseWeapon RandomRangedWeapon(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLRangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes) as BaseWeapon;
+                return Construct<BaseWeapon>(_mlRangedWeaponTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SERangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes) as BaseWeapon;
+                return Construct<BaseWeapon>(_seRangedWeaponTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(AosRangedWeaponTypes, RangedWeaponTypes) as BaseWeapon;
+                return Construct<BaseWeapon>(_aosRangedWeaponTypes);
             }
 
-            return Construct(RangedWeaponTypes) as BaseWeapon;
+            return Construct<BaseWeapon>(RangedWeaponTypes);
         }
 
-        public static BaseWeapon RandomWeapon() => RandomWeapon(false, false);
+        private static readonly Type[][] _mlWeaponTypes = [MLWeaponTypes, AosWeaponTypes, WeaponTypes];
+        private static readonly Type[][] _seWeaponTypes = [SEWeaponTypes, AosWeaponTypes, WeaponTypes];
+        private static readonly Type[][] _aosWeaponTypes = [AosWeaponTypes, WeaponTypes];
 
-        public static BaseWeapon RandomWeapon(bool inTokuno, bool isMondain)
+        public static BaseWeapon RandomWeapon(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLWeaponTypes, AosWeaponTypes, WeaponTypes) as BaseWeapon;
+                return Construct<BaseWeapon>(_mlWeaponTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SEWeaponTypes, AosWeaponTypes, WeaponTypes) as BaseWeapon;
+                return Construct<BaseWeapon>(_seWeaponTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(AosWeaponTypes, WeaponTypes) as BaseWeapon;
+                return Construct<BaseWeapon>(_aosWeaponTypes);
             }
 
-            return Construct(WeaponTypes) as BaseWeapon;
+            return Construct<BaseWeapon>(WeaponTypes);
         }
 
-        public static Item RandomWeaponOrJewelry() => RandomWeaponOrJewelry(false, false);
+        private static readonly Type[][] _mlWeaponOrJewelryTypes = [MLWeaponTypes, AosWeaponTypes, WeaponTypes, JewelryTypes];
+        private static readonly Type[][] _seWeaponOrJewelryTypes = [SEWeaponTypes, AosWeaponTypes, WeaponTypes, JewelryTypes];
+        private static readonly Type[][] _aosWeaponOrJewelryTypes = [AosWeaponTypes, WeaponTypes, JewelryTypes];
+        private static readonly Type[][] _oldWeaponOrJewelryTypes = [WeaponTypes, JewelryTypes];
 
-        public static Item RandomWeaponOrJewelry(bool inTokuno, bool isMondain)
+        public static Item RandomWeaponOrJewelry(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLWeaponTypes, AosWeaponTypes, WeaponTypes, JewelryTypes);
+                return Construct(_mlWeaponOrJewelryTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SEWeaponTypes, AosWeaponTypes, WeaponTypes, JewelryTypes);
+                return Construct(_seWeaponOrJewelryTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(AosWeaponTypes, WeaponTypes, JewelryTypes);
+                return Construct(_aosWeaponOrJewelryTypes);
             }
 
-            return Construct(WeaponTypes, JewelryTypes);
+            return Construct(_oldWeaponOrJewelryTypes);
         }
 
-        public static BaseJewel RandomJewelry() => Construct(JewelryTypes) as BaseJewel;
+        public static BaseJewel RandomJewelry() => Construct<BaseJewel>(JewelryTypes);
 
-        public static BaseArmor RandomArmor() => RandomArmor(false, false);
+        private static readonly Type[][] _mlArmorTypes = [MLArmorTypes, ArmorTypes];
+        private static readonly Type[][] _seArmorTypes = [SEArmorTypes, ArmorTypes];
 
-        public static BaseArmor RandomArmor(bool inTokuno, bool isMondain)
+        public static BaseArmor RandomArmor(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLArmorTypes, ArmorTypes) as BaseArmor;
+                return Construct<BaseArmor>(_mlArmorTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SEArmorTypes, ArmorTypes) as BaseArmor;
+                return Construct<BaseArmor>(_seArmorTypes);
             }
 
-            return Construct(ArmorTypes) as BaseArmor;
+            return Construct<BaseArmor>(ArmorTypes);
         }
 
-        public static BaseHat RandomHat() => RandomHat(false);
+        private static readonly Type[][] _seHatTypes = [SEHatTypes, AosHatTypes, HatTypes];
+        private static readonly Type[][] _aosHatTypes = [AosHatTypes, HatTypes];
 
-        public static BaseHat RandomHat(bool inTokuno)
+        public static BaseHat RandomHat(bool inTokuno = false)
         {
             if (Core.SE && inTokuno)
             {
-                return Construct(SEHatTypes, AosHatTypes, HatTypes) as BaseHat;
+                return Construct<BaseHat>(_seHatTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(AosHatTypes, HatTypes) as BaseHat;
+                return Construct<BaseHat>(_aosHatTypes);
             }
 
-            return Construct(HatTypes) as BaseHat;
+            return Construct<BaseHat>(HatTypes);
         }
 
-        public static Item RandomArmorOrHat() => RandomArmorOrHat(false, false);
+        private static readonly Type[][] _mlArmorOrHatTypes = [MLArmorTypes, ArmorTypes, AosHatTypes, HatTypes];
+        private static readonly Type[][] _seArmorOrHatTypes = [SEArmorTypes, ArmorTypes, SEHatTypes, AosHatTypes, HatTypes];
+        private static readonly Type[][] _aosArmorOrHatTypes = [ArmorTypes, AosHatTypes, HatTypes];
+        private static readonly Type[][] _oldArmorOrHatTypes = [ArmorTypes, HatTypes];
 
-        public static Item RandomArmorOrHat(bool inTokuno, bool isMondain)
+        public static Item RandomArmorOrHat(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLArmorTypes, ArmorTypes, AosHatTypes, HatTypes);
+                return Construct(_mlArmorOrHatTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SEArmorTypes, ArmorTypes, SEHatTypes, AosHatTypes, HatTypes);
+                return Construct(_seArmorOrHatTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(ArmorTypes, AosHatTypes, HatTypes);
+                return Construct(_aosArmorOrHatTypes);
             }
 
-            return Construct(ArmorTypes, HatTypes);
+            return Construct(_oldArmorOrHatTypes);
         }
+
+        private static readonly Type[][] _aosShieldTypes = [AosShieldTypes, ShieldTypes];
 
         public static BaseShield RandomShield()
         {
             if (Core.AOS)
             {
-                return Construct(AosShieldTypes, ShieldTypes) as BaseShield;
+                return Construct<BaseShield>(_aosShieldTypes);
             }
 
-            return Construct(ShieldTypes) as BaseShield;
+            return Construct<BaseShield>(ShieldTypes);
         }
 
-        public static BaseArmor RandomArmorOrShield() => RandomArmorOrShield(false, false);
+        private static readonly Type[][] _mlArmorOrShieldTypes = [MLArmorTypes, ArmorTypes, AosShieldTypes, ShieldTypes];
+        private static readonly Type[][] _seArmorOrShieldTypes = [SEArmorTypes, ArmorTypes, AosShieldTypes, ShieldTypes];
+        private static readonly Type[][] _aosArmorOrShieldTypes = [ArmorTypes, AosShieldTypes, ShieldTypes];
+        private static readonly Type[][] _oldArmorOrShieldTypes = [ArmorTypes, ShieldTypes];
 
-        public static BaseArmor RandomArmorOrShield(bool inTokuno, bool isMondain)
+        public static BaseArmor RandomArmorOrShield(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLArmorTypes, ArmorTypes, AosShieldTypes, ShieldTypes) as BaseArmor;
+                return Construct<BaseArmor>(_mlArmorOrShieldTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(SEArmorTypes, ArmorTypes, AosShieldTypes, ShieldTypes) as BaseArmor;
+                return Construct<BaseArmor>(_seArmorOrShieldTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(ArmorTypes, AosShieldTypes, ShieldTypes) as BaseArmor;
+                return Construct<BaseArmor>(_aosArmorOrShieldTypes);
             }
 
-            return Construct(ArmorTypes, ShieldTypes) as BaseArmor;
+            return Construct<BaseArmor>(_oldArmorOrShieldTypes);
         }
 
-        public static Item RandomArmorOrShieldOrJewelry() => RandomArmorOrShieldOrJewelry(false, false);
+        private static readonly Type[][] _mlArmorOrHatOrShieldOrJeweleyTypes =
+            [MLArmorTypes, ArmorTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes];
+        private static readonly Type[][] _seArmorOrHatOrShieldOrJeweleyTypes =
+            [SEArmorTypes, ArmorTypes, SEHatTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes];
+        private static readonly Type[][] _aosArmorOrHatOrShieldOrJeweleyTypes =
+            [ArmorTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes];
+        private static readonly Type[][] _oldArmorOrHatOrShieldOrJeweleyTypes =
+            [ArmorTypes, HatTypes, ShieldTypes, JewelryTypes];
 
-        public static Item RandomArmorOrShieldOrJewelry(bool inTokuno, bool isMondain)
+        public static Item RandomArmorOrShieldOrJewelry(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(MLArmorTypes, ArmorTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes);
+                return Construct(_mlArmorOrHatOrShieldOrJeweleyTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(
-                    SEArmorTypes,
-                    ArmorTypes,
-                    SEHatTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes,
-                    JewelryTypes
-                );
+                return Construct(_seArmorOrHatOrShieldOrJeweleyTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(ArmorTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes);
+                return Construct(_aosArmorOrHatOrShieldOrJeweleyTypes);
             }
 
-            return Construct(ArmorTypes, HatTypes, ShieldTypes, JewelryTypes);
+            return Construct(_oldArmorOrHatOrShieldOrJeweleyTypes);
         }
 
-        public static Item RandomArmorOrShieldOrWeapon() => RandomArmorOrShieldOrWeapon(false, false);
+        private static readonly Type[][] _mlWeaponOrRangedOrArmorOrHatOrShieldTypes =
+        [
+            MLWeaponTypes, AosWeaponTypes, WeaponTypes, MLRangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes,
+            MLArmorTypes, ArmorTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes
+        ];
 
-        public static Item RandomArmorOrShieldOrWeapon(bool inTokuno, bool isMondain)
+        private static readonly Type[][] _seWeaponOrRangedOrArmorOrHatOrShieldTypes =
+        [
+            SEWeaponTypes, AosWeaponTypes, WeaponTypes, SERangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes,
+            SEArmorTypes, ArmorTypes, SEHatTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes
+        ];
+
+        private static readonly Type[][] _aosWeaponOrRangedOrArmorOrHatOrShieldTypes =
+        [
+            AosWeaponTypes, WeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes, ArmorTypes, AosHatTypes, HatTypes,
+            AosShieldTypes, ShieldTypes
+        ];
+
+        private static readonly Type[][] _oldWeaponOrRangedOrArmorOrHatOrShieldTypes =
+        [
+            WeaponTypes, RangedWeaponTypes, ArmorTypes, HatTypes, ShieldTypes
+        ];
+
+        public static Item RandomArmorOrShieldOrWeapon(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(
-                    MLWeaponTypes,
-                    AosWeaponTypes,
-                    WeaponTypes,
-                    MLRangedWeaponTypes,
-                    AosRangedWeaponTypes,
-                    RangedWeaponTypes,
-                    MLArmorTypes,
-                    ArmorTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes
-                );
+                return Construct(_mlWeaponOrRangedOrArmorOrHatOrShieldTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(
-                    SEWeaponTypes,
-                    AosWeaponTypes,
-                    WeaponTypes,
-                    SERangedWeaponTypes,
-                    AosRangedWeaponTypes,
-                    RangedWeaponTypes,
-                    SEArmorTypes,
-                    ArmorTypes,
-                    SEHatTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes
-                );
+                return Construct(_seWeaponOrRangedOrArmorOrHatOrShieldTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(
-                    AosWeaponTypes,
-                    WeaponTypes,
-                    AosRangedWeaponTypes,
-                    RangedWeaponTypes,
-                    ArmorTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes
-                );
+                return Construct(_aosWeaponOrRangedOrArmorOrHatOrShieldTypes);
             }
 
-            return Construct(WeaponTypes, RangedWeaponTypes, ArmorTypes, HatTypes, ShieldTypes);
+            return Construct(_oldWeaponOrRangedOrArmorOrHatOrShieldTypes);
         }
 
-        public static Item RandomArmorOrShieldOrWeaponOrJewelry() => RandomArmorOrShieldOrWeaponOrJewelry(false, false);
+        private static readonly Type[][] _mlWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes =
+        [
+            MLWeaponTypes, AosWeaponTypes, WeaponTypes, MLRangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes,
+            MLArmorTypes, ArmorTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes
+        ];
 
-        public static Item RandomArmorOrShieldOrWeaponOrJewelry(bool inTokuno, bool isMondain)
+        private static readonly Type[][] _seWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes =
+        [
+            SEWeaponTypes, AosWeaponTypes, WeaponTypes, SERangedWeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes,
+            SEArmorTypes, ArmorTypes, SEHatTypes, AosHatTypes, HatTypes, AosShieldTypes, ShieldTypes, JewelryTypes
+        ];
+
+        private static readonly Type[][] _aosWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes =
+        [
+            AosWeaponTypes, WeaponTypes, AosRangedWeaponTypes, RangedWeaponTypes, ArmorTypes, AosHatTypes, HatTypes,
+            AosShieldTypes, ShieldTypes, JewelryTypes
+        ];
+
+        private static readonly Type[][] _oldWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes =
+        [
+            WeaponTypes, RangedWeaponTypes, ArmorTypes, HatTypes, ShieldTypes, JewelryTypes
+        ];
+
+        public static Item RandomArmorOrShieldOrWeaponOrJewelry(bool inTokuno = false, bool isMondain = false)
         {
             if (Core.ML && isMondain)
             {
-                return Construct(
-                    MLWeaponTypes,
-                    AosWeaponTypes,
-                    WeaponTypes,
-                    MLRangedWeaponTypes,
-                    AosRangedWeaponTypes,
-                    RangedWeaponTypes,
-                    MLArmorTypes,
-                    ArmorTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes,
-                    JewelryTypes
-                );
+                return Construct(_mlWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes);
             }
 
             if (Core.SE && inTokuno)
             {
-                return Construct(
-                    SEWeaponTypes,
-                    AosWeaponTypes,
-                    WeaponTypes,
-                    SERangedWeaponTypes,
-                    AosRangedWeaponTypes,
-                    RangedWeaponTypes,
-                    SEArmorTypes,
-                    ArmorTypes,
-                    SEHatTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes,
-                    JewelryTypes
-                );
+                return Construct(_seWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes);
             }
 
             if (Core.AOS)
             {
-                return Construct(
-                    AosWeaponTypes,
-                    WeaponTypes,
-                    AosRangedWeaponTypes,
-                    RangedWeaponTypes,
-                    ArmorTypes,
-                    AosHatTypes,
-                    HatTypes,
-                    AosShieldTypes,
-                    ShieldTypes,
-                    JewelryTypes
-                );
+                return Construct(_aosWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes);
             }
 
-            return Construct(WeaponTypes, RangedWeaponTypes, ArmorTypes, HatTypes, ShieldTypes, JewelryTypes);
+            return Construct(_oldWeaponOrRangedOrArmorOrHatOrShieldOrJewelryTypes);
         }
 
-        public static Item ChestOfHeirloomsContains() => Construct(
-            SEArmorTypes,
-            SEHatTypes,
-            SEWeaponTypes,
-            SERangedWeaponTypes,
-            JewelryTypes
-        );
+        private static readonly Type[][] _chestOfHeirloomsContentTypes =
+        [
+            SEArmorTypes, SEHatTypes, SEWeaponTypes, SERangedWeaponTypes, JewelryTypes
+        ];
+
+        public static Item RandomChestOfHeirloomsContent() => Construct(_chestOfHeirloomsContentTypes);
 
         public static Item RandomGem() => Construct(GemTypes);
 
@@ -691,19 +676,17 @@ namespace Server
 
         public static Item RandomNecromancyReagent() => Construct(NecroRegTypes);
 
-        public static Item RandomPossibleReagent() => Core.AOS ? Construct(RegTypes, NecroRegTypes) : Construct(RegTypes);
+        private static readonly Type[][] _regOrNecroRegTypes = [RegTypes, NecroRegTypes];
+
+        public static Item RandomPossibleReagent() => Core.AOS ? Construct(_regOrNecroRegTypes) : Construct(RegTypes);
 
         public static Item RandomPotion() => Construct(PotionTypes);
 
-        public static BaseInstrument RandomInstrument()
-        {
-            if (Core.SE)
-            {
-                return Construct(InstrumentTypes, SEInstrumentTypes) as BaseInstrument;
-            }
+        private static readonly Type[][] _seInstrumentTypes = [SEInstrumentTypes, InstrumentTypes];
 
-            return Construct(InstrumentTypes) as BaseInstrument;
-        }
+        public static BaseInstrument RandomInstrument() => Core.SE
+            ? Construct<BaseInstrument>(_seInstrumentTypes)
+            : Construct<BaseInstrument>(InstrumentTypes);
 
         public static Item RandomStatue() => Construct(StatueTypes);
 
@@ -718,16 +701,16 @@ namespace Server
                 _                         => RegularScrollTypes
             };
 
-            return Construct(types, Utility.RandomMinMax(minIndex, maxIndex)) as SpellScroll;
+            return Construct<SpellScroll>(types, Utility.RandomMinMax(minIndex, maxIndex));
         }
 
-        public static BaseBook RandomGrimmochJournal() => Construct(GrimmochJournalTypes) as BaseBook;
+        public static BaseBook RandomGrimmochJournal() => Construct<BaseBook>(GrimmochJournalTypes);
 
-        public static BaseBook RandomLysanderNotebook() => Construct(LysanderNotebookTypes) as BaseBook;
+        public static BaseBook RandomLysanderNotebook() => Construct<BaseBook>(LysanderNotebookTypes);
 
-        public static BaseBook RandomTavarasJournal() => Construct(TavarasJournalTypes) as BaseBook;
+        public static BaseBook RandomTavarasJournal() => Construct<BaseBook>(TavarasJournalTypes);
 
-        public static BaseBook RandomLibraryBook() => Construct(LibraryBookTypes) as BaseBook;
+        public static BaseBook RandomLibraryBook() => Construct<BaseBook>(LibraryBookTypes);
 
         public static BaseTalisman RandomTalisman()
         {
@@ -748,15 +731,7 @@ namespace Server
             else
             {
                 talisman.MaxCharges = Utility.RandomMinMax(10, 50);
-
-                if (talisman.Summoner.IsItem)
-                {
-                    talisman.MaxChargeTime = 60;
-                }
-                else
-                {
-                    talisman.MaxChargeTime = 1800;
-                }
+                talisman.MaxChargeTime = talisman.Summoner.IsItem ? 60 : 1800;
             }
 
             talisman.Blessed = BaseTalisman.GetRandomBlessed();
@@ -771,7 +746,10 @@ namespace Server
             return talisman;
         }
 
-        public static Item Construct(Type type)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Item Construct(Type type) => Construct<Item>(type);
+
+        public static T Construct<T>(Type type) where T : Item
         {
             if (type == null)
             {
@@ -780,7 +758,7 @@ namespace Server
 
             try
             {
-                return type.CreateInstance<Item>();
+                return type.CreateInstance<T>();
             }
             catch
             {
@@ -788,19 +766,29 @@ namespace Server
             }
         }
 
-        public static Item Construct(Type[] types) => Construct(types.RandomElement());
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Item Construct(params Type[] types) => Construct<Item>(types.RandomElement());
 
-        public static Item Construct(Type[] types, int index)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Construct<T>(params Type[] types) where T : Item => Construct<T>(types.RandomElement());
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Item Construct(Type[] types, int index) => Construct<Item>(types, index);
+
+        public static T Construct<T>(Type[] types, int index) where T : Item
         {
             if (index >= 0 && index < types.Length)
             {
-                return Construct(types[index]);
+                return Construct<T>(types[index]);
             }
 
             return null;
         }
 
-        public static Item Construct(params Type[][] types)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Item Construct(params Type[][] types) => Construct<Item>(types);
+
+        public static T Construct<T>(params Type[][] types) where T : Item
         {
             var totalLength = 0;
 
@@ -817,7 +805,7 @@ namespace Server
                 {
                     if (index >= 0 && index < types[i].Length)
                     {
-                        return Construct(types[i][index]);
+                        return Construct<T>(types[i][index]);
                     }
 
                     index -= types[i].Length;

--- a/Projects/UOContent/Misc/LootPack.cs
+++ b/Projects/UOContent/Misc/LootPack.cs
@@ -7,88 +7,55 @@ namespace Server
 {
     public class LootPack
     {
-        public static readonly LootPackItem[] Gold =
-        {
-            new(typeof(Gold), 1)
-        };
+        public static readonly LootPackItem[] Gold = [new LootPackItem(typeof(Gold), 1)];
 
-        public static readonly LootPackItem[] Instruments =
-        {
-            new(typeof(BaseInstrument), 1)
-        };
+        public static readonly LootPackItem[] Instruments = [new LootPackItem(typeof(BaseInstrument), 1)];
 
-        public static readonly LootPackItem[] LowScrollItems =
-        {
-            new(typeof(ClumsyScroll), 1)
-        };
+        public static readonly LootPackItem[] LowScrollItems = [new LootPackItem(typeof(ClumsyScroll), 1)];
 
-        public static readonly LootPackItem[] MedScrollItems =
-        {
-            new(typeof(ArchCureScroll), 1)
-        };
+        public static readonly LootPackItem[] MedScrollItems = [new LootPackItem(typeof(ArchCureScroll), 1)];
 
-        public static readonly LootPackItem[] HighScrollItems =
-        {
-            new(typeof(SummonAirElementalScroll), 1)
-        };
+        public static readonly LootPackItem[] HighScrollItems = [new LootPackItem(typeof(SummonAirElementalScroll), 1)];
 
-        public static readonly LootPackItem[] GemItems =
-        {
-            new(typeof(Amber), 1)
-        };
+        public static readonly LootPackItem[] GemItems = [new LootPackItem(typeof(Amber), 1)];
 
         public static readonly LootPackItem[] PotionItems =
-        {
-            new(typeof(AgilityPotion), 1),
-            new(typeof(StrengthPotion), 1),
-            new(typeof(RefreshPotion), 1),
-            new(typeof(LesserCurePotion), 1),
-            new(typeof(LesserHealPotion), 1),
-            new(typeof(LesserPoisonPotion), 1)
-        };
+        [
+            new LootPackItem(typeof(AgilityPotion), 1),
+            new LootPackItem(typeof(StrengthPotion), 1),
+            new LootPackItem(typeof(RefreshPotion), 1),
+            new LootPackItem(typeof(LesserCurePotion), 1),
+            new LootPackItem(typeof(LesserHealPotion), 1),
+            new LootPackItem(typeof(LesserPoisonPotion), 1)
+        ];
 
         public static readonly LootPackItem[] OldMagicItems =
-        {
-            new(typeof(BaseJewel), 1),
-            new(typeof(BaseArmor), 4),
-            new(typeof(BaseWeapon), 3),
-            new(typeof(BaseRanged), 1),
-            new(typeof(BaseShield), 1)
-        };
+        [
+            new LootPackItem(typeof(BaseJewel), 1),
+            new LootPackItem(typeof(BaseArmor), 4),
+            new LootPackItem(typeof(BaseWeapon), 3),
+            new LootPackItem(typeof(BaseRanged), 1),
+            new LootPackItem(typeof(BaseShield), 1)
+        ];
 
         public static readonly LootPack LowScrolls = new(
-            new[]
-            {
-                new LootPackEntry(false, LowScrollItems, 100.00, 1)
-            }
+            [new LootPackEntry(false, LowScrollItems, 100.00, 1)]
         );
 
         public static readonly LootPack MedScrolls = new(
-            new[]
-            {
-                new LootPackEntry(false, MedScrollItems, 100.00, 1)
-            }
+            [new LootPackEntry(false, MedScrollItems, 100.00, 1)]
         );
 
         public static readonly LootPack HighScrolls = new(
-            new[]
-            {
-                new LootPackEntry(false, HighScrollItems, 100.00, 1)
-            }
+            [new LootPackEntry(false, HighScrollItems, 100.00, 1)]
         );
 
         public static readonly LootPack Gems = new(
-            new[]
-            {
-                new LootPackEntry(false, GemItems, 100.00, 1)
-            }
+            [new LootPackEntry(false, GemItems, 100.00, 1)]
         );
 
         public static readonly LootPack Potions = new(
-            new[]
-            {
-                new LootPackEntry(false, PotionItems, 100.00, 1)
-            }
+            [new LootPackEntry(false, PotionItems, 100.00, 1)]
         );
 
         private readonly LootPackEntry[] m_Entries;
@@ -192,161 +159,154 @@ namespace Server
         }
 
         public static readonly LootPackItem[] AosMagicItemsRichType1 =
-        {
-            new(typeof(BaseWeapon), 211),
-            new(typeof(BaseRanged), 53),
-            new(typeof(BaseArmor), 303),
-            new(typeof(BaseShield), 39),
-            new(typeof(BaseJewel), 158)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 211),
+            new LootPackItem(typeof(BaseRanged), 53),
+            new LootPackItem(typeof(BaseArmor), 303),
+            new LootPackItem(typeof(BaseShield), 39),
+            new LootPackItem(typeof(BaseJewel), 158)
+        ];
 
         public static readonly LootPack MlRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "4d50+450"),
                 new LootPackEntry(false, AosMagicItemsRichType1, 100.00, 1, 3, 0, 75),
                 new LootPackEntry(false, AosMagicItemsRichType1, 80.00, 1, 3, 0, 75),
                 new LootPackEntry(false, AosMagicItemsRichType1, 60.00, 1, 5, 0, 100),
                 new LootPackEntry(false, Instruments, 1.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPackItem[] AosMagicItemsPoor =
-        {
-            new(typeof(BaseWeapon), 3),
-            new(typeof(BaseRanged), 1),
-            new(typeof(BaseArmor), 4),
-            new(typeof(BaseShield), 1),
-            new(typeof(BaseJewel), 2)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 3),
+            new LootPackItem(typeof(BaseRanged), 1),
+            new LootPackItem(typeof(BaseArmor), 4),
+            new LootPackItem(typeof(BaseShield), 1),
+            new LootPackItem(typeof(BaseJewel), 2)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsMeagerType1 =
-        {
-            new(typeof(BaseWeapon), 56),
-            new(typeof(BaseRanged), 14),
-            new(typeof(BaseArmor), 81),
-            new(typeof(BaseShield), 11),
-            new(typeof(BaseJewel), 42)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 56),
+            new LootPackItem(typeof(BaseRanged), 14),
+            new LootPackItem(typeof(BaseArmor), 81),
+            new LootPackItem(typeof(BaseShield), 11),
+            new LootPackItem(typeof(BaseJewel), 42)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsMeagerType2 =
-        {
-            new(typeof(BaseWeapon), 28),
-            new(typeof(BaseRanged), 7),
-            new(typeof(BaseArmor), 40),
-            new(typeof(BaseShield), 5),
-            new(typeof(BaseJewel), 21)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 28),
+            new LootPackItem(typeof(BaseRanged), 7),
+            new LootPackItem(typeof(BaseArmor), 40),
+            new LootPackItem(typeof(BaseShield), 5),
+            new LootPackItem(typeof(BaseJewel), 21)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsAverageType1 =
-        {
-            new(typeof(BaseWeapon), 90),
-            new(typeof(BaseRanged), 23),
-            new(typeof(BaseArmor), 130),
-            new(typeof(BaseShield), 17),
-            new(typeof(BaseJewel), 68)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 90),
+            new LootPackItem(typeof(BaseRanged), 23),
+            new LootPackItem(typeof(BaseArmor), 130),
+            new LootPackItem(typeof(BaseShield), 17),
+            new LootPackItem(typeof(BaseJewel), 68)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsAverageType2 =
-        {
-            new(typeof(BaseWeapon), 54),
-            new(typeof(BaseRanged), 13),
-            new(typeof(BaseArmor), 77),
-            new(typeof(BaseShield), 10),
-            new(typeof(BaseJewel), 40)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 54),
+            new LootPackItem(typeof(BaseRanged), 13),
+            new LootPackItem(typeof(BaseArmor), 77),
+            new LootPackItem(typeof(BaseShield), 10),
+            new LootPackItem(typeof(BaseJewel), 40)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsRichType2 =
-        {
-            new(typeof(BaseWeapon), 170),
-            new(typeof(BaseRanged), 43),
-            new(typeof(BaseArmor), 245),
-            new(typeof(BaseShield), 32),
-            new(typeof(BaseJewel), 128)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 170),
+            new LootPackItem(typeof(BaseRanged), 43),
+            new LootPackItem(typeof(BaseArmor), 245),
+            new LootPackItem(typeof(BaseShield), 32),
+            new LootPackItem(typeof(BaseJewel), 128)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsFilthyRichType1 =
-        {
-            new(typeof(BaseWeapon), 219),
-            new(typeof(BaseRanged), 55),
-            new(typeof(BaseArmor), 315),
-            new(typeof(BaseShield), 41),
-            new(typeof(BaseJewel), 164)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 219),
+            new LootPackItem(typeof(BaseRanged), 55),
+            new LootPackItem(typeof(BaseArmor), 315),
+            new LootPackItem(typeof(BaseShield), 41),
+            new LootPackItem(typeof(BaseJewel), 164)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsFilthyRichType2 =
-        {
-            new(typeof(BaseWeapon), 239),
-            new(typeof(BaseRanged), 60),
-            new(typeof(BaseArmor), 343),
-            new(typeof(BaseShield), 90),
-            new(typeof(BaseJewel), 45)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 239),
+            new LootPackItem(typeof(BaseRanged), 60),
+            new LootPackItem(typeof(BaseArmor), 343),
+            new LootPackItem(typeof(BaseShield), 90),
+            new LootPackItem(typeof(BaseJewel), 45)
+        ];
 
         public static readonly LootPackItem[] AosMagicItemsUltraRich =
-        {
-            new(typeof(BaseWeapon), 276),
-            new(typeof(BaseRanged), 69),
-            new(typeof(BaseArmor), 397),
-            new(typeof(BaseShield), 52),
-            new(typeof(BaseJewel), 207)
-        };
+        [
+            new LootPackItem(typeof(BaseWeapon), 276),
+            new LootPackItem(typeof(BaseRanged), 69),
+            new LootPackItem(typeof(BaseArmor), 397),
+            new LootPackItem(typeof(BaseShield), 52),
+            new LootPackItem(typeof(BaseJewel), 207)
+        ];
 
         public static readonly LootPack SePoor = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "2d10+20"),
                 new LootPackEntry(false, AosMagicItemsPoor, 1.00, 1, 5, 0, 100),
                 new LootPackEntry(false, Instruments, 0.02, 1)
-            }
+            ]
         );
 
         public static readonly LootPack SeMeager = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "4d10+40"),
                 new LootPackEntry(false, AosMagicItemsMeagerType1, 20.40, 1, 2, 0, 50),
                 new LootPackEntry(false, AosMagicItemsMeagerType2, 10.20, 1, 5, 0, 100),
                 new LootPackEntry(false, Instruments, 0.10, 1)
-            }
+            ]
         );
 
         public static readonly LootPack SeAverage = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "8d10+100"),
                 new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 3, 0, 50),
                 new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 4, 0, 75),
                 new LootPackEntry(false, AosMagicItemsAverageType2, 19.50, 1, 5, 0, 100),
                 new LootPackEntry(false, Instruments, 0.40, 1)
-            }
+            ]
         );
 
         public static readonly LootPack SeRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "15d10+225"),
                 new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 0, 75),
                 new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 0, 75),
                 new LootPackEntry(false, AosMagicItemsRichType2, 61.70, 1, 5, 0, 100),
                 new LootPackEntry(false, Instruments, 1.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack SeFilthyRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "3d100+400"),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 0, 100),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 0, 100),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType2, 77.60, 1, 5, 25, 100),
                 new LootPackEntry(false, Instruments, 2.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack SeUltraRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "6d100+600"),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
@@ -355,12 +315,11 @@ namespace Server
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
                 new LootPackEntry(false, Instruments, 2.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack SeSuperBoss = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "10d100+800"),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
@@ -373,65 +332,59 @@ namespace Server
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
                 new LootPackEntry(false, Instruments, 2.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosPoor = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "1d10+10"),
                 new LootPackEntry(false, AosMagicItemsPoor, 0.02, 1, 5, 0, 90),
                 new LootPackEntry(false, Instruments, 0.02, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosMeager = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "3d10+20"),
                 new LootPackEntry(false, AosMagicItemsMeagerType1, 1.00, 1, 2, 0, 10),
                 new LootPackEntry(false, AosMagicItemsMeagerType2, 0.20, 1, 5, 0, 90),
                 new LootPackEntry(false, Instruments, 0.10, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosAverage = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "5d10+50"),
                 new LootPackEntry(false, AosMagicItemsAverageType1, 5.00, 1, 4, 0, 20),
                 new LootPackEntry(false, AosMagicItemsAverageType1, 2.00, 1, 3, 0, 50),
                 new LootPackEntry(false, AosMagicItemsAverageType2, 0.50, 1, 5, 0, 90),
                 new LootPackEntry(false, Instruments, 0.40, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "10d10+150"),
                 new LootPackEntry(false, AosMagicItemsRichType1, 20.00, 1, 4, 0, 40),
                 new LootPackEntry(false, AosMagicItemsRichType1, 10.00, 1, 5, 0, 60),
                 new LootPackEntry(false, AosMagicItemsRichType2, 1.00, 1, 5, 0, 90),
                 new LootPackEntry(false, Instruments, 1.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosFilthyRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "2d100+200"),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType1, 33.00, 1, 4, 0, 50),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType1, 33.00, 1, 4, 0, 60),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType2, 20.00, 1, 5, 0, 75),
                 new LootPackEntry(false, AosMagicItemsFilthyRichType2, 5.00, 1, 5, 0, 100),
                 new LootPackEntry(false, Instruments, 2.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosUltraRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "5d100+500"),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
@@ -440,12 +393,11 @@ namespace Server
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 35, 100),
                 new LootPackEntry(false, Instruments, 2.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack AosSuperBoss = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "5d100+500"),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
@@ -458,64 +410,58 @@ namespace Server
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
                 new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
                 new LootPackEntry(false, Instruments, 2.00, 1)
-            }
+            ]
         );
 
         public static readonly LootPack OldPoor = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "1d25"),
                 new LootPackEntry(false, Instruments, 0.02, 1)
-            }
+            ]
         );
 
         public static readonly LootPack OldMeager = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "5d10+25"),
                 new LootPackEntry(false, Instruments, 0.10, 1),
                 new LootPackEntry(false, OldMagicItems, 1.00, 1, 1, 0, 60),
                 new LootPackEntry(false, OldMagicItems, 0.20, 1, 1, 10, 70)
-            }
+            ]
         );
 
         public static readonly LootPack OldAverage = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "10d10+50"),
                 new LootPackEntry(false, Instruments, 0.40, 1),
                 new LootPackEntry(false, OldMagicItems, 5.00, 1, 1, 20, 80),
                 new LootPackEntry(false, OldMagicItems, 2.00, 1, 1, 30, 90),
                 new LootPackEntry(false, OldMagicItems, 0.50, 1, 1, 40, 100)
-            }
+            ]
         );
 
         public static readonly LootPack OldRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "10d10+250"),
                 new LootPackEntry(false, Instruments, 1.00, 1),
                 new LootPackEntry(false, OldMagicItems, 20.00, 1, 1, 60, 100),
                 new LootPackEntry(false, OldMagicItems, 10.00, 1, 1, 65, 100),
                 new LootPackEntry(false, OldMagicItems, 1.00, 1, 1, 70, 100)
-            }
+            ]
         );
 
         public static readonly LootPack OldFilthyRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "2d125+400"),
                 new LootPackEntry(false, Instruments, 2.00, 1),
                 new LootPackEntry(false, OldMagicItems, 33.00, 1, 1, 50, 100),
                 new LootPackEntry(false, OldMagicItems, 33.00, 1, 1, 60, 100),
                 new LootPackEntry(false, OldMagicItems, 20.00, 1, 1, 70, 100),
                 new LootPackEntry(false, OldMagicItems, 5.00, 1, 1, 80, 100)
-            }
+            ]
         );
 
         public static readonly LootPack OldUltraRich = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "5d100+500"),
                 new LootPackEntry(false, Instruments, 2.00, 1),
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 40, 100),
@@ -524,12 +470,11 @@ namespace Server
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 50, 100),
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 60, 100),
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 60, 100)
-            }
+            ]
         );
 
         public static readonly LootPack OldSuperBoss = new(
-            new[]
-            {
+            [
                 new LootPackEntry(true, Gold, 100.00, "5d100+500"),
                 new LootPackEntry(false, Instruments, 2.00, 1),
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 40, 100),
@@ -542,7 +487,7 @@ namespace Server
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 60, 100),
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 60, 100),
                 new LootPackEntry(false, OldMagicItems, 100.00, 1, 1, 70, 100)
-            }
+            ]
         );
 
         public static LootPack Poor => Core.SE ? SePoor :
@@ -741,130 +686,137 @@ namespace Server
 
         public Item Mutate(Mobile from, int luckChance, Item item)
         {
-            if (item != null)
+            if (item == null)
             {
-                if (item is BaseWeapon && Utility.Random(100) < 1)
-                {
-                    item.Delete();
-                    item = new FireHorn();
-                    return item;
-                }
+                return null;
+            }
 
-                if (item is BaseWeapon or BaseArmor or BaseJewel or BaseHat)
+            if (item is BaseWeapon && Utility.Random(100) < 1)
+            {
+                item.Delete();
+                return new FireHorn();
+            }
+
+            if (item is BaseWeapon or BaseArmor or BaseJewel or BaseHat)
+            {
+                if (Core.AOS)
                 {
-                    if (Core.AOS)
+                    var bonusProps = GetBonusProperties();
+                    var min = MinIntensity;
+                    var max = MaxIntensity;
+
+                    if (bonusProps < MaxProps && LootPack.CheckLuck(luckChance))
                     {
-                        var bonusProps = GetBonusProperties();
-                        var min = MinIntensity;
-                        var max = MaxIntensity;
-
-                        if (bonusProps < MaxProps && LootPack.CheckLuck(luckChance))
-                        {
-                            ++bonusProps;
-                        }
-
-                        var props = 1 + bonusProps;
-
-                        // Make sure we're not spawning items with 6 properties.
-                        if (props > MaxProps)
-                        {
-                            props = MaxProps;
-                        }
-
-                        if (item is BaseWeapon weapon)
-                        {
-                            BaseRunicTool.ApplyAttributesTo(weapon, false, luckChance, props, MinIntensity, MaxIntensity);
-                        }
-                        else if (item is BaseArmor armor)
-                        {
-                            BaseRunicTool.ApplyAttributesTo(armor, false, luckChance, props, MinIntensity, MaxIntensity);
-                        }
-                        else if (item is BaseJewel jewel)
-                        {
-                            BaseRunicTool.ApplyAttributesTo(jewel, false, luckChance, props, MinIntensity, MaxIntensity);
-                        }
-                        else
-                        {
-                            BaseRunicTool.ApplyAttributesTo(
-                                (BaseHat)item,
-                                false,
-                                luckChance,
-                                props,
-                                MinIntensity,
-                                MaxIntensity
-                            );
-                        }
+                        ++bonusProps;
                     }
-                    else // not aos
+
+                    var props = 1 + bonusProps;
+
+                    // Make sure we're not spawning items with 6 properties.
+                    if (props > MaxProps)
                     {
-                        if (item is BaseWeapon weapon)
-                        {
-                            if (Utility.Random(100) < 80)
-                            {
-                                weapon.AccuracyLevel = (WeaponAccuracyLevel)GetRandomOldBonus();
-                            }
-
-                            if (Utility.Random(100) < 60)
-                            {
-                                weapon.DamageLevel = (WeaponDamageLevel)GetRandomOldBonus();
-                            }
-
-                            if (Utility.Random(100) < 40)
-                            {
-                                weapon.DurabilityLevel = (WeaponDurabilityLevel)GetRandomOldBonus();
-                            }
-
-                            if (Utility.Random(100) < 5)
-                            {
-                                weapon.Slayer = SlayerName.Silver;
-                            }
-
-                            if (from != null && weapon.AccuracyLevel == 0 && weapon.DamageLevel == 0 &&
-                                weapon.DurabilityLevel == 0 && weapon.Slayer == SlayerName.None && Utility.Random(100) < 5)
-                            {
-                                weapon.Slayer = SlayerGroup.GetLootSlayerType(from.GetType());
-                            }
-                        }
-                        else if (item is BaseArmor armor)
-                        {
-                            if (Utility.Random(100) < 80)
-                            {
-                                armor.ProtectionLevel = (ArmorProtectionLevel)GetRandomOldBonus();
-                            }
-
-                            if (Utility.Random(100) < 40)
-                            {
-                                armor.Durability = (ArmorDurabilityLevel)GetRandomOldBonus();
-                            }
-                        }
+                        props = MaxProps;
                     }
-                }
-                else if (item is BaseInstrument instr)
-                {
-                    SlayerName slayer;
 
-                    if (Core.AOS)
+                    if (item is BaseWeapon weapon)
                     {
-                        slayer = BaseRunicTool.GetRandomSlayer();
+                        BaseRunicTool.ApplyAttributesTo(weapon, false, luckChance, props, MinIntensity, MaxIntensity);
+                    }
+                    else if (item is BaseArmor armor)
+                    {
+                        BaseRunicTool.ApplyAttributesTo(armor, false, luckChance, props, MinIntensity, MaxIntensity);
+                    }
+                    else if (item is BaseJewel jewel)
+                    {
+                        BaseRunicTool.ApplyAttributesTo(jewel, false, luckChance, props, MinIntensity, MaxIntensity);
                     }
                     else
                     {
-                        slayer = SlayerGroup.GetLootSlayerType(from.GetType());
+                        BaseRunicTool.ApplyAttributesTo(
+                            (BaseHat)item,
+                            false,
+                            luckChance,
+                            props,
+                            MinIntensity,
+                            MaxIntensity
+                        );
                     }
-
-                    if (slayer == SlayerName.None)
+                }
+                else // not aos
+                {
+                    if (item is BaseWeapon weapon)
                     {
-                        instr.Delete();
-                        return null;
-                    }
+                        if (Utility.Random(100) < 80)
+                        {
+                            weapon.AccuracyLevel = (WeaponAccuracyLevel)GetRandomOldBonus();
+                        }
 
-                    instr.Quality = InstrumentQuality.Regular;
-                    instr.Slayer = slayer;
+                        if (Utility.Random(100) < 60)
+                        {
+                            weapon.DamageLevel = (WeaponDamageLevel)GetRandomOldBonus();
+                        }
+
+                        if (Utility.Random(100) < 40)
+                        {
+                            weapon.DurabilityLevel = (WeaponDurabilityLevel)GetRandomOldBonus();
+                        }
+
+                        if (Utility.Random(100) < 5)
+                        {
+                            weapon.Slayer = SlayerName.Silver;
+                        }
+
+                        if (from != null && weapon.AccuracyLevel == 0 && weapon.DamageLevel == 0 &&
+                            weapon.DurabilityLevel == 0 && weapon.Slayer == SlayerName.None && Utility.Random(100) < 5)
+                        {
+                            weapon.Slayer = SlayerGroup.GetLootSlayerType(from.GetType());
+                        }
+                    }
+                    else if (item is BaseArmor armor)
+                    {
+                        if (Utility.Random(100) < 80)
+                        {
+                            armor.ProtectionLevel = (ArmorProtectionLevel)GetRandomOldBonus();
+                        }
+
+                        if (Utility.Random(100) < 40)
+                        {
+                            armor.Durability = (ArmorDurabilityLevel)GetRandomOldBonus();
+                        }
+                    }
+                }
+            }
+            else if (item is BaseInstrument instr)
+            {
+                SlayerName slayer;
+
+                if (Core.AOS)
+                {
+                    slayer = BaseRunicTool.GetRandomSlayer();
+                }
+                else
+                {
+                    slayer = SlayerGroup.GetLootSlayerType(from.GetType());
                 }
 
-                if (item.Stackable)
+                if (slayer == SlayerName.None)
                 {
-                    item.Amount = Quantity.Roll();
+                    instr.Delete();
+                    return null;
+                }
+
+                instr.Quality = InstrumentQuality.Regular;
+                instr.Slayer = slayer;
+            }
+
+            if (item.Stackable)
+            {
+                item.Amount = Quantity.Roll(); // We set the amount, even if it can be negative so we get an error log
+
+                if (item.Amount <= 0)
+                {
+                    item.Delete();
+                    return null;
                 }
             }
 
@@ -878,35 +830,45 @@ namespace Server
             switch (MaxProps)
             {
                 case 1:
-                    p0 = 3;
-                    p1 = 1;
-                    break;
+                    {
+                        p0 = 3;
+                        p1 = 1;
+                        break;
+                    }
                 case 2:
-                    p0 = 6;
-                    p1 = 3;
-                    p2 = 1;
-                    break;
+                    {
+                        p0 = 6;
+                        p1 = 3;
+                        p2 = 1;
+                        break;
+                    }
                 case 3:
-                    p0 = 10;
-                    p1 = 6;
-                    p2 = 3;
-                    p3 = 1;
-                    break;
+                    {
+                        p0 = 10;
+                        p1 = 6;
+                        p2 = 3;
+                        p3 = 1;
+                        break;
+                    }
                 case 4:
-                    p0 = 16;
-                    p1 = 12;
-                    p2 = 6;
-                    p3 = 5;
-                    p4 = 1;
-                    break;
+                    {
+                        p0 = 16;
+                        p1 = 12;
+                        p2 = 6;
+                        p3 = 5;
+                        p4 = 1;
+                        break;
+                    }
                 case 5:
-                    p0 = 30;
-                    p1 = 25;
-                    p2 = 20;
-                    p3 = 15;
-                    p4 = 9;
-                    p5 = 1;
-                    break;
+                    {
+                        p0 = 30;
+                        p1 = 25;
+                        p2 = 20;
+                        p3 = 15;
+                        p4 = 9;
+                        p5 = 1;
+                        break;
+                    }
             }
 
             var pc = p0 + p1 + p2 + p3 + p4 + p5;
@@ -945,31 +907,23 @@ namespace Server
 
     public class LootPackItem
     {
-        private static readonly Type[] m_BlankTypes = { typeof(BlankScroll) };
+        private static readonly Type[] m_BlankTypes = [typeof(BlankScroll)];
 
         private static readonly Type[][] m_NecroTypes =
-        {
-            new[] // low
-            {
+        [
+            // Low
+            [
                 typeof(AnimateDeadScroll), typeof(BloodOathScroll), typeof(CorpseSkinScroll), typeof(CurseWeaponScroll),
                 typeof(EvilOmenScroll), typeof(HorrificBeastScroll), typeof(MindRotScroll), typeof(PainSpikeScroll),
                 typeof(SummonFamiliarScroll), typeof(WraithFormScroll)
-            },
-            new[] // med
-            {
-                typeof(LichFormScroll), typeof(PoisonStrikeScroll), typeof(StrangleScroll), typeof(WitherScroll)
-            },
-
+            ],
+            // Mid
+            [typeof(LichFormScroll), typeof(PoisonStrikeScroll), typeof(StrangleScroll), typeof(WitherScroll)],
+            // High
             Core.SE
-                ? new[] // high
-                {
-                    typeof(VengefulSpiritScroll), typeof(VampiricEmbraceScroll), typeof(ExorcismScroll)
-                }
-                : new[] // high
-                {
-                    typeof(VengefulSpiritScroll), typeof(VampiricEmbraceScroll)
-                }
-        };
+                ? [typeof(VengefulSpiritScroll), typeof(VampiricEmbraceScroll), typeof(ExorcismScroll)]
+                : [typeof(VengefulSpiritScroll), typeof(VampiricEmbraceScroll)]
+        ];
 
         public LootPackItem(Type type, int chance)
         {
@@ -1022,54 +976,57 @@ namespace Server
         {
             try
             {
-                Item item;
-
                 if (Type == typeof(BaseRanged))
                 {
-                    item = Loot.RandomRangedWeapon(inTokuno, isMondain);
-                }
-                else if (Type == typeof(BaseWeapon))
-                {
-                    item = Loot.RandomWeapon(inTokuno, isMondain);
-                }
-                else if (Type == typeof(BaseArmor))
-                {
-                    item = Loot.RandomArmorOrHat(inTokuno, isMondain);
-                }
-                else if (Type == typeof(BaseShield))
-                {
-                    item = Loot.RandomShield();
-                }
-                else if (Type == typeof(BaseJewel))
-                {
-                    item = Core.AOS ? Loot.RandomJewelry() : Loot.RandomArmorOrShieldOrWeapon();
-                }
-                else if (Type == typeof(BaseInstrument))
-                {
-                    item = Loot.RandomInstrument();
-                }
-                else if (Type == typeof(Amber)) // gem
-                {
-                    item = Loot.RandomGem();
-                }
-                else if (Type == typeof(ClumsyScroll)) // low scroll
-                {
-                    item = RandomScroll(0, 1, 3);
-                }
-                else if (Type == typeof(ArchCureScroll)) // med scroll
-                {
-                    item = RandomScroll(1, 4, 7);
-                }
-                else if (Type == typeof(SummonAirElementalScroll)) // high scroll
-                {
-                    item = RandomScroll(2, 8, 8);
-                }
-                else
-                {
-                    item = Type.CreateInstance<Item>();
+                    return Loot.RandomRangedWeapon(inTokuno, isMondain);
                 }
 
-                return item;
+                if (Type == typeof(BaseWeapon))
+                {
+                    return Loot.RandomWeapon(inTokuno, isMondain);
+                }
+
+                if (Type == typeof(BaseArmor))
+                {
+                    return Loot.RandomArmorOrHat(inTokuno, isMondain);
+                }
+
+                if (Type == typeof(BaseShield))
+                {
+                    return Loot.RandomShield();
+                }
+
+                if (Type == typeof(BaseJewel))
+                {
+                    return Core.AOS ? Loot.RandomJewelry() : Loot.RandomArmorOrShieldOrWeapon();
+                }
+
+                if (Type == typeof(BaseInstrument))
+                {
+                    return Loot.RandomInstrument();
+                }
+
+                if (Type == typeof(Amber)) // gem
+                {
+                    return Loot.RandomGem();
+                }
+
+                if (Type == typeof(ClumsyScroll)) // low scroll
+                {
+                    return RandomScroll(0, 1, 3);
+                }
+
+                if (Type == typeof(ArchCureScroll)) // med scroll
+                {
+                    return RandomScroll(1, 4, 7);
+                }
+
+                if (Type == typeof(SummonAirElementalScroll)) // high scroll
+                {
+                    return RandomScroll(2, 8, 8);
+                }
+
+                return Type.CreateInstance<Item>();
             }
             catch
             {


### PR DESCRIPTION
### Summary

* Adds logging if Amount goes to zero. It should never go to zero!
* Deletes an item if it mutates with zero amount.
* Eliminates possible allocation from `params` for `Type[][]` loot pack construction.
* Renames `Loot.ChestOfHeirloomsContains` to `Loot.RandomChestOfHeirloomsContent`.