### PR TITLE
fix: Fixes multiple multis in a sector iteration

### DIFF
--- a/Projects/Server/Maps/Map.StaticTileEnumerator.cs
+++ b/Projects/Server/Maps/Map.StaticTileEnumerator.cs
@@ -85,7 +85,7 @@ public partial class Map
             ref var multis = ref _multis;
             ref readonly var p = ref _point;
 
-            if (multis.MoveNext())
+            while (multis.MoveNext())
             {
                 var multi = multis.Current;
                 _currentMulti = multi;


### PR DESCRIPTION
### Summary
Fixes a bug with iterating a sector and multiple multis (boats/houses).

Closes #1702, #1705