### PR TITLE
CrimsonCinture add missing LabelNumber

### DIFF
--- a/Projects/UOContent/Items/Clothing/Artifacts/CrimsonCincture.cs
+++ b/Projects/UOContent/Items/Clothing/Artifacts/CrimsonCincture.cs
@@ -5,6 +5,8 @@ namespace Server.Items
     [SerializationGenerator(0, false)]
     public partial class CrimsonCincture : HalfApron
     {
+        public override int LabelNumber => 1075043; // Crimson Cincture
+
         [Constructible]
         public CrimsonCincture()
         {


### PR DESCRIPTION
Previously displayed as 'half apron'