### PR TITLE
fix: Converts ResurrectGump to Static/Dynamic Gumps

### DIFF
--- a/Projects/UOContent/Engines/Factions/Items/Power Faction Items/UrnOfAscension.cs
+++ b/Projects/UOContent/Engines/Factions/Items/Power Faction Items/UrnOfAscension.cs
@@ -35,7 +35,7 @@ public sealed partial class UrnOfAscension : PowerFactionItem
                 {
                     Faction.ClearSkillLoss(mob);
 
-                    mob.SendGump(new ResurrectGump(mob, from));
+                    mob.SendGump(new ResurrectGump(from));
                     used = true;
                 }
             }

--- a/Projects/UOContent/Engines/Virtues/Sacrifice.cs
+++ b/Projects/UOContent/Engines/Virtues/Sacrifice.cs
@@ -75,7 +75,7 @@ public static class SacrificeVirtue
                  * Sacrifice and cancel to have items in their backpack for free.
                  */
                 from.CloseGump<ResurrectGump>();
-                from.SendGump(new ResurrectGump(from, true));
+                from.SendGump(new ResurrectGump(from, fromSacrifice: true));
             }
             else
             {

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -1,6 +1,5 @@
 using System;
 using Server.Engines.Virtues;
-using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
 using Server.Network;
@@ -23,7 +22,7 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
     {
         builder.SetNoClose();
 
-        builder.AddPage(0);
+        builder.AddPage();
 
         builder.AddImage(0, 0, 3600);
 

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -1,0 +1,179 @@
+using Server.Engines.Virtues;
+using Server.Misc;
+using Server.Mobiles;
+using Server.Network;
+
+namespace Server.Gumps
+{
+    public class PricedResurrectGump : StaticGump<PricedResurrectGump>
+    {
+        private readonly Mobile m_Healer;
+        private readonly int m_Price;
+
+        public PricedResurrectGump(Mobile owner, Mobile healer, int price)
+            : base(150, 50)
+        {
+            m_Healer = healer;
+            m_Price = price;
+        }
+
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.SetNoClose();
+
+            builder.AddPage(0);
+
+            builder.AddImage(0, 0, 3600);
+
+            builder.AddImageTiled(0, 14, 15, 200, 3603);
+            builder.AddImageTiled(380, 14, 14, 200, 3605);
+
+            builder.AddImage(0, 201, 3606);
+
+            builder.AddImageTiled(15, 201, 370, 16, 3607);
+            builder.AddImageTiled(15, 0, 370, 16, 3601);
+
+            builder.AddImage(380, 0, 3602);
+
+            builder.AddImage(380, 201, 3608);
+
+            builder.AddImageTiled(15, 15, 365, 190, 2624);
+
+            builder.AddRadio(30, 140, 9727, 9730, true, 1);
+            builder.AddHtmlLocalized(65, 145, 300, 25, 1060015, 0x7FFF); // Grudgingly pay the money
+
+            builder.AddRadio(30, 175, 9727, 9730, false, 0);
+            builder.AddHtmlLocalized(65, 178, 300, 25, 1060016, 0x7FFF); // I'd rather stay dead, you scoundrel!!!
+
+            // Wishing to rejoin the living, are you?  I can restore your body... for a price of course...
+            builder.AddHtmlLocalized(30, 20, 360, 35, 1060017, 0x7FFF);
+
+            // Do you accept the fee, which will be withdrawn from your bank?
+            builder.AddHtmlLocalized(30, 105, 345, 40, 1060018, 0x5B2D);
+
+            builder.AddImage(65, 72, 5605);
+
+            builder.AddImageTiled(80, 90, 200, 1, 9107);
+            builder.AddImageTiled(95, 92, 200, 1, 9157);
+
+            builder.AddLabel(90, 70, 1645, m_Price.ToString());
+            builder.AddHtmlLocalized(140, 70, 100, 25, 1023823, 0x7FFF); // gold coins
+
+            builder.AddButton(290, 175, 247, 248, 2);
+
+            builder.AddImageTiled(15, 14, 365, 1, 9107);
+            builder.AddImageTiled(380, 14, 1, 190, 9105);
+            builder.AddImageTiled(15, 205, 365, 1, 9107);
+            builder.AddImageTiled(15, 14, 1, 190, 9105);
+            builder.AddImageTiled(0, 0, 395, 1, 9157);
+            builder.AddImageTiled(394, 0, 1, 217, 9155);
+            builder.AddImageTiled(0, 216, 395, 1, 9157);
+            builder.AddImageTiled(0, 0, 1, 217, 9155);
+        }
+
+        public override void OnResponse(NetState state, in RelayInfo info)
+        {
+            var from = state.Mobile;
+
+            from.CloseGump<ResurrectGump>();
+
+            if (info.ButtonID != 1 && info.ButtonID != 2)
+            {
+                return;
+            }
+
+            if (from.Map?.CanFit(from.Location, 16, false, false) != true)
+            {
+                from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
+                return;
+            }
+
+            if (info.IsSwitched(1))
+            {
+                if (Banker.Withdraw(from, m_Price))
+                {
+                    // ~1_AMOUNT~ gold has been withdrawn from your bank box.
+                    from.SendLocalizedMessage(1060398, m_Price.ToString());
+
+                    // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
+                    from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
+                }
+                else
+                {
+                    // Unfortunately, you do not have enough cash in your bank to cover the cost of the healing.
+                    from.SendLocalizedMessage(1060020);
+                    return;
+                }
+            }
+            else
+            {
+                from.SendLocalizedMessage(1060019); // You decide against paying the healer, and thus remain dead.
+                return;
+            }
+
+            from.PlaySound(0x214);
+            from.FixedEffect(0x376A, 10, 16);
+
+            from.Resurrect();
+
+            if (m_Healer != null && from != m_Healer)
+            {
+                var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
+
+                from.Hits = level switch
+                {
+                    VirtueLevel.Seeker   => AOS.Scale(from.HitsMax, 20),
+                    VirtueLevel.Follower => AOS.Scale(from.HitsMax, 40),
+                    VirtueLevel.Knight   => AOS.Scale(from.HitsMax, 80),
+                    _                    => from.Hits
+                };
+            }
+
+            var player = from as PlayerMobile;
+
+            if (from.Fame > 0)
+            {
+                var amount = from.Fame / 10;
+
+                Titles.AwardFame(from, -amount, true);
+            }
+
+            if (!Core.AOS && player?.ShortTermMurders >= 5)
+            {
+                var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
+
+                if (loss < 0.85)
+                {
+                    loss = 0.85;
+                }
+                else if (loss > 0.95)
+                {
+                    loss = 0.95;
+                }
+
+                if (from.RawStr * loss > 10)
+                {
+                    from.RawStr = (int)(from.RawStr * loss);
+                }
+
+                if (from.RawInt * loss > 10)
+                {
+                    from.RawInt = (int)(from.RawInt * loss);
+                }
+
+                if (from.RawDex * loss > 10)
+                {
+                    from.RawDex = (int)(from.RawDex * loss);
+                }
+
+                for (var s = 0; s < from.Skills.Length; s++)
+                {
+                    if (from.Skills[s].Base * loss > 35)
+                    {
+                        from.Skills[s].Base *= loss;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -138,16 +138,7 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 
         if (!Core.AOS && player?.ShortTermMurders >= 5)
         {
-            var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
-
-            if (loss < 0.85)
-            {
-                loss = 0.85;
-            }
-            else if (loss > 0.95)
-            {
-                loss = 0.95;
-            }
+            var loss = Math.Clamp((100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0, 0.85, 0.95); // 5 to 15% loss
 
             if (from.RawStr * loss > 10)
             {

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -77,12 +77,12 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 
     public override void OnResponse(NetState state, in RelayInfo info)
     {
-        var from = state.Mobile;
-
         if (info.ButtonID is not 1 and not 2)
         {
             return;
         }
+
+        var from = state.Mobile;
 
         if (from.Map?.CanFit(from.Location, 16, false, false) != true)
         {

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -79,7 +79,7 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
     {
         var from = state.Mobile;
 
-        if (info.ButtonID != 1 && info.ButtonID != 2)
+        if (info.ButtonID is not 1 and not 2)
         {
             return;
         }

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Engines.Virtues;
 using Server.Misc;
 using Server.Mobiles;

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -75,8 +75,6 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
     {
         var from = state.Mobile;
 
-        from.CloseGump<PricedResurrectGump>();
-
         if (info.ButtonID != 1 && info.ButtonID != 2)
         {
             return;

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -8,14 +8,14 @@ namespace Server.Gumps;
 
 public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 {
-    private readonly Mobile m_Healer;
-    private readonly int m_Price;
+    private readonly Mobile _healer;
+    private readonly int _price;
 
     public PricedResurrectGump(Mobile owner, Mobile healer, int price)
         : base(150, 50)
     {
-        m_Healer = healer;
-        m_Price = price;
+        _healer = healer;
+        _price = price;
     }
 
     protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -57,7 +57,7 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
         builder.AddImageTiled(80, 90, 200, 1, 9107);
         builder.AddImageTiled(95, 92, 200, 1, 9157);
 
-        builder.AddLabel(90, 70, 1645, m_Price.ToString());
+        builder.AddLabel(90, 70, 1645, _price.ToString());
         builder.AddHtmlLocalized(140, 70, 100, 25, 1023823, 0x7FFF); // gold coins
 
         builder.AddButton(290, 175, 247, 248, 2);
@@ -89,10 +89,10 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 
         if (info.IsSwitched(1))
         {
-            if (Banker.Withdraw(from, m_Price))
+            if (Banker.Withdraw(from, _price))
             {
                 // ~1_AMOUNT~ gold has been withdrawn from your bank box.
-                from.SendLocalizedMessage(1060398, m_Price.ToString());
+                from.SendLocalizedMessage(1060398, _price.ToString());
 
                 // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
                 from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
@@ -115,9 +115,9 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 
         from.Resurrect();
 
-        if (m_Healer != null && from != m_Healer)
+        if (_healer != null && from != _healer)
         {
-            var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
+            var level = VirtueSystem.GetLevel(_healer, VirtueName.Compassion);
 
             from.Hits = level switch
             {

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -1,5 +1,6 @@
 using System;
 using Server.Engines.Virtues;
+using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
 using Server.Network;
@@ -57,7 +58,7 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
         builder.AddImageTiled(80, 90, 200, 1, 9107);
         builder.AddImageTiled(95, 92, 200, 1, 9157);
 
-        builder.AddLabel(90, 70, 1645, _price.ToString());
+        builder.AddLabelPlaceholder(90, 70, 1645, "resurrectionPrice");
         builder.AddHtmlLocalized(140, 70, 100, 25, 1023823, 0x7FFF); // gold coins
 
         builder.AddButton(290, 175, 247, 248, 2);
@@ -70,6 +71,11 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
         builder.AddImageTiled(394, 0, 1, 217, 9155);
         builder.AddImageTiled(0, 216, 395, 1, 9157);
         builder.AddImageTiled(0, 0, 1, 217, 9155);
+    }
+
+    protected override void BuildStrings(ref GumpStringsBuilder builder)
+    {
+        builder.SetStringSlot("resurrectionPrice", $"{_price}");
     }
 
     public override void OnResponse(NetState state, in RelayInfo info)

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -75,7 +75,7 @@ namespace Server.Gumps
         {
             var from = state.Mobile;
 
-            from.CloseGump<ResurrectGump>();
+            from.CloseGump<PricedResurrectGump>();
 
             if (info.ButtonID != 1 && info.ButtonID != 2)
             {

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -1,4 +1,3 @@
-using System;
 using Server.Engines.Virtues;
 using Server.Misc;
 using Server.Mobiles;
@@ -11,8 +10,7 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
     private readonly Mobile _healer;
     private readonly int _price;
 
-    public PricedResurrectGump(Mobile owner, Mobile healer, int price)
-        : base(150, 50)
+    public PricedResurrectGump(Mobile healer, int price) : base(150, 50)
     {
         _healer = healer;
         _price = price;
@@ -92,26 +90,24 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
             return;
         }
 
-        if (info.IsSwitched(1))
+        if (!info.IsSwitched(1))
         {
-            if (Banker.Withdraw(from, _price))
-            {
-                // ~1_AMOUNT~ gold has been withdrawn from your bank box.
-                from.SendLocalizedMessage(1060398, _price.ToString());
+            from.SendLocalizedMessage(1060019); // You decide against paying the healer, and thus remain dead.
+            return;
+        }
 
-                // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
-                from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
-            }
-            else
-            {
-                // Unfortunately, you do not have enough cash in your bank to cover the cost of the healing.
-                from.SendLocalizedMessage(1060020);
-                return;
-            }
+        if (Banker.Withdraw(from, _price))
+        {
+            // ~1_AMOUNT~ gold has been withdrawn from your bank box.
+            from.SendLocalizedMessage(1060398, _price.ToString());
+
+            // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
+            from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
         }
         else
         {
-            from.SendLocalizedMessage(1060019); // You decide against paying the healer, and thus remain dead.
+            // Unfortunately, you do not have enough cash in your bank to cover the cost of the healing.
+            from.SendLocalizedMessage(1060020);
             return;
         }
 
@@ -133,8 +129,6 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
             };
         }
 
-        var player = from as PlayerMobile;
-
         if (from.Fame > 0)
         {
             var amount = from.Fame / 10;
@@ -142,32 +136,9 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
             Titles.AwardFame(from, -amount, true);
         }
 
-        if (!Core.AOS && player?.ShortTermMurders >= 5)
+        if (from is PlayerMobile player)
         {
-            var loss = Math.Clamp((100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0, 0.85, 0.95); // 5 to 15% loss
-
-            if (from.RawStr * loss > 10)
-            {
-                from.RawStr = (int)(from.RawStr * loss);
-            }
-
-            if (from.RawInt * loss > 10)
-            {
-                from.RawInt = (int)(from.RawInt * loss);
-            }
-
-            if (from.RawDex * loss > 10)
-            {
-                from.RawDex = (int)(from.RawDex * loss);
-            }
-
-            for (var s = 0; s < from.Skills.Length; s++)
-            {
-                if (from.Skills[s].Base * loss > 35)
-                {
-                    from.Skills[s].Base *= loss;
-                }
-            }
+            ResurrectGump.TryGiveStatLoss(player);
         }
     }
 }

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -3,175 +3,174 @@ using Server.Misc;
 using Server.Mobiles;
 using Server.Network;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 {
-    public class PricedResurrectGump : StaticGump<PricedResurrectGump>
+    private readonly Mobile m_Healer;
+    private readonly int m_Price;
+
+    public PricedResurrectGump(Mobile owner, Mobile healer, int price)
+        : base(150, 50)
     {
-        private readonly Mobile m_Healer;
-        private readonly int m_Price;
+        m_Healer = healer;
+        m_Price = price;
+    }
 
-        public PricedResurrectGump(Mobile owner, Mobile healer, int price)
-            : base(150, 50)
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.SetNoClose();
+
+        builder.AddPage(0);
+
+        builder.AddImage(0, 0, 3600);
+
+        builder.AddImageTiled(0, 14, 15, 200, 3603);
+        builder.AddImageTiled(380, 14, 14, 200, 3605);
+
+        builder.AddImage(0, 201, 3606);
+
+        builder.AddImageTiled(15, 201, 370, 16, 3607);
+        builder.AddImageTiled(15, 0, 370, 16, 3601);
+
+        builder.AddImage(380, 0, 3602);
+
+        builder.AddImage(380, 201, 3608);
+
+        builder.AddImageTiled(15, 15, 365, 190, 2624);
+
+        builder.AddRadio(30, 140, 9727, 9730, true, 1);
+        builder.AddHtmlLocalized(65, 145, 300, 25, 1060015, 0x7FFF); // Grudgingly pay the money
+
+        builder.AddRadio(30, 175, 9727, 9730, false, 0);
+        builder.AddHtmlLocalized(65, 178, 300, 25, 1060016, 0x7FFF); // I'd rather stay dead, you scoundrel!!!
+
+        // Wishing to rejoin the living, are you?  I can restore your body... for a price of course...
+        builder.AddHtmlLocalized(30, 20, 360, 35, 1060017, 0x7FFF);
+
+        // Do you accept the fee, which will be withdrawn from your bank?
+        builder.AddHtmlLocalized(30, 105, 345, 40, 1060018, 0x5B2D);
+
+        builder.AddImage(65, 72, 5605);
+
+        builder.AddImageTiled(80, 90, 200, 1, 9107);
+        builder.AddImageTiled(95, 92, 200, 1, 9157);
+
+        builder.AddLabel(90, 70, 1645, m_Price.ToString());
+        builder.AddHtmlLocalized(140, 70, 100, 25, 1023823, 0x7FFF); // gold coins
+
+        builder.AddButton(290, 175, 247, 248, 2);
+
+        builder.AddImageTiled(15, 14, 365, 1, 9107);
+        builder.AddImageTiled(380, 14, 1, 190, 9105);
+        builder.AddImageTiled(15, 205, 365, 1, 9107);
+        builder.AddImageTiled(15, 14, 1, 190, 9105);
+        builder.AddImageTiled(0, 0, 395, 1, 9157);
+        builder.AddImageTiled(394, 0, 1, 217, 9155);
+        builder.AddImageTiled(0, 216, 395, 1, 9157);
+        builder.AddImageTiled(0, 0, 1, 217, 9155);
+    }
+
+    public override void OnResponse(NetState state, in RelayInfo info)
+    {
+        var from = state.Mobile;
+
+        from.CloseGump<PricedResurrectGump>();
+
+        if (info.ButtonID != 1 && info.ButtonID != 2)
         {
-            m_Healer = healer;
-            m_Price = price;
+            return;
         }
 
-        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        if (from.Map?.CanFit(from.Location, 16, false, false) != true)
         {
-            builder.SetNoClose();
-
-            builder.AddPage(0);
-
-            builder.AddImage(0, 0, 3600);
-
-            builder.AddImageTiled(0, 14, 15, 200, 3603);
-            builder.AddImageTiled(380, 14, 14, 200, 3605);
-
-            builder.AddImage(0, 201, 3606);
-
-            builder.AddImageTiled(15, 201, 370, 16, 3607);
-            builder.AddImageTiled(15, 0, 370, 16, 3601);
-
-            builder.AddImage(380, 0, 3602);
-
-            builder.AddImage(380, 201, 3608);
-
-            builder.AddImageTiled(15, 15, 365, 190, 2624);
-
-            builder.AddRadio(30, 140, 9727, 9730, true, 1);
-            builder.AddHtmlLocalized(65, 145, 300, 25, 1060015, 0x7FFF); // Grudgingly pay the money
-
-            builder.AddRadio(30, 175, 9727, 9730, false, 0);
-            builder.AddHtmlLocalized(65, 178, 300, 25, 1060016, 0x7FFF); // I'd rather stay dead, you scoundrel!!!
-
-            // Wishing to rejoin the living, are you?  I can restore your body... for a price of course...
-            builder.AddHtmlLocalized(30, 20, 360, 35, 1060017, 0x7FFF);
-
-            // Do you accept the fee, which will be withdrawn from your bank?
-            builder.AddHtmlLocalized(30, 105, 345, 40, 1060018, 0x5B2D);
-
-            builder.AddImage(65, 72, 5605);
-
-            builder.AddImageTiled(80, 90, 200, 1, 9107);
-            builder.AddImageTiled(95, 92, 200, 1, 9157);
-
-            builder.AddLabel(90, 70, 1645, m_Price.ToString());
-            builder.AddHtmlLocalized(140, 70, 100, 25, 1023823, 0x7FFF); // gold coins
-
-            builder.AddButton(290, 175, 247, 248, 2);
-
-            builder.AddImageTiled(15, 14, 365, 1, 9107);
-            builder.AddImageTiled(380, 14, 1, 190, 9105);
-            builder.AddImageTiled(15, 205, 365, 1, 9107);
-            builder.AddImageTiled(15, 14, 1, 190, 9105);
-            builder.AddImageTiled(0, 0, 395, 1, 9157);
-            builder.AddImageTiled(394, 0, 1, 217, 9155);
-            builder.AddImageTiled(0, 216, 395, 1, 9157);
-            builder.AddImageTiled(0, 0, 1, 217, 9155);
+            from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
+            return;
         }
 
-        public override void OnResponse(NetState state, in RelayInfo info)
+        if (info.IsSwitched(1))
         {
-            var from = state.Mobile;
-
-            from.CloseGump<PricedResurrectGump>();
-
-            if (info.ButtonID != 1 && info.ButtonID != 2)
+            if (Banker.Withdraw(from, m_Price))
             {
-                return;
-            }
+                // ~1_AMOUNT~ gold has been withdrawn from your bank box.
+                from.SendLocalizedMessage(1060398, m_Price.ToString());
 
-            if (from.Map?.CanFit(from.Location, 16, false, false) != true)
-            {
-                from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
-                return;
-            }
-
-            if (info.IsSwitched(1))
-            {
-                if (Banker.Withdraw(from, m_Price))
-                {
-                    // ~1_AMOUNT~ gold has been withdrawn from your bank box.
-                    from.SendLocalizedMessage(1060398, m_Price.ToString());
-
-                    // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
-                    from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
-                }
-                else
-                {
-                    // Unfortunately, you do not have enough cash in your bank to cover the cost of the healing.
-                    from.SendLocalizedMessage(1060020);
-                    return;
-                }
+                // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
+                from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
             }
             else
             {
-                from.SendLocalizedMessage(1060019); // You decide against paying the healer, and thus remain dead.
+                // Unfortunately, you do not have enough cash in your bank to cover the cost of the healing.
+                from.SendLocalizedMessage(1060020);
                 return;
             }
+        }
+        else
+        {
+            from.SendLocalizedMessage(1060019); // You decide against paying the healer, and thus remain dead.
+            return;
+        }
 
-            from.PlaySound(0x214);
-            from.FixedEffect(0x376A, 10, 16);
+        from.PlaySound(0x214);
+        from.FixedEffect(0x376A, 10, 16);
 
-            from.Resurrect();
+        from.Resurrect();
 
-            if (m_Healer != null && from != m_Healer)
+        if (m_Healer != null && from != m_Healer)
+        {
+            var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
+
+            from.Hits = level switch
             {
-                var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
+                VirtueLevel.Seeker   => AOS.Scale(from.HitsMax, 20),
+                VirtueLevel.Follower => AOS.Scale(from.HitsMax, 40),
+                VirtueLevel.Knight   => AOS.Scale(from.HitsMax, 80),
+                _                    => from.Hits
+            };
+        }
 
-                from.Hits = level switch
-                {
-                    VirtueLevel.Seeker   => AOS.Scale(from.HitsMax, 20),
-                    VirtueLevel.Follower => AOS.Scale(from.HitsMax, 40),
-                    VirtueLevel.Knight   => AOS.Scale(from.HitsMax, 80),
-                    _                    => from.Hits
-                };
+        var player = from as PlayerMobile;
+
+        if (from.Fame > 0)
+        {
+            var amount = from.Fame / 10;
+
+            Titles.AwardFame(from, -amount, true);
+        }
+
+        if (!Core.AOS && player?.ShortTermMurders >= 5)
+        {
+            var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
+
+            if (loss < 0.85)
+            {
+                loss = 0.85;
+            }
+            else if (loss > 0.95)
+            {
+                loss = 0.95;
             }
 
-            var player = from as PlayerMobile;
-
-            if (from.Fame > 0)
+            if (from.RawStr * loss > 10)
             {
-                var amount = from.Fame / 10;
-
-                Titles.AwardFame(from, -amount, true);
+                from.RawStr = (int)(from.RawStr * loss);
             }
 
-            if (!Core.AOS && player?.ShortTermMurders >= 5)
+            if (from.RawInt * loss > 10)
             {
-                var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
+                from.RawInt = (int)(from.RawInt * loss);
+            }
 
-                if (loss < 0.85)
-                {
-                    loss = 0.85;
-                }
-                else if (loss > 0.95)
-                {
-                    loss = 0.95;
-                }
+            if (from.RawDex * loss > 10)
+            {
+                from.RawDex = (int)(from.RawDex * loss);
+            }
 
-                if (from.RawStr * loss > 10)
+            for (var s = 0; s < from.Skills.Length; s++)
+            {
+                if (from.Skills[s].Base * loss > 35)
                 {
-                    from.RawStr = (int)(from.RawStr * loss);
-                }
-
-                if (from.RawInt * loss > 10)
-                {
-                    from.RawInt = (int)(from.RawInt * loss);
-                }
-
-                if (from.RawDex * loss > 10)
-                {
-                    from.RawDex = (int)(from.RawDex * loss);
-                }
-
-                for (var s = 0; s < from.Skills.Length; s++)
-                {
-                    if (from.Skills[s].Base * loss > 35)
-                    {
-                        from.Skills[s].Base *= loss;
-                    }
+                    from.Skills[s].Base *= loss;
                 }
             }
         }

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -14,7 +14,7 @@ public enum ResurrectMessage
     Generic = 3
 }
 
-public class ResurrectGump : StaticGump<ResurrectGump>
+public class ResurrectGump : DynamicGump
 {
     private readonly bool _fromSacrifice;
     private readonly Mobile _healer;
@@ -46,7 +46,7 @@ public class ResurrectGump : StaticGump<ResurrectGump>
         _resurrectMessage = msg;
     }
 
-    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
     {
         builder.AddPage(0);
 

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -48,7 +48,7 @@ public class ResurrectGump : DynamicGump
 
     protected override void BuildLayout(ref DynamicGumpBuilder builder)
     {
-        builder.AddPage(0);
+        builder.AddPage();
 
         builder.AddBackground(0, 0, 400, 350, 2600);
 

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -100,12 +100,12 @@ public class ResurrectGump : DynamicGump
 
     public override void OnResponse(NetState state, in RelayInfo info)
     {
-        var from = state.Mobile;
-
         if (info.ButtonID is not 1 and not 2)
         {
             return;
         }
+
+        var from = state.Mobile;
 
         if (from.Map?.CanFit(from.Location, 16, false, false) != true)
         {

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -14,12 +14,12 @@ namespace Server.Gumps
         Generic = 3
     }
 
-    public class ResurrectGump : Gump
+    public class ResurrectGump : StaticGump<ResurrectGump>
     {
         private readonly bool m_FromSacrifice;
         private readonly Mobile m_Healer;
         private readonly double m_HitsScalar;
-        private readonly int m_Price;
+        private readonly ResurrectMessage m_ResurrectMessage;
 
         public ResurrectGump(Mobile owner, double hitsScalar)
             : this(owner, owner, ResurrectMessage.Generic, false, hitsScalar)
@@ -44,82 +44,28 @@ namespace Server.Gumps
             m_Healer = healer;
             m_FromSacrifice = fromSacrifice;
             m_HitsScalar = hitsScalar;
+            m_ResurrectMessage = msg;
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage(0);
 
-            AddBackground(0, 0, 400, 350, 2600);
+            builder.AddBackground(0, 0, 400, 350, 2600);
 
-            AddHtmlLocalized(0, 20, 400, 35, 1011022); // <center>Resurrection</center>
+            builder.AddHtmlLocalized(0, 20, 400, 35, 1011022); // <center>Resurrection</center>
 
             /* It is possible for you to be resurrected here by this healer. Do you wish to try?<br>
              * CONTINUE - You chose to try to come back to life now.<br>
              * CANCEL - You prefer to remain a ghost for now.
              */
-            AddHtmlLocalized(50, 55, 300, 140, 1011023 + (int)msg, true, true);
+            builder.AddHtmlLocalized(50, 55, 300, 140, 1011023 + (int)m_ResurrectMessage, true, true);
 
-            AddButton(200, 227, 4005, 4007, 0);
-            AddHtmlLocalized(235, 230, 110, 35, 1011012); // CANCEL
+            builder.AddButton(200, 227, 4005, 4007, 0);
+            builder.AddHtmlLocalized(235, 230, 110, 35, 1011012); // CANCEL
 
-            AddButton(65, 227, 4005, 4007, 1);
-            AddHtmlLocalized(100, 230, 110, 35, 1011011); // CONTINUE
-        }
-
-        public ResurrectGump(Mobile owner, Mobile healer, int price)
-            : base(150, 50)
-        {
-            m_Healer = healer;
-            m_Price = price;
-
-            Closable = false;
-
-            AddPage(0);
-
-            AddImage(0, 0, 3600);
-
-            AddImageTiled(0, 14, 15, 200, 3603);
-            AddImageTiled(380, 14, 14, 200, 3605);
-
-            AddImage(0, 201, 3606);
-
-            AddImageTiled(15, 201, 370, 16, 3607);
-            AddImageTiled(15, 0, 370, 16, 3601);
-
-            AddImage(380, 0, 3602);
-
-            AddImage(380, 201, 3608);
-
-            AddImageTiled(15, 15, 365, 190, 2624);
-
-            AddRadio(30, 140, 9727, 9730, true, 1);
-            AddHtmlLocalized(65, 145, 300, 25, 1060015, 0x7FFF); // Grudgingly pay the money
-
-            AddRadio(30, 175, 9727, 9730, false, 0);
-            AddHtmlLocalized(65, 178, 300, 25, 1060016, 0x7FFF); // I'd rather stay dead, you scoundrel!!!
-
-            // Wishing to rejoin the living, are you?  I can restore your body... for a price of course...
-            AddHtmlLocalized(30, 20, 360, 35, 1060017, 0x7FFF);
-
-            // Do you accept the fee, which will be withdrawn from your bank?
-            AddHtmlLocalized(30, 105, 345, 40, 1060018, 0x5B2D);
-
-            AddImage(65, 72, 5605);
-
-            AddImageTiled(80, 90, 200, 1, 9107);
-            AddImageTiled(95, 92, 200, 1, 9157);
-
-            AddLabel(90, 70, 1645, price.ToString());
-            AddHtmlLocalized(140, 70, 100, 25, 1023823, 0x7FFF); // gold coins
-
-            AddButton(290, 175, 247, 248, 2);
-
-            AddImageTiled(15, 14, 365, 1, 9107);
-            AddImageTiled(380, 14, 1, 190, 9105);
-            AddImageTiled(15, 205, 365, 1, 9107);
-            AddImageTiled(15, 14, 1, 190, 9105);
-            AddImageTiled(0, 0, 395, 1, 9157);
-            AddImageTiled(394, 0, 1, 217, 9155);
-            AddImageTiled(0, 216, 395, 1, 9157);
-            AddImageTiled(0, 0, 1, 217, 9155);
+            builder.AddButton(65, 227, 4005, 4007, 1);
+            builder.AddHtmlLocalized(100, 230, 110, 35, 1011011); // CONTINUE
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
@@ -137,32 +83,6 @@ namespace Server.Gumps
             {
                 from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
                 return;
-            }
-
-            if (m_Price > 0)
-            {
-                if (info.IsSwitched(1))
-                {
-                    if (Banker.Withdraw(from, m_Price))
-                    {
-                        // ~1_AMOUNT~ gold has been withdrawn from your bank box.
-                        from.SendLocalizedMessage(1060398, m_Price.ToString());
-
-                        // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
-                        from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());
-                    }
-                    else
-                    {
-                        // Unfortunately, you do not have enough cash in your bank to cover the cost of the healing.
-                        from.SendLocalizedMessage(1060020);
-                        return;
-                    }
-                }
-                else
-                {
-                    from.SendLocalizedMessage(1060019); // You decide against paying the healer, and thus remain dead.
-                    return;
-                }
             }
 
             from.PlaySound(0x214);

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -102,7 +102,7 @@ public class ResurrectGump : DynamicGump
     {
         var from = state.Mobile;
 
-        if (info.ButtonID != 1 && info.ButtonID != 2)
+        if (info.ButtonID is not 1 and not 2)
         {
             return;
         }

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -38,8 +38,7 @@ public class ResurrectGump : StaticGump<ResurrectGump>
     public ResurrectGump(
         Mobile owner, Mobile healer, ResurrectMessage msg = ResurrectMessage.Generic,
         bool fromSacrifice = false, double hitsScalar = 0.0
-    )
-        : base(100, 0)
+    ) : base(100, 0)
     {
         m_Healer = healer;
         m_FromSacrifice = fromSacrifice;

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -111,11 +111,9 @@ public class ResurrectGump : StaticGump<ResurrectGump>
 
             if (pack != null && corpse != null)
             {
-                var items = new List<Item>(corpse.Items);
-
-                for (var i = 0; i < items.Count; ++i)
+                for (var i = corpse.Items.Count - 1; i >= 0; --i)
                 {
-                    var item = items[i];
+                    var item = corpse.Items[i];
 
                     if (item.Layer != Layer.Hair && item.Layer != Layer.FacialHair && item.Movable)
                     {

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System;
 using Server.Engines.Virtues;
 using Server.Misc;
 using Server.Mobiles;
@@ -132,7 +132,7 @@ public class ResurrectGump : StaticGump<ResurrectGump>
 
         if (!Core.AOS && player?.ShortTermMurders >= 5)
         {
-            var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
+            var loss = Math.Clamp((100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0, 0.85, 0.95); // 5 to 15% loss
 
             if (loss < 0.85)
             {

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -4,178 +4,177 @@ using Server.Misc;
 using Server.Mobiles;
 using Server.Network;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public enum ResurrectMessage
 {
-    public enum ResurrectMessage
+    ChaosShrine = 0,
+    VirtueShrine = 1,
+    Healer = 2,
+    Generic = 3
+}
+
+public class ResurrectGump : StaticGump<ResurrectGump>
+{
+    private readonly bool m_FromSacrifice;
+    private readonly Mobile m_Healer;
+    private readonly double m_HitsScalar;
+    private readonly ResurrectMessage m_ResurrectMessage;
+
+    public ResurrectGump(Mobile owner, double hitsScalar)
+        : this(owner, owner, ResurrectMessage.Generic, false, hitsScalar)
     {
-        ChaosShrine = 0,
-        VirtueShrine = 1,
-        Healer = 2,
-        Generic = 3
     }
 
-    public class ResurrectGump : StaticGump<ResurrectGump>
+    public ResurrectGump(Mobile owner, ResurrectMessage msg) : this(owner, owner, msg)
     {
-        private readonly bool m_FromSacrifice;
-        private readonly Mobile m_Healer;
-        private readonly double m_HitsScalar;
-        private readonly ResurrectMessage m_ResurrectMessage;
+    }
 
-        public ResurrectGump(Mobile owner, double hitsScalar)
-            : this(owner, owner, ResurrectMessage.Generic, false, hitsScalar)
+    public ResurrectGump(Mobile owner, bool fromSacrifice = false)
+        : this(owner, owner, ResurrectMessage.Generic, fromSacrifice)
+    {
+    }
+
+    public ResurrectGump(
+        Mobile owner, Mobile healer, ResurrectMessage msg = ResurrectMessage.Generic,
+        bool fromSacrifice = false, double hitsScalar = 0.0
+    )
+        : base(100, 0)
+    {
+        m_Healer = healer;
+        m_FromSacrifice = fromSacrifice;
+        m_HitsScalar = hitsScalar;
+        m_ResurrectMessage = msg;
+    }
+
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage(0);
+
+        builder.AddBackground(0, 0, 400, 350, 2600);
+
+        builder.AddHtmlLocalized(0, 20, 400, 35, 1011022); // <center>Resurrection</center>
+
+        /* It is possible for you to be resurrected here by this healer. Do you wish to try?<br>
+         * CONTINUE - You chose to try to come back to life now.<br>
+         * CANCEL - You prefer to remain a ghost for now.
+         */
+        builder.AddHtmlLocalized(50, 55, 300, 140, 1011023 + (int)m_ResurrectMessage, true, true);
+
+        builder.AddButton(200, 227, 4005, 4007, 0);
+        builder.AddHtmlLocalized(235, 230, 110, 35, 1011012); // CANCEL
+
+        builder.AddButton(65, 227, 4005, 4007, 1);
+        builder.AddHtmlLocalized(100, 230, 110, 35, 1011011); // CONTINUE
+    }
+
+    public override void OnResponse(NetState state, in RelayInfo info)
+    {
+        var from = state.Mobile;
+
+        from.CloseGump<ResurrectGump>();
+
+        if (info.ButtonID != 1 && info.ButtonID != 2)
         {
+            return;
         }
 
-        public ResurrectGump(Mobile owner, ResurrectMessage msg) : this(owner, owner, msg)
+        if (from.Map?.CanFit(from.Location, 16, false, false) != true)
         {
+            from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
+            return;
         }
 
-        public ResurrectGump(Mobile owner, bool fromSacrifice = false)
-            : this(owner, owner, ResurrectMessage.Generic, fromSacrifice)
+        from.PlaySound(0x214);
+        from.FixedEffect(0x376A, 10, 16);
+
+        from.Resurrect();
+
+        if (m_Healer != null && from != m_Healer)
         {
-        }
+            var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
 
-        public ResurrectGump(
-            Mobile owner, Mobile healer, ResurrectMessage msg = ResurrectMessage.Generic,
-            bool fromSacrifice = false, double hitsScalar = 0.0
-        )
-            : base(100, 0)
-        {
-            m_Healer = healer;
-            m_FromSacrifice = fromSacrifice;
-            m_HitsScalar = hitsScalar;
-            m_ResurrectMessage = msg;
-        }
-
-        protected override void BuildLayout(ref StaticGumpBuilder builder)
-        {
-            builder.AddPage(0);
-
-            builder.AddBackground(0, 0, 400, 350, 2600);
-
-            builder.AddHtmlLocalized(0, 20, 400, 35, 1011022); // <center>Resurrection</center>
-
-            /* It is possible for you to be resurrected here by this healer. Do you wish to try?<br>
-             * CONTINUE - You chose to try to come back to life now.<br>
-             * CANCEL - You prefer to remain a ghost for now.
-             */
-            builder.AddHtmlLocalized(50, 55, 300, 140, 1011023 + (int)m_ResurrectMessage, true, true);
-
-            builder.AddButton(200, 227, 4005, 4007, 0);
-            builder.AddHtmlLocalized(235, 230, 110, 35, 1011012); // CANCEL
-
-            builder.AddButton(65, 227, 4005, 4007, 1);
-            builder.AddHtmlLocalized(100, 230, 110, 35, 1011011); // CONTINUE
-        }
-
-        public override void OnResponse(NetState state, in RelayInfo info)
-        {
-            var from = state.Mobile;
-
-            from.CloseGump<ResurrectGump>();
-
-            if (info.ButtonID != 1 && info.ButtonID != 2)
+            from.Hits = level switch
             {
-                return;
-            }
+                VirtueLevel.Seeker   => AOS.Scale(from.HitsMax, 20),
+                VirtueLevel.Follower => AOS.Scale(from.HitsMax, 40),
+                VirtueLevel.Knight   => AOS.Scale(from.HitsMax, 80),
+                _                    => from.Hits
+            };
+        }
 
-            if (from.Map?.CanFit(from.Location, 16, false, false) != true)
+        var player = from as PlayerMobile;
+
+        if (m_FromSacrifice && player != null)
+        {
+            player.Virtues.AvailableResurrects -= 1;
+
+            var pack = player.Backpack;
+            var corpse = player.Corpse;
+
+            if (pack != null && corpse != null)
             {
-                from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
-                return;
-            }
+                var items = new List<Item>(corpse.Items);
 
-            from.PlaySound(0x214);
-            from.FixedEffect(0x376A, 10, 16);
-
-            from.Resurrect();
-
-            if (m_Healer != null && from != m_Healer)
-            {
-                var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
-
-                from.Hits = level switch
+                for (var i = 0; i < items.Count; ++i)
                 {
-                    VirtueLevel.Seeker   => AOS.Scale(from.HitsMax, 20),
-                    VirtueLevel.Follower => AOS.Scale(from.HitsMax, 40),
-                    VirtueLevel.Knight   => AOS.Scale(from.HitsMax, 80),
-                    _                    => from.Hits
-                };
-            }
+                    var item = items[i];
 
-            var player = from as PlayerMobile;
-
-            if (m_FromSacrifice && player != null)
-            {
-                player.Virtues.AvailableResurrects -= 1;
-
-                var pack = player.Backpack;
-                var corpse = player.Corpse;
-
-                if (pack != null && corpse != null)
-                {
-                    var items = new List<Item>(corpse.Items);
-
-                    for (var i = 0; i < items.Count; ++i)
+                    if (item.Layer != Layer.Hair && item.Layer != Layer.FacialHair && item.Movable)
                     {
-                        var item = items[i];
-
-                        if (item.Layer != Layer.Hair && item.Layer != Layer.FacialHair && item.Movable)
-                        {
-                            pack.DropItem(item);
-                        }
+                        pack.DropItem(item);
                     }
                 }
             }
+        }
 
-            if (from.Fame > 0)
+        if (from.Fame > 0)
+        {
+            var amount = from.Fame / 10;
+
+            Titles.AwardFame(from, -amount, true);
+        }
+
+        if (!Core.AOS && player?.ShortTermMurders >= 5)
+        {
+            var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
+
+            if (loss < 0.85)
             {
-                var amount = from.Fame / 10;
-
-                Titles.AwardFame(from, -amount, true);
+                loss = 0.85;
+            }
+            else if (loss > 0.95)
+            {
+                loss = 0.95;
             }
 
-            if (!Core.AOS && player?.ShortTermMurders >= 5)
+            if (from.RawStr * loss > 10)
             {
-                var loss = (100.0 - (4.0 + player.ShortTermMurders / 5.0)) / 100.0; // 5 to 15% loss
-
-                if (loss < 0.85)
-                {
-                    loss = 0.85;
-                }
-                else if (loss > 0.95)
-                {
-                    loss = 0.95;
-                }
-
-                if (from.RawStr * loss > 10)
-                {
-                    from.RawStr = (int)(from.RawStr * loss);
-                }
-
-                if (from.RawInt * loss > 10)
-                {
-                    from.RawInt = (int)(from.RawInt * loss);
-                }
-
-                if (from.RawDex * loss > 10)
-                {
-                    from.RawDex = (int)(from.RawDex * loss);
-                }
-
-                for (var s = 0; s < from.Skills.Length; s++)
-                {
-                    if (from.Skills[s].Base * loss > 35)
-                    {
-                        from.Skills[s].Base *= loss;
-                    }
-                }
+                from.RawStr = (int)(from.RawStr * loss);
             }
 
-            if (from.Alive && m_HitsScalar > 0)
+            if (from.RawInt * loss > 10)
             {
-                from.Hits = (int)(from.HitsMax * m_HitsScalar);
+                from.RawInt = (int)(from.RawInt * loss);
             }
+
+            if (from.RawDex * loss > 10)
+            {
+                from.RawDex = (int)(from.RawDex * loss);
+            }
+
+            for (var s = 0; s < from.Skills.Length; s++)
+            {
+                if (from.Skills[s].Base * loss > 35)
+                {
+                    from.Skills[s].Base *= loss;
+                }
+            }
+        }
+
+        if (from.Alive && m_HitsScalar > 0)
+        {
+            from.Hits = (int)(from.HitsMax * m_HitsScalar);
         }
     }
 }

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -72,8 +72,6 @@ public class ResurrectGump : StaticGump<ResurrectGump>
     {
         var from = state.Mobile;
 
-        from.CloseGump<ResurrectGump>();
-
         if (info.ButtonID != 1 && info.ButtonID != 2)
         {
             return;

--- a/Projects/UOContent/Gumps/ResurrectGump.cs
+++ b/Projects/UOContent/Gumps/ResurrectGump.cs
@@ -16,10 +16,10 @@ public enum ResurrectMessage
 
 public class ResurrectGump : StaticGump<ResurrectGump>
 {
-    private readonly bool m_FromSacrifice;
-    private readonly Mobile m_Healer;
-    private readonly double m_HitsScalar;
-    private readonly ResurrectMessage m_ResurrectMessage;
+    private readonly bool _fromSacrifice;
+    private readonly Mobile _healer;
+    private readonly double _hitsScalar;
+    private readonly ResurrectMessage _resurrectMessage;
 
     public ResurrectGump(Mobile owner, double hitsScalar)
         : this(owner, owner, ResurrectMessage.Generic, false, hitsScalar)
@@ -40,10 +40,10 @@ public class ResurrectGump : StaticGump<ResurrectGump>
         bool fromSacrifice = false, double hitsScalar = 0.0
     ) : base(100, 0)
     {
-        m_Healer = healer;
-        m_FromSacrifice = fromSacrifice;
-        m_HitsScalar = hitsScalar;
-        m_ResurrectMessage = msg;
+        _healer = healer;
+        _fromSacrifice = fromSacrifice;
+        _hitsScalar = hitsScalar;
+        _resurrectMessage = msg;
     }
 
     protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -58,7 +58,7 @@ public class ResurrectGump : StaticGump<ResurrectGump>
          * CONTINUE - You chose to try to come back to life now.<br>
          * CANCEL - You prefer to remain a ghost for now.
          */
-        builder.AddHtmlLocalized(50, 55, 300, 140, 1011023 + (int)m_ResurrectMessage, true, true);
+        builder.AddHtmlLocalized(50, 55, 300, 140, 1011023 + (int)_resurrectMessage, true, true);
 
         builder.AddButton(200, 227, 4005, 4007, 0);
         builder.AddHtmlLocalized(235, 230, 110, 35, 1011012); // CANCEL
@@ -87,9 +87,9 @@ public class ResurrectGump : StaticGump<ResurrectGump>
 
         from.Resurrect();
 
-        if (m_Healer != null && from != m_Healer)
+        if (_healer != null && from != _healer)
         {
-            var level = VirtueSystem.GetLevel(m_Healer, VirtueName.Compassion);
+            var level = VirtueSystem.GetLevel(_healer, VirtueName.Compassion);
 
             from.Hits = level switch
             {
@@ -102,7 +102,7 @@ public class ResurrectGump : StaticGump<ResurrectGump>
 
         var player = from as PlayerMobile;
 
-        if (m_FromSacrifice && player != null)
+        if (_fromSacrifice && player != null)
         {
             player.Virtues.AvailableResurrects -= 1;
 
@@ -167,9 +167,9 @@ public class ResurrectGump : StaticGump<ResurrectGump>
             }
         }
 
-        if (from.Alive && m_HitsScalar > 0)
+        if (from.Alive && _hitsScalar > 0)
         {
-            from.Hits = (int)(from.HitsMax * m_HitsScalar);
+            from.Hits = (int)(from.HitsMax * _hitsScalar);
         }
     }
 }

--- a/Projects/UOContent/Items/Skill Items/Misc/Bandage.cs
+++ b/Projects/UOContent/Items/Skill Items/Misc/Bandage.cs
@@ -311,7 +311,7 @@ public class BandageContext : Timer
             else
             {
                 Patient.CloseGump<ResurrectGump>();
-                Patient.SendGump(new ResurrectGump(Patient, Healer));
+                Patient.SendGump(new ResurrectGump(Healer));
             }
         }
         else if (Patient.Poisoned)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
@@ -89,12 +89,12 @@ public partial class AnkhOfSacrificeComponent : AddonComponent
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            var from = state.Mobile;
-
             if (info.ButtonID is not 1 and not 2)
             {
                 return;
             }
+
+            var from = state.Mobile;
 
             if (from.Map?.CanFit(from.Location, 16, false, false) != true)
             {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
@@ -83,7 +83,7 @@ public partial class AnkhOfSacrificeComponent : AddonComponent
 
     private class AnkhResurrectGump : ResurrectGump
     {
-        public AnkhResurrectGump(Mobile owner, ResurrectMessage msg) : base(owner, owner, msg)
+        public AnkhResurrectGump(Mobile owner, ResurrectMessage msg) : base(owner, msg)
         {
         }
 
@@ -91,21 +91,23 @@ public partial class AnkhOfSacrificeComponent : AddonComponent
         {
             var from = state.Mobile;
 
-            if (info.ButtonID is 1 or 2)
+            if (info.ButtonID is not (1 or 2))
             {
-                if (from.Map?.CanFit(from.Location, 16, false, false) != true)
-                {
-                    from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
-                    return;
-                }
-
-                if (from is PlayerMobile mobile)
-                {
-                    mobile.AnkhNextUse = Core.Now + TimeSpan.FromHours(1);
-                }
-
-                base.OnResponse(state, info);
+                return;
             }
+
+            if (from.Map?.CanFit(from.Location, 16, false, false) != true)
+            {
+                from.SendLocalizedMessage(502391); // Thou can not be resurrected there!
+                return;
+            }
+
+            if (from is PlayerMobile mobile)
+            {
+                mobile.AnkhNextUse = Core.Now + TimeSpan.FromHours(1);
+            }
+
+            base.OnResponse(state, info);
         }
     }
 }

--- a/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
@@ -91,7 +91,7 @@ public partial class AnkhOfSacrificeComponent : AddonComponent
         {
             var from = state.Mobile;
 
-            if (info.ButtonID is not (1 or 2))
+            if (info.ButtonID is not 1 and not 2)
             {
                 return;
             }

--- a/Projects/UOContent/Mobiles/Healers/PricedHealer.cs
+++ b/Projects/UOContent/Mobiles/Healers/PricedHealer.cs
@@ -36,8 +36,8 @@ public partial class PricedHealer : BaseHealer
         m.PlaySound(0x214);
         m.FixedEffect(0x376A, 10, 16);
 
-        m.CloseGump<ResurrectGump>();
-        m.SendGump(new ResurrectGump(m, this, Price));
+        m.CloseGump<PricedResurrectGump>();
+        m.SendGump(new PricedResurrectGump(m, this, Price));
     }
 
     public override bool CheckResurrect(Mobile m) => true;

--- a/Projects/UOContent/Mobiles/Healers/PricedHealer.cs
+++ b/Projects/UOContent/Mobiles/Healers/PricedHealer.cs
@@ -37,7 +37,7 @@ public partial class PricedHealer : BaseHealer
         m.FixedEffect(0x376A, 10, 16);
 
         m.CloseGump<PricedResurrectGump>();
-        m.SendGump(new PricedResurrectGump(m, this, Price));
+        m.SendGump(new PricedResurrectGump(this, Price));
     }
 
     public override bool CheckResurrect(Mobile m) => true;

--- a/Projects/UOContent/Spells/Chivalry/NobleSacrifice.cs
+++ b/Projects/UOContent/Spells/Chivalry/NobleSacrifice.cs
@@ -75,7 +75,7 @@ namespace Server.Spells.Chivalry
                         {
                             m.FixedParticles(0x375A, 1, 15, 5005, 5, 3, EffectLayer.Head);
                             m.CloseGump<ResurrectGump>();
-                            m.SendGump(new ResurrectGump(m, Caster));
+                            m.SendGump(new ResurrectGump(Caster));
                             sacrifice = true;
                         }
                     }

--- a/Projects/UOContent/Spells/Eighth/Resurrection.cs
+++ b/Projects/UOContent/Spells/Eighth/Resurrection.cs
@@ -62,7 +62,7 @@ namespace Server.Spells.Eighth
                 m.FixedEffect(0x376A, 10, 16);
 
                 m.CloseGump<ResurrectGump>();
-                m.SendGump(new ResurrectGump(m, Caster));
+                m.SendGump(new ResurrectGump(Caster));
             }
         }
 


### PR DESCRIPTION
Looked into migrating the `ResurrectionGump`.

It turns out that it covers both the regular use and a special RunUO gump for the `PricedHealer`.  Therefore I split it into two new `StaticGump` implementations.  They share much of the same logic in their response handler, and I'm open to suggestions for how to abstract that out.