### PR TITLE
fix: Fixes PooledRefList ToList returning wrong size

### DIFF
--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -419,7 +419,7 @@ public static class Utility
     // This requires copying the List, which is an O(n) operation.
     public static List<R> ToList<T, R>(this PooledRefList<T> poolList) where T : R
     {
-        var size = poolList._size;
+        var size = poolList.Count;
         var items = poolList._items;
 
         var list = new List<R>(size);
@@ -428,7 +428,7 @@ public static class Utility
             return list;
         }
 
-        for (var i = 0; i < items.Length; i++)
+        for (var i = 0; i < size; i++)
         {
             list.Add(items[i]);
         }

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -1274,7 +1274,10 @@ namespace Server.Gumps
                              i < 9 && index >= 0 && index < m_List.Count;
                              ++i, ++index)
                         {
-                            var a = (Account)m_List[index];
+                            if (m_List[index] is not Account a)
+                            {
+                                continue;
+                            }
 
                             var offset = 200 + i * 20;
 


### PR DESCRIPTION
### Summary

- Fixed a bug caused by a bad assumption. If `m_List[index]` is sparse and null values are casted, the server does not crash.
- Fixed a bug where `PooledRefList.ToList` extension method returned the wrong list size.