### PR TITLE
fix: Hair and facial hair "teleporting" when mobile dies several times

### DIFF
--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePackets.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/MobilePackets.cs
@@ -590,7 +590,7 @@ namespace Server.Tests.Network
                         itemID |= 0x8000;
                     }
 
-                    Stream.Write(HairInfo.FakeSerial(beheld.Serial));
+                    Stream.Write(beheld.Hair.VirtualSerial);
                     Stream.Write((ushort)itemID);
                     Stream.Write((byte)Layer.Hair);
 
@@ -621,7 +621,7 @@ namespace Server.Tests.Network
                         itemID |= 0x8000;
                     }
 
-                    Stream.Write(FacialHairInfo.FakeSerial(beheld.Serial));
+                    Stream.Write(beheld.FacialHair.VirtualSerial);
                     Stream.Write((ushort)itemID);
                     Stream.Write((byte)Layer.FacialHair);
 

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/VirtualHairPacketTests.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/VirtualHairPacketTests.cs
@@ -17,7 +17,7 @@ namespace Server.Tests
             var expected = new HairEquipUpdate(m).Compile();
 
             var ns = PacketTestUtilities.CreateTestNetState();
-            ns.SendHairEquipUpdatePacket(m, HairInfo.FakeSerial(m.Serial), m.HairItemID, m.HairHue, Layer.Hair);
+            ns.SendHairEquipUpdatePacket(m, (uint)m.Hair.VirtualSerial, m.Hair.ItemID, m.Hair.Hue, Layer.Hair);
 
             var result = ns.SendPipe.Reader.AvailableToRead();
             AssertThat.Equal(result, expected);
@@ -32,7 +32,7 @@ namespace Server.Tests
             var expected = new RemoveHair(m).Compile();
 
             var ns = PacketTestUtilities.CreateTestNetState();
-            ns.SendRemoveHairPacket(HairInfo.FakeSerial(m.Serial));
+            ns.SendRemoveHairPacket((uint) m.Hair.VirtualSerial);
 
             var result = ns.SendPipe.Reader.AvailableToRead();
             AssertThat.Equal(result, expected);

--- a/Projects/Server.Tests/Tests/Network/Packets/Outgoing/VirtualHairPackets.cs
+++ b/Projects/Server.Tests/Tests/Network/Packets/Outgoing/VirtualHairPackets.cs
@@ -7,7 +7,7 @@ namespace Server.Network
         {
             var hue = parent.SolidHueOverride >= 0 ? parent.SolidHueOverride : parent.HairHue;
 
-            Stream.Write(HairInfo.FakeSerial(parent.Serial));
+            Stream.Write(parent.Hair.VirtualSerial);
             Stream.Write((short)parent.HairItemID);
             Stream.Write((byte)0);
             Stream.Write((byte)Layer.Hair);
@@ -23,7 +23,7 @@ namespace Server.Network
         {
             var hue = parent.SolidHueOverride >= 0 ? parent.SolidHueOverride : parent.FacialHairHue;
 
-            Stream.Write(FacialHairInfo.FakeSerial(parent.Serial));
+            Stream.Write(parent.FacialHair.VirtualSerial);
             Stream.Write((short)parent.FacialHairItemID);
             Stream.Write((byte)0);
             Stream.Write((byte)Layer.FacialHair);
@@ -37,7 +37,7 @@ namespace Server.Network
         public RemoveHair(Mobile parent)
             : base(0x1D, 5)
         {
-            Stream.Write(HairInfo.FakeSerial(parent.Serial));
+            Stream.Write(parent.Hair.VirtualSerial);
         }
     }
 
@@ -46,7 +46,7 @@ namespace Server.Network
         public RemoveFacialHair(Mobile parent)
             : base(0x1D, 5)
         {
-            Stream.Write(FacialHairInfo.FakeSerial(parent.Serial));
+            Stream.Write(parent.FacialHair.VirtualSerial);
         }
     }
 }

--- a/Projects/Server/Items/VirtualHair.cs
+++ b/Projects/Server/Items/VirtualHair.cs
@@ -65,15 +65,16 @@ public static class OutgoingVirtualHairPackets
     }
 }
 
-public abstract class BaseHairInfo
+public abstract class BaseVirtualHairInfo
 {
-    protected BaseHairInfo(int itemid, int hue = 0)
+    protected BaseVirtualHairInfo(int itemid, int hue = 0)
     {
         ItemID = itemid;
         Hue = hue;
+        VirtualSerial = World.NewVirtual;
     }
 
-    protected BaseHairInfo(IGenericReader reader)
+    protected BaseVirtualHairInfo(IGenericReader reader)
     {
         var version = reader.ReadInt();
 
@@ -86,6 +87,8 @@ public abstract class BaseHairInfo
                     break;
                 }
         }
+
+        VirtualSerial = World.NewVirtual;
     }
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -100,48 +103,42 @@ public abstract class BaseHairInfo
         writer.Write(ItemID);
         writer.Write(Hue);
     }
+
+    public Serial VirtualSerial { get; private set; } = Serial.Zero;
 }
 
-public class HairInfo : BaseHairInfo
+public class VirtualHairInfo : BaseVirtualHairInfo
 {
-    public HairInfo(int itemid)
+    public VirtualHairInfo(int itemid)
         : base(itemid)
     {
     }
 
-    public HairInfo(int itemid, int hue)
+    public VirtualHairInfo(int itemid, int hue)
         : base(itemid, hue)
     {
     }
 
-    public HairInfo(IGenericReader reader)
+    public VirtualHairInfo(IGenericReader reader)
         : base(reader)
     {
     }
-
-    // TODO: Can we make this higher for newer clients?
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static uint FakeSerial(Serial m) => 0x7FFFFFFF - 0x400 - m.Value * 4;
 }
 
-public class FacialHairInfo : BaseHairInfo
+public class VirtualFacialHairInfo : BaseVirtualHairInfo
 {
-    public FacialHairInfo(int itemid)
+    public VirtualFacialHairInfo(int itemid)
         : base(itemid)
     {
     }
 
-    public FacialHairInfo(int itemid, int hue)
+    public VirtualFacialHairInfo(int itemid, int hue)
         : base(itemid, hue)
     {
     }
 
-    public FacialHairInfo(IGenericReader reader)
+    public VirtualFacialHairInfo(IGenericReader reader)
         : base(reader)
     {
     }
-
-    // TODO: Can we make this higher for newer clients?
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static uint FakeSerial(Serial m) => 0x7FFFFFFF - 0x400 - 1 - m.Value* 4;
 }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -187,7 +187,7 @@ public delegate bool AllowBeneficialHandler(Mobile from, Mobile target);
 public delegate bool AllowHarmfulHandler(Mobile from, Mobile target);
 
 public delegate Container CreateCorpseHandler(
-    Mobile from, HairInfo hair, FacialHairInfo facialhair, List<Item> initialContent, List<Item> equippedItems
+    Mobile from, VirtualHairInfo hair, VirtualFacialHairInfo facialhair, List<Item> initialContent, List<Item> equippedItems
 );
 
 public delegate int AOSStatusHandler(Mobile from, int index);
@@ -273,7 +273,11 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     private TimerExecutionToken _expireAggrTimerToken;
     private TimerExecutionToken _expireCombatantTimerToken;
     private TimerExecutionToken _expireCriminalTimerToken;
-    private FacialHairInfo m_FacialHair;
+    private VirtualFacialHairInfo m_FacialHair;
+    public VirtualFacialHairInfo FacialHair
+    {
+        get => m_FacialHair ??= new VirtualFacialHairInfo(FacialHairItemID, FacialHairHue);
+    }
     private int m_Fame, m_Karma;
     private bool m_Female, m_Warmode, m_Hidden, m_Blessed, m_Flying;
     private int m_Followers, m_FollowersMax;
@@ -282,7 +286,11 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     private BaseGuild m_Guild;
     private string m_GuildTitle;
 
-    private HairInfo m_Hair;
+    private VirtualHairInfo m_Hair;
+    public VirtualHairInfo Hair
+    {
+        get => m_Hair ??= new VirtualHairInfo(HairItemID, HairHue);
+    }
     private int m_Hits, m_Stam, m_Mana;
 
     private Item m_Holding;
@@ -2170,7 +2178,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         {
             if (m_Hair == null && value > 0)
             {
-                m_Hair = new HairInfo(value);
+                m_Hair = new VirtualHairInfo(value);
             }
             else if (value <= 0)
             {
@@ -2193,7 +2201,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         {
             if (m_FacialHair == null && value > 0)
             {
-                m_FacialHair = new FacialHairInfo(value);
+                m_FacialHair = new VirtualFacialHairInfo(value);
             }
             else if (value <= 0)
             {
@@ -2708,14 +2716,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             sendFacialHair = true;
         }
 
-        var hairSerial = HairInfo.FakeSerial(Serial);
+        var hairSerial = Hair.VirtualSerial;
         var hairLength = removeHair
             ? OutgoingVirtualHairPackets.RemovePacketLength
             : OutgoingVirtualHairPackets.EquipUpdatePacketLength;
 
         Span<byte> hairPacket = stackalloc byte[hairLength].InitializePacket();
 
-        var facialHairSerial = FacialHairInfo.FakeSerial(Serial);
+        var facialHairSerial = FacialHair.VirtualSerial;
         var facialHairLength = removeFacialHair
             ? OutgoingVirtualHairPackets.RemovePacketLength
             : OutgoingVirtualHairPackets.EquipUpdatePacketLength;
@@ -2806,14 +2814,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             {
                 if (removeHair)
                 {
-                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(hairPacket, hairSerial);
+                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(hairPacket, (uint)hairSerial);
                 }
                 else
                 {
                     OutgoingVirtualHairPackets.CreateHairEquipUpdatePacket(
                         hairPacket,
                         this,
-                        hairSerial,
+                        (uint)hairSerial,
                         HairItemID,
                         HairHue,
                         Layer.Hair
@@ -2827,14 +2835,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             {
                 if (removeFacialHair)
                 {
-                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(facialHairPacket, facialHairSerial);
+                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(facialHairPacket, (uint)facialHairSerial);
                 }
                 else
                 {
                     OutgoingVirtualHairPackets.CreateHairEquipUpdatePacket(
                         facialHairPacket,
                         this,
-                        facialHairSerial,
+                        (uint)facialHairSerial,
                         FacialHairItemID,
                         FacialHairHue,
                         Layer.FacialHair
@@ -2943,14 +2951,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             {
                 if (removeHair)
                 {
-                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(hairPacket, hairSerial);
+                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(hairPacket, (uint)hairSerial);
                 }
                 else
                 {
                     OutgoingVirtualHairPackets.CreateHairEquipUpdatePacket(
                         hairPacket,
                         this,
-                        hairSerial,
+                        (uint)hairSerial,
                         HairItemID,
                         HairHue,
                         Layer.Hair
@@ -2964,14 +2972,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             {
                 if (removeFacialHair)
                 {
-                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(facialHairPacket, facialHairSerial);
+                    OutgoingVirtualHairPackets.CreateRemoveHairPacket(facialHairPacket, (uint)facialHairSerial);
                 }
                 else
                 {
                     OutgoingVirtualHairPackets.CreateHairEquipUpdatePacket(
                         facialHairPacket,
                         this,
-                        facialHairSerial,
+                        (uint)facialHairSerial,
                         FacialHairItemID,
                         FacialHairHue,
                         Layer.FacialHair
@@ -4764,19 +4772,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             }
         }
 
-        HairInfo hair = null;
-        if (m_Hair != null)
-        {
-            hair = new HairInfo(m_Hair.ItemID, m_Hair.Hue);
-        }
-
-        FacialHairInfo facialhair = null;
-        if (m_FacialHair != null)
-        {
-            facialhair = new FacialHairInfo(m_FacialHair.ItemID, m_FacialHair.Hue);
-        }
-
-        var c = CreateCorpseHandler?.Invoke(this, hair, facialhair, content, equip);
+        var c = CreateCorpseHandler?.Invoke(this, Hair, FacialHair, content, equip);
 
         if (m_Map != null)
         {
@@ -6092,12 +6088,12 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                     if ((hairflag & 0x01) != 0)
                     {
-                        m_Hair = new HairInfo(reader);
+                        m_Hair = new VirtualHairInfo(reader);
                     }
 
                     if ((hairflag & 0x02) != 0)
                     {
-                        m_FacialHair = new FacialHairInfo(reader);
+                        m_FacialHair = new VirtualFacialHairInfo(reader);
                     }
 
                     goto case 29;

--- a/Projects/Server/Network/Packets/OutgoingMobilePackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingMobilePackets.cs
@@ -672,7 +672,7 @@ public static class OutgoingMobilePackets
                 itemID |= 0x8000;
             }
 
-            writer.Write(HairInfo.FakeSerial(beheld.Serial));
+            writer.Write(beheld.Hair.VirtualSerial);
             writer.Write((ushort)itemID);
             writer.Write((byte)Layer.Hair);
 
@@ -695,7 +695,7 @@ public static class OutgoingMobilePackets
                 itemID |= 0x8000;
             }
 
-            writer.Write(FacialHairInfo.FakeSerial(beheld.Serial));
+            writer.Write(beheld.FacialHair.VirtualSerial);
             writer.Write((ushort)itemID);
             writer.Write((byte)Layer.FacialHair);
 

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -419,7 +419,7 @@ public static class Utility
     // This requires copying the List, which is an O(n) operation.
     public static List<R> ToList<T, R>(this PooledRefList<T> poolList) where T : R
     {
-        var size = poolList._size;
+        var size = poolList.Count;
         var items = poolList._items;
 
         var list = new List<R>(size);
@@ -428,7 +428,7 @@ public static class Utility
             return list;
         }
 
-        for (var i = 0; i < items.Length; i++)
+        for (var i = 0; i < size; i++)
         {
             list.Add(items[i]);
         }

--- a/Projects/UOContent.Tests/Tests/Items/Misc/Corpses/Packets.cs
+++ b/Projects/UOContent.Tests/Tests/Items/Misc/Corpses/Packets.cs
@@ -38,13 +38,13 @@ public sealed class CorpseEquip : Packet
             if (beheld.Hair?.ItemID > 0)
             {
                 Stream.Write((byte)(Layer.Hair + 1));
-                Stream.Write(HairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                Stream.Write(beheld.Hair.VirtualSerial);
             }
 
             if (beheld.FacialHair?.ItemID > 0)
             {
                 Stream.Write((byte)(Layer.FacialHair + 1));
-                Stream.Write(FacialHairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                Stream.Write(beheld.FacialHair.VirtualSerial);
             }
 
             Stream.Write((byte)Layer.Invalid);
@@ -98,7 +98,7 @@ public sealed class CorpseContent : Packet
 
             if (beheld.Hair?.ItemID > 0)
             {
-                Stream.Write(HairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                Stream.Write(beheld.Hair.VirtualSerial);
                 Stream.Write((ushort)beheld.Hair.ItemID);
                 Stream.Write((byte)0); // signed, itemID offset
                 Stream.Write((ushort)1);
@@ -112,7 +112,7 @@ public sealed class CorpseContent : Packet
 
             if (beheld.FacialHair?.ItemID > 0)
             {
-                Stream.Write(FacialHairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                Stream.Write(beheld.FacialHair.VirtualSerial);
                 Stream.Write((ushort)beheld.FacialHair.ItemID);
                 Stream.Write((byte)0); // signed, itemID offset
                 Stream.Write((ushort)1);
@@ -177,7 +177,7 @@ public sealed class CorpseContent6017 : Packet
 
             if (beheld.Hair?.ItemID > 0)
             {
-                Stream.Write(HairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                Stream.Write(beheld.Hair.VirtualSerial);
                 Stream.Write((ushort)beheld.Hair.ItemID);
                 Stream.Write((byte)0); // signed, itemID offset
                 Stream.Write((ushort)1);
@@ -192,7 +192,7 @@ public sealed class CorpseContent6017 : Packet
 
             if (beheld.FacialHair?.ItemID > 0)
             {
-                Stream.Write(FacialHairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                Stream.Write(beheld.FacialHair.VirtualSerial);
                 Stream.Write((ushort)beheld.FacialHair.ItemID);
                 Stream.Write((byte)0); // signed, itemID offset
                 Stream.Write((ushort)1);

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Items/SchmendrickApprenticeCorpse.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Items/SchmendrickApprenticeCorpse.cs
@@ -51,17 +51,17 @@ public partial class SchmendrickApprenticeCorpse : Corpse
         new Spellbook()
     ];
 
-    private static HairInfo GetHair()
+    private static VirtualHairInfo GetHair()
     {
         _hairHue = Race.Human.RandomHairHue();
-        return new HairInfo(Race.Human.RandomHair(false), _hairHue);
+        return new VirtualHairInfo(Race.Human.RandomHair(false), _hairHue);
     }
 
-    private static FacialHairInfo GetFacialHair()
+    private static VirtualFacialHairInfo GetFacialHair()
     {
         _hairHue = Race.Human.RandomHairHue();
 
-        return new FacialHairInfo(Race.Human.RandomFacialHair(false), _hairHue);
+        return new VirtualFacialHairInfo(Race.Human.RandomFacialHair(false), _hairHue);
     }
 
     public override void AddNameProperty(IPropertyList list)

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Mobiles/MilitiaFighter.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Mobiles/MilitiaFighter.cs
@@ -84,7 +84,7 @@ public partial class MilitiaFighter : BaseCreature
 [SerializationGenerator(0, false)]
 public partial class MilitiaFighterCorpse : Corpse
 {
-    public MilitiaFighterCorpse(Mobile owner, HairInfo hair, FacialHairInfo facialhair, List<Item> equipItems) : base(
+    public MilitiaFighterCorpse(Mobile owner, VirtualHairInfo hair, VirtualFacialHairInfo facialhair, List<Item> equipItems) : base(
         owner,
         hair,
         facialhair,

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -1274,7 +1274,10 @@ namespace Server.Gumps
                              i < 9 && index >= 0 && index < m_List.Count;
                              ++i, ++index)
                         {
-                            var a = (Account)m_List[index];
+                            if (m_List[index] is not Account a)
+                            {
+                                continue;
+                            }
 
                             var offset = 200 + i * 20;
 

--- a/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
@@ -7,6 +7,7 @@ using Server.Engines.PartySystem;
 using Server.Engines.Quests.Doom;
 using Server.Engines.Quests.Haven;
 using Server.Guilds;
+using Server.Items.Misc.Corpses;
 using Server.Misc;
 using Server.Mobiles;
 using Server.Network;
@@ -64,7 +65,7 @@ public enum CorpseFlag
     SelfLooted = 0x00000080
 }
 
-[SerializationGenerator(13, false)]
+[SerializationGenerator(14, false)]
 public partial class Corpse : Container, ICarvable
 {
     public static readonly TimeSpan MonsterLootRightSacrifice = TimeSpan.FromMinutes(2.0);
@@ -132,6 +133,14 @@ public partial class Corpse : Container, ICarvable
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private List<Item> _equipItems;
 
+    [SerializableField(14, setter: "private")]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private CorpseHair _hair;
+
+    [SerializableField(15, setter: "private")]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private CorpseFacialHair _facialHair;
+
     // Why was this public?
     // public override bool IsPublicContainer => true;
 
@@ -139,7 +148,7 @@ public partial class Corpse : Container, ICarvable
     {
     }
 
-    public Corpse(Mobile owner, HairInfo hair, FacialHairInfo facialhair, List<Item> equipItems)
+    public Corpse(Mobile owner, VirtualHairInfo hair, VirtualFacialHairInfo facialHair, List<Item> equipItems)
         : base(0x2006)
     {
         // To suppress console warnings, stackable must be true
@@ -163,8 +172,8 @@ public partial class Corpse : Container, ICarvable
         _kills = owner.Kills;
         SetFlag(CorpseFlag.Criminal, owner.Criminal);
 
-        Hair = hair;
-        FacialHair = facialhair;
+        _hair = new CorpseHair(this, hair.ItemID, hair.Hue);
+        _facialHair = new CorpseFacialHair(this, facialHair.ItemID, facialHair.Hue);
 
         // This corpse does not turn to bones if: the owner is not a player
         SetFlag(CorpseFlag.NoBones, !owner.Player);
@@ -237,6 +246,28 @@ public partial class Corpse : Container, ICarvable
         DevourCorpse();
     }
 
+    // Added corpse hair and corpse facial hair
+    private void MigrateFrom(V13Content content)
+    {
+        _restoreEquip = content.RestoreEquip;
+        _flags = content.Flags;
+        _timeOfDeath = content.TimeOfDeath;
+        _restoreTable = content.RestoreTable;
+        _decayTimer = new InternalTimer(this, content.DecayTimerDelay);
+        _decayTimer.Start();
+        _looters = content.Looters;
+        _killer = content.Killer;
+        _aggressors = content.Aggressors;
+        _owner = content.Owner;
+        _corpseName = content.CorpseName;
+        _accessLevel = content.AccessLevel;
+        _guild = content.Guild;
+        _kills = content.Kills;
+        _equipItems = content.EquipItems;
+        _hair = new CorpseHair(this);
+        _facialHair = new CorpseFacialHair(this);
+    }
+
     [CommandProperty(AccessLevel.GameMaster)]
     public virtual bool InstancedCorpse => Core.SE && Core.Now < TimeOfDeath + InstancedCorpseTime;
 
@@ -247,10 +278,6 @@ public partial class Corpse : Container, ICarvable
     // Name of the first PlayerMobile who used Forensic Evaluation on the corpse
     [CommandProperty(AccessLevel.GameMaster)]
     public string Forensicist { get; set; }
-
-    public HairInfo Hair { get; }
-
-    public FacialHairInfo FacialHair { get; }
 
     [CommandProperty(AccessLevel.GameMaster)]
     public bool IsBones => GetFlag(CorpseFlag.IsBones);
@@ -493,7 +520,7 @@ public partial class Corpse : Container, ICarvable
     }
 
     public static Container Mobile_CreateCorpseHandler(
-        Mobile owner, HairInfo hair, FacialHairInfo facialhair,
+        Mobile owner, VirtualHairInfo hair, VirtualFacialHairInfo facialhair,
         List<Item> initialContent, List<Item> equipItems
     )
     {

--- a/Projects/UOContent/Items/Misc/Corpses/CorpseFacialHair.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/CorpseFacialHair.cs
@@ -1,0 +1,26 @@
+using ModernUO.Serialization;
+
+namespace Server.Items.Misc.Corpses;
+
+[SerializationGenerator(0, false)]
+public partial class CorpseFacialHair
+{
+    [SerializableField(0)]
+    int _itemID;
+
+    [SerializableField(1)]
+    int _hue;
+
+    [DirtyTrackingEntity]
+    public Corpse Owner { get; set; }
+
+    public CorpseFacialHair(Corpse owner, int itemID=0, int hue=0)
+    {
+        Owner = owner;
+        _itemID = itemID;
+        _hue = hue;
+        VirtualSerial = World.NewVirtual;
+    }
+
+    public Serial VirtualSerial { get; private set; } = Serial.Zero;
+}

--- a/Projects/UOContent/Items/Misc/Corpses/CorpseHair.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/CorpseHair.cs
@@ -1,0 +1,26 @@
+using ModernUO.Serialization;
+
+namespace Server.Items.Misc.Corpses;
+
+[SerializationGenerator(0, false)]
+public partial class CorpseHair
+{
+    [SerializableField(0)]
+    int _itemID;
+
+    [SerializableField(1)]
+    int _hue;
+
+    [DirtyTrackingEntity]
+    public Corpse Owner { get; set; }
+
+    public CorpseHair(Corpse owner, int itemID=0, int hue=0)
+    {
+        Owner = owner;
+        _itemID = itemID;
+        _hue = hue;
+        VirtualSerial = World.NewVirtual;
+    }
+
+    public Serial VirtualSerial { get; private set; } = Serial.Zero;
+}

--- a/Projects/UOContent/Items/Misc/Corpses/CorpsePackets.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/CorpsePackets.cs
@@ -52,13 +52,13 @@ public static class CorpsePackets
             if (beheld.Hair?.ItemID > 0)
             {
                 writer.Write((byte)(Layer.Hair + 1));
-                writer.Write(HairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                writer.Write(beheld.Hair.VirtualSerial);
             }
 
             if (beheld.FacialHair?.ItemID > 0)
             {
                 writer.Write((byte)(Layer.FacialHair + 1));
-                writer.Write(FacialHairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                writer.Write(beheld.FacialHair.VirtualSerial);
             }
         }
 
@@ -122,7 +122,7 @@ public static class CorpsePackets
         {
             if (hairItemID > 0)
             {
-                writer.Write(HairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                writer.Write(beheld.Hair.VirtualSerial);
                 writer.Write((ushort)hairItemID);
                 writer.Write((byte)0); // signed, itemID offset
                 writer.Write((ushort)1);
@@ -139,7 +139,7 @@ public static class CorpsePackets
 
             if (facialHairItemID > 0)
             {
-                writer.Write(FacialHairInfo.FakeSerial(beheld.Owner.Serial) - 2);
+                writer.Write(beheld.FacialHair.VirtualSerial);
                 writer.Write((ushort)facialHairItemID);
                 writer.Write((byte)0); // signed, itemID offset
                 writer.Write((ushort)1);


### PR DESCRIPTION
* Added World.NewVirtual for creating virtual serial numbers
* Reserved range 0x7EEEEEEE to 0x7FFFFFFF for virtual serials
* Hair and Facial hair (for mobiles) now use virtual serials instead of FakeSerial() functions
* Added CorpseHair and CorpseFacialHair, serializable types which Corpses create based on the virtual hair and facial hair of the mobile that died

Corpse hair and facial hair now persists across save/load and hair and facial hair no longer teleport to newest corpse.