### PR TITLE
fix: Fixes character creation issues. Adds Royal City

### DIFF
--- a/Projects/UOContent/Accounting/AccountHandler.cs
+++ b/Projects/UOContent/Accounting/AccountHandler.cs
@@ -402,7 +402,7 @@ public static class AccountHandler
             logger.Information("Login: {NetState} Account '{Username}' at character list", e.State, un);
             e.State.Account = acct;
             e.Accepted = true;
-            e.CityInfo = CharacterCreation.GetStartingCities(acct.Young);
+            e.CityInfo = CharacterCreation.GetStartingCities();
         }
     }
 

--- a/Projects/UOContent/Misc/CharacterCreation.cs
+++ b/Projects/UOContent/Misc/CharacterCreation.cs
@@ -15,8 +15,8 @@ public static class CharacterCreation
     private static readonly ILogger logger = LogFactory.GetLogger(typeof(CharacterCreation));
 
     // Allowed skills that are not race or era specific
-    private static readonly HashSet<SkillName> _allowedStartingSkills = new()
-    {
+    private static readonly HashSet<SkillName> _allowedStartingSkills =
+    [
         SkillName.Alchemy,
         SkillName.Anatomy,
         SkillName.AnimalLore,
@@ -72,114 +72,87 @@ public static class CharacterCreation
         SkillName.Tracking,
         SkillName.Veterinary,
         SkillName.Wrestling
-    };
+    ];
 
     private static readonly TimeSpan BadStartMessageDelay = TimeSpan.FromSeconds(3.5);
 
-    public static readonly CityInfo[] NewHavenInn =
-    {
-        new("New Haven", "The Bountiful Harvest Inn", 3503, 2574, 14, Map.Trammel)
-    };
-
-    // TODO: Verify this location (v5.0.8.3 client)
-    public static readonly CityInfo[] OldHavenBank =
-    {
-        new("Haven", "Haven bank", 3677, 2513, -1, Map.Trammel)
-    };
-
-    // Map property is not supported (Pre v6 clients)
     public static readonly CityInfo[] OldHavenStartingCities =
-    {
-        new("Yew", "The Empath Abbey", 633, 858, 0),
-        new("Minoc", "The Barnacle", 2476, 413, 15),
-        new("Britain", "Sweet Dreams Inn", 1496, 1628, 10),
-        new("Moonglow", "The Scholars Inn", 4408, 1168, 0),
-        new("Trinsic", "The Traveler's Inn", 1845, 2745, 0),
-        new("Magincia", "The Great Horns Tavern", 3734, 2222, 20),
-        new("Jhelom", "The Mercenary Inn", 1374, 3826, 0),
-        new("Skara Brae", "The Falconer's Inn", 618, 2234, 0),
-        new("Vesper", "The Ironwood Inn", 2771, 976, 0),
-        new("Occlo", "Buckler's Hideaway", 3667, 2625, 0)
-    };
+    [
+        new CityInfo("Haven", "The Bountiful Harvest Inn", 3677, 2625, 0, Map.Trammel),
+        new CityInfo("Britain", "Sweet Dreams Inn", 1075074, 1496, 1628, 10, Map.Trammel),
+        new CityInfo("Magincia", "The Great Horns Tavern", 1075077, 3734, 2222, 20, Map.Trammel),
+    ];
 
-    // TODO: Move to JSON files
     public static readonly CityInfo[] FeluccaStartingCities =
-    {
-        new("Yew", "The Empath Abbey", 633, 858, 0, Map.Felucca),
-        new("Minoc", "The Barnacle", 2476, 413, 15, Map.Felucca),
-        new("Britain", "Sweet Dreams Inn", 1496, 1628, 10, Map.Felucca),
-        // TODO: Add New Magincia
-        new("Moonglow", "The Scholars Inn", 4408, 1168, 0, Map.Felucca),
-        new("Trinsic", "The Traveler's Inn", 1845, 2745, 0, Map.Felucca),
-        new("Magincia", "The Great Horns Tavern", 3734, 2222, 20, Map.Felucca),
-        new("Jhelom", "The Mercenary Inn", 1374, 3826, 0, Map.Felucca),
-        new("Skara Brae", "The Falconer's Inn", 618, 2234, 0, Map.Felucca),
-        new("Vesper", "The Ironwood Inn", 2771, 976, 0, Map.Felucca),
-    };
+    [
+        new CityInfo("Yew", "The Empath Abbey", 1075072, 633, 858, 0, Map.Felucca),
+        new CityInfo("Minoc", "The Barnacle", 1075073, 2476, 413, 15, Map.Felucca),
+        new CityInfo("Britain", "Sweet Dreams Inn", 1075074, 1496, 1628, 10, Map.Felucca),
+        new CityInfo("Moonglow", "The Scholars Inn", 1075075, 4408, 1168, 0, Map.Felucca),
+        new CityInfo("Trinsic", "The Traveler's Inn", 1075076, 1845, 2745, 0, Map.Felucca),
+        new CityInfo("Magincia", "The Great Horns Tavern", 1075077, 3734, 2222, 20, Map.Felucca),
+        new CityInfo("Jhelom", "The Mercenary Inn", 1075078, 1374, 3826, 0, Map.Felucca),
+        new CityInfo("Skara Brae", "The Falconer's Inn", 1075079, 618, 2234, 0, Map.Felucca),
+        new CityInfo("Vesper", "The Ironwood Inn", 1075080, 2771, 976, 0, Map.Felucca)
+    ];
 
-    // TODO: Move to JSON files
     public static readonly CityInfo[] TrammelStartingCities =
-    {
-        new("New Haven", "New Haven Bank", 1150168, 3667, 2625, 0, Map.Trammel),
-        new("Yew", "The Empath Abbey", 1075072, 633, 858, 0, Map.Trammel),
-        new("Minoc", "The Barnacle", 1075073, 2476, 413, 15, Map.Trammel),
-        new("Britain", "The Wayfarer's Inn", 1075074, 1602, 1591, 20, Map.Trammel),
-        // TODO: Add New Magincia
-        new("Moonglow", "The Scholars Inn", 1075075, 4408, 1168, 0, Map.Trammel),
-        new("Trinsic", "The Traveler's Inn", 1075076, 1845, 2745, 0, Map.Trammel),
-        new("Jhelom", "The Mercenary Inn", 1075078, 1374, 3826, 0, Map.Trammel),
-        new("Skara Brae", "The Falconer's Inn", 1075079, 618, 2234, 0, Map.Trammel),
-        new("Vesper", "The Ironwood Inn", 1075080, 2771, 976, 0, Map.Trammel)
-    };
+    [
+        new CityInfo("Yew", "The Empath Abbey", 1075072, 633, 858, 0, Map.Trammel),
+        new CityInfo("Minoc", "The Barnacle", 1075073, 2476, 413, 15, Map.Trammel),
+        new CityInfo("Moonglow", "The Scholars Inn", 1075075, 4408, 1168, 0, Map.Trammel),
+        new CityInfo("Trinsic", "The Traveler's Inn", 1075076, 1845, 2745, 0, Map.Trammel),
+        new CityInfo("Jhelom", "The Mercenary Inn", 1075078, 1374, 3826, 0, Map.Trammel),
+        new CityInfo("Skara Brae", "The Falconer's Inn", 1075079, 618, 2234, 0, Map.Trammel),
+        new CityInfo("Vesper", "The Ironwood Inn", 1075080, 2771, 976, 0, Map.Trammel),
+    ];
+
+    public static readonly CityInfo[] NewHavenStartingCities =
+    [
+        new CityInfo("New Haven", "The Bountiful Harvest Inn", 1150168, 3503, 2574, 14, Map.Trammel),
+        new CityInfo("Britain", "The Wayfarer's Inn", 1075074, 1602, 1591, 20, Map.Trammel)
+        // Magincia removed because it burned down.
+    ];
+
+    public static readonly CityInfo[] StartingCitiesSA =
+    [
+        new CityInfo("Royal City", "Royal City Inn", 1150169, 738, 3486, -19, Map.TerMur)
+    ];
 
     private static CityInfo[] _availableStartingCities;
 
-    public static CityInfo[] GetStartingCities(bool isYoung)
-    {
-        if (isYoung && ExpansionInfo.CoreExpansion.MapSelectionFlags.Includes(MapSelectionFlags.Trammel))
-        {
-            return TileMatrix.Pre6000ClientSupport ? OldHavenBank : NewHavenInn;
-        }
-
-        return _availableStartingCities ??= ConstructAvailableStartingCities();
-    }
+    public static CityInfo[] GetStartingCities() =>
+        _availableStartingCities ??= ConstructAvailableStartingCities();
 
     private static CityInfo[] ConstructAvailableStartingCities()
     {
-        if (!TileMatrix.Pre6000ClientSupport)
-        {
-            return OldHavenStartingCities;
-        }
-
+        var pre6000ClientSupport = TileMatrix.Pre6000ClientSupport;
         var availableMaps = ExpansionInfo.CoreExpansion.MapSelectionFlags;
         var trammelAvailable = availableMaps.Includes(MapSelectionFlags.Trammel);
-        var feluccaAvailable = availableMaps.Includes(MapSelectionFlags.Felucca);
+        var terMerAvailable = availableMaps.Includes(MapSelectionFlags.TerMur);
 
-        var length = (trammelAvailable ? TrammelStartingCities.Length : 0) +
-                     (feluccaAvailable ? FeluccaStartingCities.Length : 0);
-
-        if (length == 0)
-        {
-            logger.Error("Both Felucca and Trammel are unavailable maps, therefore no starting cities are available.");
-            return Array.Empty<CityInfo>();
-        }
-
-        var cities = new CityInfo[length];
-        var index = 0;
         if (trammelAvailable)
         {
-            Array.Copy(TrammelStartingCities, 0, cities, index, TrammelStartingCities.Length);
-            index += TrammelStartingCities.Length;
+            if (pre6000ClientSupport)
+            {
+                return [..OldHavenStartingCities, ..TrammelStartingCities];
+            }
+
+            if (terMerAvailable)
+            {
+                return [..NewHavenStartingCities, ..TrammelStartingCities, ..StartingCitiesSA];
+            }
+
+            return [..NewHavenStartingCities, ..TrammelStartingCities];
         }
 
-        if (feluccaAvailable)
+        if (availableMaps.Includes(MapSelectionFlags.Felucca))
         {
-            Array.Copy(FeluccaStartingCities, 0, cities, index, FeluccaStartingCities.Length);
+            return FeluccaStartingCities;
         }
 
-        // TODO: Add Royal City for gargoyles
-
-        return cities;
+        logger.Error("No starting cities are available.");
+        return [];
     }
 
     public static void Initialize()
@@ -333,6 +306,11 @@ public static class CharacterCreation
             }
         }
 
+        if (Core.SA)
+        {
+            return args.City;
+        }
+
         var flags = args.State?.Flags ?? ClientFlags.None;
         var profession = ProfessionInfo.Professions[args.Profession];
 
@@ -353,12 +331,11 @@ public static class CharacterCreation
                      * Haven on the Trammel facet.
                      */
                     Timer.StartTimer(BadStartMessageDelay, () => m.SendLocalizedMessage(1062205));
-
-                    return GetStartingCities(true)[0];
+                    return GetStartingCities()[0];
                 }
             case "paladin":
                 {
-                    return GetStartingCities(true)[0];
+                    return GetStartingCities()[0];
                 }
             case "samurai":
                 {
@@ -380,8 +357,7 @@ public static class CharacterCreation
                      * Haven on the Trammel facet.
                      */
                     Timer.StartTimer(BadStartMessageDelay, () => m.SendLocalizedMessage(1063487));
-
-                    return GetStartingCities(true)[0];
+                    return GetStartingCities()[0];
                 }
             case "ninja":
                 {
@@ -403,7 +379,7 @@ public static class CharacterCreation
                      * Haven on the Trammel facet.
                      */
                     Timer.StartTimer(BadStartMessageDelay, () => m.SendLocalizedMessage(1063487));
-                    return GetStartingCities(true)[0];
+                    return GetStartingCities()[0];
                 }
         }
 
@@ -645,7 +621,7 @@ public static class CharacterCreation
                 {
                     addSkillItems = false;
 
-                    int[] hues = { 0x1A8, 0xEC, 0x99, 0x90, 0xB5, 0x336, 0x89 };
+                    int[] hues = [0x1A8, 0xEC, 0x99, 0x90, 0xB5, 0x336, 0x89];
                     // TODO: Verify that's ALL the hues for that above.
 
                     if (elf)


### PR DESCRIPTION
### Summary

- Removes new player "Haven Only" starting city.
- Fixed New/Old haven placement.
- Removed force-profession starting location for SA+.
- Added Royal City for SA+
- Removed Occlo for Pre-AOS.