### PR TITLE
fix: Fixes issue with cached static gump strings. Fixes bad gump colors

### DIFF
--- a/Projects/Server/Gumps/GumpStringsBuilder.cs
+++ b/Projects/Server/Gumps/GumpStringsBuilder.cs
@@ -91,8 +91,10 @@ public ref struct GumpStringsBuilder
 
         if (_finalizeLayout)
         {
-            _hashes[hash] = _stringsCount++;
+            _hashes[hash] = _stringsCount;
         }
+
+        _stringsCount++;
     }
 
     public void FinalizeStrings(ref StaticGumpBuilder builder)

--- a/Projects/Server/Text/TextDefinitionExtensions.cs
+++ b/Projects/Server/Text/TextDefinitionExtensions.cs
@@ -50,22 +50,15 @@ public static class TextDefinitionExtensions
         }
         else if (def.String != null)
         {
-            if (stringColor >= 0) // 8 bits per RGB component (24 bit RGB)
-            {
-                builder.AddHtml(
-                    x,
-                    y,
-                    width,
-                    height,
-                    def.String.Color(stringColor),
-                    back,
-                    scroll
-                );
-            }
-            else
-            {
-                builder.AddHtml(x, y, width, height, def.String, back, scroll);
-            }
+            builder.AddHtml(
+                x,
+                y,
+                width,
+                height,
+                stringColor >= 0 ? def.String.Color(stringColor) : def.String, // 8 bits per RGB component (24 bit RGB)
+                back,
+                scroll
+            );
         }
     }
 
@@ -100,22 +93,15 @@ public static class TextDefinitionExtensions
         }
         else if (def.String != null)
         {
-            if (stringColor >= 0) // 8 bits per RGB component (24 bit RGB)
-            {
-                builder.AddHtml(
-                    x,
-                    y,
-                    width,
-                    height,
-                    def.String.Color(stringColor),
-                    back,
-                    scroll
-                );
-            }
-            else
-            {
-                builder.AddHtml(x, y, width, height, def.String, back, scroll);
-            }
+            builder.AddHtml(
+                x,
+                y,
+                width,
+                height,
+                stringColor >= 0 ? def.String.Color(stringColor) : def.String, // 8 bits per RGB component (24 bit RGB)
+                back,
+                scroll
+            );
         }
     }
 
@@ -150,22 +136,15 @@ public static class TextDefinitionExtensions
         }
         else if (def.String != null)
         {
-            if (stringColor >= 0) // 8 bits per RGB component (24 bit RGB)
-            {
-                g.AddHtml(
-                    x,
-                    y,
-                    width,
-                    height,
-                    def.String.Color(stringColor),
-                    back,
-                    scroll
-                );
-            }
-            else
-            {
-                g.AddHtml(x, y, width, height, def.String, back, scroll);
-            }
+            g.AddHtml(
+                x,
+                y,
+                width,
+                height,
+                stringColor >= 0 ? def.String.Color(stringColor) : def.String, // 8 bits per RGB component (24 bit RGB)
+                back,
+                scroll
+            );
         }
     }
 
@@ -195,22 +174,15 @@ public static class TextDefinitionExtensions
         }
         else if (def.String != null)
         {
-            if (stringColor >= 0) // 8 bits per RGB component (24 bit RGB)
-            {
-                g.AddHtml(
-                    x,
-                    y,
-                    width,
-                    height,
-                    string.Format(def.String, args).Color(stringColor),
-                    back,
-                    scroll
-                );
-            }
-            else
-            {
-                g.AddHtml(x, y, width, height, string.Format(def.String, args), back, scroll);
-            }
+            g.AddHtml(
+                x,
+                y,
+                width,
+                height,
+                stringColor >= 0 ? string.Format(def.String, args).Color(stringColor) : string.Format(def.String, args), // 8 bits per RGB component (24 bit RGB)
+                back,
+                scroll
+            );
         }
     }
 

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1528,4 +1528,28 @@ public static class Utility
 
         return false;
     }
+
+    public static int C16232(this int c16)
+    {
+        c16 &= 0x7FFF;
+
+        var r = ((c16 >> 10) & 0x1F) << 3;
+        var g = ((c16 >> 05) & 0x1F) << 3;
+        var b = (c16 & 0x1F) << 3;
+
+        return (r << 16) | (g << 8) | b;
+    }
+
+    public static int C16216(this int c16) => c16 & 0x7FFF;
+
+    public static int C32216(this int c32)
+    {
+        c32 &= 0xFFFFFF;
+
+        var r = ((c32 >> 16) & 0xFF) >> 3;
+        var g = ((c32 >> 08) & 0xFF) >> 3;
+        var b = (c32 & 0xFF) >> 3;
+
+        return (r << 10) | (g << 5) | b;
+    }
 }

--- a/Projects/UOContent/Engines/Bulk Orders/SmallBODAcceptGump.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/SmallBODAcceptGump.cs
@@ -36,7 +36,7 @@ namespace Server.Engines.BulkOrders
 
             AddHtmlLocalized(40, 96, 120, 20, 1045136, 0x7FFF); // Item requested:
             AddItem(385, 96, deed.Graphic);
-            AddHtmlLocalized(40, 120, 210, 20, deed.Number, 0xFFFFFF);
+            AddHtmlLocalized(40, 120, 210, 20, deed.Number, 0x7FFF);
 
             if (deed.RequireExceptional || deed.Material != BulkMaterialType.None)
             {

--- a/Projects/UOContent/Engines/ConPVP/Gumps/TournamentBracketGump.cs
+++ b/Projects/UOContent/Engines/ConPVP/Gumps/TournamentBracketGump.cs
@@ -291,7 +291,7 @@ namespace Server.Engines.ConPVP
                             {
                                 if (part.Players[0] is PlayerMobile pm && pm.DuelPlayer != null)
                                 {
-                                    name = name.Color(pm.DuelPlayer.Eliminated ? 0x6633333 : 0x336666);
+                                    name = name.Color(pm.DuelPlayer.Eliminated ? 0x663333 : 0x336666);
                                 }
                             }
 
@@ -327,7 +327,7 @@ namespace Server.Engines.ConPVP
                             {
                                 if (mob is PlayerMobile pm && pm.DuelPlayer != null)
                                 {
-                                    name = name.Color(pm.DuelPlayer.Eliminated ? 0x6633333 : 0x336666);
+                                    name = name.Color(pm.DuelPlayer.Eliminated ? 0x663333 : 0x336666);
                                 }
                             }
 

--- a/Projects/UOContent/Engines/Help/PageQueueGump.cs
+++ b/Projects/UOContent/Engines/Help/PageQueueGump.cs
@@ -37,7 +37,7 @@ namespace Server.Engines.Help
             AddImageTiled(9, 11, 21, 53, 0xBBC);
 
             AddButton(10, 12, 0x7D2, 0x7D2, 0);
-            AddHtmlLocalized(34, 28, 65, 24, 3001002, 0xFFFFFF); // Message
+            AddHtmlLocalized(34, 28, 65, 24, 3001002, 0x7FFF); // Message
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)

--- a/Projects/UOContent/Engines/ML Quests/Gumps/BaseQuestGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/BaseQuestGump.cs
@@ -65,7 +65,7 @@ namespace Server.Engines.MLQuests.Gumps
             AddImage(379, 60, 0x15A9);
             AddImage(425, 0, 0x28C9);
             AddImage(90, 33, 0x232D);
-            AddHtmlLocalized(130, 45, 270, 16, label, 0xFFFFFF);
+            AddHtmlLocalized(130, 45, 270, 16, label, 0x7FFF);
             AddImageTiled(130, 65, 175, 1, 0x238D);
         }
 
@@ -149,7 +149,7 @@ namespace Server.Engines.MLQuests.Gumps
                 0x2710
             );
 
-            quest.Description.AddHtmlText(this, 98, 156, 312, 240, false, true, 0x15F90, 0xBDE784);
+            quest.Description.AddHtmlText(this, 98, 156, 312, 240, false, true, 0x5F90, 0xBDE784);
         }
 
         public void AddObjectives(MLQuest quest)
@@ -250,7 +250,7 @@ namespace Server.Engines.MLQuests.Gumps
 
         public void AddConversation(TextDefinition text)
         {
-            text.AddHtmlText(this, 98, 140, 312, 180, false, true, 0x15F90, 0xBDE784);
+            text.AddHtmlText(this, 98, 140, 312, 180, false, true, 0x5F90, 0xBDE784);
         }
 
         /* OSI gump IDs:

--- a/Projects/UOContent/Engines/ML Quests/Gumps/InfoNPCGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/InfoNPCGump.cs
@@ -11,7 +11,7 @@ namespace Server.Engines.MLQuests.Gumps
 
             BuildPage();
             title.AddHtmlText(this, 160, 108, 250, 16, false, false, 0x2710, 0x4AC684);
-            message.AddHtmlText(this, 98, 156, 312, 180, false, true, 0x15F90, 0xBDE784);
+            message.AddHtmlText(this, 98, 156, 312, 180, false, true, 0x5F90, 0xBDE784);
         }
     }
 }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestCancelConfirmGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestCancelConfirmGump.cs
@@ -57,21 +57,21 @@ namespace Server.Engines.MLQuests.Gumps
              * <BR>
              * Are you certain you wish to cancel at this time?
              */
-            AddHtmlLocalized(25, 55, 300, 120, 1060836, 0xFFFFFF);
+            AddHtmlLocalized(25, 55, 300, 120, 1060836, 0x7FFF);
 
             var quest = instance.Quest;
 
             if (quest.IsChainTriggered || quest.NextQuest != null)
             {
                 AddRadio(25, 145, 0x25F8, 0x25FB, false, 2);
-                AddHtmlLocalized(60, 150, 280, 20, 1075023, 0xFFFFFF); // Yes, I want to quit this entire chain!
+                AddHtmlLocalized(60, 150, 280, 20, 1075023, 0x7FFF); // Yes, I want to quit this entire chain!
             }
 
             AddRadio(25, 180, 0x25F8, 0x25FB, true, 1);
-            AddHtmlLocalized(60, 185, 280, 20, 1049005, 0xFFFFFF); // Yes, I really want to quit this quest!
+            AddHtmlLocalized(60, 185, 280, 20, 1049005, 0x7FFF); // Yes, I really want to quit this quest!
 
             AddRadio(25, 215, 0x25F8, 0x25FB, false, 0);
-            AddHtmlLocalized(60, 220, 280, 20, 1049006, 0xFFFFFF); // No, I don't want to quit.
+            AddHtmlLocalized(60, 220, 280, 20, 1049006, 0x7FFF); // No, I don't want to quit.
 
             AddButton(265, 220, 0xF7, 0xF8, 7);
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/BaseObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/BaseObjective.cs
@@ -56,7 +56,7 @@ namespace Server.Engines.MLQuests.Objectives
 
         public static void WriteTimeRemaining(Gump g, ref int y, TimeSpan timeRemaining)
         {
-            g.AddHtmlLocalized(103, y, 120, 16, 1062379, 0x15F90); // Est. time remaining:
+            g.AddHtmlLocalized(103, y, 120, 16, 1062379, 0x5F90); // Est. time remaining:
             g.AddLabel(223, y, 0x481, timeRemaining.TotalSeconds.ToString("F0"));
             y += 16;
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
@@ -50,7 +50,7 @@ namespace Server.Engines.MLQuests.Objectives
             {
                 var amount = DesiredAmount.ToString();
 
-                g.AddHtmlLocalized(98, y, 350, 16, 1072205, 0x15F90); // Obtain
+                g.AddHtmlLocalized(98, y, 350, 16, 1072205, 0x5F90); // Obtain
                 g.AddLabel(143, y, 0x481, amount);
 
                 if (Name.Number > 0)
@@ -67,7 +67,7 @@ namespace Server.Engines.MLQuests.Objectives
             {
                 if (Name.Number > 0)
                 {
-                    g.AddHtmlLocalized(98, y, 312, 32, Name.Number, 0x15F90);
+                    g.AddHtmlLocalized(98, y, 312, 32, Name.Number, 0x5F90);
                 }
                 else if (Name.String != null)
                 {
@@ -207,11 +207,11 @@ namespace Server.Engines.MLQuests.Objectives
             {
                 base.WriteToGump(g, ref y);
 
-                g.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x15F90); // Total
+                g.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
                 g.AddLabel(223, y, 0x481, GetCurrentTotal().ToString());
                 y += 16;
 
-                g.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x15F90); // Return to
+                g.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to
                 g.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Instance.QuesterType));
                 y += 16;
             }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/DeliverObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/DeliverObjective.cs
@@ -74,7 +74,7 @@ namespace Server.Engines.MLQuests.Objectives
         {
             var amount = Amount.ToString();
 
-            g.AddHtmlLocalized(98, y, 312, 16, 1072207, 0x15F90); // Deliver
+            g.AddHtmlLocalized(98, y, 312, 16, 1072207, 0x5F90); // Deliver
             g.AddLabel(143, y, 0x481, amount);
 
             if (Name.Number > 0)
@@ -89,7 +89,7 @@ namespace Server.Engines.MLQuests.Objectives
 
             y += 32;
 
-            g.AddHtmlLocalized(103, y, 120, 16, 1072379, 0x15F90); // Deliver to
+            g.AddHtmlLocalized(103, y, 120, 16, 1072379, 0x5F90); // Deliver to
             g.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Destination));
 
             y += 16;

--- a/Projects/UOContent/Engines/ML Quests/Objectives/EscortObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/EscortObjective.cs
@@ -65,11 +65,11 @@ namespace Server.Engines.MLQuests.Objectives
 
         public override void WriteToGump(Gump g, ref int y)
         {
-            g.AddHtmlLocalized(98, y, 312, 16, 1072206, 0x15F90); // Escort to
+            g.AddHtmlLocalized(98, y, 312, 16, 1072206, 0x5F90); // Escort to
 
             if (Destination.Name.Number > 0)
             {
-                g.AddHtmlLocalized(173, y, 312, 20, Destination.Name.Number, 0xFFFFFF);
+                g.AddHtmlLocalized(173, y, 312, 20, Destination.Name.Number, 0x7FFF);
             }
             else if (Destination.Name.String != null)
             {

--- a/Projects/UOContent/Engines/ML Quests/Objectives/GainSkillObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/GainSkillObjective.cs
@@ -73,7 +73,7 @@ namespace Server.Engines.MLQuests.Objectives
             var skillLabel = AosSkillBonuses.GetLabel(Skill);
             var args = $"#{skillLabel}\t{ThresholdFixed / 10.0:0.#}";
 
-            g.AddHtmlLocalized(98, y, 312, 16, 1077485, args, 0x15F90); // Increase ~1_SKILL~ to ~2_VALUE~
+            g.AddHtmlLocalized(98, y, 312, 16, 1077485, args, 0x5F90); // Increase ~1_SKILL~ to ~2_VALUE~
             y += 16;
         }
 
@@ -158,7 +158,7 @@ namespace Server.Engines.MLQuests.Objectives
 
             if (IsCompleted())
             {
-                g.AddHtmlLocalized(113, y, 312, 20, 1055121, 0xFFFFFF); // Complete
+                g.AddHtmlLocalized(113, y, 312, 20, 1055121, 0x7FFF); // Complete
                 y += 16;
             }
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/KillObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/KillObjective.cs
@@ -27,7 +27,7 @@ namespace Server.Engines.MLQuests.Objectives
         {
             var amount = DesiredAmount.ToString();
 
-            g.AddHtmlLocalized(98, y, 312, 16, 1072204, 0x15F90); // Slay
+            g.AddHtmlLocalized(98, y, 312, 16, 1072204, 0x5F90); // Slay
             g.AddLabel(133, y, 0x481, amount);
 
             if (Name.Number > 0)
@@ -43,11 +43,11 @@ namespace Server.Engines.MLQuests.Objectives
 
             if (Area != null)
             {
-                g.AddHtmlLocalized(103, y, 312, 20, 1018327, 0x15F90); // Location
+                g.AddHtmlLocalized(103, y, 312, 20, 1018327, 0x5F90); // Location
 
                 if (Area.Name.Number > 0)
                 {
-                    g.AddHtmlLocalized(223, y, 312, 20, Area.Name.Number, 0xFFFFFF);
+                    g.AddHtmlLocalized(223, y, 312, 20, Area.Name.Number, 0x7FFF);
                 }
                 else if (Area.Name.String != null)
                 {
@@ -127,11 +127,11 @@ namespace Server.Engines.MLQuests.Objectives
 
             base.WriteToGump(g, ref y);
 
-            g.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x15F90); // Total
+            g.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
             g.AddLabel(223, y, 0x481, Slain.ToString());
             y += 16;
 
-            g.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x15F90); // Return to
+            g.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to
             g.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Instance.QuesterType));
             y += 16;
         }

--- a/Projects/UOContent/Engines/ML Quests/Rewards/BaseReward.cs
+++ b/Projects/UOContent/Engines/ML Quests/Rewards/BaseReward.cs
@@ -14,7 +14,7 @@ namespace Server.Engines.MLQuests.Rewards
 
         public void WriteToGump(Gump g, int x, ref int y)
         {
-            Name.AddHtmlText(g, x, y, 280, LabelHeight, false, false, 0x15F90, 0xBDE784);
+            Name.AddHtmlText(g, x, y, 280, LabelHeight, false, false, 0x5F90, 0xBDE784);
         }
 
         public abstract void AddRewardItems(PlayerMobile pm, List<Item> rewards);

--- a/Projects/UOContent/Engines/Plants/MainPlantGump.cs
+++ b/Projects/UOContent/Engines/Plants/MainPlantGump.cs
@@ -155,7 +155,7 @@ namespace Server.Engines.Plants
                             AddItem(92, 167, 0x1B9D);
                             AddItem(161, 167, 0x1B9D);
 
-                            AddHtmlLocalized(136, 167, 42, 20, message, 0x00FC00);
+                            AddHtmlLocalized(136, 167, 42, 20, message, 0xFC00);
 
                             break;
                         }
@@ -164,7 +164,7 @@ namespace Server.Engines.Plants
                             AddItem(91, 164, 0x18E6);
                             AddItem(161, 164, 0x18E6);
 
-                            AddHtmlLocalized(132, 167, 42, 20, message, 0x00C207);
+                            AddHtmlLocalized(132, 167, 42, 20, message, 0xC207);
 
                             break;
                         }
@@ -173,7 +173,7 @@ namespace Server.Engines.Plants
                             AddItem(96, 168, 0xC61);
                             AddItem(162, 168, 0xC61);
 
-                            AddHtmlLocalized(129, 167, 42, 20, message, 0x008200);
+                            AddHtmlLocalized(129, 167, 42, 20, message, 0x8200);
 
                             break;
                         }
@@ -182,7 +182,7 @@ namespace Server.Engines.Plants
                             AddItem(93, 162, 0x1A99);
                             AddItem(162, 162, 0x1A99);
 
-                            AddHtmlLocalized(129, 167, 42, 20, message, 0x0083E0);
+                            AddHtmlLocalized(129, 167, 42, 20, message, 0x83E0);
 
                             break;
                         }

--- a/Projects/UOContent/Engines/Quests/Core/QuestSystem.cs
+++ b/Projects/UOContent/Engines/Quests/Core/QuestSystem.cs
@@ -682,39 +682,15 @@ namespace Server.Engines.Quests
         {
         }
 
-        public static int C16232(int c16)
-        {
-            c16 &= 0x7FFF;
-
-            var r = ((c16 >> 10) & 0x1F) << 3;
-            var g = ((c16 >> 05) & 0x1F) << 3;
-            var b = (c16 & 0x1F) << 3;
-
-            return (r << 16) | (g << 8) | b;
-        }
-
-        public static int C16216(int c16) => c16 & 0x7FFF;
-
-        public static int C32216(int c32)
-        {
-            c32 &= 0xFFFFFF;
-
-            var r = ((c32 >> 16) & 0xFF) >> 3;
-            var g = ((c32 >> 08) & 0xFF) >> 3;
-            var b = (c32 & 0xFF) >> 3;
-
-            return (r << 10) | (g << 5) | b;
-        }
-
         public void AddHtmlObject(int x, int y, int width, int height, object message, int color, bool back, bool scroll)
         {
             if (message is int html)
             {
-                AddHtmlLocalized(x, y, width, height, html, C16216(color), back, scroll);
+                AddHtmlLocalized(x, y, width, height, html, color.C16216(), back, scroll);
             }
             else
             {
-                AddHtml(x, y, width, height, message.ToString().Color(C16232(color)), back, scroll);
+                AddHtml(x, y, width, height, message.ToString().Color(color.C16216()), back, scroll);
             }
         }
     }

--- a/Projects/UOContent/Engines/Quests/Terrible Hatchlings/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Terrible Hatchlings/Objectives.cs
@@ -12,7 +12,7 @@ namespace Server.Engines.Quests.Zento
             if (!Completed)
             {
                 // Deathwatch Beetle Hatchlings killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0x12DC6BF);
+                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
                 gump.AddLabel(70, 280, 0x64, "0");
                 gump.AddLabel(100, 280, 0x64, "/");
@@ -47,7 +47,7 @@ namespace Server.Engines.Quests.Zento
             if (!Completed)
             {
                 // Deathwatch Beetle Hatchlings killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0x12DC6BF);
+                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
                 gump.AddLabel(70, 280, 0x64, "1");
                 gump.AddLabel(100, 280, 0x64, "/");
@@ -95,7 +95,7 @@ namespace Server.Engines.Quests.Zento
             if (!Completed)
             {
                 // Deathwatch Beetle Hatchlings killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0x12DC6BF);
+                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
                 gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
                 gump.AddLabel(100, 280, 0x64, "/");

--- a/Projects/UOContent/Gumps/BaseConfirmGump.cs
+++ b/Projects/UOContent/Gumps/BaseConfirmGump.cs
@@ -33,13 +33,13 @@ namespace Server.Gumps
             AddImage(2, 2, 0x2716);
             AddHtmlLocalized(25, 25, 200, 20, TitleNumber, 0x7D00);
             AddImage(25, 40, 0xBBF);
-            AddHtmlLocalized(25, 55, 300, 120, LabelNumber, 0xFFFFFF);
+            AddHtmlLocalized(25, 55, 300, 120, LabelNumber, 0x7FFF);
 
             AddRadio(25, 175, 0x25F8, 0x25FB, true, (int)Buttons.Break);
             AddRadio(25, 210, 0x25F8, 0x25FB, false, (int)Buttons.Close);
 
-            AddHtmlLocalized(60, 180, 280, 20, 1074976, 0xFFFFFF);
-            AddHtmlLocalized(60, 215, 280, 20, 1074977, 0xFFFFFF);
+            AddHtmlLocalized(60, 180, 280, 20, 1074976, 0x7FFF);
+            AddHtmlLocalized(60, 215, 280, 20, 1074977, 0x7FFF);
 
             AddButton(265, 220, 0xF7, 0xF8, (int)Buttons.Confirm);
         }

--- a/Projects/UOContent/Gumps/RewardGump.cs
+++ b/Projects/UOContent/Gumps/RewardGump.cs
@@ -190,11 +190,11 @@ namespace Server.Gumps
 
             AddHtmlLocalized(25, 22, 200, 20, 1074974, 0x7D00); // Confirm Selection
             AddImage(25, 40, 0xBBF);
-            AddHtmlLocalized(25, 55, 300, 120, 1074975, 0xFFFFFF); // Are you sure you wish to select this?
+            AddHtmlLocalized(25, 55, 300, 120, 1074975, 0x7FFF); // Are you sure you wish to select this?
             AddRadio(25, 175, 0x25F8, 0x25FB, true, 1);
             AddRadio(25, 210, 0x25F8, 0x25FB, false, 0);
-            AddHtmlLocalized(60, 180, 280, 20, 1074976, 0xFFFFFF); // Yes
-            AddHtmlLocalized(60, 215, 280, 20, 1074977, 0xFFFFFF); // No
+            AddHtmlLocalized(60, 180, 280, 20, 1074976, 0x7FFF); // Yes
+            AddHtmlLocalized(60, 215, 280, 20, 1074977, 0x7FFF); // No
             AddButton(265, 220, 0xF7, 0xF8, 7);
         }
 

--- a/Projects/UOContent/Gumps/StaticWarningGump.cs
+++ b/Projects/UOContent/Gumps/StaticWarningGump.cs
@@ -42,7 +42,7 @@ public abstract class StaticWarningGump<T> : StaticGump<T> where T : StaticWarni
 
         builder.AddImageTiled(10, 10, width - 20, 20, 2624);
         builder.AddAlphaRegion(10, 10, width - 20, 20);
-        builder.AddHtmlLocalized(10, 10, width - 20, 20, header, (short)headerColor);
+        builder.AddHtmlLocalized(10, 10, width - 20, 20, header, headerColor);
 
         builder.AddImageTiled(10, 40, width - 20, height - 80, 2624);
         builder.AddAlphaRegion(10, 40, width - 20, height - 80);

--- a/Projects/UOContent/Gumps/WarningGump.cs
+++ b/Projects/UOContent/Gumps/WarningGump.cs
@@ -55,7 +55,7 @@ public class WarningGump : DynamicGump
 
         builder.AddImageTiled(10, 10, _width - 20, 20, 2624);
         builder.AddAlphaRegion(10, 10, _width - 20, 20);
-        builder.AddHtmlLocalized(10, 10, _width - 20, 20, _header, (short)_headerColor);
+        builder.AddHtmlLocalized(10, 10, _width - 20, 20, _header, _headerColor);
 
         builder.AddImageTiled(10, 40, _width - 20, _height - 80, 2624);
         builder.AddAlphaRegion(10, 40, _width - 20, _height - 80);

--- a/Projects/UOContent/Gumps/YoungGumps.cs
+++ b/Projects/UOContent/Gumps/YoungGumps.cs
@@ -38,17 +38,17 @@ namespace Server.Gumps
             AddHtmlLocalized(190, 24, 120, 20, 1046287, 0x7D00); // You have died.
 
             // As a ghost you cannot interact with the world. You cannot touch items nor can you use them.
-            AddHtmlLocalized(50, 50, 380, 40, 1046288, 0xFFFFFF);
+            AddHtmlLocalized(50, 50, 380, 40, 1046288, 0x7FFF);
             // You can pass through doors as though they do not exist.  However, you cannot pass through walls.
-            AddHtmlLocalized(50, 100, 380, 45, 1046289, 0xFFFFFF);
+            AddHtmlLocalized(50, 100, 380, 45, 1046289, 0x7FFF);
             // Since you are a new player, any items you had on your person at the time of your death will be in your backpack upon resurrection.
-            AddHtmlLocalized(50, 140, 380, 60, 1046291, 0xFFFFFF);
+            AddHtmlLocalized(50, 140, 380, 60, 1046291, 0x7FFF);
             // To be resurrected you must find a healer in town or wandering in the wilderness.  Some powerful players may also be able to resurrect you.
-            AddHtmlLocalized(50, 204, 380, 65, 1046292, 0xFFFFFF);
+            AddHtmlLocalized(50, 204, 380, 65, 1046292, 0x7FFF);
             // While you are still in young status, you will be transported to the nearest healer (along with your items) at the time of your death.
-            AddHtmlLocalized(50, 269, 380, 65, 1046293, 0xFFFFFF);
+            AddHtmlLocalized(50, 269, 380, 65, 1046293, 0x7FFF);
             // To rejoin the world of the living simply walk near one of the NPC healers, and they will resurrect you as long as you are not marked as a criminal.
-            AddHtmlLocalized(50, 334, 380, 70, 1046294, 0xFFFFFF);
+            AddHtmlLocalized(50, 334, 380, 70, 1046294, 0x7FFF);
 
             AddButton(195, 410, 0xF8, 0xF9, 0);
         }

--- a/Projects/UOContent/Items/Aquarium/AquariumGump.cs
+++ b/Projects/UOContent/Items/Aquarium/AquariumGump.cs
@@ -40,17 +40,17 @@ namespace Server.Items
             // item name
             if (item.LabelNumber != 0)
             {
-                AddHtmlLocalized(20, 217, 250, 20, item.LabelNumber, 0xFFFFFF); // Name
+                AddHtmlLocalized(20, 217, 250, 20, item.LabelNumber, 0x7FFF); // Name
             }
 
             // item details
             if (item is BaseFish fish)
             {
-                AddHtmlLocalized(20, 239, 315, 20, fish.GetDescription(), 0xFFFFFF);
+                AddHtmlLocalized(20, 239, 315, 20, fish.GetDescription(), 0x7FFF);
             }
             else
             {
-                AddHtmlLocalized(20, 239, 315, 20, 1073634, 0xFFFFFF); // An aquarium decoration
+                AddHtmlLocalized(20, 239, 315, 20, 1073634, 0x7FFF); // An aquarium decoration
             }
 
             // item image
@@ -71,14 +71,14 @@ namespace Server.Items
             if (page < m_Aquarium.Items.Count)
             {
                 AddButton(195, 280, 0xFA5, 0xFA7, 0, GumpButtonType.Page, page + 1);
-                AddHtmlLocalized(230, 283, 100, 18, 1044045, 0xFFFFFF); // NEXT PAGE
+                AddHtmlLocalized(230, 283, 100, 18, 1044045, 0x7FFF); // NEXT PAGE
             }
 
             // previous page
             if (page > 1)
             {
                 AddButton(45, 280, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page - 1);
-                AddHtmlLocalized(80, 283, 100, 18, 1044044, 0xFFFFFF); // PREV PAGE
+                AddHtmlLocalized(80, 283, 100, 18, 1044044, 0x7FFF); // PREV PAGE
             }
         }
 

--- a/Projects/UOContent/Items/Containers/TreasureMapChest.cs
+++ b/Projects/UOContent/Items/Containers/TreasureMapChest.cs
@@ -465,15 +465,15 @@ public partial class TreasureMapChest : LockableContainer
             AddBackground(30, 0, 240, 240, 2620);
 
             // When this treasure chest is removed, any items still inside of it will be lost.
-            AddHtmlLocalized(45, 15, 200, 80, 1048125, 0xFFFFFF);
+            AddHtmlLocalized(45, 15, 200, 80, 1048125, 0x7FFF);
             // Are you certain you're ready to remove this chest?
-            AddHtmlLocalized(45, 95, 200, 60, 1048126, 0xFFFFFF);
+            AddHtmlLocalized(45, 95, 200, 60, 1048126, 0x7FFF);
 
             AddButton(40, 153, 4005, 4007, 1);
-            AddHtmlLocalized(75, 155, 180, 40, 1048127, 0xFFFFFF); // Remove the Treasure Chest
+            AddHtmlLocalized(75, 155, 180, 40, 1048127, 0x7FFF); // Remove the Treasure Chest
 
             AddButton(40, 195, 4005, 4007, 2);
-            AddHtmlLocalized(75, 197, 180, 35, 1006045, 0xFFFFFF); // Cancel
+            AddHtmlLocalized(75, 197, 180, 35, 1006045, 0x7FFF); // Cancel
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Special Scrolls/SpecialScroll.cs
+++ b/Projects/UOContent/Items/Special/Special Scrolls/SpecialScroll.cs
@@ -95,17 +95,17 @@ public abstract partial class SpecialScroll : Item
 
             AddHtmlLocalized(40, 48, 387, 100, _scroll.Message, true, true);
 
-            AddHtmlLocalized(125, 148, 200, 20, 1049478, 0xFFFFFF); // Do you wish to use this scroll?
+            AddHtmlLocalized(125, 148, 200, 20, 1049478, 0x7FFF); // Do you wish to use this scroll?
 
             AddButton(100, 172, 4005, 4007, 1);
-            AddHtmlLocalized(135, 172, 120, 20, 1046362, 0xFFFFFF); // Yes
+            AddHtmlLocalized(135, 172, 120, 20, 1046362, 0x7FFF); // Yes
 
             AddButton(275, 172, 4005, 4007, 0);
-            AddHtmlLocalized(310, 172, 120, 20, 1046363, 0xFFFFFF); // No
+            AddHtmlLocalized(310, 172, 120, 20, 1046363, 0x7FFF); // No
 
             if (_scroll.Title != 0)
             {
-                AddHtmlLocalized(40, 20, 260, 20, _scroll.Title, 0xFFFFFF);
+                AddHtmlLocalized(40, 20, 260, 20, _scroll.Title, 0x7FFF);
             }
             else
             {
@@ -116,7 +116,7 @@ public abstract partial class SpecialScroll : Item
 
             if (skillLabel > 0)
             {
-                AddHtmlLocalized(310, 20, 120, 20, skillLabel, 0xFFFFFF);
+                AddHtmlLocalized(310, 20, 120, 20, skillLabel, 0x7FFF);
             }
         }
 


### PR DESCRIPTION
### Summary
- Fixes an issue that causes CUO to crash due to bad string caching in static gumps
- Fixes wrong/bad 16bit html gump hues.
- Moves `C16232` (16-bit to 32-bit) and `C32216` (32-bit to 16-bit) to Utility class for broader use.

TODO:
- Some gumps have different 32bit (for string content) vs 16bit (for localized content) strings. Does this matter?