### PR TITLE
fix: Fixes incorrect interpolation in legacy gumps

### DIFF
--- a/Projects/Server/Gumps/Legacy/GumpHtmlLocalized.cs
+++ b/Projects/Server/Gumps/Legacy/GumpHtmlLocalized.cs
@@ -103,18 +103,30 @@ public class GumpHtmlLocalized : GumpEntry
 
     public override void AppendTo(ref SpanWriter writer, OrderedSet<string> strings, ref int entries, ref int switches)
     {
-        var background = Background ? "1" : "0";
-        var scrollbar = Scrollbar ? "1" : "0";
-        writer.WriteAscii(
-            Type switch
-            {
-                GumpHtmlLocalizedType.Plain =>
-                    $"{{ xmfhtmlgump {X} {Y} {Width} {Height} {Number} {background} {scrollbar} }}",
-                GumpHtmlLocalizedType.Color =>
-                    $"{{ xmfhtmlgumpcolor {X} {Y} {Width} {Height} {Number} {background} {scrollbar} {Color} }}",
-                _ =>
-                    $"{{ xmfhtmltok {X} {Y} {Width} {Height} {background} {scrollbar} {Color} {Number} @{Args}@ }}"
-            }
-        );
+        switch (Type)
+        {
+            default:
+            case GumpHtmlLocalizedType.Plain:
+                {
+                    writer.WriteAscii(
+                        $"{{ xmfhtmlgump {X} {Y} {Width} {Height} {Number} {(Background ? "1" : "0")} {(Scrollbar ? "1" : "0")} }}"
+                    );
+                    break;
+                }
+            case GumpHtmlLocalizedType.Color:
+                {
+                    writer.WriteAscii(
+                        $"{{ xmfhtmlgumpcolor {X} {Y} {Width} {Height} {Number} {(Background ? "1" : "0")} {(Scrollbar ? "1" : "0")} {Color} }}"
+                    );
+                    break;
+                }
+            case GumpHtmlLocalizedType.Args:
+                {
+                    writer.WriteAscii(
+                        $"{{ xmfhtmltok {X} {Y} {Width} {Height} {(Background ? "1" : "0")} {(Scrollbar ? "1" : "0")} {Color} {Number} @{Args}@ }}"
+                    );
+                    break;
+                }
+        }
     }
 }

--- a/Projects/Server/Gumps/Legacy/GumpImage.cs
+++ b/Projects/Server/Gumps/Legacy/GumpImage.cs
@@ -41,16 +41,25 @@ public class GumpImage : GumpEntry
 
     public override void AppendTo(ref SpanWriter writer, OrderedSet<string> strings, ref int entries, ref int switches)
     {
-        var hasHue = Hue != 0;
         var hasClass = !string.IsNullOrEmpty(Class);
-        writer.WriteAscii(
-            hasHue switch
+        if (Hue != 0)
+        {
+            if (hasClass)
             {
-                true when hasClass  => $"{{ gumppic {X} {Y} {GumpID} hue={Hue} class={Class} }}",
-                true                => $"{{ gumppic {X} {Y} {GumpID} hue={Hue} }}",
-                false when hasClass => $"{{ gumppic {X} {Y} {GumpID} class={Class} }}",
-                false               => $"{{ gumppic {X} {Y} {GumpID} }}",
+                writer.WriteAscii($"{{ gumppic {X} {Y} {GumpID} hue={Hue} class={Class} }}");
             }
-        );
+            else
+            {
+                writer.WriteAscii($"{{ gumppic {X} {Y} {GumpID} hue={Hue} }}");
+            }
+        }
+        else if (hasClass)
+        {
+            writer.WriteAscii($"{{ gumppic {X} {Y} {GumpID} class={Class} }}");
+        }
+        else
+        {
+            writer.WriteAscii($"{{ gumppic {X} {Y} {GumpID} }}");
+        }
     }
 }


### PR DESCRIPTION
### Summary
- Fixes wrong interpolation.

> [!Important]
> *Developer Note*
> Do not use ternary/switch expressions inside arguments to functions that take custom interpolations.
> Doing so will result in the interpolation handler not being used, and a **string will be allocated instead**.

### Incorrect ❌
<img width="710" alt="image" src="https://github.com/modernuo/ModernUO/assets/3953314/6f2be160-78d0-4a97-940e-3ffb29df844a">


### Correct ✅
<img width="787" alt="image" src="https://github.com/modernuo/ModernUO/assets/3953314/ca407d39-47a9-41d7-a354-d0ce62656816">