### PR TITLE
GoGump code optimization

### DIFF
--- a/Projects/UOContent/Gumps/Go/GoGump.cs
+++ b/Projects/UOContent/Gumps/Go/GoGump.cs
@@ -7,12 +7,12 @@ namespace Server.Gumps
 {
     public class GoGump : Gump
     {
-        private static LocationTree Felucca;
-        private static LocationTree Trammel;
-        private static LocationTree Ilshenar;
-        private static LocationTree Malas;
-        private static LocationTree Tokuno;
-        private static LocationTree TerMur;
+        public static readonly LocationTree Felucca;
+        public static readonly LocationTree Trammel;
+        public static readonly LocationTree Ilshenar;
+        public static readonly LocationTree Malas;
+        public static readonly LocationTree Tokuno;
+        public static readonly LocationTree TerMur;
 
         private static readonly int PrevLabelOffsetX = PrevWidth + 1;
         private static readonly int PrevLabelOffsetY = 0;
@@ -31,6 +31,16 @@ namespace Server.Gumps
         private readonly int m_Page;
 
         private readonly LocationTree m_Tree;
+
+        static GoGump()
+        {
+            Felucca = new LocationTree("felucca", Map.Felucca);
+            Trammel = new LocationTree("trammel", Map.Trammel);
+            Ilshenar = new LocationTree("ilshenar", Map.Ilshenar);
+            Malas = new LocationTree("malas", Map.Malas);
+            Tokuno = new LocationTree("tokuno", Map.Tokuno);
+            TerMur = new LocationTree("termur", Map.TerMur);
+        }
 
         private GoGump(int page, Mobile from, LocationTree tree, GoCategory node) : base(50, 50)
         {
@@ -173,27 +183,27 @@ namespace Server.Gumps
 
             if (from.Map == Map.Ilshenar)
             {
-                tree = Ilshenar ??= new LocationTree("ilshenar", Map.Ilshenar);
+                tree = Ilshenar;
             }
             else if (from.Map == Map.Felucca)
             {
-                tree = Felucca ??= new LocationTree("felucca", Map.Felucca);
+                tree = Felucca;
             }
             else if (from.Map == Map.Trammel)
             {
-                tree = Trammel ??= new LocationTree("trammel", Map.Trammel);
+                tree = Trammel;
             }
             else if (from.Map == Map.Malas)
             {
-                tree = Malas ??= new LocationTree("malas", Map.Malas);
+                tree = Malas;
             }
             else if (from.Map == Map.Tokuno)
             {
-                tree = Tokuno ??= new LocationTree("tokuno", Map.Tokuno);
+                tree = Tokuno;
             }
             else
             {
-                tree = TerMur ??= new LocationTree("termur", Map.TerMur);
+                tree = TerMur;
             }
 
             if (!tree.LastBranch.TryGetValue(from, out var branch))


### PR DESCRIPTION
This update is not mine, I don't know the author. I got this from Discord, but it makes perfect sense to me. In the author words:

> # Overview
> 
> The GoGump class was updated to comply with the constraints of static readonly fields in C#. Specifically, static readonly fields cannot be assigned to outside of a static constructor or a variable initializer. The changes ensure that these fields are properly initialized.
> 
> # Detailed Changes
>
> ## Added Static Constructor:
> 
>A static constructor was introduced to handle the initialization of static readonly fields.
> 
> Static constructors are special constructors that are called automatically before any static members are accessed and are ideal for initializing static fields.
> 
> ## Initialization of Static Readonly Fields:
>
> The fields Felucca, Trammel, Ilshenar, Malas, Tokuno, and TerMur are static readonly. These fields represent different LocationTree instances.
> 
> Previously, these fields were being assigned values within the DisplayTo method, which caused compilation errors because static readonly fields can only be assigned in a static constructor or variable initializer.
> 
> The assignments were moved to the static constructor to comply with the language rules.
>
> ## Removed In-Method Assignments:
> 
>Assignments within the DisplayTo method were removed because they were moved to the static constructor.
>
> The DisplayTo method now simply checks the current map and sets the appropriate LocationTree without attempting to assign values to the static readonly fields.

Additionally, this update also allows the famous _Staff Runebook_ script to work.