### PR TITLE
fix: Fixes crashing due to bad packet assumptions.

### DIFF
--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -806,16 +806,20 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             return ParserState.AwaitingPartialPacket;
         }
 
-        if (handler.Ingame)
+        if (handler.InGameOnly)
         {
-            if (Mobile == null)
+            if (Mobile?.Deleted != false)
             {
-                LogInfo($"received packet 0x{packetId:X2} before having been attached to a mobile");
+                LogInfo($"Received packet 0x{packetId:X2} before having been attached to a mobile.");
                 return ParserState.Error;
             }
+        }
 
-            if (Mobile.Deleted)
+        if (handler.OutOfGameOnly)
+        {
+            if (Mobile?.Deleted == false)
             {
+                LogInfo($"Received packet 0x{packetId:X2} after having been attached to a mobile.");
                 return ParserState.Error;
             }
         }

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -808,20 +808,23 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
         if (handler.InGameOnly)
         {
-            if (Mobile?.Deleted != false)
+            if (Mobile == null)
             {
                 LogInfo($"Received packet 0x{packetId:X2} before having been attached to a mobile.");
                 return ParserState.Error;
             }
-        }
 
-        if (handler.OutOfGameOnly)
-        {
-            if (Mobile?.Deleted == false)
+            if (Mobile.Deleted)
             {
-                LogInfo($"Received packet 0x{packetId:X2} after having been attached to a mobile.");
+                LogInfo($"Received packet 0x{packetId:X2} after having been attached to a deleted mobile.");
                 return ParserState.Error;
             }
+        }
+
+        if (handler.OutOfGameOnly && Mobile?.Deleted == false)
+        {
+            LogInfo($"Received packet 0x{packetId:X2} after having been attached to a mobile.");
+            return ParserState.Error;
         }
 
         var throttler = handler.ThrottleCallback;

--- a/Projects/Server/Network/PacketHandler.cs
+++ b/Projects/Server/Network/PacketHandler.cs
@@ -21,11 +21,20 @@ public unsafe class PacketHandler
 {
     private readonly int _length;
 
-    public PacketHandler(int packetID, int length, bool ingame, delegate*<NetState, SpanReader, void> onReceive)
+    public PacketHandler(
+        int packetID, delegate*<NetState, SpanReader, void> onReceive,
+        int length = 0, bool inGameOnly = false, bool outGameOnly = false
+    ) : this(packetID, length, inGameOnly, outGameOnly, onReceive)
+    {
+
+    }
+
+    public PacketHandler(int packetID, int length, bool inGameOnly, bool outGameOnly, delegate*<NetState, SpanReader, void> onReceive)
     {
         _length = length;
         PacketID = packetID;
-        Ingame = ingame;
+        InGameOnly = inGameOnly;
+        OutOfGameOnly = outGameOnly;
         OnReceive = onReceive;
     }
 
@@ -37,5 +46,7 @@ public unsafe class PacketHandler
 
     public delegate*<int, NetState, bool> ThrottleCallback { get; set; }
 
-    public bool Ingame { get; }
+    public bool InGameOnly { get; }
+
+    public bool OutOfGameOnly { get; }
 }

--- a/Projects/Server/Network/Packets/IncomingPackets.cs
+++ b/Projects/Server/Network/Packets/IncomingPackets.cs
@@ -25,9 +25,20 @@ public static class IncomingPackets
     public static PacketHandler[] Handlers { get; } = new PacketHandler[0x100];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe void Register(int packetID, int length, bool ingame,
-        delegate*<NetState, SpanReader, void> onReceive) =>
-        Register(new PacketHandler(packetID, length, ingame, onReceive));
+    public static unsafe void Register(
+        int packetID, delegate*<NetState, SpanReader, void> onReceive, int length = 0, bool ingameOnly = false,
+        bool outgameOnly = false
+    ) => Register(packetID, length, ingameOnly, outgameOnly, onReceive);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void Register(
+        int packetID, int length, bool ingame, delegate*<NetState, SpanReader, void> onReceive
+    ) => Register(packetID, length, ingame, false, onReceive);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void Register(
+        int packetID, int length, bool ingame, bool outgame, delegate*<NetState, SpanReader, void> onReceive
+    ) => Register(new PacketHandler(packetID, length, ingame, outgame, onReceive));
 
     public static void Register(PacketHandler packetHandler)
     {

--- a/Projects/UOContent/Assistants/AssistantProtocol.cs
+++ b/Projects/UOContent/Assistants/AssistantProtocol.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace Server.Network;
 
@@ -12,8 +13,13 @@ public static class AssistantProtocol
         _handlers = ProtocolExtensions<AssistantsProtocolInfo>.Register(new AssistantsProtocolInfo());
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void Register(int cmd, bool ingame, delegate*<NetState, SpanReader, void> onReceive) =>
-        _handlers[cmd] = new PacketHandler(cmd, 0, ingame, onReceive);
+        Register(cmd, ingame, false, onReceive);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void Register(int cmd, bool ingame, bool outgame, delegate*<NetState, SpanReader, void> onReceive) =>
+        _handlers[cmd] = new PacketHandler(cmd, onReceive, inGameOnly: ingame, outGameOnly: outgame);
 
     private struct AssistantsProtocolInfo : IProtocolExtensionsInfo
     {

--- a/Projects/UOContent/Network/ContainerGridPacketHandler.cs
+++ b/Projects/UOContent/Network/ContainerGridPacketHandler.cs
@@ -19,9 +19,9 @@ namespace Server.Network;
 
 public unsafe class ContainerGridPacketHandler : PacketHandler
 {
-    public ContainerGridPacketHandler(int packetID, int length, bool ingame,
+    public ContainerGridPacketHandler(int packetID, int length, bool inGameOnly,
         delegate*<NetState, SpanReader, void> onReceive)
-        : base(packetID, length, ingame, onReceive)
+        : base(packetID, length, inGameOnly, onReceive)
     {
     }
 

--- a/Projects/UOContent/Network/ContainerGridPacketHandler.cs
+++ b/Projects/UOContent/Network/ContainerGridPacketHandler.cs
@@ -19,9 +19,8 @@ namespace Server.Network;
 
 public unsafe class ContainerGridPacketHandler : PacketHandler
 {
-    public ContainerGridPacketHandler(int packetID, int length, bool inGameOnly,
-        delegate*<NetState, SpanReader, void> onReceive)
-        : base(packetID, length, inGameOnly, onReceive)
+    public ContainerGridPacketHandler(int packetID, int length, delegate*<NetState, SpanReader, void> onReceive)
+        : base(packetID, length, true, false, onReceive)
     {
     }
 

--- a/Projects/UOContent/Network/FreeshardProtocol.cs
+++ b/Projects/UOContent/Network/FreeshardProtocol.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System.Buffers;
+using System.Runtime.CompilerServices;
 
 namespace Server.Network
 {
@@ -27,8 +28,14 @@ namespace Server.Network
             _handlers = ProtocolExtensions<FreeshardProtocolInfo>.Register(new FreeshardProtocolInfo());
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe void Register(int cmd, bool ingame, delegate*<NetState, SpanReader, void> onReceive) =>
-            _handlers[cmd] = new PacketHandler(cmd, 0, ingame, onReceive);
+            Register(cmd, ingame, false, onReceive);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void Register(
+            int cmd, bool ingame, bool outgame, delegate*<NetState, SpanReader, void> onReceive
+        ) => _handlers[cmd] = new PacketHandler(cmd, onReceive, inGameOnly: ingame, outGameOnly: outgame);
 
         private struct FreeshardProtocolInfo : IProtocolExtensionsInfo
         {

--- a/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
@@ -65,9 +65,9 @@ public static class IncomingAccountPackets
         IncomingPackets.Register(0xA0, &PlayServer, 3, outgameOnly: true);
         IncomingPackets.Register(0xBD, &ClientVersion);
         IncomingPackets.Register(0xCF, &AccountLogin, outgameOnly: true);
-        IncomingPackets.Register(0xE1,&ClientType);
+        IncomingPackets.Register(0xE1, &ClientType);
         IncomingPackets.Register(0xEF, &LoginServerSeed, 21, outgameOnly: true);
-        IncomingPackets.Register(0xF8,  &CreateCharacter, 106, outgameOnly: true);
+        IncomingPackets.Register(0xF8, &CreateCharacter, 106, outgameOnly: true);
     }
 
     public static void CreateCharacter(NetState state, SpanReader reader)

--- a/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
@@ -57,18 +57,17 @@ public static class IncomingAccountPackets
 
     public static unsafe void Configure()
     {
-        IncomingPackets.Register(0x00, 104, false, &CreateCharacter);
-        IncomingPackets.Register(0x5D, 73, false, &PlayCharacter);
-        IncomingPackets.Register(0x80, 62, false, &AccountLogin);
-        IncomingPackets.Register(0x83, 39, false, &DeleteCharacter);
-        IncomingPackets.Register(0x91, 65, false, &GameLogin);
-        IncomingPackets.Register(0xA0, 3, false, &PlayServer);
-        IncomingPackets.Register(0xBB, 9, false, &AccountID);
-        IncomingPackets.Register(0xBD, 0, false, &ClientVersion);
-        IncomingPackets.Register(0xCF, 0, false, &AccountLogin);
-        IncomingPackets.Register(0xE1, 0, false, &ClientType);
-        IncomingPackets.Register(0xEF, 21, false, &LoginServerSeed);
-        IncomingPackets.Register(0xF8, 106, false, &CreateCharacter);
+        IncomingPackets.Register(0x00, &CreateCharacter, 104, outgameOnly: true);
+        IncomingPackets.Register(0x5D, &PlayCharacter, 73, outgameOnly: true);
+        IncomingPackets.Register(0x80, &AccountLogin, 62, outgameOnly: true);
+        IncomingPackets.Register(0x83, &DeleteCharacter, 39, outgameOnly: true);
+        IncomingPackets.Register(0x91, &GameLogin, 65, outgameOnly: true);
+        IncomingPackets.Register(0xA0, &PlayServer, 3, outgameOnly: true);
+        IncomingPackets.Register(0xBD, &ClientVersion);
+        IncomingPackets.Register(0xCF, &AccountLogin, outgameOnly: true);
+        IncomingPackets.Register(0xE1,&ClientType);
+        IncomingPackets.Register(0xEF, &LoginServerSeed, 21, outgameOnly: true);
+        IncomingPackets.Register(0xF8,  &CreateCharacter, 106, outgameOnly: true);
     }
 
     public static void CreateCharacter(NetState state, SpanReader reader)

--- a/Projects/UOContent/Network/Packets/IncomingExtendedCommandPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingExtendedCommandPackets.cs
@@ -14,6 +14,7 @@
  *************************************************************************/
 
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using Server.ContextMenus;
 using Server.Items;
 using Server.Mobiles;
@@ -70,12 +71,18 @@ public static class IncomingExtendedCommandPackets
     {
     }
 
-    public static unsafe void RegisterExtended(int packetID, bool ingame,
-        delegate*<NetState, SpanReader, void> onReceive)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void RegisterExtended(
+        int packetID, bool ingame, delegate*<NetState, SpanReader, void> onReceive
+    ) => RegisterExtended(packetID, ingame, false, onReceive);
+
+    public static unsafe void RegisterExtended(
+        int packetID, bool ingame, bool outgame, delegate*<NetState, SpanReader, void> onReceive
+    )
     {
         if (packetID is >= 0 and < 0x100)
         {
-            _extendedHandlers[packetID] = new PacketHandler(packetID, 0, ingame, onReceive);
+            _extendedHandlers[packetID] = new PacketHandler(packetID, onReceive, inGameOnly: ingame, outGameOnly: outgame);
         }
     }
 

--- a/Projects/UOContent/Network/Packets/IncomingExtendedCommandPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingExtendedCommandPackets.cs
@@ -102,7 +102,7 @@ public static class IncomingExtendedCommandPackets
             return;
         }
 
-        if (ph.Ingame && state.Mobile?.Deleted != false)
+        if (ph.InGameOnly && state.Mobile?.Deleted != false)
         {
             if (state.Mobile == null)
             {

--- a/Projects/UOContent/Network/Packets/IncomingItemPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingItemPackets.cs
@@ -26,7 +26,7 @@ public static class IncomingItemPackets
     public static unsafe void Configure()
     {
         IncomingPackets.Register(0x07, 7, true, &LiftReq);
-        IncomingPackets.Register(new ContainerGridPacketHandler(0x08, 14, true, &DropReq));
+        IncomingPackets.Register(new ContainerGridPacketHandler(0x08, 14, &DropReq));
         IncomingPackets.Register(0x13, 10, true, &EquipReq);
         IncomingPackets.Register(0xEC, 0, false, &EquipMacro);
         IncomingPackets.Register(0xED, 0, false, &UnequipMacro);

--- a/Projects/UOContent/Network/ProtocolExtensions.cs
+++ b/Projects/UOContent/Network/ProtocolExtensions.cs
@@ -46,19 +46,30 @@ namespace Server.Network
                 return;
             }
 
-            if (ph.InGameOnly && state.Mobile == null)
+            var from = state.Mobile;
+
+            if (ph.InGameOnly)
             {
-                state.LogInfo($"Sent in-game packet (0x{packetId:X2}x{cmd:X2}) before having been attached to a mobile");
-                state.Disconnect("Sent in-game packet before being attached to a mobile.");
+                if (from == null)
+                {
+                    state.Disconnect($"Received packet 0x{packetId:X2}x{cmd:X2} before having been attached to a mobile.");
+                    return;
+                }
+
+                if (from.Deleted)
+                {
+                    state.Disconnect($"Received packet 0x{packetId:X2}x{cmd:X2} after having been attached to a deleted mobile.");
+                    return;
+                }
             }
-            else if (ph.InGameOnly && state.Mobile.Deleted)
+
+            if (ph.OutOfGameOnly && from?.Deleted == false)
             {
-                state.Disconnect(string.Empty);
+                state.Disconnect($"Received packet 0x{packetId:X2}x{cmd:X2} after having been attached to a mobile.");
+                return;
             }
-            else
-            {
-                ph.OnReceive(state, reader);
-            }
+
+            ph.OnReceive(state, reader);
         }
     }
 }

--- a/Projects/UOContent/Network/ProtocolExtensions.cs
+++ b/Projects/UOContent/Network/ProtocolExtensions.cs
@@ -46,12 +46,12 @@ namespace Server.Network
                 return;
             }
 
-            if (ph.Ingame && state.Mobile == null)
+            if (ph.InGameOnly && state.Mobile == null)
             {
                 state.LogInfo($"Sent in-game packet (0x{packetId:X2}x{cmd:X2}) before having been attached to a mobile");
                 state.Disconnect("Sent in-game packet before being attached to a mobile.");
             }
-            else if (ph.Ingame && state.Mobile.Deleted)
+            else if (ph.InGameOnly && state.Mobile.Deleted)
             {
                 state.Disconnect(string.Empty);
             }


### PR DESCRIPTION
### Summary
- Fixes various exploits that can crash the shard when the client misbehaves.
- Clients will now be disconnected if they send packets that are marked as out of game only (new flag), while they are in-game.


> [!Note]
> **Developer Note**
> Added an `OutOfGameOnly` which should be used to flag packets as only available out of the game.
> This is the opposite of, yet not the converse to `InGameOnly`.