### PR TITLE
fix: Changes IPAddress comparison to use UInt128

### DIFF
--- a/Projects/UOContent/Commands/AddonGenerator.cs
+++ b/Projects/UOContent/Commands/AddonGenerator.cs
@@ -174,7 +174,7 @@ public class AddonGenerator
 
         using var target = PooledRefList<Item>.Create();
 
-        foreach(Static s in map.GetItemsInBounds<Static>(bounds))
+        foreach (Static s in map.GetItemsInBounds<Static>(bounds))
         {
             if (!range || s.Z >= min && s.Z <= max)
             {
@@ -189,7 +189,7 @@ public class AddonGenerator
         }
 
         // Get correct bounds
-        foreach(Item item in target)
+        foreach (Item item in target)
         {
             if (item.Z < center.Z)
             {
@@ -241,7 +241,7 @@ public class AddonGenerator
             }
         }
 
-        foreach(Item item in target)
+        foreach (Item item in target)
         {
             int xOffset = item.X - center.X;
             int yOffset = item.Y - center.Y;

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleManagementGump.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleManagementGump.cs
@@ -324,17 +324,10 @@ public class HouseRaffleManagementGump : Gump
                 return 1;
             }
 
-            var a = x.Address.GetAddressBytes();
-            var b = y.Address.GetAddressBytes();
-
-            for (var i = 0; i < a.Length && i < b.Length; i++)
+            var addressCompare = x.Address.ToUInt128().CompareTo(y.Address.ToUInt128());
+            if (addressCompare != 0)
             {
-                var compare = a[i].CompareTo(b[i]);
-
-                if (compare != 0)
-                {
-                    return compare;
-                }
+                return addressCompare;
             }
 
             return x.Date.CompareTo(y.Date);


### PR DESCRIPTION
### Summary

House raffle (as an example) was comparing IP Addresses byte by byte to sort them on the gump. We recommend using the `ToUInt128` convenience to avoid memory allocations (40bytes), and because it is up to 3x faster.