### PR TITLE
fix: BaseEscortable Destination not returned properly.

### DIFF
--- a/Projects/UOContent/Mobiles/Townfolk/BaseEscortable.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/BaseEscortable.cs
@@ -819,6 +819,8 @@ public partial class BaseEscortable : BaseCreature
                 _destinationString = null;
                 return null;
             }
+
+            return _destination;
         }
 
         // Destination is invalid, so set it to null and return.
@@ -881,7 +883,7 @@ public class EscortDestinationInfo
 
         if (!validTown)
         {
-            logger.Error( "No valid escort destinations found. Please check {TownNames}.", townNamesVariable);
+            logger.Error("No valid escort destinations found. Please check {TownNames}.", townNamesVariable);
         }
     }
 


### PR DESCRIPTION
Escortables are not working properly when ML Quest is set to False, they don't return any destination when all is fine.