### PR TITLE
fix: Adds back socket connected event

### DIFF
--- a/Projects/Server/Network/TcpServer.cs
+++ b/Projects/Server/Network/TcpServer.cs
@@ -272,9 +272,9 @@ public static class TcpServer
             var firewalled = Firewall.IsBlocked(remoteIP);
             if (!firewalled)
             {
-                var socketConnectedEventContext = new SocketConnectedEventContext(socket);
-                EventSink.InvokeSocketConnected(socketConnectedEventContext);
-                firewalled = !socketConnectedEventContext.ConnectionAllowed;
+                var socketConnectedArgs = new SocketConnectedEventArgs(socket);
+                EventSink.InvokeSocketConnected(socketConnectedArgs);
+                firewalled = !socketConnectedArgs.ConnectionAllowed;
             }
 
             if (firewalled)
@@ -318,19 +318,19 @@ public static class TcpServer
     public static class EventSink
     {
         // IMPORTANT: This is executed asynchronously! Do not run any game thread code on these delegates!
-        public static event Action<SocketConnectedEventContext> SocketConnected;
+        public static event Action<SocketConnectedEventArgs> SocketConnected;
 
-        internal static void InvokeSocketConnected(SocketConnectedEventContext context) =>
+        internal static void InvokeSocketConnected(SocketConnectedEventArgs context) =>
             SocketConnected?.Invoke(context);
     }
 
-    public class SocketConnectedEventContext
+    public class SocketConnectedEventArgs
     {
         public Socket Socket { get; }
 
         public bool ConnectionAllowed { get; set; } = true;
 
-        internal SocketConnectedEventContext(Socket socket) => Socket = socket;
+        internal SocketConnectedEventArgs(Socket socket) => Socket = socket;
 
         public void FirewallConnection()
         {

--- a/Projects/Server/Network/TcpServer.cs
+++ b/Projects/Server/Network/TcpServer.cs
@@ -331,11 +331,5 @@ public static class TcpServer
         public bool ConnectionAllowed { get; set; } = true;
 
         internal SocketConnectedEventArgs(Socket socket) => Socket = socket;
-
-        public void FirewallConnection()
-        {
-            Firewall.RequestAddSingleIPEntry(((IPEndPoint)Socket.RemoteEndPoint)!.Address.ToString());
-            ConnectionAllowed = false;
-        }
     }
 }


### PR DESCRIPTION
### Summary
Adds back the `SocketConnected` event. This event only fires asynchronously! (TcpServer thread).

Example:
```cs

public static void Configure()
{
    TcpServer.EventSink.SocketConnected += OnSocketConnected;
}

// WARNING: Executed on the TcpServer thread!
private static void OnSocketConnected(TcpServer.SocketConnectedEventArgs args)
{
    if (... logic here...)
    {
        AdminFirewall.Add(((IPEndPoint)Socket.RemoteEndPoint)!.Address);
    }
}
```