### PR TITLE
fix: Fixes double calls with Target cancel and spell sequences

### DIFF
--- a/Projects/Server/Targeting/Target.cs
+++ b/Projects/Server/Targeting/Target.cs
@@ -159,6 +159,7 @@ public abstract class Target
         Map map = null;
         Item item = null;
         Mobile mobile = null;
+        var isValidTargetType = true;
 
         bool valid = targeted switch
         {
@@ -166,12 +167,15 @@ public abstract class Target
             StaticTarget staticTarget => CanTarget(from, staticTarget, ref loc, ref map),
             Item i                    => CanTarget(from, item = i, ref loc, ref map),
             Mobile m                  => CanTarget(from, mobile = m, ref loc, ref map),
-            _                         => false
+            _                         => isValidTargetType = false
         };
 
         if (!valid)
         {
-            OnTargetCancel(from, TargetCancelType.InvalidTarget);
+            if (!isValidTargetType)
+            {
+                OnTargetUntargetable(from, targeted);
+            }
         }
         else if (map == null || map != from.Map || Range >= 0 && !from.InRange(loc, Range))
         {

--- a/Projects/Server/Targeting/Target.cs
+++ b/Projects/Server/Targeting/Target.cs
@@ -201,7 +201,7 @@ public abstract class Target
         {
             OnTargetUntargetable(from, targeted);
         }
-        else if (mobile?.CheckTarget(from, this, mobile) == false)
+        else if (mobile?.CheckTarget(from, this, targeted) == false)
         {
             OnTargetUntargetable(from, mobile);
         }

--- a/Projects/Server/Targeting/TargetCancelType.cs
+++ b/Projects/Server/Targeting/TargetCancelType.cs
@@ -5,6 +5,5 @@ public enum TargetCancelType
     Overridden,
     Canceled,
     Disconnected,
-    Timeout,
-    InvalidTarget
+    Timeout
 }

--- a/Projects/Server/Targeting/TargetCancelType.cs
+++ b/Projects/Server/Targeting/TargetCancelType.cs
@@ -5,5 +5,6 @@ public enum TargetCancelType
     Overridden,
     Canceled,
     Disconnected,
-    Timeout
+    Timeout,
+    InvalidTarget
 }

--- a/Projects/UOContent/Items/Skill Items/Tailor Items/Misc/Scissors.cs
+++ b/Projects/UOContent/Items/Skill Items/Tailor Items/Misc/Scissors.cs
@@ -59,19 +59,9 @@ public partial class Scissors : Item
                 // Didn't your parents ever tell you not to run with scissors in your hand?!
                 from.SendLocalizedMessage(1063305);
             }
-            else if (targeted is Item item && !item.Movable)
+            else if (targeted is Item item and IScissorable scissorable && (targeted is PlagueBeastInnard or PlagueBeastMutationCore || item.Movable))
             {
-                if (item is IScissorable obj && obj is PlagueBeastInnard or PlagueBeastMutationCore)
-                {
-                    if (CanScissor(from, obj) && obj.Scissor(from, m_Item))
-                    {
-                        from.PlaySound(0x248);
-                    }
-                }
-            }
-            else if (targeted is IScissorable obj)
-            {
-                if (CanScissor(from, obj) && obj.Scissor(from, m_Item))
+                if (CanScissor(from, scissorable) && scissorable.Scissor(from, m_Item))
                 {
                     from.PlaySound(0x248);
                 }
@@ -84,13 +74,15 @@ public partial class Scissors : Item
 
         protected override void OnNonlocalTarget(Mobile from, object targeted)
         {
-            if (targeted is not (IScissorable obj and (PlagueBeastInnard or PlagueBeastMutationCore)))
+            if (targeted is not PlagueBeastInnard and not PlagueBeastMutationCore)
             {
                 base.OnNonlocalTarget(from, targeted);
                 return;
             }
 
-            if (CanScissor(from, obj) && obj.Scissor(from, m_Item))
+            var scissorable = (IScissorable)targeted;
+
+            if (CanScissor(from, scissorable) && scissorable.Scissor(from, m_Item))
             {
                 from.PlaySound(0x248);
             }

--- a/Projects/UOContent/Spells/Chivalry/CleanseByFire.cs
+++ b/Projects/UOContent/Spells/Chivalry/CleanseByFire.cs
@@ -98,8 +98,6 @@ namespace Server.Spells.Chivalry
 
                 AOS.Damage(Caster, Caster, damage, 0, 100, 0, 0, 0, true);
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Chivalry/CloseWounds.cs
+++ b/Projects/UOContent/Spells/Chivalry/CloseWounds.cs
@@ -78,8 +78,6 @@ namespace Server.Spells.Chivalry
                 m.FixedParticles(0x376A, 1, 62, 9923, 3, 3, EffectLayer.Waist);
                 m.FixedParticles(0x3779, 1, 46, 9502, 5, 3, EffectLayer.Waist);
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Chivalry/RemoveCurse.cs
+++ b/Projects/UOContent/Spells/Chivalry/RemoveCurse.cs
@@ -124,8 +124,6 @@ namespace Server.Spells.Chivalry
                     m.PlaySound(0x1DF);
                 }
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Chivalry/SacredJourney.cs
+++ b/Projects/UOContent/Spells/Chivalry/SacredJourney.cs
@@ -109,8 +109,6 @@ namespace Server.Spells.Chivalry
                 Caster.MoveToWorld(loc, map);
                 Caster.PlaySound(0x1FC);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()
@@ -122,6 +120,7 @@ namespace Server.Spells.Chivalry
             else
             {
                 Effect(m_Entry.Location, m_Entry.Map, true);
+                FinishSequence();
             }
         }
 

--- a/Projects/UOContent/Spells/Eighth/EnergyVortex.cs
+++ b/Projects/UOContent/Spells/Eighth/EnergyVortex.cs
@@ -40,8 +40,6 @@ namespace Server.Spells.Eighth
 
                 BaseCreature.Summon(new EnergyVortex(), false, Caster, new Point3D(p), 0x212, duration);
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Eighth/Resurrection.cs
+++ b/Projects/UOContent/Spells/Eighth/Resurrection.cs
@@ -64,8 +64,6 @@ namespace Server.Spells.Eighth
                 m.CloseGump<ResurrectGump>();
                 m.SendGump(new ResurrectGump(m, Caster));
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Fifth/BladeSpirits.cs
+++ b/Projects/UOContent/Spells/Fifth/BladeSpirits.cs
@@ -37,8 +37,6 @@ namespace Server.Spells.Fifth
                 var duration = TimeSpan.FromSeconds(Core.AOS ? 120 : Utility.Random(80, 40));
                 BaseCreature.Summon(new BladeSpirits(), false, Caster, new Point3D(p), 0x212, duration);
             }
-
-            FinishSequence();
         }
 
         public override TimeSpan GetCastDelay()

--- a/Projects/UOContent/Spells/Fifth/DispelField.cs
+++ b/Projects/UOContent/Spells/Fifth/DispelField.cs
@@ -47,8 +47,6 @@ namespace Server.Spells.Fifth
 
                 item.Delete();
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fifth/MagicReflect.cs
+++ b/Projects/UOContent/Spells/Fifth/MagicReflect.cs
@@ -99,8 +99,6 @@ namespace Server.Spells.Fifth
                         BuffInfo.AddBuff(Caster, new BuffInfo(BuffIcon.MagicReflection, 1075817, buffFormat, true));
                     }
                 }
-
-                FinishSequence();
             }
             else
             {
@@ -129,9 +127,9 @@ namespace Server.Spells.Fifth
                         Caster.SendLocalizedMessage(1005385); // The spell will not adhere to you at this time.
                     }
                 }
-
-                FinishSequence();
             }
+
+            FinishSequence();
         }
 
         public static void EndReflect(Mobile m)

--- a/Projects/UOContent/Spells/Fifth/MindBlast.cs
+++ b/Projects/UOContent/Spells/Fifth/MindBlast.cs
@@ -106,8 +106,6 @@ namespace Server.Spells.Fifth
 
                 SpellHelper.Damage(this, target, damage, 0, 0, 100, 0, 0);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fifth/Paralyze.cs
+++ b/Projects/UOContent/Spells/Fifth/Paralyze.cs
@@ -78,8 +78,6 @@ namespace Server.Spells.Fifth
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fifth/PoisonField.cs
+++ b/Projects/UOContent/Spells/Fifth/PoisonField.cs
@@ -53,8 +53,6 @@ public class PoisonFieldSpell : MagerySpell, ISpellTargetingPoint3D
                 new PoisonField(itemID, targetLoc, Caster, Caster.Map, duration, i);
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/First/Clumsy.cs
+++ b/Projects/UOContent/Spells/First/Clumsy.cs
@@ -43,8 +43,6 @@ namespace Server.Spells.First
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/First/Feeblemind.cs
+++ b/Projects/UOContent/Spells/First/Feeblemind.cs
@@ -45,8 +45,6 @@ namespace Server.Spells.First
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/First/Heal.cs
+++ b/Projects/UOContent/Spells/First/Heal.cs
@@ -69,8 +69,6 @@ namespace Server.Spells.First
                 m.FixedParticles(0x376A, 9, 32, 5005, EffectLayer.Waist);
                 m.PlaySound(0x1F2);
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/First/MagicArrow.cs
+++ b/Projects/UOContent/Spells/First/MagicArrow.cs
@@ -64,8 +64,6 @@ namespace Server.Spells.First
 
                 SpellHelper.Damage(this, m, damage, 0, 100, 0, 0, 0);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/First/NightSight.cs
+++ b/Projects/UOContent/Spells/First/NightSight.cs
@@ -1,80 +1,58 @@
 using System;
 using Server.Targeting;
 
-namespace Server.Spells.First
+namespace Server.Spells.First;
+
+public class NightSightSpell : MagerySpell, ISpellTargetingMobile
 {
-    public class NightSightSpell : MagerySpell
+    private static readonly SpellInfo _info = new(
+        "Night Sight",
+        "In Lor",
+        236,
+        9031,
+        Reagent.SulfurousAsh,
+        Reagent.SpidersSilk
+    );
+
+    public NightSightSpell(Mobile caster, Item scroll = null) : base(caster, scroll, _info)
     {
-        private static readonly SpellInfo _info = new(
-            "Night Sight",
-            "In Lor",
-            236,
-            9031,
-            Reagent.SulfurousAsh,
-            Reagent.SpidersSilk
-        );
+    }
 
-        public NightSightSpell(Mobile caster, Item scroll = null) : base(caster, scroll, _info)
+    public override SpellCircle Circle => SpellCircle.First;
+
+    public override void OnCast()
+    {
+        Caster.Target = new SpellTargetMobile(this, TargetFlags.Beneficial, 12);
+    }
+
+    public void Target(Mobile m)
+    {
+        if (CheckBSequence(m))
         {
-        }
+            SpellHelper.Turn(Caster, m);
 
-        public override SpellCircle Circle => SpellCircle.First;
-
-        public override void OnCast()
-        {
-            Caster.Target = new NightSightTarget(this);
-        }
-
-        private class NightSightTarget : Target
-        {
-            private readonly Spell m_Spell;
-
-            public NightSightTarget(Spell spell) : base(12, false, TargetFlags.Beneficial) => m_Spell = spell;
-
-            protected override void OnTarget(Mobile from, object targeted)
+            if (m.BeginAction<LightCycle>())
             {
-                if (targeted is Mobile targ && m_Spell.CheckBSequence(targ))
-                {
-                    SpellHelper.Turn(m_Spell.Caster, targ);
+                new LightCycle.NightSightTimer(m).Start();
 
-                    if (targ.BeginAction<LightCycle>())
-                    {
-                        new LightCycle.NightSightTimer(targ).Start();
-                        var level =
-                            (int)(LightCycle.DungeonLevel *
-                                  ((Core.AOS
-                                      ? targ.Skills.Magery.Value
-                                      : from.Skills.Magery.Value) / 100));
+                var skill = (Core.AOS ? m.Skills.Magery.Value : Caster.Skills.Magery.Value) / 100;
+                var level = (int)(LightCycle.DungeonLevel * skill);
 
-                        targ.LightLevel = Math.Max(level, 0);
+                m.LightLevel = Math.Max(level, 0);
 
-                        targ.FixedParticles(0x376A, 9, 32, 5007, EffectLayer.Waist);
-                        targ.PlaySound(0x1E3);
+                m.FixedParticles(0x376A, 9, 32, 5007, EffectLayer.Waist);
+                m.PlaySound(0x1E3);
 
-                        BuffInfo.AddBuff(
-                            targ,
-                            new BuffInfo(BuffIcon.NightSight, 1075643)
-                        ); // Night Sight/You ignore lighting effects
-                    }
-                    else
-                    {
-                        if (from == targ)
-                        {
-                            from.SendMessage("You already have nightsight.");
-                        }
-                        else
-                        {
-                            from.SendMessage("They already have nightsight.");
-                        }
-                    }
-                }
-
-                m_Spell.FinishSequence();
+                // Night Sight/You ignore lighting effects
+                BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.NightSight, 1075643));
             }
-
-            protected override void OnTargetFinish(Mobile from)
+            else if (m == Caster)
             {
-                m_Spell.FinishSequence();
+                m.SendMessage("You already have nightsight.");
+            }
+            else
+            {
+                m.SendMessage("They already have nightsight.");
             }
         }
     }

--- a/Projects/UOContent/Spells/First/Weaken.cs
+++ b/Projects/UOContent/Spells/First/Weaken.cs
@@ -43,8 +43,6 @@ namespace Server.Spells.First
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/ArchCure.cs
+++ b/Projects/UOContent/Spells/Fourth/ArchCure.cs
@@ -91,8 +91,6 @@ namespace Server.Spells.Fourth
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/ArchProtection.cs
+++ b/Projects/UOContent/Spells/Fourth/ArchProtection.cs
@@ -29,10 +29,14 @@ namespace Server.Spells.Fourth
 
         public void Target(IPoint3D p)
         {
+            if (Caster.Map == null)
+            {
+                return;
+            }
+
             if (CheckSequence())
             {
                 SpellHelper.Turn(Caster, p);
-
                 SpellHelper.GetSurfaceTop(ref p);
 
                 var loc = new Point3D(p);
@@ -40,12 +44,6 @@ namespace Server.Spells.Fourth
                 if (!Core.AOS)
                 {
                     Effects.PlaySound(loc, Caster.Map, 0x299);
-                }
-
-                if (Caster.Map == null)
-                {
-                    FinishSequence();
-                    return;
                 }
 
                 using var targets = PooledRefQueue<Mobile>.Create();
@@ -92,8 +90,6 @@ namespace Server.Spells.Fourth
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/Curse.cs
+++ b/Projects/UOContent/Spells/Fourth/Curse.cs
@@ -101,8 +101,6 @@ namespace Server.Spells.Fourth
                     DoHurtFizzle();
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/FireField.cs
+++ b/Projects/UOContent/Spells/Fourth/FireField.cs
@@ -56,8 +56,6 @@ public class FireFieldSpell : MagerySpell, ISpellTargetingPoint3D
                 new FireFieldItem(itemID, targetLoc, Caster, Caster.Map, duration, i);
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/GreaterHeal.cs
+++ b/Projects/UOContent/Spells/Fourth/GreaterHeal.cs
@@ -57,8 +57,6 @@ namespace Server.Spells.Fourth
                 m.FixedParticles(0x376A, 9, 32, 5030, EffectLayer.Waist);
                 m.PlaySound(0x202);
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Fourth/Lightning.cs
+++ b/Projects/UOContent/Spells/Fourth/Lightning.cs
@@ -53,8 +53,6 @@ namespace Server.Spells.Fourth
 
                 SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/ManaDrain.cs
+++ b/Projects/UOContent/Spells/Fourth/ManaDrain.cs
@@ -73,8 +73,6 @@ namespace Server.Spells.Fourth
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Fourth/Recall.cs
+++ b/Projects/UOContent/Spells/Fourth/Recall.cs
@@ -101,8 +101,6 @@ namespace Server.Spells.Fourth
                 Caster.MoveToWorld(loc, map);
                 Caster.PlaySound(0x1FC);
             }
-
-            FinishSequence();
         }
 
         public override void GetCastSkills(out double min, out double max)
@@ -130,6 +128,7 @@ namespace Server.Spells.Fourth
             else
             {
                 Effect(m_Entry.Location, m_Entry.Map, true);
+                FinishSequence();
             }
         }
 

--- a/Projects/UOContent/Spells/Mysticism/AnimatedWeaponSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/AnimatedWeaponSpell.cs
@@ -51,8 +51,6 @@ public class AnimatedWeaponSpell : MysticSpell, ISpellTargetingPoint3D
 
             Effects.SendTargetParticles(summon, 0x3728, 10, 10, 0x13AA, (EffectLayer)255);
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Mysticism/BombardSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/BombardSpell.cs
@@ -26,63 +26,61 @@ public class BombardSpell : MysticSpell, ISpellTargetingMobile
 
     public override void OnCast()
     {
-            Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful);
-        }
+        Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful);
+    }
 
     public void Target(Mobile m)
     {
-            if (CheckHSequence(m))
+        if (CheckHSequence(m))
+        {
+            SpellHelper.Turn(Caster, m);
+
+            if (HasDelayedDamageContext(m))
             {
-                SpellHelper.Turn(Caster, m);
+                DoHurtFizzle();
+                return;
+            }
 
-                if (HasDelayedDamageContext(m))
+            var source = Caster;
+
+            if (SpellHelper.CheckReflect(6, ref source, ref m))
+            {
+                Timer.StartTimer(TimeSpan.FromSeconds(0.5), () =>
                 {
-                    DoHurtFizzle();
-                    return;
-                }
-
-                var source = Caster;
-
-                if (SpellHelper.CheckReflect(6, ref source, ref m))
-                {
-                    Timer.StartTimer(TimeSpan.FromSeconds(0.5), () =>
-                    {
-                        source.MovingEffect(m, 0x1363, 12, 1, false, true, 0, 0);
-                        source.PlaySound(0x64B);
-                    });
-                }
-
-                Caster.MovingEffect(m, 0x1363, 12, 1, false, true, 0, 0);
-                Caster.PlaySound(0x64B);
-
-                SpellHelper.Damage(this, m, GetNewAosDamage(40, 1, 5, m), 100, 0, 0, 0, 0);
-
-                Timer.StartTimer(TimeSpan.FromSeconds(1.2), () =>
-                {
-                    if (CheckResisted(m))
-                    {
-                        return;
-                    }
-
-                    var damageSkill = GetDamageSkill(Caster);
-                    var resist = GetResistSkill(m);
-
-                    int secs = Math.Max(0, (int)(damageSkill / 10 - resist / 10));
-
-                    if (secs > 0)
-                    {
-                        m.Paralyze(TimeSpan.FromSeconds(secs));
-                    }
-
-                    // Up to 12% chance by checking mysticism + imbuing/focus against resist
-                    var knockBackChance = (GetBaseSkill(Caster) + damageSkill - resist) / 20;
-                    if (knockBackChance > 0 && Utility.RandomDouble() < knockBackChance)
-                    {
-                        m.Move(Caster.GetDirectionTo(m));
-                    }
+                    source.MovingEffect(m, 0x1363, 12, 1, false, true, 0, 0);
+                    source.PlaySound(0x64B);
                 });
             }
 
-            FinishSequence();
+            Caster.MovingEffect(m, 0x1363, 12, 1, false, true, 0, 0);
+            Caster.PlaySound(0x64B);
+
+            SpellHelper.Damage(this, m, GetNewAosDamage(40, 1, 5, m), 100, 0, 0, 0, 0);
+
+            Timer.StartTimer(TimeSpan.FromSeconds(1.2), () =>
+            {
+                if (CheckResisted(m))
+                {
+                    return;
+                }
+
+                var damageSkill = GetDamageSkill(Caster);
+                var resist = GetResistSkill(m);
+
+                int secs = Math.Max(0, (int)(damageSkill / 10 - resist / 10));
+
+                if (secs > 0)
+                {
+                    m.Paralyze(TimeSpan.FromSeconds(secs));
+                }
+
+                // Up to 12% chance by checking mysticism + imbuing/focus against resist
+                var knockBackChance = (GetBaseSkill(Caster) + damageSkill - resist) / 20;
+                if (knockBackChance > 0 && Utility.RandomDouble() < knockBackChance)
+                {
+                    m.Move(Caster.GetDirectionTo(m));
+                }
+            });
         }
+    }
 }

--- a/Projects/UOContent/Spells/Mysticism/CleansingWindsSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/CleansingWindsSpell.cs
@@ -129,8 +129,6 @@ public class CleansingWindsSpell : MysticSpell, ISpellTargetingMobile
                 }
             }
         }
-
-        FinishSequence();
     }
 
     public static int RemoveCurses(Mobile m)

--- a/Projects/UOContent/Spells/Mysticism/EagleStrikeSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/EagleStrikeSpell.cs
@@ -51,8 +51,6 @@ public class EagleStrikeSpell : MysticSpell, ISpellTargetingMobile
 
             Timer.StartTimer(TimeSpan.FromSeconds(1.0), () => Damage(m));
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Mysticism/HailStormSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/HailStormSpell.cs
@@ -69,8 +69,6 @@ public class HailStormSpell : MysticSpell, ISpellTargetingPoint3D
                 }
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Mysticism/NetherCycloneSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/NetherCycloneSpell.cs
@@ -85,8 +85,6 @@ public class NetherCycloneSpell : MysticSpell, ISpellTargetingPoint3D
                 }
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Mysticism/SpellPlagueSpell.cs
+++ b/Projects/UOContent/Spells/Mysticism/SpellPlagueSpell.cs
@@ -35,13 +35,13 @@ public class SpellPlagueSpell : MysticSpell, ISpellTargetingMobile
         Caster.Target = new SpellTargetMobile(this, TargetFlags.Harmful);
     }
 
-    public void Target(Mobile targeted)
+    public void Target(Mobile m)
     {
-        if (CheckHSequence(targeted))
+        if (CheckHSequence(m))
         {
-            SpellHelper.Turn(Caster, targeted);
+            SpellHelper.Turn(Caster, m);
 
-            SpellHelper.CheckReflect(6, Caster, ref targeted);
+            SpellHelper.CheckReflect(6, Caster, ref m);
 
             /* The target is hit with an explosion of chaos damage and then inflicted
              * with the spell plague curse. Each time the target is damaged while under
@@ -53,26 +53,24 @@ public class SpellPlagueSpell : MysticSpell, ISpellTargetingMobile
              * plagues so that they are applied one after the other.
              */
 
-            VisualEffect(targeted);
+            VisualEffect(m);
 
             // Before Time of Legends, SDI was not applied to initial damage.
-            var damage = GetNewAosDamage(33, 1, 5, Core.TOL, targeted);
-            SpellHelper.Damage(this, targeted, damage, 0, 0, 0, 0, 0);
+            var damage = GetNewAosDamage(33, 1, 5, Core.TOL, m);
+            SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 0);
 
-            var timer = new SpellPlagueTimer(this, targeted);
+            var timer = new SpellPlagueTimer(this, m);
 
-            if (_table.TryGetValue(targeted, out var oldtimer))
+            if (_table.TryGetValue(m, out var oldtimer))
             {
                 oldtimer.SetNext(timer);
             }
             else
             {
-                _table[targeted] = timer;
+                _table[m] = timer;
                 timer.StartPlague();
             }
         }
-
-        FinishSequence();
     }
 
     public static bool UnderEffect(Mobile m) => _table.ContainsKey(m);

--- a/Projects/UOContent/Spells/Necromancy/BloodOathSpell.cs
+++ b/Projects/UOContent/Spells/Necromancy/BloodOathSpell.cs
@@ -92,8 +92,6 @@ public class BloodOathSpell : NecromancerSpell, ISpellTargetingMobile
             _table[m] = timer;
             HarmfulSpell(m);
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/CorpseSkin.cs
+++ b/Projects/UOContent/Spells/Necromancy/CorpseSkin.cs
@@ -91,8 +91,6 @@ public class CorpseSkinSpell : NecromancerSpell, ISpellTargetingMobile
 
             HarmfulSpell(m);
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/EvilOmen.cs
+++ b/Projects/UOContent/Spells/Necromancy/EvilOmen.cs
@@ -66,8 +66,6 @@ public class EvilOmenSpell : NecromancerSpell, ISpellTargetingMobile
 
             BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.EvilOmen, 1075647, 1075648, duration, m));
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/MindRot.cs
+++ b/Projects/UOContent/Spells/Necromancy/MindRot.cs
@@ -59,8 +59,6 @@ public class MindRotSpell : NecromancerSpell, ISpellTargetingMobile
 
             HarmfulSpell(m);
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/PainSpike.cs
+++ b/Projects/UOContent/Spells/Necromancy/PainSpike.cs
@@ -81,8 +81,6 @@ public class PainSpikeSpell : NecromancerSpell, ISpellTargetingMobile
             // SpellHelper.Damage( this, m, damage, 100, 0, 0, 0, 0, Misc.DFAlgorithm.PainSpike );
             HarmfulSpell(m);
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/PoisonStrike.cs
+++ b/Projects/UOContent/Spells/Necromancy/PoisonStrike.cs
@@ -142,8 +142,6 @@ public class PoisonStrikeSpell : NecromancerSpell, ISpellTargetingMobile
                 }
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/Strangle.cs
+++ b/Projects/UOContent/Spells/Necromancy/Strangle.cs
@@ -107,8 +107,6 @@ public class StrangleSpell : NecromancerSpell, ISpellTargetingMobile
 
         var t_Duration = TimeSpan.FromSeconds(length);
         BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Strangle, 1075794, 1075795, t_Duration, m, args));
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Necromancy/VengefulSpirit.cs
+++ b/Projects/UOContent/Spells/Necromancy/VengefulSpirit.cs
@@ -62,8 +62,6 @@ public class VengefulSpiritSpell : NecromancerSpell, ISpellTargetingMobile
                 rev.FixedParticles(0x373A, 1, 15, 9909, EffectLayer.Waist);
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Ninjitsu/ShadowJump.cs
+++ b/Projects/UOContent/Spells/Ninjitsu/ShadowJump.cs
@@ -92,8 +92,6 @@ public class Shadowjump : NinjaSpell, ISpellTargetingPoint3D
 
             Stealth.OnUse(m); // stealth check after the shadow jump
         }
-
-        FinishSequence();
     }
 
     public override bool CheckCast()

--- a/Projects/UOContent/Spells/Second/Agility.cs
+++ b/Projects/UOContent/Spells/Second/Agility.cs
@@ -36,8 +36,6 @@ namespace Server.Spells.Second
 
                 BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Agility, 1075841, length, m, percentage.ToString()));
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Second/Cunning.cs
+++ b/Projects/UOContent/Spells/Second/Cunning.cs
@@ -36,8 +36,6 @@ namespace Server.Spells.Second
 
                 BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Cunning, 1075843, length, m, percentage.ToString()));
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Second/Cure.cs
+++ b/Projects/UOContent/Spells/Second/Cure.cs
@@ -55,8 +55,6 @@ namespace Server.Spells.Second
                 m.FixedParticles(0x373A, 10, 15, 5012, EffectLayer.Waist);
                 m.PlaySound(0x1E0);
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Second/Harm.cs
+++ b/Projects/UOContent/Spells/Second/Harm.cs
@@ -71,8 +71,6 @@ namespace Server.Spells.Second
 
                 SpellHelper.Damage(this, m, damage, 0, 0, 100, 0, 0);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Second/MagicTrap.cs
+++ b/Projects/UOContent/Spells/Second/MagicTrap.cs
@@ -78,8 +78,6 @@ namespace Server.Spells.Second
 
                 Effects.PlaySound(loc, item.Map, 0x1EF);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Second/RemoveTrap.cs
+++ b/Projects/UOContent/Spells/Second/RemoveTrap.cs
@@ -48,8 +48,6 @@ namespace Server.Spells.Second
                 cont.TrapPower = 0;
                 cont.TrapLevel = 0;
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Second/Strength.cs
+++ b/Projects/UOContent/Spells/Second/Strength.cs
@@ -36,8 +36,6 @@ namespace Server.Spells.Second
 
                 BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Strength, 1075845, length, m, percentage.ToString()));
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Seventh/ChainLightning.cs
+++ b/Projects/UOContent/Spells/Seventh/ChainLightning.cs
@@ -95,8 +95,6 @@ namespace Server.Spells.Seventh
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Seventh/EnergyField.cs
+++ b/Projects/UOContent/Spells/Seventh/EnergyField.cs
@@ -67,8 +67,6 @@ public class EnergyFieldSpell : MagerySpell, ISpellTargetingPoint3D
                 );
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Seventh/FlameStrike.cs
+++ b/Projects/UOContent/Spells/Seventh/FlameStrike.cs
@@ -54,8 +54,6 @@ namespace Server.Spells.Seventh
 
                 SpellHelper.Damage(this, m, damage, 0, 100, 0, 0, 0);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Seventh/GateTravel.cs
+++ b/Projects/UOContent/Spells/Seventh/GateTravel.cs
@@ -94,8 +94,6 @@ public class GateTravelSpell : MagerySpell, IRecallSpell
             firstGate.LinkedGate = secondGate;
             secondGate.LinkedGate = firstGate;
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()
@@ -107,6 +105,7 @@ public class GateTravelSpell : MagerySpell, IRecallSpell
         else
         {
             Effect(m_Entry.Location, m_Entry.Map, true);
+            FinishSequence();
         }
     }
 

--- a/Projects/UOContent/Spells/Seventh/ManaVampire.cs
+++ b/Projects/UOContent/Spells/Seventh/ManaVampire.cs
@@ -75,8 +75,6 @@ namespace Server.Spells.Seventh
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Seventh/MassDispel.cs
+++ b/Projects/UOContent/Spells/Seventh/MassDispel.cs
@@ -72,8 +72,6 @@ namespace Server.Spells.Seventh
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Seventh/MeteorSwarm.cs
+++ b/Projects/UOContent/Spells/Seventh/MeteorSwarm.cs
@@ -100,8 +100,6 @@ namespace Server.Spells.Seventh
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/Dispel.cs
+++ b/Projects/UOContent/Spells/Sixth/Dispel.cs
@@ -54,8 +54,6 @@ namespace Server.Spells.Sixth
                     Caster.SendLocalizedMessage(1010084); // The creature resisted the attempt to dispel it!
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/EnergyBolt.cs
+++ b/Projects/UOContent/Spells/Sixth/EnergyBolt.cs
@@ -59,8 +59,6 @@ namespace Server.Spells.Sixth
                 // Deal the damage
                 SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 100);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/Explosion.cs
+++ b/Projects/UOContent/Spells/Sixth/Explosion.cs
@@ -39,10 +39,8 @@ namespace Server.Spells.Sixth
                 SpellHelper.Turn(Caster, m);
                 SpellHelper.CheckReflect((int)Circle, Caster, ref m);
 
-                var t = new InternalTimer(this, Caster, defender, m).Start();
+                new InternalTimer(this, Caster, defender, m).Start();
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/Invisibility.cs
+++ b/Projects/UOContent/Spells/Sixth/Invisibility.cs
@@ -67,8 +67,6 @@ namespace Server.Spells.Sixth
 
                 _table[m] = timerToken;
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Sixth/Mark.cs
+++ b/Projects/UOContent/Spells/Sixth/Mark.cs
@@ -55,8 +55,6 @@ namespace Server.Spells.Sixth
                 Caster.PlaySound(0x1FA);
                 Effects.SendLocationEffect(Caster, 14201, 16);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/MassCurse.cs
+++ b/Projects/UOContent/Spells/Sixth/MassCurse.cs
@@ -54,8 +54,6 @@ namespace Server.Spells.Sixth
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
+++ b/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
@@ -67,8 +67,6 @@ public class ParalyzeFieldSpell : MagerySpell, ISpellTargetingPoint3D
                 );
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()

--- a/Projects/UOContent/Spells/Sixth/Reveal.cs
+++ b/Projects/UOContent/Spells/Sixth/Reveal.cs
@@ -51,8 +51,6 @@ namespace Server.Spells.Sixth
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Spellweaving/GiftOfLife.cs
+++ b/Projects/UOContent/Spells/Spellweaving/GiftOfLife.cs
@@ -68,8 +68,6 @@ namespace Server.Spells.Spellweaving
 
                 BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.GiftOfLife, 1031615, 1075807, duration, m, null, true));
             }
-
-            FinishSequence();
         }
 
         public static void Initialize()

--- a/Projects/UOContent/Spells/Spellweaving/GiftOfRenewal.cs
+++ b/Projects/UOContent/Spells/Spellweaving/GiftOfRenewal.cs
@@ -65,8 +65,6 @@ namespace Server.Spells.Spellweaving
                     );
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Spellweaving/NatureFury.cs
+++ b/Projects/UOContent/Spells/Spellweaving/NatureFury.cs
@@ -51,8 +51,6 @@ namespace Server.Spells.Spellweaving
 
                 new InternalTimer(nf).Start();
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Spellweaving/WordOfDeath.cs
+++ b/Projects/UOContent/Spells/Spellweaving/WordOfDeath.cs
@@ -68,8 +68,6 @@ namespace Server.Spells.Spellweaving
 
                 SpellHelper.Damage(this, m, damage, 0, 0, 0, 0, 0, 100);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Targeting/RecallSpellTarget.cs
+++ b/Projects/UOContent/Spells/Targeting/RecallSpellTarget.cs
@@ -3,90 +3,73 @@ using Server.Multis;
 using Server.Network;
 using Server.Targeting;
 
-namespace Server.Spells
+namespace Server.Spells;
+
+public class RecallSpellTarget : Target
 {
-    public class RecallSpellTarget : Target
+    private readonly IRecallSpell _spell;
+    private readonly bool _toBoat;
+
+    public RecallSpellTarget(IRecallSpell spell, bool toBoat = true) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
     {
-        private readonly IRecallSpell _spell;
-        private readonly bool m_ToBoat;
+        _spell = spell;
+        _toBoat = toBoat;
+        _spell.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
+    }
 
-        public RecallSpellTarget(IRecallSpell spell, bool toBoat = true) : base(Core.ML ? 10 : 12, false, TargetFlags.None)
+    protected override void OnTarget(Mobile from, object o)
+    {
+        if (o is RecallRune rune)
         {
-            _spell = spell;
-            m_ToBoat = toBoat;
-            _spell.Caster.LocalOverheadMessage(MessageType.Regular, 0x3B2, 501029); // Select Marked item.
-        }
+            if (!rune.Marked)
+            {
+                from.SendLocalizedMessage(501805); // That rune is not yet marked.
+                return;
+            }
 
-        protected override void OnTarget(Mobile from, object o)
+            _spell.Effect(rune.Target, rune.TargetMap, true);
+        }
+        else if (o is Runebook runebook)
         {
-            if (o is RecallRune rune)
-            {
-                if (rune.Marked)
-                {
-                    _spell.Effect(rune.Target, rune.TargetMap, true);
-                }
-                else
-                {
-                    from.SendLocalizedMessage(501805); // That rune is not yet marked.
-                }
-            }
-            else if (o is Runebook runebook)
-            {
-                var e = runebook.Default;
+            var e = runebook.Default;
 
-                if (e != null)
-                {
-                    _spell.Effect(e.Location, e.Map, true);
-                }
-                else
-                {
-                    from.SendLocalizedMessage(502354); // Target is not marked.
-                }
-            }
-            else if (m_ToBoat && o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat)
+            if (e == null)
             {
-                if (!boat.Deleted && boat.CheckKey(key.KeyValue))
-                {
-                    _spell.Effect(boat.GetMarkedLocation(), boat.Map, false);
-                }
-                else
-                {
-                    from.NetState.SendMessageLocalized(
-                        from.Serial,
-                        from.Body,
-                        MessageType.Regular,
-                        0x3B2,
-                        3,
-                        502357, // I can not recall from that object.
-                        from.Name
-                    );
-                }
+                from.SendLocalizedMessage(502354); // Target is not marked.
+                return;
             }
-            else if (o is HouseRaffleDeed deed && deed.ValidLocation())
-            {
-                _spell.Effect(deed.PlotLocation, deed.PlotFacet, true);
-            }
-            else
-            {
-                from.NetState.SendMessageLocalized(
-                    from.Serial,
-                    from.Body,
-                    MessageType.Regular,
-                    0x3B2,
-                    3,
-                    502357, // I can not recall from that object.
-                    from.Name
-                );
-            }
+
+            _spell.Effect(e.Location, e.Map, true);
         }
-
-        protected override void OnNonlocalTarget(Mobile from, object o)
+        else if (_toBoat && o is Key key && key.KeyValue != 0 && key.Link is BaseBoat boat && !boat.Deleted &&
+                 boat.CheckKey(key.KeyValue))
         {
+            _spell.Effect(boat.GetMarkedLocation(), boat.Map, false);
         }
-
-        protected override void OnTargetFinish(Mobile from)
+        else if (o is HouseRaffleDeed deed && deed.ValidLocation())
         {
-            _spell?.FinishSequence();
+            _spell.Effect(deed.PlotLocation, deed.PlotFacet, true);
         }
+        else
+        {
+            from.NetState.SendMessageLocalized(
+                from.Serial,
+                from.Body,
+                MessageType.Regular,
+                0x3B2,
+                3,
+                502357, // I can not recall from that object.
+                from.Name
+            );
+        }
+    }
+
+    protected override void OnNonlocalTarget(Mobile from, object o)
+    {
+    }
+
+    protected override void OnTargetFinish(Mobile from)
+    {
+        _spell?.FinishSequence();
     }
 }

--- a/Projects/UOContent/Spells/Targeting/SpellTargetMobile.cs
+++ b/Projects/UOContent/Spells/Targeting/SpellTargetMobile.cs
@@ -4,7 +4,7 @@ namespace Server.Spells
 {
     public interface ISpellTargetingMobile : ISpell
     {
-        void Target(Mobile from);
+        void Target(Mobile m);
     }
 
     public class SpellTargetMobile : Target, ISpellTarget

--- a/Projects/UOContent/Spells/Third/Bless.cs
+++ b/Projects/UOContent/Spells/Third/Bless.cs
@@ -40,8 +40,6 @@ namespace Server.Spells.Third
 
                 BuffInfo.AddBuff(m, new BuffInfo(BuffIcon.Bless, 1075847, 1075848, length, m, args));
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Third/Fireball.cs
+++ b/Projects/UOContent/Spells/Third/Fireball.cs
@@ -55,8 +55,6 @@ namespace Server.Spells.Third
 
                 SpellHelper.Damage(this, m, damage, 0, 100, 0, 0, 0);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Third/MagicLock.cs
+++ b/Projects/UOContent/Spells/Third/MagicLock.cs
@@ -58,8 +58,6 @@ namespace Server.Spells.Third
                 cont.LockLevel = ILockpickable.MagicLock; // signal magic lock
                 cont.Locked = true;
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Third/Poison.cs
+++ b/Projects/UOContent/Spells/Third/Poison.cs
@@ -95,8 +95,6 @@ namespace Server.Spells.Third
 
                 HarmfulSpell(m);
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Third/Telekinesis.cs
+++ b/Projects/UOContent/Spells/Third/Telekinesis.cs
@@ -68,8 +68,6 @@ namespace Server.Spells.Third
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Third/Teleport.cs
+++ b/Projects/UOContent/Spells/Third/Teleport.cs
@@ -112,8 +112,6 @@ namespace Server.Spells.Third
                     queue.Dequeue().OnMoveOver(m);
                 }
             }
-
-            FinishSequence();
         }
 
         public override bool CheckCast()

--- a/Projects/UOContent/Spells/Third/Unlock.cs
+++ b/Projects/UOContent/Spells/Third/Unlock.cs
@@ -80,8 +80,6 @@ namespace Server.Spells.Third
                     }
                 }
             }
-
-            FinishSequence();
         }
 
         public override void OnCast()

--- a/Projects/UOContent/Spells/Third/WallOfStone.cs
+++ b/Projects/UOContent/Spells/Third/WallOfStone.cs
@@ -42,22 +42,16 @@ public class WallOfStoneSpell : MagerySpell, ISpellTargetingPoint3D
                 var targetLoc = new Point3D(eastToWest ? p.X + i : p.X, eastToWest ? p.Y : p.Y + i, p.Z);
                 var canFit = SpellHelper.AdjustField(ref targetLoc, Caster.Map, 22, true);
 
-                // Effects.SendLocationParticles( EffectItem.Create( loc, Caster.Map, EffectItem.DefaultDuration ), 0x376A, 9, 10, 5025 );
-
                 if (!canFit)
                 {
                     continue;
                 }
 
-                Item item = new WallOfStone(targetLoc, Caster.Map, Caster);
+                var item = new WallOfStone(targetLoc, Caster.Map, Caster);
 
                 Effects.SendLocationParticles(item, 0x376A, 9, 10, 5025);
-
-                // new WallOfStone( loc, Caster.Map, Caster );
             }
         }
-
-        FinishSequence();
     }
 
     public override void OnCast()


### PR DESCRIPTION
### Summary
- Cleans up target cancellation being called incorrectly.
- An invalid target type (which should never happen), now calls `OnTargetUntargetable` instead of `OnTargetCanceled`
- Removes double calls to `FinishSequence` in Spells.
