### PR TITLE
fix: Fixes commodity resource property hue

### DIFF
--- a/Projects/UOContent/Items/Food/Cooking.cs
+++ b/Projects/UOContent/Items/Food/Cooking.cs
@@ -65,8 +65,8 @@ public partial class SackFlour : Item, IHasQuantity
         _quantity = 20;
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public int Quantity
     {
         get => _quantity;

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
@@ -5,11 +5,6 @@ namespace Server.Items;
 [SerializationGenerator(2, false)]
 public abstract partial class BaseIngot : Item, ICommodity
 {
-    [InvalidateProperties]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    [SerializableField(0)]
-    private CraftResource _resource;
-
     public BaseIngot(CraftResource resource, int amount = 1) : base(0x1BF2)
     {
         Stackable = true;
@@ -20,6 +15,24 @@ public abstract partial class BaseIngot : Item, ICommodity
     }
 
     public override double DefaultWeight => 0.1;
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
+    }
 
     public override int LabelNumber
     {

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
@@ -16,8 +16,8 @@ public abstract partial class BaseIngot : Item, ICommodity
 
     public override double DefaultWeight => 0.1;
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
@@ -17,8 +17,8 @@ public abstract partial class BaseOre : Item
         _resource = resource;
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
@@ -17,10 +17,23 @@ public abstract partial class BaseOre : Item
         _resource = resource;
     }
 
-    [InvalidateProperties]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    [SerializableField(0)]
-    private CraftResource _resource;
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
+    }
 
     public override int LabelNumber
     {

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Scales.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Scales.cs
@@ -5,11 +5,6 @@ namespace Server.Items;
 [SerializationGenerator(1, false)]
 public abstract partial class BaseScales : Item, ICommodity
 {
-    [InvalidateProperties]
-    [SerializableField(0)]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    private CraftResource _resource;
-
     public BaseScales(CraftResource resource, int amount = 1) : base(0x26B4)
     {
         Stackable = true;
@@ -17,6 +12,24 @@ public abstract partial class BaseScales : Item, ICommodity
         Hue = CraftResources.GetHue(resource);
 
         _resource = resource;
+    }
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
     }
 
     public override int LabelNumber => 1053139; // dragon scales

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Scales.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Scales.cs
@@ -14,8 +14,8 @@ public abstract partial class BaseScales : Item, ICommodity
         _resource = resource;
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Resources/Masonry/Granite.cs
+++ b/Projects/UOContent/Items/Resources/Masonry/Granite.cs
@@ -5,11 +5,6 @@ namespace Server.Items;
 [SerializationGenerator(2, false)]
 public abstract partial class BaseGranite : Item
 {
-    [InvalidateProperties]
-    [SerializableField(0)]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    private CraftResource _resource;
-
     public BaseGranite(CraftResource resource) : base(0x1779)
     {
         Hue = CraftResources.GetHue(resource);
@@ -19,6 +14,24 @@ public abstract partial class BaseGranite : Item
     }
 
     public override double DefaultWeight => Core.ML ? 1.0 : 10.0;
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
+    }
 
     public override int LabelNumber => 1044607; // high quality granite
 

--- a/Projects/UOContent/Items/Resources/Masonry/Granite.cs
+++ b/Projects/UOContent/Items/Resources/Masonry/Granite.cs
@@ -15,8 +15,8 @@ public abstract partial class BaseGranite : Item
 
     public override double DefaultWeight => Core.ML ? 1.0 : 10.0;
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Resources/Tailor/Hides.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Hides.cs
@@ -1,15 +1,11 @@
 using ModernUO.Serialization;
+using Server.Engines.Craft;
 
 namespace Server.Items;
 
 [SerializationGenerator(2, false)]
 public abstract partial class BaseHides : Item, ICommodity
 {
-    [InvalidateProperties]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    [SerializableField(0)]
-    private CraftResource _resource;
-
     public BaseHides(CraftResource resource, int amount = 1) : base(0x1079)
     {
         Stackable = true;
@@ -18,6 +14,24 @@ public abstract partial class BaseHides : Item, ICommodity
         Hue = CraftResources.GetHue(resource);
 
         _resource = resource;
+    }
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
     }
 
     public override int LabelNumber

--- a/Projects/UOContent/Items/Resources/Tailor/Hides.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Hides.cs
@@ -16,8 +16,8 @@ public abstract partial class BaseHides : Item, ICommodity
         _resource = resource;
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
@@ -5,11 +5,6 @@ namespace Server.Items;
 [SerializationGenerator(2, false)]
 public abstract partial class BaseLeather : Item, ICommodity
 {
-    [InvalidateProperties]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    [SerializableField(0)]
-    private CraftResource _resource;
-
     public BaseLeather(CraftResource resource, int amount = 1) : base(0x1081)
     {
         Stackable = true;
@@ -18,6 +13,24 @@ public abstract partial class BaseLeather : Item, ICommodity
         Hue = CraftResources.GetHue(resource);
 
         _resource = resource;
+    }
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
     }
 
     public override int LabelNumber

--- a/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
@@ -15,8 +15,8 @@ public abstract partial class BaseLeather : Item, ICommodity
         _resource = resource;
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Skill Items/Carpenter Items/Board.cs
+++ b/Projects/UOContent/Items/Skill Items/Carpenter Items/Board.cs
@@ -6,10 +6,6 @@ namespace Server.Items;
 [SerializationGenerator(4, false)]
 public partial class Board : Item, ICommodity
 {
-    [InvalidateProperties]
-    [SerializableField(0)]
-    private CraftResource _resource;
-
     [Constructible]
     public Board(int amount = 1) : this(CraftResource.RegularWood, amount)
     {
@@ -23,6 +19,24 @@ public partial class Board : Item, ICommodity
 
         _resource = resource;
         Hue = CraftResources.GetHue(resource);
+    }
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
     }
 
     int ICommodity.DescriptionNumber

--- a/Projects/UOContent/Items/Skill Items/Carpenter Items/Board.cs
+++ b/Projects/UOContent/Items/Skill Items/Carpenter Items/Board.cs
@@ -21,8 +21,8 @@ public partial class Board : Item, ICommodity
         Hue = CraftResources.GetHue(resource);
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Skill Items/Fishing/Misc/MessageInABottle.cs
+++ b/Projects/UOContent/Items/Skill Items/Fishing/Misc/MessageInABottle.cs
@@ -24,8 +24,8 @@ public partial class MessageInABottle : Item
 
     public override int LabelNumber => 1041080; // a message in a bottle
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public int Level
     {
         get => _level;

--- a/Projects/UOContent/Items/Skill Items/Fishing/Misc/SOS.cs
+++ b/Projects/UOContent/Items/Skill Items/Fishing/Misc/SOS.cs
@@ -103,8 +103,8 @@ public partial class SOS : Item
     [CommandProperty(AccessLevel.GameMaster)]
     public bool IsAncient => _level >= 4;
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public int Level
     {
         get => _level;

--- a/Projects/UOContent/Items/Skill Items/Lumberjack/Log.cs
+++ b/Projects/UOContent/Items/Skill Items/Lumberjack/Log.cs
@@ -6,11 +6,6 @@ namespace Server.Items;
 [Flippable(0x1bdd, 0x1be0)]
 public partial class Log : Item, ICommodity, IAxe
 {
-    [InvalidateProperties]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    [SerializableField(0)]
-    private CraftResource _resource;
-
     [Constructible]
     public Log(int amount = 1) : this(CraftResource.RegularWood, amount)
     {
@@ -30,6 +25,24 @@ public partial class Log : Item, ICommodity, IAxe
 
         _resource = resource;
         Hue = CraftResources.GetHue(resource);
+    }
+
+    [CommandProperty(AccessLevel.GameMaster)]
+    [SerializableProperty(0)]
+    public CraftResource Resource
+    {
+        get => _resource;
+        set
+        {
+            if (_resource != value)
+            {
+                _resource = value;
+                Hue = CraftResources.GetHue(value);
+
+                InvalidateProperties();
+                this.MarkDirty();
+            }
+        }
     }
 
     public virtual bool Axe(Mobile from, BaseAxe axe) => TryCreateBoards(from, 0, new Board());

--- a/Projects/UOContent/Items/Skill Items/Lumberjack/Log.cs
+++ b/Projects/UOContent/Items/Skill Items/Lumberjack/Log.cs
@@ -27,8 +27,8 @@ public partial class Log : Item, ICommodity, IAxe
         Hue = CraftResources.GetHue(resource);
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
         get => _resource;

--- a/Projects/UOContent/Items/Special/MiniHouses.cs
+++ b/Projects/UOContent/Items/Special/MiniHouses.cs
@@ -14,8 +14,8 @@ public partial class MiniHouseAddon : BaseAddon
         Construct();
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(0)]
+    [CommandProperty(AccessLevel.GameMaster)]
     public MiniHouseType Type
     {
         get => _type;


### PR DESCRIPTION
### Summary

- Fixes resource commodities so the hue changes when setting the resource
- Fixes some commodities not being able to be modified in-game.