### PR TITLE
feat: Adds leather/metal food, fixes weapons/armors with wrong materials

### DIFF
--- a/Projects/UOContent/Engines/Ethics/Evil/Mobiles/UnholySteed.cs
+++ b/Projects/UOContent/Engines/Ethics/Evil/Mobiles/UnholySteed.cs
@@ -48,7 +48,7 @@ namespace Server.Mobiles
         public override string CorpseName => "an unholy corpse";
         public override bool IsDispellable => false;
         public override bool IsBondable => false;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         private static MonsterAbility[] _abilities = { MonsterAbilities.FireBreath };
         public override MonsterAbility[] GetMonsterAbilities() => _abilities;

--- a/Projects/UOContent/Engines/Ethics/Hero/Mobiles/HolySteed.cs
+++ b/Projects/UOContent/Engines/Ethics/Hero/Mobiles/HolySteed.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
         public override string CorpseName => "a holy corpse";
         public override bool IsDispellable => false;
         public override bool IsBondable => false;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         private static MonsterAbility[] _abilities = { MonsterAbilities.FireBreath };
         public override MonsterAbility[] GetMonsterAbilities() => _abilities;

--- a/Projects/UOContent/Engines/Factions/Mobiles/FactionWarHorse.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/FactionWarHorse.cs
@@ -65,7 +65,7 @@ namespace Server.Factions
             }
         }
 
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override void OnDoubleClick(Mobile from)
         {

--- a/Projects/UOContent/Items/Armor/Helmets/BoneHelm.cs
+++ b/Projects/UOContent/Items/Armor/Helmets/BoneHelm.cs
@@ -23,6 +23,6 @@ namespace Server.Items
 
         public override int ArmorBase => 30;
 
-        public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
+        public override ArmorMaterialType MaterialType => ArmorMaterialType.Bone;
     }
 }

--- a/Projects/UOContent/Items/Shields/GargishWoodenShield.cs
+++ b/Projects/UOContent/Items/Shields/GargishWoodenShield.cs
@@ -19,4 +19,6 @@ public partial class GargishWoodenShield : BaseShield
     public override int AosStrReq => 20;
 
     public override int RequiredRaces => Race.AllowGargoylesOnly;
+
+    public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
 }

--- a/Projects/UOContent/Items/Shields/WoodenKiteShield.cs
+++ b/Projects/UOContent/Items/Shields/WoodenKiteShield.cs
@@ -20,4 +20,6 @@ public partial class WoodenKiteShield : BaseShield
     public override int AosStrReq => 20;
 
     public override int ArmorBase => 12;
+
+    public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
 }

--- a/Projects/UOContent/Items/Shields/WoodenShield.cs
+++ b/Projects/UOContent/Items/Shields/WoodenShield.cs
@@ -20,4 +20,6 @@ public partial class WoodenShield : BaseShield
     public override int AosStrReq => 20;
 
     public override int ArmorBase => 8;
+
+    public override ArmorMaterialType MaterialType => ArmorMaterialType.Wood;
 }

--- a/Projects/UOContent/Items/Wands/BaseWand.cs
+++ b/Projects/UOContent/Items/Wands/BaseWand.cs
@@ -43,6 +43,7 @@ public abstract partial class BaseWand : BaseBashing
         Attributes.SpellChanneling = 1;
         Attributes.CastSpeed = -1;
         WeaponAttributes.MageWeapon = Utility.RandomMinMax(1, 10);
+        Resource = CraftResource.None;
     }
 
     public override WeaponAbility PrimaryAbility => WeaponAbility.Dismount;

--- a/Projects/UOContent/Items/Weapons/ML Weapons/ElvenCompositeLongbow.cs
+++ b/Projects/UOContent/Items/Weapons/ML Weapons/ElvenCompositeLongbow.cs
@@ -8,7 +8,11 @@ namespace Server.Items
     public partial class ElvenCompositeLongbow : BaseRanged
     {
         [Constructible]
-        public ElvenCompositeLongbow() : base(0x2D1E) => Weight = 8.0;
+        public ElvenCompositeLongbow() : base(0x2D1E)
+        {
+            Weight = 8.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override int EffectID => 0xF42;
         public override Type AmmoType => typeof(Arrow);

--- a/Projects/UOContent/Items/Weapons/ML Weapons/MagicalShortbow.cs
+++ b/Projects/UOContent/Items/Weapons/ML Weapons/MagicalShortbow.cs
@@ -8,7 +8,11 @@ namespace Server.Items
     public partial class MagicalShortbow : BaseRanged
     {
         [Constructible]
-        public MagicalShortbow() : base(0x2D2B) => Weight = 6.0;
+        public MagicalShortbow() : base(0x2D2B)
+        {
+            Weight = 6.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override int EffectID => 0xF42;
         public override Type AmmoType => typeof(Arrow);

--- a/Projects/UOContent/Items/Weapons/ML Weapons/WildStaff.cs
+++ b/Projects/UOContent/Items/Weapons/ML Weapons/WildStaff.cs
@@ -7,7 +7,11 @@ namespace Server.Items
     public partial class WildStaff : BaseStaff
     {
         [Constructible]
-        public WildStaff() : base(0x2D25) => Weight = 8.0;
+        public WildStaff() : base(0x2D25)
+        {
+            Weight = 8.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override WeaponAbility PrimaryAbility => WeaponAbility.Block;
         public override WeaponAbility SecondaryAbility => WeaponAbility.ForceOfNature;

--- a/Projects/UOContent/Items/Weapons/Ranged/Bow.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/Bow.cs
@@ -12,6 +12,7 @@ namespace Server.Items
         {
             Weight = 6.0;
             Layer = Layer.TwoHanded;
+            Resource = CraftResource.RegularWood;
         }
 
         public override int EffectID => 0xF42;

--- a/Projects/UOContent/Items/Weapons/Ranged/CompositeBow.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/CompositeBow.cs
@@ -8,7 +8,11 @@ namespace Server.Items
     public partial class CompositeBow : BaseRanged
     {
         [Constructible]
-        public CompositeBow() : base(0x26C2) => Weight = 5.0;
+        public CompositeBow() : base(0x26C2)
+        {
+            Weight = 5.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override int EffectID => 0xF42;
         public override Type AmmoType => typeof(Arrow);

--- a/Projects/UOContent/Items/Weapons/Ranged/Crossbow.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/Crossbow.cs
@@ -12,6 +12,7 @@ namespace Server.Items
         {
             Weight = 7.0;
             Layer = Layer.TwoHanded;
+            Resource = CraftResource.RegularWood;
         }
 
         public override int EffectID => 0x1BFE;

--- a/Projects/UOContent/Items/Weapons/Ranged/HeavyCrossbow.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/HeavyCrossbow.cs
@@ -12,6 +12,7 @@ namespace Server.Items
         {
             Weight = 9.0;
             Layer = Layer.TwoHanded;
+            Resource = CraftResource.RegularWood;
         }
 
         public override int EffectID => 0x1BFE;

--- a/Projects/UOContent/Items/Weapons/Ranged/JukaBow.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/JukaBow.cs
@@ -10,6 +10,7 @@ namespace Server.Items
         [Constructible]
         public JukaBow()
         {
+            Resource = CraftResource.RegularWood;
         }
 
         public override int AosStrengthReq => 80;

--- a/Projects/UOContent/Items/Weapons/Ranged/RepeatingCrossbow.cs
+++ b/Projects/UOContent/Items/Weapons/Ranged/RepeatingCrossbow.cs
@@ -8,7 +8,11 @@ namespace Server.Items
     public partial class RepeatingCrossbow : BaseRanged
     {
         [Constructible]
-        public RepeatingCrossbow() : base(0x26C3) => Weight = 6.0;
+        public RepeatingCrossbow() : base(0x26C3)
+        {
+            Weight = 6.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override int EffectID => 0x1BFE;
         public override Type AmmoType => typeof(Bolt);

--- a/Projects/UOContent/Items/Weapons/SE Weapons/Yumi.cs
+++ b/Projects/UOContent/Items/Weapons/SE Weapons/Yumi.cs
@@ -12,6 +12,7 @@ namespace Server.Items
         {
             Weight = 9.0;
             Layer = Layer.TwoHanded;
+            Resource = CraftResource.RegularWood;
         }
 
         public override int EffectID => 0xF42;

--- a/Projects/UOContent/Items/Weapons/Staves/GlassStaff.cs
+++ b/Projects/UOContent/Items/Weapons/Staves/GlassStaff.cs
@@ -7,8 +7,11 @@ namespace Server.Items
     public partial class GlassStaff : BaseStaff
     {
         [Constructible]
-        public GlassStaff() : base(0x905) =>
+        public GlassStaff() : base(0x905)
+        {
             Weight = 4.0;
+            Resource = CraftResource.None;
+        }
 
         public override WeaponAbility PrimaryAbility => WeaponAbility.DoubleStrike;
         public override WeaponAbility SecondaryAbility => WeaponAbility.MortalStrike;

--- a/Projects/UOContent/Items/Weapons/Staves/GnarledStaff.cs
+++ b/Projects/UOContent/Items/Weapons/Staves/GnarledStaff.cs
@@ -7,7 +7,11 @@ namespace Server.Items
     public partial class GnarledStaff : BaseStaff
     {
         [Constructible]
-        public GnarledStaff() : base(0x13F8) => Weight = 3.0;
+        public GnarledStaff() : base(0x13F8)
+        {
+            Weight = 3.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override WeaponAbility PrimaryAbility => WeaponAbility.ConcussionBlow;
         public override WeaponAbility SecondaryAbility => WeaponAbility.ForceOfNature;

--- a/Projects/UOContent/Items/Weapons/Staves/QuarterStaff.cs
+++ b/Projects/UOContent/Items/Weapons/Staves/QuarterStaff.cs
@@ -7,7 +7,11 @@ namespace Server.Items
     public partial class QuarterStaff : BaseStaff
     {
         [Constructible]
-        public QuarterStaff() : base(0xE89) => Weight = 4.0;
+        public QuarterStaff() : base(0xE89)
+        {
+            Weight = 4.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override WeaponAbility PrimaryAbility => WeaponAbility.DoubleStrike;
         public override WeaponAbility SecondaryAbility => WeaponAbility.ConcussionBlow;

--- a/Projects/UOContent/Items/Weapons/Staves/SerpentstoneStaff.cs
+++ b/Projects/UOContent/Items/Weapons/Staves/SerpentstoneStaff.cs
@@ -10,6 +10,7 @@ namespace Server.Items
         [Constructible]
         public SerpentstoneStaff() : base(0x906)
         {
+            Resource = CraftResource.RegularWood;
         }
 
         public override WeaponAbility PrimaryAbility => WeaponAbility.CrushingBlow;

--- a/Projects/UOContent/Items/Weapons/Staves/ShepherdsCrook.cs
+++ b/Projects/UOContent/Items/Weapons/Staves/ShepherdsCrook.cs
@@ -11,7 +11,11 @@ namespace Server.Items
     public partial class ShepherdsCrook : BaseStaff
     {
         [Constructible]
-        public ShepherdsCrook() : base(0xE81) => Weight = 4.0;
+        public ShepherdsCrook() : base(0xE81)
+        {
+            Weight = 4.0;
+            Resource = CraftResource.RegularWood;
+        }
 
         public override WeaponAbility PrimaryAbility => WeaponAbility.CrushingBlow;
         public override WeaponAbility SecondaryAbility => WeaponAbility.Disarm;

--- a/Projects/UOContent/Mobiles/Animals/Bears/BlackBear.cs
+++ b/Projects/UOContent/Mobiles/Animals/Bears/BlackBear.cs
@@ -46,7 +46,7 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 12;
-        public override FoodType FavoriteFood => FoodType.Fish | FoodType.Meat | FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.Fish | FoodType.Meat | FoodType.FruitsAndVeggies;
         public override PackInstinct PackInstinct => PackInstinct.Bear;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Bears/BrownBear.cs
+++ b/Projects/UOContent/Mobiles/Animals/Bears/BrownBear.cs
@@ -45,7 +45,7 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 12;
-        public override FoodType FavoriteFood => FoodType.Fish | FoodType.FruitsAndVegies | FoodType.Meat;
+        public override FoodType FavoriteFood => FoodType.Fish | FoodType.FruitsAndVeggies | FoodType.Meat;
         public override PackInstinct PackInstinct => PackInstinct.Bear;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Bears/GrizzlyBear.cs
+++ b/Projects/UOContent/Mobiles/Animals/Bears/GrizzlyBear.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
 
         public override int Meat => 2;
         public override int Hides => 16;
-        public override FoodType FavoriteFood => FoodType.Fish | FoodType.FruitsAndVegies | FoodType.Meat;
+        public override FoodType FavoriteFood => FoodType.Fish | FoodType.FruitsAndVeggies | FoodType.Meat;
         public override PackInstinct PackInstinct => PackInstinct.Bear;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Bears/PolarBear.cs
+++ b/Projects/UOContent/Mobiles/Animals/Bears/PolarBear.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
 
         public override int Meat => 2;
         public override int Hides => 16;
-        public override FoodType FavoriteFood => FoodType.Fish | FoodType.FruitsAndVegies | FoodType.Meat;
+        public override FoodType FavoriteFood => FoodType.Fish | FoodType.FruitsAndVeggies | FoodType.Meat;
         public override PackInstinct PackInstinct => PackInstinct.Bear;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Cows/Cow.cs
+++ b/Projects/UOContent/Mobiles/Animals/Cows/Cow.cs
@@ -60,7 +60,7 @@ namespace Server.Mobiles
 
         public override int Meat => 8;
         public override int Hides => 12;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override void OnDoubleClick(Mobile from)
         {

--- a/Projects/UOContent/Mobiles/Animals/Misc/Boar.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Boar.cs
@@ -44,6 +44,6 @@ namespace Server.Mobiles
         public override string DefaultName => "a boar";
 
         public override int Meat => 2;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Misc/Goat.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Goat.cs
@@ -43,6 +43,6 @@ namespace Server.Mobiles
 
         public override int Meat => 2;
         public override int Hides => 8;
-        public override FoodType FavoriteFood => FoodType.GrainsAndHay | FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.GrainsAndHay | FoodType.FruitsAndVeggies | FoodType.Leather;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Misc/Gorilla.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Gorilla.cs
@@ -45,6 +45,6 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 6;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Misc/GreatHart.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/GreatHart.cs
@@ -44,7 +44,7 @@ namespace Server.Mobiles
 
         public override int Meat => 6;
         public override int Hides => 15;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override int GetAttackSound() => 0x82;
 

--- a/Projects/UOContent/Mobiles/Animals/Misc/Hind.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Hind.cs
@@ -43,7 +43,7 @@ namespace Server.Mobiles
 
         public override int Meat => 5;
         public override int Hides => 8;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override int GetAttackSound() => 0x82;
 

--- a/Projects/UOContent/Mobiles/Animals/Misc/Llama.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Llama.cs
@@ -43,6 +43,6 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 12;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Misc/MountainGoat.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/MountainGoat.cs
@@ -47,6 +47,6 @@ namespace Server.Mobiles
 
         public override int Meat => 2;
         public override int Hides => 12;
-        public override FoodType FavoriteFood => FoodType.GrainsAndHay | FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.GrainsAndHay | FoodType.FruitsAndVeggies;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Misc/PackHorse.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/PackHorse.cs
@@ -60,7 +60,7 @@ namespace Server.Mobiles
 
         public override int Meat => 3;
         public override int Hides => 10;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override bool OnBeforeDeath()
         {

--- a/Projects/UOContent/Mobiles/Animals/Misc/PackLlama.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/PackLlama.cs
@@ -59,7 +59,7 @@ namespace Server.Mobiles
         public override string DefaultName => "a pack llama";
 
         public override int Meat => 1;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override bool OnBeforeDeath()
         {

--- a/Projects/UOContent/Mobiles/Animals/Misc/Pig.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Pig.cs
@@ -42,6 +42,6 @@ namespace Server.Mobiles
         public override string DefaultName => "a pig";
 
         public override int Meat => 1;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Misc/Sheep.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Sheep.cs
@@ -64,7 +64,7 @@ namespace Server.Mobiles
 
         public override int Meat => 3;
         public override MeatType MeatType => MeatType.LambLeg;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override int Wool => Body == 0xCF ? 3 : 0;
 

--- a/Projects/UOContent/Mobiles/Animals/Mounts/DesertOstard.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/DesertOstard.cs
@@ -41,7 +41,7 @@ namespace Server.Mobiles
         public override string CorpseName => "an ostard corpse";
 
         public override int Meat => 3;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
         public override PackInstinct PackInstinct => PackInstinct.Ostard;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Mounts/ForestOstard.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/ForestOstard.cs
@@ -42,7 +42,7 @@ namespace Server.Mobiles
         public override string CorpseName => "an ostard corpse";
 
         public override int Meat => 3;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
         public override PackInstinct PackInstinct => PackInstinct.Ostard;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Mounts/FrenziedOstard.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/FrenziedOstard.cs
@@ -46,7 +46,7 @@ namespace Server.Mobiles
         public override string CorpseName => "an ostard corpse";
 
         public override int Meat => 3;
-        public override FoodType FavoriteFood => FoodType.Meat | FoodType.Fish | FoodType.Eggs | FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.Meat | FoodType.Fish | FoodType.Eggs | FoodType.FruitsAndVeggies;
         public override PackInstinct PackInstinct => PackInstinct.Ostard;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Horse.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Horse.cs
@@ -59,6 +59,6 @@ namespace Server.Mobiles
 
         public override int Meat => 3;
         public override int Hides => 10;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Kirin.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Kirin.cs
@@ -62,7 +62,7 @@ namespace Server.Mobiles
         public override int Meat => 3;
         public override int Hides => 10;
         public override HideType HideType => HideType.Horned;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override void OnDisallowedRider(Mobile m)
         {

--- a/Projects/UOContent/Mobiles/Animals/Mounts/RidableLlama.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/RidableLlama.cs
@@ -47,6 +47,6 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 12;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ridgeback.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ridgeback.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
         public override int Meat => 1;
         public override int Hides => 12;
         public override HideType HideType => HideType.Spined;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override bool OverrideBondingReqs() => true;
 

--- a/Projects/UOContent/Mobiles/Animals/Mounts/SavageRidgeback.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/SavageRidgeback.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
         public override int Meat => 1;
         public override int Hides => 12;
         public override HideType HideType => HideType.Spined;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override bool OverrideBondingReqs() => true;
 

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Unicorn.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Unicorn.cs
@@ -61,7 +61,7 @@ namespace Server.Mobiles
         public override int Meat => 3;
         public override int Hides => 10;
         public override HideType HideType => HideType.Horned;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
 
         public override void OnDisallowedRider(Mobile m)
         {

--- a/Projects/UOContent/Mobiles/Animals/Mounts/War Horses/BaseWarHorse.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/War Horses/BaseWarHorse.cs
@@ -55,6 +55,6 @@ namespace Server.Mobiles
         public override int StepsMax => 6400;
         public override string CorpseName => "a war horse corpse";
 
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/Animals/Reptiles/LavaLizard.cs
+++ b/Projects/UOContent/Mobiles/Animals/Reptiles/LavaLizard.cs
@@ -50,7 +50,7 @@ namespace Server.Mobiles
         public override string DefaultName => "a lava lizard";
         public override int Hides => 12;
         public override HideType HideType => HideType.Spined;
-        public override FoodType FavoriteFood => FoodType.Metal;
+        public override FoodType FavoriteFood => FoodType.Metal | FoodType.Gold;
 
         private static MonsterAbility[] _abilities = { MonsterAbilities.FireBreath };
         public override MonsterAbility[] GetMonsterAbilities() => _abilities;

--- a/Projects/UOContent/Mobiles/Animals/Reptiles/LavaLizard.cs
+++ b/Projects/UOContent/Mobiles/Animals/Reptiles/LavaLizard.cs
@@ -50,6 +50,7 @@ namespace Server.Mobiles
         public override string DefaultName => "a lava lizard";
         public override int Hides => 12;
         public override HideType HideType => HideType.Spined;
+        public override FoodType FavoriteFood => FoodType.Metal;
 
         private static MonsterAbility[] _abilities = { MonsterAbilities.FireBreath };
         public override MonsterAbility[] GetMonsterAbilities() => _abilities;

--- a/Projects/UOContent/Mobiles/Animals/Rodents/GiantRat.cs
+++ b/Projects/UOContent/Mobiles/Animals/Rodents/GiantRat.cs
@@ -46,7 +46,7 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 6;
-        public override FoodType FavoriteFood => FoodType.Fish | FoodType.Meat | FoodType.FruitsAndVegies | FoodType.Eggs;
+        public override FoodType FavoriteFood => FoodType.Fish | FoodType.Meat | FoodType.FruitsAndVeggies | FoodType.Eggs;
 
         public override void GenerateLoot()
         {

--- a/Projects/UOContent/Mobiles/Animals/Rodents/JackRabbit.cs
+++ b/Projects/UOContent/Mobiles/Animals/Rodents/JackRabbit.cs
@@ -44,7 +44,7 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 1;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies;
 
         public override int GetAttackSound() => 0xC9;
 

--- a/Projects/UOContent/Mobiles/Animals/Rodents/Rabbit.cs
+++ b/Projects/UOContent/Mobiles/Animals/Rodents/Rabbit.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
 
         public override int Meat => 1;
         public override int Hides => 1;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies;
 
         public override int GetAttackSound() => 0xC9;
 

--- a/Projects/UOContent/Mobiles/Animals/Rodents/SewerRat.cs
+++ b/Projects/UOContent/Mobiles/Animals/Rodents/SewerRat.cs
@@ -45,7 +45,7 @@ namespace Server.Mobiles
         public override string DefaultName => "a sewer rat";
 
         public override int Meat => 1;
-        public override FoodType FavoriteFood => FoodType.Meat | FoodType.Eggs | FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.Meat | FoodType.Eggs | FoodType.FruitsAndVeggies;
 
         public override void GenerateLoot()
         {

--- a/Projects/UOContent/Mobiles/Animals/Town Critters/Bird.cs
+++ b/Projects/UOContent/Mobiles/Animals/Town Critters/Bird.cs
@@ -56,7 +56,7 @@ namespace Server.Mobiles
         public override MeatType MeatType => MeatType.Bird;
         public override int Meat => 1;
         public override int Feathers => 25;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 
     [SerializationGenerator(0, false)]
@@ -98,6 +98,6 @@ namespace Server.Mobiles
         public override MeatType MeatType => MeatType.Bird;
         public override int Meat => 1;
         public override int Feathers => 25;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
     }
 }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -4268,7 +4268,7 @@ namespace Server.Mobiles
 
         public virtual bool CheckFeed(Mobile from, Item dropped)
         {
-            if (IsDeadPet || !Controlled || (ControlMaster != from && !IsPetFriend(from)))
+            if (IsDeadPet || !Controlled || ControlMaster != from && !IsPetFriend(from))
             {
                 return false;
             }
@@ -4306,7 +4306,6 @@ namespace Server.Mobiles
                     m_Loyalty = Math.Min(MaxLoyalty, Utility.CoinFlips(amount, MaxLoyaltyIncrease) * 10);
                 }
 
-                /* if (happier )*/
                 // looks like in OSI pets say they are happier even if they are at maximum loyalty
                 SayTo(from, 502060); // Your pet looks happier.
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -4194,7 +4194,7 @@ namespace Server.Mobiles
             // Goat special case
             if (type == FoodType.Leather)
             {
-                if (fed is BaseLeather or Pouch or Server.Items.Backpack or StrongBackpack)
+                if (fed is BaseLeather or Bag or Pouch or Server.Items.Backpack or StrongBackpack)
                 {
                     return true;
                 }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -269,7 +269,8 @@ namespace Server.Mobiles
             typeof(SpoonLeft), typeof(SpoonRight), typeof(Knife), typeof(KnifeLeft),
             typeof(KnifeRight), typeof(DrawKnife), typeof(Hammer), typeof(Froe), typeof(Inshave),
             typeof(Nails), typeof(RunicDovetailSaw), typeof(RunicHammer), typeof(Skillet),
-            typeof(SledgeHammer), typeof(Tongs), typeof(TinkerTools)
+            typeof(SledgeHammer), typeof(Tongs), typeof(TinkerTools), typeof(SmithHammer),
+            typeof(AncientSmithyHammer), typeof(Scorp)
         };
 
         private bool _summoned;

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -4181,6 +4181,7 @@ namespace Server.Mobiles
             CheckFoodPreference(f, FoodType.Meat) ||
             CheckFoodPreference(f, FoodType.FruitsAndVeggies) ||
             CheckFoodPreference(f, FoodType.Gold) ||
+            CheckFoodPreference(f, FoodType.Metal) ||
             CheckFoodPreference(f, FoodType.Leather);
 
         private bool CheckFoodPreference(Item fed, FoodType type)

--- a/Projects/UOContent/Mobiles/Monsters/ML/Animal/CuSidhe.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Animal/CuSidhe.cs
@@ -73,7 +73,7 @@ namespace Server.Mobiles
 
         public override bool CanHeal => true;
         public override bool CanHealOwner => true;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies;
         public override bool CanAngerOnTame => true;
         public override bool StatLossAfterTame => true;
         public override int Hides => 10;

--- a/Projects/UOContent/Mobiles/Monsters/ML/Animal/Squirrel.cs
+++ b/Projects/UOContent/Mobiles/Monsters/ML/Animal/Squirrel.cs
@@ -39,6 +39,6 @@ namespace Server.Mobiles
         public override string DefaultName => "a squirrell";
 
         public override int Meat => 1;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies;
     }
 }

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Slime.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/Slime.cs
@@ -47,7 +47,7 @@ namespace Server.Mobiles
         public override Poison PoisonImmune => Poison.Lesser;
         public override Poison HitPoison => Poison.Lesser;
 
-        public override FoodType FavoriteFood => FoodType.Meat | FoodType.Fish | FoodType.FruitsAndVegies |
+        public override FoodType FavoriteFood => FoodType.Meat | FoodType.Fish | FoodType.FruitsAndVeggies |
                                                  FoodType.GrainsAndHay | FoodType.Eggs;
 
         public override void GenerateLoot()

--- a/Projects/UOContent/Mobiles/Monsters/SE/RuneBeetle.cs
+++ b/Projects/UOContent/Mobiles/Monsters/SE/RuneBeetle.cs
@@ -68,7 +68,7 @@ namespace Server.Mobiles
 
         public override Poison PoisonImmune => Poison.Greater;
         public override Poison HitPoison => Poison.Greater;
-        public override FoodType FavoriteFood => FoodType.FruitsAndVegies | FoodType.GrainsAndHay;
+        public override FoodType FavoriteFood => FoodType.FruitsAndVeggies | FoodType.GrainsAndHay;
         public override bool CanAngerOnTame => true;
 
         public override WeaponAbility GetWeaponAbility() => WeaponAbility.BleedAttack;

--- a/Projects/UOContent/Skills/AnimalLore.cs
+++ b/Projects/UOContent/Skills/AnimalLore.cs
@@ -34,47 +34,36 @@ namespace Server.SkillHandlers
                 {
                     from.SendLocalizedMessage(500331); // The spirits of the dead are not the province of animal lore.
                 }
-                else if (targeted is BaseCreature c)
+                else if (targeted is not BaseCreature c)
                 {
-                    if (!c.IsDeadPet)
-                    {
-                        if (c.Body.IsAnimal || c.Body.IsMonster || c.Body.IsSea)
-                        {
-                            if (!c.Controlled && from.Skills.AnimalLore.Value < 100.0)
-                            {
-                                from.SendLocalizedMessage(
-                                    1049674
-                                ); // At your skill level, you can only lore tamed creatures.
-                            }
-                            else if (!c.Controlled && !c.Tamable && from.Skills.AnimalLore.Value < 110.0)
-                            {
-                                from.SendLocalizedMessage(
-                                    1049675
-                                ); // At your skill level, you can only lore tamed or tameable creatures.
-                            }
-                            else if (!from.CheckTargetSkill(SkillName.AnimalLore, c, 0.0, 120.0))
-                            {
-                                from.SendLocalizedMessage(500334); // You can't think of anything you know offhand.
-                            }
-                            else
-                            {
-                                from.CloseGump<AnimalLoreGump>();
-                                from.SendGump(new AnimalLoreGump(c));
-                            }
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(500329); // That's not an animal!
-                        }
-                    }
-                    else
-                    {
-                        from.SendLocalizedMessage(500331); // The spirits of the dead are not the province of animal lore.
-                    }
+                    from.SendLocalizedMessage(500329); // That's not an animal!
+                }
+                else if (c.IsDeadPet)
+                {
+                    from.SendLocalizedMessage(500331); // The spirits of the dead are not the province of animal lore.
+                }
+                else if (!c.Body.IsAnimal && c.Body is { IsMonster: false, IsSea: false })
+                {
+                    from.SendLocalizedMessage(500329); // That's not an animal!
+                }
+                else if (!c.Controlled && from.Skills.AnimalLore.Value < 100.0)
+                {
+                    // At your skill level, you can only lore tamed creatures.
+                    from.SendLocalizedMessage(1049674);
+                }
+                else if (!c.Controlled && !c.Tamable && from.Skills.AnimalLore.Value < 110.0)
+                {
+                    // At your skill level, you can only lore tamed or tameable creatures.
+                    from.SendLocalizedMessage(1049675);
+                }
+                else if (!from.CheckTargetSkill(SkillName.AnimalLore, c, 0.0, 120.0))
+                {
+                    from.SendLocalizedMessage(500334); // You can't think of anything you know offhand.
                 }
                 else
                 {
-                    from.SendLocalizedMessage(500329); // That's not an animal!
+                    from.CloseGump<AnimalLoreGump>();
+                    from.SendGump(new AnimalLoreGump(c));
                 }
             }
         }
@@ -181,23 +170,20 @@ namespace Server.SkillHandlers
                 AddHtml(320, 168, 35, 18, FormatElement(c.PhysicalResistance));
 
                 AddHtmlLocalized(153, 186, 160, 18, 1061647, LabelColor); // Fire
-                AddHtml(320, 186, 35, 18, FormatElement(c.FireResistance));
+                AddHtml(320, 186, 35, 18, FormatElement(c.FireResistance, "#FF0000"));
 
                 AddHtmlLocalized(153, 204, 160, 18, 1061648, LabelColor); // Cold
-                AddHtml(320, 204, 35, 18, FormatElement(c.ColdResistance));
+                AddHtml(320, 204, 35, 18, FormatElement(c.ColdResistance, "#000080"));
 
                 AddHtmlLocalized(153, 222, 160, 18, 1061649, LabelColor); // Poison
-                AddHtml(320, 222, 35, 18, FormatElement(c.PoisonResistance));
+                AddHtml(320, 222, 35, 18, FormatElement(c.PoisonResistance, "#008000"));
 
                 AddHtmlLocalized(153, 240, 160, 18, 1061650, LabelColor); // Energy
-                AddHtml(320, 240, 35, 18, FormatElement(c.EnergyResistance));
+                AddHtml(320, 240, 35, 18, FormatElement(c.EnergyResistance, "#BF80FF"));
 
                 AddButton(340, 358, 5601, 5605, 0, GumpButtonType.Page, page + 1);
                 AddButton(317, 358, 5603, 5607, 0, GumpButtonType.Page, page - 1);
-            }
 
-            if (Core.AOS)
-            {
                 AddPage(++page);
 
                 AddImage(128, 152, 2086);
@@ -207,16 +193,16 @@ namespace Server.SkillHandlers
                 AddHtml(320, 168, 35, 18, FormatElement(c.PhysicalDamage));
 
                 AddHtmlLocalized(153, 186, 160, 18, 1061647, LabelColor); // Fire
-                AddHtml(320, 186, 35, 18, FormatElement(c.FireDamage));
+                AddHtml(320, 186, 35, 18, FormatElement(c.FireDamage, "#FF0000"));
 
                 AddHtmlLocalized(153, 204, 160, 18, 1061648, LabelColor); // Cold
-                AddHtml(320, 204, 35, 18, FormatElement(c.ColdDamage));
+                AddHtml(320, 204, 35, 18, FormatElement(c.ColdDamage, "#000080"));
 
                 AddHtmlLocalized(153, 222, 160, 18, 1061649, LabelColor); // Poison
-                AddHtml(320, 222, 35, 18, FormatElement(c.PoisonDamage));
+                AddHtml(320, 222, 35, 18, FormatElement(c.PoisonDamage, "#008000"));
 
                 AddHtmlLocalized(153, 240, 160, 18, 1061650, LabelColor); // Energy
-                AddHtml(320, 240, 35, 18, FormatElement(c.EnergyDamage));
+                AddHtml(320, 240, 35, 18, FormatElement(c.EnergyDamage, "#BF80FF"));
 
                 if (Core.ML)
                 {
@@ -256,6 +242,8 @@ namespace Server.SkillHandlers
                 AddHtml(320, 240, 35, 18, FormatSkill(c, SkillName.Poisoning));
             }
 
+            // TODO: Add remaining combat skills
+
             AddImage(128, 260, 2086);
             AddHtmlLocalized(147, 258, 160, 18, 3001032, 200); // Lore & Knowledge
 
@@ -268,6 +256,8 @@ namespace Server.SkillHandlers
             AddHtmlLocalized(153, 312, 160, 18, 1044106, LabelColor); // Meditation
             AddHtml(320, 312, 35, 18, FormatSkill(c, SkillName.Meditation));
 
+            // TODO: Add remaining skills
+
             AddButton(340, 358, 5601, 5605, 0, GumpButtonType.Page, page + 1);
             AddButton(317, 358, 5603, 5607, 0, GumpButtonType.Page, page - 1);
 
@@ -278,7 +268,11 @@ namespace Server.SkillHandlers
 
             var foodPref = 3000340;
 
-            if ((c.FavoriteFood & FoodType.FruitsAndVegies) != 0)
+            if ((c.FavoriteFood & FoodType.Meat) != 0)
+            {
+                foodPref = 1049564; // Meat
+            }
+            else if ((c.FavoriteFood & FoodType.FruitsAndVeggies) != 0)
             {
                 foodPref = 1049565; // Fruits and Vegetables
             }
@@ -290,14 +284,16 @@ namespace Server.SkillHandlers
             {
                 foodPref = 1049568; // Fish
             }
-            else if ((c.FavoriteFood & FoodType.Meat) != 0)
+            else if ((c.FavoriteFood & FoodType.Metal) != 0)
             {
-                foodPref = 1049564; // Meat
+                foodPref = 1049567; // Metal
             }
             else if ((c.FavoriteFood & FoodType.Eggs) != 0)
             {
                 foodPref = 1044477; // Eggs
             }
+
+            // TODO: Add 1115752 "Blackrock Stew" as a food type
 
             AddHtmlLocalized(153, 168, 160, 18, foodPref, LabelColor);
 
@@ -340,6 +336,10 @@ namespace Server.SkillHandlers
             }
 
             AddHtmlLocalized(153, 204, 160, 18, packInstinct, LabelColor);
+
+            // TODO: Add Pet Slots
+
+            // TODO: Add Abilities
 
             if (!Core.AOS)
             {
@@ -402,14 +402,16 @@ namespace Server.SkillHandlers
             return $"<div align=right>{val:F1}</div>";
         }
 
-        private static string FormatElement(int val)
+        private static string FormatElement(int val, string color = null)
         {
-            if (val <= 0)
+            if (color == null)
             {
-                return "<div align=right>---</div>";
+                return val == 0 ? "<div align=right>---</div>" : $"<div align=right>{val}%</div>";
             }
 
-            return $"<div align=right>{val}%</div>";
+            return val == 0
+                ? $"<BASEFONT COLOR={color}><div align=right>---</div>"
+                : $"<BASEFONT COLOR={color}><div align=right>{val}%</div>";
         }
 
         private static string FormatDamage(int min, int max)


### PR DESCRIPTION
### Summary
- Fixes the name `Vegies` to `Veggies`
- Adds feeding leather to goats
- Adds metal for Lava Lizards
- Fixes Bone Helm being classified as plate instead of bone.
- Fixes wooden shields not classified as wood.

### Note
On OSI, the preferred foods on the animal lore gump doesn't contain all possible favorite food categories. Furthermore, the one listed is not necessarily always the "first" in the list of possible categories. We aren't going to try and fix that since it isn't important.