### PR TITLE
fix: Fixes timer interval & index offset

### DIFF
--- a/Projects/Server/Timer/Timer.cs
+++ b/Projects/Server/Timer/Timer.cs
@@ -70,7 +70,6 @@ public partial class Timer
     public TimeSpan Interval { get; set; }
     public int Index { get; private set; }
     public int Count { get; private set; }
-    public int RemainingCount => Count - Index;
     public bool Running { get; private set; }
 
     public TimerProfile GetProfile() => !Core.Profiling ? null : TimerProfile.Acquire(ToString() ?? "null");

--- a/Projects/UOContent/Spells/Spellweaving/GiftOfRenewal.cs
+++ b/Projects/UOContent/Spells/Spellweaving/GiftOfRenewal.cs
@@ -102,7 +102,8 @@ namespace Server.Spells.Spellweaving
 
             protected override void OnTick()
             {
-                if (Index + 1 == Count)
+                // Last tick will change running to false
+                if (!Running)
                 {
                     StopEffect(_mobile);
                     _mobile.PlaySound(0x455);


### PR DESCRIPTION
### Summary

- Fixes timer intervals not continuing
- Fixes `Timer.Index` being off by 1. Should start at 0 for the first OnTick
- Simplifies Gift of Renewal end check
- Fixes force of nature not applying at the proper time and simplifies the timer logic.