### PR TITLE
fix: Fixes timers not stopping before OnTick

### DIFF
--- a/Projects/Server/Timer/Timer.TimerWheel.cs
+++ b/Projects/Server/Timer/Timer.TimerWheel.cs
@@ -151,17 +151,14 @@ public partial class Timer
         prof?.Finish();
 
         // If the timer has been altered (restarted, returned etc) then bail
-        if (timer.Version != version)
+        if (finished || timer.Version != version)
         {
             return;
         }
 
-        if (!finished)
-        {
-            timer.Delay = timer.Interval;
-            timer.Next = DateTime.UtcNow + timer.Interval;
-            AddTimer(timer, (long)timer.Delay.TotalMilliseconds);
-        }
+        timer.Delay = timer.Interval;
+        timer.Next = DateTime.UtcNow + timer.Interval;
+        AddTimer(timer, (long)timer.Delay.TotalMilliseconds);
     }
 
     private static void AddTimer(Timer timer, long delay)

--- a/Projects/Server/Timer/Timer.cs
+++ b/Projects/Server/Timer/Timer.cs
@@ -153,21 +153,7 @@ public partial class Timer
 
         Running = false;
 
-        // We are the head on the timer ring
-        if (_rings[_ring][_slot] == this)
-        {
-            _rings[_ring][_slot] = _nextTimer;
-        }
-
-        // We are the head on the executing ring
-        if (_executingRings[_ring] == this)
-        {
-            _executingRings[_ring] = _nextTimer;
-        }
-
         Detach();
-
-        Version++;
         OnDetach();
 
         var prof = GetProfile();
@@ -175,6 +161,7 @@ public partial class Timer
         {
             prof.Stopped++;
         }
+        Version++;
     }
 
     protected virtual void OnTick()
@@ -213,6 +200,18 @@ public partial class Timer
 
     private void Detach()
     {
+        // We are the head on the timer ring
+        if (_rings[_ring][_slot] == this)
+        {
+            _rings[_ring][_slot] = _nextTimer;
+        }
+
+        // We are the head on the executing ring
+        if (_executingRings[_ring] == this)
+        {
+            _executingRings[_ring] = _nextTimer;
+        }
+
         if (_prevTimer != null)
         {
             _prevTimer._nextTimer = _nextTimer;

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -746,7 +746,7 @@ public static class Utility
     public static T RandomList<T>(params T[] list) => list.RandomElement();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T RandomElement<T>(this ReadOnlySpan<T> list) => list.Length == 0 ? (T)default : list[Random(list.Length)];
+    public static T RandomElement<T>(this ReadOnlySpan<T> list) => list.Length == 0 ? default : list[Random(list.Length)];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T RandomElement<T>(this T[] list) => list.RandomElement(default);


### PR DESCRIPTION
### Summary

Timers that have no more counts left are considered _Stopped_ (`Running` = `false`). This means that an OnTick that calls Start(), should start properly. GreenThorns uses this for it's multiple effect transitions.


### TODO

- [x] Test Explosion Potions and other classes that check for `timer.Running` during OnTick to make sure they function properly