### PR TITLE
fix: Fixes bad localized messages

### DIFF
--- a/Projects/UOContent/Items/Special/Holiday/SnowStatue.cs
+++ b/Projects/UOContent/Items/Special/Holiday/SnowStatue.cs
@@ -91,7 +91,7 @@ public partial class SnowStatueDeed : Item
             AddBackground(0, 0, 360, 225, 0xA28);
 
             AddPage(1);
-            AddLabel(45, 15, 0, Localization.GetText(1156487, from.Language)); // Select One:
+            AddHtmlLocalized(45, 15, 200, 20, 1156487); // Select One:
 
             AddItem(35, 75, 0x456E);
             AddButton(65, 50, 0x845, 0x846, 1);

--- a/Projects/UOContent/Spells/First/CreateFood.cs
+++ b/Projects/UOContent/Spells/First/CreateFood.cs
@@ -48,9 +48,9 @@ public class CreateFoodSpell : MagerySpell
 
                 if (Caster.NetState != null)
                 {
-                    var foodName = Localization.GetText(food.LabelNumber, Caster.Language);
+                    // Not translated to the casters language because affixes are ascii only
+                    var foodName = Localization.GetText(food.LabelNumber);
 
-                    // Note: On OSI, the food name is not localized.
                     // You magically create food in your backpack:
                     Caster.SendLocalizedMessage(1042695, true, $" {foodName}");
                 }


### PR DESCRIPTION
### Summary
- Apparently affixes and other old packets do not support unicode, so we can't translate them. On OSI they use English for quite a bit.