### PR TITLE
fix: Fixes max items serialization issue

### DIFF
--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -83,6 +83,9 @@ public partial class Container : Item
     [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeMaxItems() => _maxItems != -1;
 
+    [SerializableFieldDefault(0)]
+    private int MaxItemsDefaultValue() => -1;
+
     [EncodedInt]
     [SerializableProperty(1)]
     [CommandProperty(AccessLevel.GameMaster)]


### PR DESCRIPTION
### Summary

Fixes an issue where max items is deserialized as 0 instead of -1. To fix broken containers, run the following in-game:
`[global set maxitems -1 where container maxitems = 0`

In vanilla MUO, there are no containers that actually have max items set to 0.