### PR TITLE
Fix ConsoleInput for Linux users with try/catch.

### DIFF
--- a/Projects/Server/Console/ConsoleInputHandler.cs
+++ b/Projects/Server/Console/ConsoleInputHandler.cs
@@ -156,7 +156,8 @@ public static class ConsoleInputHandler
 
         while (!token.IsCancellationRequested)
         {
-            try {
+            try
+            {
                 var input = Console.ReadLine()?.Trim();
 
                 if (Volatile.Read(ref _expectUserInput))
@@ -183,7 +184,8 @@ public static class ConsoleInputHandler
 
                 action?.Invoke(splitInput.Length > 1 ? splitInput[1] : string.Empty);
             }
-            catch ( Exception e ) {
+            catch (Exception e)
+            {
                 logger.Warning(e, "Failed to process console input");
             }
         }

--- a/Projects/Server/Console/ConsoleInputHandler.cs
+++ b/Projects/Server/Console/ConsoleInputHandler.cs
@@ -183,8 +183,8 @@ public static class ConsoleInputHandler
 
                 action?.Invoke(splitInput.Length > 1 ? splitInput[1] : string.Empty);
             }
-            catch {
-                logger.Warning("Failed to process console input");
+            catch ( Exception e ) {
+                logger.Warning(e, "Failed to process console input");
             }
         }
     }


### PR DESCRIPTION
Fix a rare Input/Output bug in Console Input Handler for Linux users, as discussed in [Discord](https://discord.com/channels/751317910504603701/751348235116871711/1245159640287678507):
```
Error:
System.IO.IOException: Input/output error
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Interop.CheckIo(Int64 result, String path, Boolean isDirError)
   at System.IO.StdInReader.ReadKey()
   at System.IO.StdInReader.ReadLineCore(Boolean consumeKeys)
   at System.IO.StdInReader.ReadLine()
   at System.IO.SyncTextReader.ReadLine()
   at System.Console.ReadLine()
   at Server.ConsoleInputHandler.ProcessConsoleInput() in ...ModernUO/Projects/Server/Console/ConsoleInputHandler.cs:line 156
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
This exception is fatal, press return to exit
```
Thank you @kamronbatman !!!