### PR TITLE
fix: Fix NetStateGumps and other Gumps cleanup

### DIFF
--- a/Projects/UOContent/Engines/ConPVP/AcceptDuelGump.cs
+++ b/Projects/UOContent/Engines/ConPVP/AcceptDuelGump.cs
@@ -244,7 +244,7 @@ namespace Server.Engines.ConPVP
                         m_Challenger.SendMessage($"{m_Challenged.Name} has accepted the request.");
                         m_Challenged.SendMessage($"You have accepted the request from {m_Challenger.Name}.");
 
-                        foreach (var g in m_Challenger.GetAllGumps())
+                        foreach (var g in m_Challenger.GetGumps())
                         {
                             if (g is ParticipantGump pg && pg.Participant == m_Participant)
                             {

--- a/Projects/UOContent/Engines/ConPVP/DuelContext.cs
+++ b/Projects/UOContent/Engines/ConPVP/DuelContext.cs
@@ -1541,7 +1541,7 @@ namespace Server.Engines.ConPVP
                                 p.Nullify(pl);
                                 pm.DuelPlayer = null;
 
-                                foreach (var g in init.GetAllGumps())
+                                foreach (var g in init.GetGumps())
                                 {
                                     if (g is ParticipantGump pg && pg.Participant == p)
                                     {
@@ -1576,7 +1576,7 @@ namespace Server.Engines.ConPVP
 
                                 var send = true;
 
-                                foreach (var g in init.GetAllGumps())
+                                foreach (var g in init.GetGumps())
                                 {
                                     if (g is ParticipantGump pg && pg.Participant == p)
                                     {
@@ -1620,7 +1620,7 @@ namespace Server.Engines.ConPVP
 
                                 var send = true;
 
-                                foreach (var g in init.GetAllGumps())
+                                foreach (var g in init.GetGumps())
                                 {
                                     if (g is ParticipantGump pg && pg.Participant == p)
                                     {

--- a/Projects/UOContent/Gumps/Base/GumpSystem.IncomingPackets.cs
+++ b/Projects/UOContent/Gumps/Base/GumpSystem.IncomingPackets.cs
@@ -37,15 +37,18 @@ public static partial class GumpSystem
 
         BaseGump baseGump = null;
 
-        foreach (var g in GetAll(state))
+        if (_gumps.TryGetValue(state, out var gumps))
         {
-            if (g.Serial != serial || g.TypeID != typeId)
+            foreach (var g in gumps)
             {
-                continue;
-            }
+                if (g.Serial != serial || g.TypeID != typeId)
+                {
+                    continue;
+                }
 
-            baseGump = g;
-            break;
+                baseGump = g;
+                break;
+            }
         }
 
         if (baseGump != null)

--- a/Projects/UOContent/Gumps/Base/GumpSystem.cs
+++ b/Projects/UOContent/Gumps/Base/GumpSystem.cs
@@ -13,7 +13,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  *************************************************************************/
 
-using Server.Logging;
 using Server.Network;
 using System;
 using System.Collections.Generic;

--- a/Projects/UOContent/Gumps/Base/GumpSystem.cs
+++ b/Projects/UOContent/Gumps/Base/GumpSystem.cs
@@ -26,7 +26,6 @@ namespace Server.Gumps;
 
 public static partial class GumpSystem
 {
-    private const int InitialCapacity = 4;
     public const int GumpCap = 512;
 
     private static readonly Dictionary<NetState, List<BaseGump>> _gumps = [];
@@ -146,7 +145,7 @@ public static partial class GumpSystem
         }
         else
         {
-            list = new List<BaseGump>(InitialCapacity) { gump };
+            list = [gump];
         }
 
         gump.SendTo(ns);
@@ -175,7 +174,7 @@ public static partial class GumpSystem
 
         if (!exists)
         {
-            list = new List<BaseGump>(InitialCapacity);
+            list = [];
         }
 
         return new NetStateGumps(list, ns);

--- a/Projects/UOContent/Gumps/Base/NetStateGumps.cs
+++ b/Projects/UOContent/Gumps/Base/NetStateGumps.cs
@@ -17,9 +17,10 @@ using Server.Logging;
 using Server.Network;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace Server.Gumps.Base;
+namespace Server.Gumps;
 
 public readonly ref struct NetStateGumps
 {
@@ -112,6 +113,7 @@ public readonly ref struct NetStateGumps
         gump.SendTo(_state);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<BaseGump>.Enumerator GetEnumerator() =>
         ((ReadOnlySpan<BaseGump>)CollectionsMarshal.AsSpan(_gumps)).GetEnumerator();
 }

--- a/Projects/UOContent/Gumps/Base/NetStateGumps.cs
+++ b/Projects/UOContent/Gumps/Base/NetStateGumps.cs
@@ -36,7 +36,7 @@ public readonly ref struct NetStateGumps
 
     public bool Close<T>() where T : BaseGump
     {
-        if (_state == null || _gumps == null)
+        if (_state == null)
         {
             return false;
         }
@@ -58,7 +58,7 @@ public readonly ref struct NetStateGumps
 
     public T Find<T>() where T : BaseGump
     {
-        if (_state == null || _gumps == null)
+        if (_state == null)
         {
             return null;
         }
@@ -78,7 +78,7 @@ public readonly ref struct NetStateGumps
 
     public void Send(BaseGump gump, bool singleton = false)
     {
-        if (_state == null || _gumps == null || _state.CannotSendPackets()) // Cannot send packets handles _state null check
+        if (_state.CannotSendPackets()) // Cannot send packets handles _state null check
         {
             return;
         }

--- a/Projects/UOContent/Gumps/PricedResurrectGump.cs
+++ b/Projects/UOContent/Gumps/PricedResurrectGump.cs
@@ -15,7 +15,6 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
         _healer = healer;
         _price = price;
 
-        // Close this gump when
         TypeID = GetTypeId(typeof(ResurrectGump));
     }
 
@@ -101,8 +100,8 @@ public class PricedResurrectGump : StaticGump<PricedResurrectGump>
 
         if (Banker.Withdraw(from, _price))
         {
-            // ~1_AMOUNT~ gold has been withdrawn from your bank box.
-            from.SendLocalizedMessage(1060398, _price.ToString());
+            // ~1_AMOUNT~ gold has been withdrawn from your bank to cover the price of the healing.
+            from.SendLocalizedMessage(1060021, _price.ToString());
 
             // You have ~1_AMOUNT~ gold in cash remaining in your bank box.
             from.SendLocalizedMessage(1060022, Banker.GetBalance(from).ToString());

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -1727,17 +1727,14 @@ namespace Server.Mobiles
             {
                 var gumps = NetState.GetGumps();
 
-                if (gumps.Has<ResurrectGump>())
+                if (Alive)
                 {
-                    if (Alive)
-                    {
-                        gumps.Close<ResurrectGump>();
-                    }
-                    else
-                    {
-                        SendLocalizedMessage(500111); // You are frozen and cannot move.
-                        return false;
-                    }
+                    gumps.Close<ResurrectGump>();
+                }
+                else if (gumps.Has<ResurrectGump>())
+                {
+                    SendLocalizedMessage(500111); // You are frozen and cannot move.
+                    return false;
                 }
             }
 

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -1723,10 +1723,22 @@ namespace Server.Mobiles
 
         public override bool Move(Direction d)
         {
-            if (NetState != null && Alive && !NetState.CloseGump<ResurrectGump>())
+            if (NetState != null)
             {
-                SendLocalizedMessage(500111); // You are frozen and cannot move.
-                return false;
+                var gumps = NetState.GetGumps();
+
+                if (gumps.Has<ResurrectGump>())
+                {
+                    if (Alive)
+                    {
+                        gumps.Close<ResurrectGump>();
+                    }
+                    else
+                    {
+                        SendLocalizedMessage(500111); // You are frozen and cannot move.
+                        return false;
+                    }
+                }
             }
 
             // var speed = ComputeMovementSpeed(d);

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "8.0.0",
     "rollForward": "latestMajor",
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "8.0.0",
     "rollForward": "latestMajor",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
Fixes wrong behavior of NetStateGumps: added null check to send gump in case of null NetState and removed empty list.

Added gump list max size checks.

Removed unused/unwanted methods.