### PR TITLE
Fix RecipeScroll displays cliloc number in properties instead of name

### DIFF
--- a/Projects/UOContent/Items/Skill Items/Misc/RecipeScroll.cs
+++ b/Projects/UOContent/Items/Skill Items/Misc/RecipeScroll.cs
@@ -40,7 +40,7 @@ public partial class RecipeScroll : Item
         {
             if (r.TextDefinition.Number > 0)
             {
-                list.Add(1049644, r.TextDefinition.Number); // [~1_stuff~]
+                list.AddLocalized(1049644, r.TextDefinition.Number); // [~1_stuff~]
             }
             else
             {


### PR DESCRIPTION
Needs to be list.AddLocalized, otherwise property list will display the cliloc number instead of the name...

Before:
![image](https://github.com/modernuo/ModernUO/assets/6239195/137bb549-967b-4e9c-82a8-418ddad7221e)
After:
![image](https://github.com/modernuo/ModernUO/assets/6239195/c919c180-7ea5-4da5-84a9-12229121e201)
