### PR TITLE
fix: Make RelayInfo zero allocation

### DIFF
--- a/Projects/Server/Buffers/SpanReader.cs
+++ b/Projects/Server/Buffers/SpanReader.cs
@@ -165,19 +165,12 @@ public ref struct SpanReader
         return value;
     }
 
-    /// <summary>
-    /// Check the string in the buffer without converting it with the provided encoding.
-    /// </summary>
-    /// <param name="encoding">Text encoding used for char size calculation</param>
-    /// <param name="fixedLength">Max buffer length to check</param>
-    /// <returns>Byte length of the found string</returns>
-    /// <exception cref="OutOfMemoryException"></exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int SkipString(Encoding encoding, int fixedLength = -1)
+    public string ReadString(Encoding encoding, bool safeString = false, int fixedLength = -1)
     {
         if (fixedLength == 0)
         {
-            return 0;
+            return "";
         }
 
         int byteLength = encoding.GetByteLengthForEncoding();
@@ -202,26 +195,11 @@ public ref struct SpanReader
 
         var span = _buffer.Slice(Position, size);
         var index = span.IndexOfTerminator(byteLength);
-        var length = index < 0 ? size : index;
 
-        Position += isFixedLength ? size : length;
-
-        return length;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ReadString(Encoding encoding, bool safeString = false, int fixedLength = -1)
-    {
-        var start = Position;
-        var byteLength = SkipString(encoding, fixedLength);
-
-        if (byteLength == 0)
-        {
-            return default;
-        }
+        Position += isFixedLength || index < 0  ? size : index;
 
         // The string is either as long as the first terminator character, remaining buffer size, or fixed length.
-        return TextEncoding.GetString(Buffer.Slice(start, byteLength), encoding, safeString);
+        return TextEncoding.GetString(span[..(index < 0 ? size : index)], encoding, safeString);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -305,8 +283,8 @@ public ref struct SpanReader
         return Position = Math.Max(0, origin switch
         {
             SeekOrigin.Current => Position + offset,
-            SeekOrigin.End => _buffer.Length + offset,
-            _ => offset // Begin
+            SeekOrigin.End     => _buffer.Length + offset,
+            _                  => offset // Begin
         });
     }
 

--- a/Projects/Server/Gumps/RelayInfo.cs
+++ b/Projects/Server/Gumps/RelayInfo.cs
@@ -20,13 +20,13 @@ namespace Server.Gumps;
 
 public readonly ref struct RelayInfo
 {
-    private readonly ReadOnlySpan<ushort> textIds;
-    private readonly ReadOnlySpan<Range> textRanges;
-    private readonly ReadOnlySpan<byte> rawTextData;
+    private readonly ReadOnlySpan<ushort> _textIds;
+    private readonly ReadOnlySpan<Range> _textRanges;
+    private readonly ReadOnlySpan<byte> _rawTextData;
 
     public RelayInfo(
         int buttonID,
-        int[] switches,
+        ReadOnlySpan<int> switches,
         ReadOnlySpan<ushort> textIds,
         ReadOnlySpan<Range> textRanges,
         ReadOnlySpan<byte> rawTextData
@@ -34,9 +34,9 @@ public readonly ref struct RelayInfo
     {
         ButtonID = buttonID;
         Switches = switches;
-        this.textIds = textIds;
-        this.textRanges = textRanges;
-        this.rawTextData = rawTextData;
+        _textIds = textIds;
+        _textRanges = textRanges;
+        _rawTextData = rawTextData;
     }
 
     public int ButtonID { get; }
@@ -50,13 +50,13 @@ public readonly ref struct RelayInfo
 
     public string GetTextEntry(int entryId)
     {
-        int index = textIds.IndexOf((ushort)entryId);
+        int index = _textIds.IndexOf((ushort)entryId);
 
         if (index == -1)
         {
             return default;
         }
 
-        return TextEncoding.GetString(rawTextData[textRanges[index]], TextEncoding.Unicode, true);
+        return TextEncoding.GetString(_rawTextData[_textRanges[index]], TextEncoding.Unicode, true);
     }
 }

--- a/Projects/Server/Gumps/RelayInfo.cs
+++ b/Projects/Server/Gumps/RelayInfo.cs
@@ -20,43 +20,36 @@ namespace Server.Gumps;
 
 public readonly ref struct RelayInfo
 {
+    private readonly ReadOnlySpan<byte> _textBlock;
     private readonly ReadOnlySpan<ushort> _textIds;
     private readonly ReadOnlySpan<Range> _textRanges;
-    private readonly ReadOnlySpan<byte> _rawTextData;
 
     public RelayInfo(
-        int buttonID,
+        int buttonId,
         ReadOnlySpan<int> switches,
         ReadOnlySpan<ushort> textIds,
         ReadOnlySpan<Range> textRanges,
-        ReadOnlySpan<byte> rawTextData
-        )
+        ReadOnlySpan<byte> textBlock
+    )
     {
-        ButtonID = buttonID;
+        ButtonID = buttonId;
         Switches = switches;
         _textIds = textIds;
         _textRanges = textRanges;
-        _rawTextData = rawTextData;
+        _textBlock = textBlock;
     }
 
     public int ButtonID { get; }
 
     public ReadOnlySpan<int> Switches { get; }
 
-    public bool IsSwitched(int switchID)
-    {
-        return Switches.Contains(switchID);
-    }
+    public bool IsSwitched(int switchId) => Switches.Contains(switchId);
 
     public string GetTextEntry(int entryId)
     {
         int index = _textIds.IndexOf((ushort)entryId);
-
-        if (index == -1)
-        {
-            return default;
-        }
-
-        return TextEncoding.GetString(_rawTextData[_textRanges[index]], TextEncoding.Unicode, true);
+        return index == -1
+            ? default
+            : TextEncoding.GetString(_textBlock[_textRanges[index]], TextEncoding.Unicode, true);
     }
 }

--- a/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
@@ -452,8 +452,10 @@ public static class IncomingPlayerPackets
                 }
 
                 textIds[i] = textId;
-                textFields[i] = (reader.Position - textOffset)..textLength;
-                reader.Seek(textLength, SeekOrigin.Current);
+                var offset = reader.Position - textOffset;
+                var length = textLength * 2;
+                textFields[i] = offset..(offset + length);
+                reader.Seek(length, SeekOrigin.Current);
             }
 
             var textBlock = reader.Buffer.Slice(textOffset, reader.Position - textOffset);

--- a/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
@@ -458,9 +458,9 @@ public static class IncomingPlayerPackets
 
             var textBlock = reader.Buffer.Slice(textOffset, reader.Position - textOffset);
 
-            state.RemoveGump(g);
+            state.RemoveGump(gump);
 
-            var prof = GumpProfile.Acquire(g.GetType());
+            var prof = GumpProfile.Acquire(gump.GetType());
 
             prof?.Start();
 
@@ -471,7 +471,7 @@ public static class IncomingPlayerPackets
                 textFields,
                 textBlock
             );
-            g.OnResponse(state, relayInfo);
+            gump.OnResponse(state, relayInfo);
 
             prof?.Finish();
         }

--- a/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingPlayerPackets.cs
@@ -446,7 +446,7 @@ public static class IncomingPlayerPackets
             Span<Range> textFields = stackalloc Range[textCount];
 
             var textOffset = reader.Position;
-            for (var i = 0; i < textCount; ++i)
+            for (var i = 0; i < textCount; i++)
             {
                 var textId = reader.ReadUInt16();
                 var textLength = reader.ReadUInt16();


### PR DESCRIPTION
Removed TextEntry struct and added deferred text response handling for gumps with spans.

The string instantiation is deferred to GetTextEntry method.