### PR TITLE
feat: refactor/restyle `HouseGump` and supporting gumps

### DIFF
--- a/Projects/UOContent/Gumps/Houses/ConfirmDemolishHouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/ConfirmDemolishHouseGump.cs
@@ -58,7 +58,7 @@ public class ConfirmDemolishHouseGump : StaticGump<ConfirmDemolishHouseGump>
 
         if (info.ButtonID != 1)
         {
-            state.Mobile.SendGump(new HouseGump(state.Mobile, _house, HouseGump.Section.Options));
+            state.Mobile.SendGump(new HouseGump(state.Mobile, _house, HouseGumpSection.Options));
             return;
         }
 

--- a/Projects/UOContent/Gumps/Houses/ConfirmDemolishHouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/ConfirmDemolishHouseGump.cs
@@ -36,7 +36,7 @@ public class ConfirmDemolishHouseGump : StaticGump<ConfirmDemolishHouseGump>
          * Once the house is demolished, anyone can attempt to place a new house on the vacant land.
          * This action will not un-condemn any other houses on your account, nor will it end your 7-day waiting period (if it applies to you).
          * Are you sure you wish to continue?
-        */
+         */
         builder.AddHtmlLocalized(10, 40, 400, 200, 1061795, 32512, false, true);
 
         builder.AddImageTiled(10, 250, 400, 20, 2624);
@@ -51,14 +51,14 @@ public class ConfirmDemolishHouseGump : StaticGump<ConfirmDemolishHouseGump>
 
     public override void OnResponse(NetState state, in RelayInfo info)
     {
-        if (info.ButtonID != 1 || _house.Deleted)
+        if (_house.Deleted || !_house.IsOwner(state.Mobile))
         {
             return;
         }
 
-        if (!_house.IsOwner(state.Mobile))
+        if (info.ButtonID != 1)
         {
-
+            state.Mobile.SendGump(new HouseGump(state.Mobile, _house, HouseGump.Section.Options));
             return;
         }
 

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -6,13 +6,6 @@ using Server.Prompts;
 
 namespace Server.Gumps;
 
-public enum HousePeopleType
-{
-    Bans,
-    CoOwners,
-    Friends,
-}
-
 public class HouseGump : DynamicGump
 {
     public enum Page

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -80,6 +80,11 @@ public class HouseGump : DynamicGump
         }
     }
 
+    private void AddBackButton(ref DynamicGumpBuilder builder, int buttonId)
+    {
+        builder.AddButton(15, 389, 0xFAE, 0xFB0, buttonId); // back button
+    }
+
     private void AddTableOfContents(ref DynamicGumpBuilder builder)
     {
         builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
@@ -146,8 +151,6 @@ public class HouseGump : DynamicGump
                     break;
                 }
         }
-
-        Console.WriteLine($"{_section}");
     }
 
     private void BuildInfoPage(ref DynamicGumpBuilder builder)
@@ -219,8 +222,7 @@ public class HouseGump : DynamicGump
         builder.AddHtmlLocalized(50, 295, 280, 20, 1011261); // Lift a ban
         builder.AddButton(15, 295, 0xFB1, 0xFA3, 0, GumpButtonType.Page, (int)Page.ListBans);
 
-        // builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
-        builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoInfo);
+        AddBackButton(ref builder, (int)Button.GotoInfo);
 
         BuildBansPage(ref builder);
         BuildCoOwnersPage(ref builder);
@@ -233,7 +235,7 @@ public class HouseGump : DynamicGump
 
         if (_house.Bans.Count <= 0)
         {
-            builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoFriends); // Back button
+            AddBackButton(ref builder, (int)Button.GotoFriends);
             return;
         }
 
@@ -267,7 +269,7 @@ public class HouseGump : DynamicGump
                 builder.AddHtmlLocalized(240, 280, 150, 20, 1011261); // Lift a ban
                 builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveBans);
 
-                builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoFriends); // Back button
+                AddBackButton(ref builder, (int)Button.GotoFriends);
             }
 
             builder.AddCheckbox(15, 130 + i % pageSize * 20, 0xD2, 0xD3, false, i);
@@ -286,7 +288,7 @@ public class HouseGump : DynamicGump
 
         if (_house.CoOwners.Count <= 0)
         {
-            builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoFriends); // Back button
+            AddBackButton(ref builder, (int)Button.GotoFriends);
             return;
         }
 
@@ -320,7 +322,7 @@ public class HouseGump : DynamicGump
                 builder.AddHtmlLocalized(240, 280, 150, 20, 1018036); // Remove a co-owner
                 builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveCoOwners);
 
-                builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoFriends); // Back button
+                AddBackButton(ref builder, (int)Button.GotoFriends);
             }
 
             builder.AddCheckbox(15, 130 + i % pageSize * 20, 0xD2, 0xD3, false, i);
@@ -339,7 +341,7 @@ public class HouseGump : DynamicGump
 
         if (_house.Friends.Count <= 0)
         {
-            builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoFriends); // Back button
+            AddBackButton(ref builder, (int)Button.GotoFriends);
             return;
         }
 
@@ -373,7 +375,7 @@ public class HouseGump : DynamicGump
                 builder.AddHtmlLocalized(240, 280, 150, 20, 1018037); // Remove a friend
                 builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveFriends);
 
-                builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoFriends); // Back button
+                AddBackButton(ref builder, (int)Button.GotoFriends);
             }
 
             builder.AddCheckbox(15, 130 + i % pageSize * 20, 0xD2, 0xD3, false, i);
@@ -430,7 +432,7 @@ public class HouseGump : DynamicGump
             builder.AddHtmlLocalized(95, 285, 200, 30, 1011250); // Change the sign type
         }
 
-        builder.AddButton(15, 389, 0xFAE, 0xFB0, (int)Button.GotoInfo); // back button
+        AddBackButton(ref builder, (int)Button.GotoInfo);
 
         builder.AddPage((int)Page.ShopSigns);
 
@@ -702,8 +704,6 @@ public class HouseGump : DynamicGump
                         from.SendGump(new ConfirmDemolishHouseGump(_house));
                     }
 
-
-                    from.SendGump(new HouseGump(from, _house, Section.Options));
                     break;
                 }
             case Button.ChangePrivacy: // Declare public/private
@@ -802,11 +802,6 @@ public class HouseGump : DynamicGump
             case Button.GotoOptions:
                 from.SendGump(new HouseGump(from, _house, Section.Options));
                 break;
-        }
-
-        if (_section != Section.Info)
-        {
-            from.SendGump(new HouseGump(from, _house));
         }
     }
 

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -30,8 +30,8 @@ namespace Server.Gumps
 
             builder.AddPage();
 
-            builder.AddBackground(0, 0, 420, 430, 5054);
-            builder.AddBackground(10, 10, 400, 410, 3000);
+            builder.AddBackground(0, 0, 420, 430, 0x6DB);
+            builder.AddBackground(5, 5, 410, 420, 0xBB8);
 
             builder.AddButton(20, 388, 4005, 4007, 0);
             builder.AddHtmlLocalized(55, 388, 300, 20, 1011104); // Return to previous menu
@@ -128,8 +128,8 @@ namespace Server.Gumps
 
             builder.AddPage();
 
-            builder.AddBackground(0, 0, 420, 430, 5054);
-            builder.AddBackground(10, 10, 400, 410, 3000);
+            builder.AddBackground(0, 0, 420, 430, 0x6DB);
+            builder.AddBackground(5, 5, 410, 420, 0xBB8);
 
             builder.AddButton(20, 388, 4005, 4007, 0);
             builder.AddHtmlLocalized(55, 388, 300, 20, 1011104); // Return to previous menu
@@ -226,6 +226,12 @@ namespace Server.Gumps
 
     public class HouseSignSelectionGump : DynamicGump
     {
+        private enum Page
+        {
+            ShopSigns = 1,
+            GuildSigns = 2,
+        }
+
         private readonly BaseHouse _house;
 
         public override bool Singleton => true;
@@ -258,7 +264,7 @@ namespace Server.Gumps
                 }
             }
 
-            builder.AddPage(1);
+            builder.AddPage((int)Page.ShopSigns);
 
             for (var i = 0; i < 24; ++i)
             {
@@ -267,12 +273,12 @@ namespace Server.Gumps
             }
 
             builder.AddHtmlLocalized(240, 360, 129, 20, 1011254); // Guild sign choices
-            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 2);
+            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.GuildSigns);
 
             builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
             builder.AddButton(360, 389, 0xFB7, 0xFB9, 1);
 
-            builder.AddPage(2);
+            builder.AddPage((int)Page.GuildSigns);
 
             for (var i = 0; i < 29; ++i)
             {
@@ -281,7 +287,7 @@ namespace Server.Gumps
             }
 
             builder.AddHtmlLocalized(240, 360, 129, 20, 1011255); // Shop sign choices
-            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 1);
+            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.ShopSigns);
 
             builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
             builder.AddButton(360, 389, 0xFB7, 0xFB9, 1);
@@ -339,6 +345,16 @@ namespace Server.Gumps
 
     public class HouseOptionsGump : DynamicGump
     {
+        private enum Button
+        {
+            ChangeName = 1,
+            TransferOwnership = 2,
+            Demolish,
+            ChangePrivacy = 4,
+            ChangeKeys = 5,
+            ChangeSign = 6,
+        }
+
         private readonly BaseHouse _house;
 
         public override bool Singleton => true;
@@ -372,25 +388,25 @@ namespace Server.Gumps
             }
 
             builder.AddItem(22, 144, 0xFBF); // scribe's pen
-            builder.AddButton(65, 146, 0x16CD, 0x16CE, 1);
+            builder.AddButton(65, 146, 0x16CD, 0x16CE, (int)Button.ChangeName);
             builder.AddHtmlLocalized(95, 145, 200, 20, 1011236); // Change this house's name!
 
             builder.AddImage(10, 165, 0x1196); // right facing arrow
-            builder.AddButton(65, 181, 0x16CD, 0x16CE, 2);
+            builder.AddButton(65, 181, 0x16CD, 0x16CE, (int)Button.TransferOwnership);
             builder.AddHtmlLocalized(95, 180, 200, 30, 1011248); // Transfer ownership of the house
 
             builder.AddItem(10, 211, 0x14F0); // deed
-            builder.AddButton(65, 216, 0x16CD, 0x16CE, 3);
+            builder.AddButton(65, 216, 0x16CD, 0x16CE, (int)Button.Demolish);
             builder.AddHtmlLocalized(95, 215, 300, 30, 1011249); // Demolish house and get deed back
 
             if (!_house.Public)
             {
                 builder.AddItem(14, 252, 0x176B); // keyring with keys
-                builder.AddButton(65, 251, 0x16CD, 0x16CE, 5);
+                builder.AddButton(65, 251, 0x16CD, 0x16CE, (int)Button.ChangeKeys);
                 builder.AddHtmlLocalized(95, 250, 355, 30, 1011247); // Change the house locks
 
                 builder.AddItem(14, 284, 0xBC4); // inn sign
-                builder.AddButton(65, 286, 0x16CD, 0x16CE, 4);
+                builder.AddButton(65, 286, 0x16CD, 0x16CE, (int)Button.ChangePrivacy);
                 builder.AddHtmlLocalized(
                     95,
                     285,
@@ -402,11 +418,11 @@ namespace Server.Gumps
             else
             {
                 builder.AddItem(14, 247, 0xBD2); // default sign
-                builder.AddButton(65, 251, 0x16CD, 0x16CE, 4);
+                builder.AddButton(65, 251, 0x16CD, 0x16CE, (int)Button.ChangePrivacy);
                 builder.AddHtmlLocalized(95, 250, 300, 30, 1011252); // Declare this building to be private.
 
                 builder.AddItem(14, 284, 0xBCA); // artist sign
-                builder.AddButton(65, 286, 0x16CD, 0x16CE, 6);
+                builder.AddButton(65, 286, 0x16CD, 0x16CE, (int)Button.ChangeSign);
                 builder.AddHtmlLocalized(95, 285, 200, 30, 1011250); // Change the sign type
             }
         }
@@ -449,16 +465,16 @@ namespace Server.Gumps
                 return;
             }
 
-            switch (info.ButtonID)
+            switch ((Button)info.ButtonID)
             {
-                case 1: // Rename sign
+                case Button.ChangeName: // Rename sign
                     {
                         from.Prompt = new RenamePrompt(_house);
                         from.SendLocalizedMessage(501302); // What dost thou wish the sign to say?
 
                         break;
                     }
-                case 2: // Transfer ownership
+                case Button.TransferOwnership: // Transfer ownership
                     {
                         if (!isOwner)
                         {
@@ -471,7 +487,7 @@ namespace Server.Gumps
 
                         break;
                     }
-                case 3: // Demolish house
+                case Button.Demolish: // Demolish house
                     {
                         if (isOwner)
                         {
@@ -492,7 +508,7 @@ namespace Server.Gumps
                         from.SendGump(new HouseOptionsGump(_house));
                         break;
                     }
-                case 4: // Declare public/private
+                case Button.ChangePrivacy: // Declare public/private
                     {
                         if (!isOwner)
                         {
@@ -530,7 +546,7 @@ namespace Server.Gumps
                         from.SendGump(new HouseOptionsGump(_house));
                         break;
                     }
-                case 5: // Change locks
+                case Button.ChangeKeys: // Change locks
                     {
                         if (!isOwner)
                         {
@@ -555,7 +571,7 @@ namespace Server.Gumps
                         from.SendGump(new HouseOptionsGump(_house));
                         break;
                     }
-                case 6: // Change sign type
+                case Button.ChangeSign: // Change sign type
                     {
                         if (!isOwner)
                         {

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -4,968 +4,808 @@ using Server.Multis;
 using Server.Network;
 using Server.Prompts;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public enum HousePeopleType
 {
-    public class HouseListGump : DynamicGump
+    Bans,
+    CoOwners,
+    Friends,
+}
+
+public class HouseGump : DynamicGump
+{
+    public enum Page
     {
-        private readonly BaseHouse _house;
-        private readonly bool _accountOf;
-        private readonly List<Mobile> _list;
-        private readonly int _number;
+        Info = 1,
+        People = 2,
+        Options = 3,
+        ShopSigns = 4,
+        GuildSigns = 5,
+        ListBans = 10,
+        ListCoOwners = 30,
+        ListFriends = 50,
+    }
 
-        public HouseListGump(int number, List<Mobile> list, BaseHouse house, bool accountOf) : base(20, 30)
+    private enum Button
+    {
+        // People Buttons
+        AddCoOwner = 1,
+        RemoveCoOwners = 2,
+        ClearCoOwners = 3,
+        AddFriend = 4,
+        RemoveFriends = 5,
+        ClearFriends = 6,
+        Ban = 7,
+        Eject = 8,
+        RemoveBans = 9,
+
+        // Options Buttons
+        ChangeName = 11,
+        TransferOwnership = 12,
+        Demolish = 13,
+        ChangePrivacy = 14,
+        ChangeKeys = 15,
+        ChangeSign = 16,
+    }
+
+    private readonly BaseHouse _house;
+
+    private readonly bool _isOwner;
+    private readonly bool _isCoOwner;
+    private readonly bool _isFriend;
+
+    public override bool Singleton => true;
+
+    public HouseGump(Mobile from, BaseHouse house) : base(50, 50)
+    {
+        _house = house;
+
+        var isCombatRestricted = house.IsCombatRestricted(from);
+
+        _isOwner = _house.IsOwner(from);
+        _isCoOwner = _isOwner || _house.IsCoOwner(from);
+        _isFriend = _isCoOwner || _house.IsFriend(from);
+
+        if (isCombatRestricted)
         {
-            _accountOf = accountOf;
-            _list = list;
-            _number = number;
-            _house = house;
-        }
-
-        protected override void BuildLayout(ref DynamicGumpBuilder builder)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            builder.AddPage();
-
-            builder.AddBackground(0, 0, 420, 430, 0x6DB);
-            builder.AddBackground(5, 5, 410, 420, 0xBB8);
-
-            builder.AddButton(20, 388, 4005, 4007, 0);
-            builder.AddHtmlLocalized(55, 388, 300, 20, 1011104); // Return to previous menu
-
-            builder.AddHtmlLocalized(20, 20, 350, 20, _number);
-
-            if (_list == null)
-            {
-                return;
-            }
-
-            for (var i = 0; i < _list.Count; ++i)
-            {
-                if (i % 16 == 0)
-                {
-                    if (i != 0)
-                    {
-                        builder.AddButton(370, 20, 4005, 4007, 0, GumpButtonType.Page, i / 16 + 1);
-                    }
-
-                    builder.AddPage(i / 16 + 1);
-
-                    if (i != 0)
-                    {
-                        builder.AddButton(340, 20, 4014, 4016, 0, GumpButtonType.Page, i / 16);
-                    }
-                }
-
-                var m = _list[i];
-
-                string name;
-
-                if (m == null || (name = m.Name) == null || (name = name.Trim()).Length <= 0)
-                {
-                    continue;
-                }
-
-                builder.AddLabel(
-                    55,
-                    55 + i % 16 * 20,
-                    0,
-                    _accountOf && m.Player && m.Account != null
-                        ? $"Account of {name}"
-                        : name
-                );
-            }
-        }
-
-        public override void OnResponse(NetState state, in RelayInfo info)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            var from = state.Mobile;
-
-            from.SendGump(new HouseGump(from, _house));
+            _isFriend = _isCoOwner = _isOwner = false;
         }
     }
 
-    public class HouseRemoveGump : DynamicGump
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
     {
-        private readonly bool _accountOf;
-        private readonly List<Mobile> _copy;
-        private readonly BaseHouse _house;
-        private readonly List<Mobile> _list;
-        private readonly int _number;
-
-        public HouseRemoveGump(int number, List<Mobile> list, BaseHouse house, bool accountOf) : base(20, 30)
+        if (_house.Deleted)
         {
-            if (house.Deleted)
-            {
-                return;
-            }
+            return;
+        }
 
-            _house = house;
-            _list = list;
-            _number = number;
-            _accountOf = accountOf;
+        builder.AddPage();
 
-            if (list != null)
+        builder.AddBackground(0, 0, 420, 430, 0x6DB);
+        builder.AddBackground(5, 5, 410, 420, 0xBB8);
+
+        builder.AddImage(15, 15, 100);
+
+        if (_house.Sign != null)
+        {
+            var lines = _house.Sign.GetName().Wrap(10, 6);
+
+            for (int i = 0, y = (101 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
             {
-                _copy = new List<Mobile>(list);
+                var s = lines[i];
+
+                builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
             }
         }
 
-        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        if (!_isFriend)
         {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            builder.AddPage();
-
-            builder.AddBackground(0, 0, 420, 430, 0x6DB);
-            builder.AddBackground(5, 5, 410, 420, 0xBB8);
-
-            builder.AddButton(20, 388, 4005, 4007, 0);
-            builder.AddHtmlLocalized(55, 388, 300, 20, 1011104); // Return to previous menu
-
-            builder.AddButton(20, 365, 4005, 4007, 1);
-            builder.AddHtmlLocalized(55, 365, 300, 20, 1011270); // Remove now!
-
-            builder.AddHtmlLocalized(20, 20, 350, 20, _number);
-
-            if (_list == null)
-            {
-                return;
-            }
-
-            for (var i = 0; i < _list.Count; ++i)
-            {
-                if (i % 15 == 0)
-                {
-                    if (i != 0)
-                    {
-                        builder.AddButton(370, 20, 4005, 4007, 0, GumpButtonType.Page, i / 15 + 1);
-                    }
-
-                    builder.AddPage(i / 15 + 1);
-
-                    if (i != 0)
-                    {
-                        builder.AddButton(340, 20, 4014, 4016, 0, GumpButtonType.Page, i / 15);
-                    }
-                }
-
-                var m = _list[i];
-
-                string name;
-
-                if (m == null || (name = m.Name) == null || (name = name.Trim()).Length <= 0)
-                {
-                    continue;
-                }
-
-                builder.AddCheckbox(34, 52 + i % 15 * 20, 0xD2, 0xD3, false, i);
-                builder.AddLabel(
-                    55,
-                    52 + i % 15 * 20,
-                    0,
-                    _accountOf && m.Player && m.Account != null
-                        ? $"Account of {name}"
-                        : name
-                );
-            }
+            return;
         }
 
-        public override void OnResponse(NetState state, in RelayInfo info)
+        builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
+        builder.AddButton(370, 20, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Info);
+
+        builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
+        builder.AddButton(370, 50, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.People);
+
+        builder.AddHtmlLocalized(314, 79, 75, 20, 1011235);                                    // OPTIONS
+        builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Options); // HouseOptionsGump
+
+        BuildInfoPage(ref builder);
+        BuildPeoplePages(ref builder);
+        BuildOptionsPages(ref builder);
+    }
+
+    private void BuildInfoPage(ref DynamicGumpBuilder builder)
+    {
+        // Info page
+        builder.AddPage((int)Page.Info);
+
+        builder.AddHtmlLocalized(20, 135, 100, 20, 1011242); // Owned by:
+        builder.AddHtml(100, 135, 100, 20, GetOwnerName());
+
+        builder.AddHtmlLocalized(20, 175, 275, 20, 1011237); // Number of locked down items:
+        builder.AddHtml(320, 175, 50, 20, _house.LockDownCount.ToString());
+
+        builder.AddHtmlLocalized(20, 200, 275, 20, 1011238); // Maximum locked down items:
+        builder.AddHtml(320, 200, 50, 20, _house.MaxLockDowns.ToString());
+
+        builder.AddHtmlLocalized(20, 225, 275, 20, 1011239); // Number of secure containers:
+        builder.AddHtml(320, 225, 50, 20, _house.SecureCount.ToString());
+
+        builder.AddHtmlLocalized(20, 250, 275, 20, 1011240); // Maximum number of secure containers:
+        builder.AddHtml(320, 250, 50, 20, _house.MaxSecures.ToString());
+
+        builder.AddHtmlLocalized(20, 290, 400, 20, 1018032); // This house is properly placed.
+        builder.AddHtmlLocalized(20, 310, 400, 20, 1018035); // This house is of modern design.
+
+        if (_house.Public)
         {
-            if (_house.Deleted)
+            // TODO: Validate exact placement
+            builder.AddHtmlLocalized(20, 345, 275, 20, 1011241); // Number of visits this building has had
+            builder.AddHtml(320, 345, 50, 20, _house.Visits.ToString());
+        }
+
+        builder.AddButton(360, 389, 0xFB1, 0xFB3, 0);
+    }
+
+    private void BuildPeoplePages(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage((int)Page.People);
+
+        builder.AddHtmlLocalized(50, 130, 150, 20, 1011266); // List of co-owners
+        builder.AddButton(15, 130, 0xFA8, 0xFAA, 0, GumpButtonType.Page, (int)Page.ListCoOwners);
+
+        builder.AddHtmlLocalized(50, 150, 150, 20, 1011267); // Add a co-owner
+        builder.AddButton(15, 150, 0xFBD, 0xFBF, (int)Button.AddCoOwner);
+
+        builder.AddHtmlLocalized(50, 170, 150, 20, 1018036); // Remove a co-owner
+        builder.AddButton(15, 170, 0xFA2, 0xFA4, 0, GumpButtonType.Page, (int)Page.ListCoOwners);
+
+        builder.AddHtmlLocalized(50, 190, 150, 20, 1011268); // Clear co-owner list
+        builder.AddButton(15, 190, 0xFB1, 0xFB3, (int)Button.ClearCoOwners);
+
+        builder.AddHtmlLocalized(240, 130, 155, 20, 1011243); // List of Friends
+        builder.AddButton(200, 130, 0xFA8, 0xFAA, 0, GumpButtonType.Page, (int)Page.ListFriends);
+
+        builder.AddHtmlLocalized(240, 150, 155, 20, 1011244); // Add a Friend
+        builder.AddButton(200, 150, 0xFBD, 0xFBF, (int)Button.AddFriend);
+
+        builder.AddHtmlLocalized(240, 170, 155, 20, 1018037); // Remove a Friend
+        builder.AddButton(200, 170, 0xFA2, 0xFA4, 0, GumpButtonType.Page, (int)Page.ListFriends);
+
+        builder.AddHtmlLocalized(240, 190, 155, 20, 1011245); // Clear Friends list
+        builder.AddButton(200, 190, 0xFB1, 0xFB3, (int)Button.ClearFriends);
+
+        builder.AddHtmlLocalized(50, 235, 280, 20, 1011260); // View a list of banned people
+        builder.AddButton(15, 235, 0xFA8, 0xFAA, 0, GumpButtonType.Page, (int)Page.ListBans);
+
+        builder.AddHtmlLocalized(50, 255, 280, 20, 1011258); // Ban someone from the house
+        builder.AddButton(15, 255, 0xFA2, 0xFA4, (int)Button.Ban);
+
+        builder.AddHtmlLocalized(50, 275, 280, 20, 1011259); // Eject someone from the house
+        builder.AddButton(15, 275, 0xFAE, 0xFB0, (int)Button.Eject);
+
+        builder.AddHtmlLocalized(50, 295, 280, 20, 1011261); // Lift a ban
+        builder.AddButton(15, 295, 0xFB1, 0xFA3, 0, GumpButtonType.Page, (int)Page.ListBans);
+
+        builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
+
+        var pageSize = 10;
+
+        BuildBansPage(ref builder, pageSize);
+        BuildCoOwnersPage(ref builder, pageSize);
+        BuildFriendsPage(ref builder, pageSize);
+    }
+
+    private void BuildBansPage(ref DynamicGumpBuilder builder, int pageSize = 10)
+    {
+        builder.AddPage((int)Page.ListBans);
+
+        if (_house.Bans.Count <= 0)
+        {
+            builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.People); // Back button
+            return;
+        }
+
+        for (var i = 0; i < _house.Bans.Count; ++i)
+        {
+            if (i % pageSize == 0)
             {
-                return;
+                if (i + pageSize < _house.Bans.Count)
+                {
+                    builder.AddButton(370, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListBans);
+                }
+
+                builder.AddPage(i / pageSize + (int)Page.ListBans);
+
+                if (i > 0)
+                {
+                    builder.AddButton(
+                        335,
+                        310,
+                        4014,
+                        4016,
+                        0,
+                        GumpButtonType.Page,
+                        i / pageSize + (int)Page.ListBans - 1
+                    );
+                }
+
+                builder.AddHtmlLocalized(260, 250, 150, 20, 1011258); // View a list of banned people
+                builder.AddButton(370, 250, 0xFBD, 0xFBF, (int)Button.Ban);
+
+                builder.AddHtmlLocalized(240, 280, 150, 20, 1011261); // Lift a ban
+                builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveBans);
+
+                builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
             }
 
-            var from = state.Mobile;
+            builder.AddCheckbox(15, 130 + i % pageSize * 20, 0xD2, 0xD3, false, i);
+            builder.AddLabel(
+                35,
+                130 + i % pageSize * 20,
+                0,
+                _house.Bans[i].Name
+            );
+        }
+    }
 
-            if (_list != null && info.ButtonID == 1) // Remove now
+    private void BuildCoOwnersPage(ref DynamicGumpBuilder builder, int pageSize = 10)
+    {
+        builder.AddPage((int)Page.ListCoOwners);
+
+        if (_house.CoOwners.Count <= 0)
+        {
+            builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.People); // Back button
+            return;
+        }
+
+        for (var i = 0; i < _house.CoOwners.Count; ++i)
+        {
+            if (i % pageSize == 0)
             {
-                var switches = info.Switches;
-
-                if (switches.Length > 0)
+                if (i + pageSize < _house.CoOwners.Count)
                 {
+                    builder.AddButton(370, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListCoOwners);
+                }
+
+                builder.AddPage(i / pageSize + (int)Page.ListCoOwners);
+
+                if (i > 0)
+                {
+                    builder.AddButton(
+                        335,
+                        310,
+                        4014,
+                        4016,
+                        0,
+                        GumpButtonType.Page,
+                        i / pageSize + (int)Page.ListCoOwners - 1
+                    );
+                }
+
+                builder.AddHtmlLocalized(260, 250, 150, 20, 1011267); // Add a co-owner
+                builder.AddButton(370, 250, 0xFBD, 0xFBF, (int)Button.AddCoOwner);
+
+                builder.AddHtmlLocalized(240, 280, 150, 20, 1018036); // Remove a co-owner
+                builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveCoOwners);
+
+                builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
+            }
+
+            builder.AddCheckbox(15, 130 + i % pageSize * 20, 0xD2, 0xD3, false, i);
+            builder.AddLabel(
+                35,
+                130 + i % pageSize * 20,
+                0,
+                _house.CoOwners[i].Name
+            );
+        }
+    }
+
+    private void BuildFriendsPage(ref DynamicGumpBuilder builder, int pageSize = 10)
+    {
+        builder.AddPage((int)Page.ListFriends);
+
+        if (_house.Friends.Count <= 0)
+        {
+            builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.People); // Back button
+            return;
+        }
+
+        for (var i = 0; i < _house.Friends.Count; ++i)
+        {
+            if (i % pageSize == 0)
+            {
+                if (i + pageSize < _house.Friends.Count)
+                {
+                    builder.AddButton(370, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListFriends);
+                }
+
+                builder.AddPage(i / pageSize + (int)Page.ListFriends);
+
+                if (i > 0)
+                {
+                    builder.AddButton(
+                        335,
+                        310,
+                        4014,
+                        4016,
+                        0,
+                        GumpButtonType.Page,
+                        i / pageSize + (int)Page.ListFriends - 1
+                    );
+                }
+
+                builder.AddHtmlLocalized(260, 250, 150, 20, 1011244); // Add a friend
+                builder.AddButton(370, 250, 0xFBD, 0xFBF, (int)Button.AddFriend);
+
+                builder.AddHtmlLocalized(240, 280, 150, 20, 1018037); // Remove a friend
+                builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveFriends);
+
+                builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
+            }
+
+            builder.AddCheckbox(15, 130 + i % pageSize * 20, 0xD2, 0xD3, false, i);
+            builder.AddLabel(
+                35,
+                130 + i % pageSize * 20,
+                0,
+                _house.Friends[i].Name
+            );
+        }
+    }
+
+    private void BuildOptionsPages(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage((int)Page.Options);
+
+        builder.AddItem(22, 144, 0xFBF); // scribe's pen
+        builder.AddButton(65, 146, 0x16CD, 0x16CE, (int)Button.ChangeName);
+        builder.AddHtmlLocalized(95, 145, 200, 20, 1011236); // Change this house's name!
+
+        builder.AddImage(10, 165, 0x1196); // right facing arrow
+        builder.AddButton(65, 181, 0x16CD, 0x16CE, (int)Button.TransferOwnership);
+        builder.AddHtmlLocalized(95, 180, 200, 30, 1011248); // Transfer ownership of the house
+
+        builder.AddItem(10, 211, 0x14F0); // deed
+        builder.AddButton(65, 216, 0x16CD, 0x16CE, (int)Button.Demolish);
+        builder.AddHtmlLocalized(95, 215, 300, 30, 1011249); // Demolish house and get deed back
+
+        if (!_house.Public)
+        {
+            builder.AddItem(14, 252, 0x176B); // keyring with keys
+            builder.AddButton(65, 251, 0x16CD, 0x16CE, (int)Button.ChangeKeys);
+            builder.AddHtmlLocalized(95, 250, 355, 30, 1011247); // Change the house locks
+
+            builder.AddItem(14, 284, 0xBC4); // inn sign
+            builder.AddButton(65, 286, 0x16CD, 0x16CE, (int)Button.ChangePrivacy);
+            builder.AddHtmlLocalized(
+                95,
+                285,
+                300,
+                90,
+                1011253
+            ); // Declare this building to be public. This will make your front door unlockable.
+        }
+        else
+        {
+            builder.AddItem(14, 247, 0xBD2); // default sign
+            builder.AddButton(65, 251, 0x16CD, 0x16CE, (int)Button.ChangePrivacy);
+            builder.AddHtmlLocalized(95, 250, 300, 30, 1011252); // Declare this building to be private.
+
+            builder.AddItem(14, 284, 0xBCA); // artist sign
+            // builder.AddButton(65, 286, 0x16CD, 0x16CE, (int)Button.ChangeSign);
+            builder.AddButton(65, 286, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.ShopSigns);
+            builder.AddHtmlLocalized(95, 285, 200, 30, 1011250); // Change the sign type
+        }
+
+        builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
+
+        builder.AddPage((int)Page.ShopSigns);
+
+        for (var i = 0; i < 24; ++i)
+        {
+            builder.AddRadio(16 + i / 4 * 65, 137 + i % 4 * 35, 210, 211, false, i + 1);
+            builder.AddItem(36 + i / 4 * 65, 130 + i % 4 * 35, 2980 + i * 2);
+        }
+
+        builder.AddHtmlLocalized(240, 360, 129, 20, 1011254); // Guild sign choices
+        builder.AddButton(360, 359, 0xFA5, 0xFA7, 0, GumpButtonType.Page, (int)Page.GuildSigns);
+
+        builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
+        builder.AddButton(360, 389, 0xFB7, 0xFB9, (int)Button.ChangeSign);
+
+        builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Options);
+
+        builder.AddPage((int)Page.GuildSigns);
+
+        for (var i = 0; i < 29; ++i)
+        {
+            builder.AddRadio(16 + i / 5 * 65, 137 + i % 5 * 35, 210, 211, false, i + 25);
+            builder.AddItem(36 + i / 5 * 65, 130 + i % 5 * 35, 3028 + i * 2);
+        }
+
+        builder.AddHtmlLocalized(240, 360, 129, 20, 1011255); // Shop sign choices
+        builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.ShopSigns);
+
+        builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
+        builder.AddButton(360, 389, 0xFB7, 0xFB9, (int)Button.ChangeSign);
+
+        builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Options);
+    }
+
+    public override void OnResponse(NetState state, in RelayInfo info)
+    {
+        if (_house.Deleted)
+        {
+            return;
+        }
+
+        var from = state.Mobile;
+
+        if (info.ButtonID < 0)
+        {
+            from.SendGump(new HouseGump(from, _house));
+            return;
+        }
+
+        var isCombatRestricted = _house.IsCombatRestricted(from);
+
+        var isOwner = _house.IsOwner(from);
+        var isCoOwner = isOwner || _house.IsCoOwner(from);
+        var isFriend = isCoOwner || _house.IsFriend(from);
+
+        if (isCombatRestricted)
+        {
+            isFriend = isOwner = false;
+        }
+
+        if (!isFriend || !from.Alive)
+        {
+            return;
+        }
+
+        Item sign = _house.Sign;
+
+        if (sign == null || from.Map != sign.Map || !from.InRange(sign.GetWorldLocation(), 18))
+        {
+            return;
+        }
+
+        switch ((Button)info.ButtonID)
+        {
+            case Button.AddCoOwner: // Add co-owner
+                {
+                    if (isOwner)
+                    {
+                        from.SendLocalizedMessage(
+                            501328
+                        ); // Target the person you wish to name a co-owner of your household.
+                        from.Target = new CoOwnerTarget(true, _house);
+                    }
+                    else
+                    {
+                        from.SendLocalizedMessage(501327); // Only the house owner may add Co-owners.
+                    }
+
+                    break;
+                }
+            case Button.RemoveCoOwners: // Remove co-owner
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501329); // Only the house owner may remove co-owners.
+                        break;
+                    }
+
+                    var switches = info.Switches;
+
+                    if (switches.Length <= 0)
+                    {
+                        break;
+                    }
+
+                    List<Mobile> _copy = [.._house.CoOwners];
+
                     for (var i = 0; i < switches.Length; ++i)
                     {
                         var index = switches[i];
 
                         if (index >= 0 && index < _copy.Count)
                         {
-                            _list.Remove(_copy[index]);
+                            _house.CoOwners.Remove(_copy[index]);
                         }
                     }
 
-                    if (_list.Count > 0)
-                    {
-                        var gumps = from.GetGumps();
+                    from.SendGump(new HouseGump(from, _house));
 
-                        gumps.Close<HouseGump>();
-                        gumps.Close<HouseListGump>();
-                        gumps.Close<HouseRemoveGump>();
-                        gumps.Send(new HouseRemoveGump(_number, _list, _house, _accountOf));
-                        return;
-                    }
-                }
-            }
-
-            from.SendGump(new HouseGump(from, _house));
-        }
-    }
-
-    public class HouseSignSelectionGump : DynamicGump
-    {
-        private enum Page
-        {
-            ShopSigns = 1,
-            GuildSigns = 2,
-        }
-
-        private readonly BaseHouse _house;
-
-        public override bool Singleton => true;
-
-        public HouseSignSelectionGump(BaseHouse house) : base(20, 30) => _house = house;
-
-        protected override void BuildLayout(ref DynamicGumpBuilder builder)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            builder.AddPage();
-
-            builder.AddBackground(0, 0, 420, 430, 0x6DB);
-            builder.AddBackground(5, 5, 410, 420, 0xBB8);
-
-            builder.AddImage(15, 15, 100);
-
-            if (_house.Sign != null)
-            {
-                var lines = _house.Sign.GetName().Wrap(10, 6);
-
-                for (int i = 0, y = (101 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
-                {
-                    var s = lines[i];
-
-                    builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
-                }
-            }
-
-            builder.AddPage((int)Page.ShopSigns);
-
-            for (var i = 0; i < 24; ++i)
-            {
-                builder.AddRadio(16 + i / 4 * 65, 137 + i % 4 * 35, 210, 211, false, i + 1);
-                builder.AddItem(36 + i / 4 * 65, 130 + i % 4 * 35, 2980 + i * 2);
-            }
-
-            builder.AddHtmlLocalized(240, 360, 129, 20, 1011254); // Guild sign choices
-            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.GuildSigns);
-
-            builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
-            builder.AddButton(360, 389, 0xFB7, 0xFB9, 1);
-
-            builder.AddPage((int)Page.GuildSigns);
-
-            for (var i = 0; i < 29; ++i)
-            {
-                builder.AddRadio(16 + i / 5 * 65, 137 + i % 5 * 35, 210, 211, false, i + 25);
-                builder.AddItem(36 + i / 5 * 65, 130 + i % 5 * 35, 3028 + i * 2);
-            }
-
-            builder.AddHtmlLocalized(240, 360, 129, 20, 1011255); // Shop sign choices
-            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.ShopSigns);
-
-            builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
-            builder.AddButton(360, 389, 0xFB7, 0xFB9, 1);
-        }
-
-        public override void OnResponse(NetState state, in RelayInfo info)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            var from = state.Mobile;
-
-            if (!_house.Public || info.Switches.Length <= 0 || info.ButtonID == 0)
-            {
-                from.SendGump(new HouseGump(from, _house));
-                return;
-            }
-
-            var isCombatRestricted = _house.IsCombatRestricted(from);
-
-            var isOwner = _house.IsOwner(from);
-            var isCoOwner = isOwner || _house.IsCoOwner(from);
-            var isFriend = isCoOwner || _house.IsFriend(from);
-
-            if (isCombatRestricted)
-            {
-                isFriend = isOwner = false;
-            }
-
-            if (!isFriend || !from.Alive)
-            {
-                return;
-            }
-
-            if (!isOwner)
-            {
-                from.SendLocalizedMessage(501307); // Only the house owner may do this.
-                from.SendGump(new HouseGump(from, _house));
-                return;
-            }
-
-            var index = info.Switches[0] - 1;
-
-            if (index is >= 0 and < 53)
-            {
-                _house.ChangeSignType(2980 + index * 2);
-            }
-
-            // back to HouseOptionsGump because that opened HouseSignSelectionGump
-            from.SendGump(new HouseOptionsGump(_house));
-        }
-    }
-
-    public class HouseOptionsGump : DynamicGump
-    {
-        private enum Button
-        {
-            ChangeName = 1,
-            TransferOwnership = 2,
-            Demolish,
-            ChangePrivacy = 4,
-            ChangeKeys = 5,
-            ChangeSign = 6,
-        }
-
-        private readonly BaseHouse _house;
-
-        public override bool Singleton => true;
-
-        public HouseOptionsGump(BaseHouse house) : base(20, 30) => _house = house;
-
-        protected override void BuildLayout(ref DynamicGumpBuilder builder)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            builder.AddPage();
-
-            builder.AddBackground(0, 0, 420, 430, 0x6DB);
-            builder.AddBackground(5, 5, 410, 420, 0xBB8);
-
-            builder.AddImage(15, 15, 100);
-
-            if (_house.Sign != null)
-            {
-                var lines = _house.Sign.GetName().Wrap(10, 6);
-
-                for (int i = 0, y = (101 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
-                {
-                    var s = lines[i];
-
-                    builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
-                }
-            }
-
-            builder.AddItem(22, 144, 0xFBF); // scribe's pen
-            builder.AddButton(65, 146, 0x16CD, 0x16CE, (int)Button.ChangeName);
-            builder.AddHtmlLocalized(95, 145, 200, 20, 1011236); // Change this house's name!
-
-            builder.AddImage(10, 165, 0x1196); // right facing arrow
-            builder.AddButton(65, 181, 0x16CD, 0x16CE, (int)Button.TransferOwnership);
-            builder.AddHtmlLocalized(95, 180, 200, 30, 1011248); // Transfer ownership of the house
-
-            builder.AddItem(10, 211, 0x14F0); // deed
-            builder.AddButton(65, 216, 0x16CD, 0x16CE, (int)Button.Demolish);
-            builder.AddHtmlLocalized(95, 215, 300, 30, 1011249); // Demolish house and get deed back
-
-            if (!_house.Public)
-            {
-                builder.AddItem(14, 252, 0x176B); // keyring with keys
-                builder.AddButton(65, 251, 0x16CD, 0x16CE, (int)Button.ChangeKeys);
-                builder.AddHtmlLocalized(95, 250, 355, 30, 1011247); // Change the house locks
-
-                builder.AddItem(14, 284, 0xBC4); // inn sign
-                builder.AddButton(65, 286, 0x16CD, 0x16CE, (int)Button.ChangePrivacy);
-                builder.AddHtmlLocalized(
-                    95,
-                    285,
-                    300,
-                    90,
-                    1011253
-                ); // Declare this building to be public. This will make your front door unlockable.
-            }
-            else
-            {
-                builder.AddItem(14, 247, 0xBD2); // default sign
-                builder.AddButton(65, 251, 0x16CD, 0x16CE, (int)Button.ChangePrivacy);
-                builder.AddHtmlLocalized(95, 250, 300, 30, 1011252); // Declare this building to be private.
-
-                builder.AddItem(14, 284, 0xBCA); // artist sign
-                builder.AddButton(65, 286, 0x16CD, 0x16CE, (int)Button.ChangeSign);
-                builder.AddHtmlLocalized(95, 285, 200, 30, 1011250); // Change the sign type
-            }
-        }
-
-        public override void OnResponse(NetState state, in RelayInfo info)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            var from = state.Mobile;
-
-            if (info.ButtonID == 0)
-            {
-                from.SendGump(new HouseGump(from, _house));
-                return;
-            }
-
-            var isCombatRestricted = _house.IsCombatRestricted(from);
-
-            var isOwner = _house.IsOwner(from);
-            var isCoOwner = isOwner || _house.IsCoOwner(from);
-            var isFriend = isCoOwner || _house.IsFriend(from);
-
-            if (isCombatRestricted)
-            {
-                isFriend = isOwner = false;
-            }
-
-            if (!isFriend || !from.Alive)
-            {
-                return;
-            }
-
-            Item sign = _house.Sign;
-
-            if (sign == null || from.Map != sign.Map || !from.InRange(sign.GetWorldLocation(), 18))
-            {
-                return;
-            }
-
-            switch ((Button)info.ButtonID)
-            {
-                case Button.ChangeName: // Rename sign
-                    {
-                        from.Prompt = new RenamePrompt(_house);
-                        from.SendLocalizedMessage(501302); // What dost thou wish the sign to say?
-
-                        break;
-                    }
-                case Button.TransferOwnership: // Transfer ownership
-                    {
-                        if (!isOwner)
-                        {
-                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
-                            break;
-                        }
-
-                        from.SendLocalizedMessage(501309); // Target the person to whom you wish to give this house.
-                        from.Target = new HouseOwnerTarget(_house);
-
-                        break;
-                    }
-                case Button.Demolish: // Demolish house
-                    {
-                        if (isOwner)
-                        {
-                            if (!Guild.NewGuildSystem && _house.FindGuildstone() != null)
-                            {
-                                from.SendLocalizedMessage(501389); // You cannot redeed a house with a guildstone inside.
-                            }
-                            else
-                            {
-                                from.SendGump(new ConfirmDemolishHouseGump(_house));
-                            }
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501320); // Only the house owner may do this.
-                        }
-
-                        from.SendGump(new HouseOptionsGump(_house));
-                        break;
-                    }
-                case Button.ChangePrivacy: // Declare public/private
-                    {
-                        if (!isOwner)
-                        {
-                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
-                            break;
-                        }
-
-                        if (_house.Public && _house.PlayerVendors.Count > 0)
-                        {
-                            from.SendLocalizedMessage(
-                                501887
-                            ); // You have vendors working out of this building. It cannot be declared private until there are no vendors in place.
-                            break;
-                        }
-
-                        _house.Public = !_house.Public;
-                        if (!_house.Public)
-                        {
-                            _house.ChangeLocks(from);
-
-                            from.SendLocalizedMessage(501888); // This house is now private.
-                            from.SendLocalizedMessage(
-                                501306
-                            ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
-                        }
-                        else
-                        {
-                            _house.RemoveKeys(from);
-                            _house.RemoveLocks();
-                            from.SendLocalizedMessage(
-                                501886
-                            ); // This house is now public. Friends of the house my now have vendors working out of this building.
-                        }
-
-                        from.SendGump(new HouseOptionsGump(_house));
-                        break;
-                    }
-                case Button.ChangeKeys: // Change locks
-                    {
-                        if (!isOwner)
-                        {
-                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
-                            break;
-                        }
-
-                        if (_house.Public)
-                        {
-                            from.SendLocalizedMessage(501669); // Public houses are always unlocked.
-                        }
-                        else
-                        {
-                            _house.RemoveKeys(from);
-                            _house.ChangeLocks(from);
-
-                            from.SendLocalizedMessage(
-                                501306
-                            ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
-                        }
-
-                        from.SendGump(new HouseOptionsGump(_house));
-                        break;
-                    }
-                case Button.ChangeSign: // Change sign type
-                    {
-                        if (!isOwner)
-                        {
-                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
-                            break;
-                        }
-
-                        from.SendGump(new HouseSignSelectionGump(_house));
-                        break;
-                    }
-            }
-        }
-    }
-
-    public class HouseGump : DynamicGump
-    {
-        private readonly BaseHouse _house;
-
-        private readonly bool _isOwner;
-        private readonly bool _isCoOwner;
-        private readonly bool _isFriend;
-
-        public override bool Singleton => true;
-
-
-        public HouseGump(Mobile from, BaseHouse house) : base(20, 30)
-        {
-            if (house.Deleted)
-            {
-                return;
-            }
-
-            _house = house;
-
-            from.CloseGump<HouseListGump>();
-            from.CloseGump<HouseRemoveGump>();
-
-            var isCombatRestricted = house.IsCombatRestricted(from);
-
-            _isOwner = _house.IsOwner(from);
-            _isCoOwner = _isOwner || _house.IsCoOwner(from);
-            _isFriend = _isCoOwner || _house.IsFriend(from);
-
-            if (isCombatRestricted)
-            {
-                _isFriend = _isCoOwner = _isOwner = false;
-            }
-
-            from.SendMessage("HouseGump");
-        }
-
-        protected override void BuildLayout(ref DynamicGumpBuilder builder)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            builder.AddPage();
-
-            if (_isFriend)
-            {
-                builder.AddBackground(0, 0, 420, 430, 0x6DB);
-                builder.AddBackground(5, 5, 410, 420, 0xBB8);
-            }
-
-            builder.AddImage(15, 15, 100);
-
-            if (_house.Sign != null)
-            {
-                var lines = _house.Sign.GetName().Wrap(10, 6);
-
-                for (int i = 0, y = (101 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
-                {
-                    var s = lines[i];
-
-                    builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
-                }
-            }
-
-            if (!_isFriend)
-            {
-                return;
-            }
-
-            builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
-            builder.AddButton(370, 20, 0x16CD, 0x16CE, 0, GumpButtonType.Page, 1);
-
-            builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
-            builder.AddButton(370, 50, 0x16CD, 0x16CE, 0, GumpButtonType.Page, 2);
-
-            builder.AddHtmlLocalized(314, 79, 75, 20, 1011235); // OPTIONS
-            // builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, 3);
-            builder.AddButton(370, 79, 0x16CD, 0x16CE, 21); // HouseOptionsGump
-
-            builder.AddButton(360, 389, 0xFB1, 0xFB3, 0);
-            builder.AddHtmlLocalized(320, 390, 75, 20, 1011441); // EXIT
-
-            // Info page
-            builder.AddPage(1);
-
-            builder.AddHtmlLocalized(20, 135, 100, 20, 1011242); // Owned by:
-            builder.AddHtml(100, 135, 100, 20, GetOwnerName());
-
-            builder.AddHtmlLocalized(20, 175, 275, 20, 1011237); // Number of locked down items:
-            builder.AddHtml(320, 175, 50, 20, _house.LockDownCount.ToString());
-
-            builder.AddHtmlLocalized(20, 200, 275, 20, 1011238); // Maximum locked down items:
-            builder.AddHtml(320, 200, 50, 20, _house.MaxLockDowns.ToString());
-
-            builder.AddHtmlLocalized(20, 225, 275, 20, 1011239); // Number of secure containers:
-            builder.AddHtml(320, 225, 50, 20, _house.SecureCount.ToString());
-
-            builder.AddHtmlLocalized(20, 250, 275, 20, 1011240); // Maximum number of secure containers:
-            builder.AddHtml(320, 250, 50, 20, _house.MaxSecures.ToString());
-
-            builder.AddHtmlLocalized(20, 290, 400, 20, 1018032); // This house is properly placed.
-            builder.AddHtmlLocalized(20, 310, 400, 20, 1018035); // This house is of modern design.
-
-            if (_house.Public)
-            {
-                // TODO: Validate exact placement
-                builder.AddHtmlLocalized(20, 345, 275, 20, 1011241); // Number of visits this building has had
-                builder.AddHtml(320, 345, 50, 20, _house.Visits.ToString());
-            }
-
-            // Friends page
-            builder.AddPage(2);
-
-            builder.AddHtmlLocalized(45, 130, 150, 20, 1011266); // List of co-owners
-            builder.AddButton(20, 130, 2714, 2715, 2);
-
-            builder.AddHtmlLocalized(45, 150, 150, 20, 1011267); // Add a co-owner
-            builder.AddButton(20, 150, 2714, 2715, 3);
-
-            builder.AddHtmlLocalized(45, 170, 150, 20, 1018036); // Remove a co-owner
-            builder.AddButton(20, 170, 2714, 2715, 4);
-
-            builder.AddHtmlLocalized(45, 190, 150, 20, 1011268); // Clear co-owner list
-            builder.AddButton(20, 190, 2714, 2715, 5);
-
-            builder.AddHtmlLocalized(225, 130, 155, 20, 1011243); // List of Friends
-            builder.AddButton(200, 130, 2714, 2715, 6);
-
-            builder.AddHtmlLocalized(225, 150, 155, 20, 1011244); // Add a Friend
-            builder.AddButton(200, 150, 2714, 2715, 7);
-
-            builder.AddHtmlLocalized(225, 170, 155, 20, 1018037); // Remove a Friend
-            builder.AddButton(200, 170, 2714, 2715, 8);
-
-            builder.AddHtmlLocalized(225, 190, 155, 20, 1011245); // Clear Friends list
-            builder.AddButton(200, 190, 2714, 2715, 9);
-
-            builder.AddHtmlLocalized(120, 215, 280, 20, 1011258); // Ban someone from the house
-            builder.AddButton(95, 215, 2714, 2715, 10);
-
-            builder.AddHtmlLocalized(120, 235, 280, 20, 1011259); // Eject someone from the house
-            builder.AddButton(95, 235, 2714, 2715, 11);
-
-            builder.AddHtmlLocalized(120, 255, 280, 20, 1011260); // View a list of banned people
-            builder.AddButton(95, 255, 2714, 2715, 12);
-
-            builder.AddHtmlLocalized(120, 275, 280, 20, 1011261); // Lift a ban
-            builder.AddButton(95, 275, 2714, 2715, 13);
-        }
-
-        private string GetOwnerName()
-        {
-            var m = _house.Owner;
-
-            if (m == null)
-            {
-                return "(unowned)";
-            }
-
-            string name;
-
-            if ((name = m.Name) == null || (name = name.Trim()).Length <= 0)
-            {
-                name = "(no name)";
-            }
-
-            return name;
-        }
-
-        public override void OnResponse(NetState sender, in RelayInfo info)
-        {
-            if (_house.Deleted)
-            {
-                return;
-            }
-
-            var from = sender.Mobile;
-
-            var isCombatRestricted = _house.IsCombatRestricted(from);
-
-            var isOwner = _house.IsOwner(from);
-            var isCoOwner = isOwner || _house.IsCoOwner(from);
-            var isFriend = isCoOwner || _house.IsFriend(from);
-
-            if (isCombatRestricted)
-            {
-                isFriend = isCoOwner = isOwner = false;
-            }
-
-            if (!isFriend || !from.Alive)
-            {
-                return;
-            }
-
-            Item sign = _house.Sign;
-
-            if (sign == null || from.Map != sign.Map || !from.InRange(sign.GetWorldLocation(), 18))
-            {
-                return;
-            }
-
-            var gumps = from.GetGumps();
-
-            switch (info.ButtonID)
-            {
-                case 2: // List of co-owners
-                    {
-                        gumps.Close<HouseGump>();
-                        gumps.Close<HouseRemoveGump>();
-                        gumps.Close<HouseListGump>();
-                        gumps.Send(new HouseListGump(1011275, _house.CoOwners, _house, false));
-
-                        break;
-                    }
-                case 3: // Add co-owner
-                    {
-                        if (isOwner)
-                        {
-                            from.SendLocalizedMessage(
-                                501328
-                            ); // Target the person you wish to name a co-owner of your household.
-                            from.Target = new CoOwnerTarget(true, _house);
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501327); // Only the house owner may add Co-owners.
-                        }
-
-                        break;
-                    }
-                case 4: // Remove co-owner
-                    {
-                        if (isOwner)
-                        {
-                            gumps.Close<HouseGump>();
-                            gumps.Close<HouseListGump>();
-                            gumps.Close<HouseRemoveGump>();
-                            gumps.Send(new HouseRemoveGump(1011274, _house.CoOwners, _house, false));
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501329); // Only the house owner may remove co-owners.
-                        }
-
-                        break;
-                    }
-                case 5: // Clear co-owners
-                    {
-                        if (isOwner)
-                        {
-                            _house.CoOwners?.Clear();
-
-                            from.SendLocalizedMessage(501333); // All co-owners have been removed from this house.
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501330); // Only the house owner may remove co-owners.
-                        }
-
-                        break;
-                    }
-                case 6: // List friends
-                    {
-                        gumps.Close<HouseGump>();
-                        gumps.Close<HouseRemoveGump>();
-                        gumps.Close<HouseListGump>();
-                        gumps.Send(new HouseListGump(1011273, _house.Friends, _house, false));
-
-                        break;
-                    }
-                case 7: // Add friend
-                    {
-                        if (isCoOwner)
-                        {
-                            from.SendLocalizedMessage(
-                                501317
-                            ); // Target the person you wish to name a friend of your household.
-                            from.Target = new HouseFriendTarget(true, _house);
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501316); // Only the house owner may add friends.
-                        }
-
-                        break;
-                    }
-                case 8: // Remove friend
-                    {
-                        if (isCoOwner)
-                        {
-                            gumps.Close<HouseGump>();
-                            gumps.Close<HouseListGump>();
-                            gumps.Close<HouseRemoveGump>();
-                            gumps.Send(new HouseRemoveGump(1011272, _house.Friends, _house, false));
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501318); // Only the house owner may remove friends.
-                        }
-
-                        break;
-                    }
-                case 9: // Clear friends
-                    {
-                        if (isCoOwner)
-                        {
-                            _house.Friends?.Clear();
-
-                            from.SendLocalizedMessage(501332); // All friends have been removed from this house.
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501319); // Only the house owner may remove friends.
-                        }
-
-                        break;
-                    }
-                case 10: // Ban
-                    {
-                        from.SendLocalizedMessage(501325); // Target the individual to ban from this house.
-                        from.Target = new HouseBanTarget(true, _house);
-
-                        break;
-                    }
-                case 11: // Eject
-                    {
-                        from.SendLocalizedMessage(501326); // Target the individual to eject from this house.
-                        from.Target = new HouseKickTarget(_house);
-
-                        break;
-                    }
-                case 12: // List bans
-                    {
-                        gumps.Close<HouseGump>();
-                        gumps.Close<HouseRemoveGump>();
-                        gumps.Close<HouseListGump>();
-                        gumps.Send(new HouseListGump(1011271, _house.Bans, _house, true));
-
-                        break;
-                    }
-                case 13: // Remove ban
-                    {
-                        gumps.Close<HouseGump>();
-                        gumps.Close<HouseListGump>();
-                        gumps.Close<HouseRemoveGump>();
-                        gumps.Send(new HouseRemoveGump(1011269, _house.Bans, _house, true));
-
-                        break;
-                    }
-
-                case 21:
-                    from.CloseGump<HouseGump>();
-                    from.SendGump(new HouseOptionsGump(_house));
                     break;
-            }
+                }
+            case Button.ClearCoOwners: // Clear co-owners
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501329); // Only the house owner may remove co-owners.
+                        break;
+                    }
+
+                    _house.CoOwners?.Clear();
+
+                    from.SendLocalizedMessage(501333); // All co-owners have been removed from this house.
+
+                    break;
+                }
+            case Button.AddFriend: // Add friend
+                {
+                    if (!isCoOwner)
+                    {
+                        from.SendLocalizedMessage(501316); // Only the house owner may add friends.
+                        break;
+                    }
+
+                    from.SendLocalizedMessage(
+                        501317
+                    ); // Target the person you wish to name a friend of your household.
+                    from.Target = new HouseFriendTarget(true, _house);
+
+                    break;
+                }
+            case Button.RemoveFriends: // Remove friend
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501329); // Only the house owner may remove co-owners.
+                        break;
+                    }
+
+                    var switches = info.Switches;
+
+                    if (switches.Length <= 0)
+                    {
+                        break;
+                    }
+
+                    List<Mobile> _copy = [.._house.Friends];
+
+                    for (var i = 0; i < switches.Length; ++i)
+                    {
+                        var index = switches[i];
+
+                        if (index >= 0 && index < _copy.Count)
+                        {
+                            _house.Friends.Remove(_copy[index]);
+                        }
+                    }
+
+                    from.SendGump(new HouseGump(from, _house));
+
+                    break;
+                }
+            case Button.ClearFriends: // Clear friends
+                {
+                    if (!isCoOwner)
+                    {
+                        from.SendLocalizedMessage(501329); // Only the house owner may remove co-owners.
+                        break;
+                    }
+
+                    _house.Friends?.Clear();
+
+                    from.SendLocalizedMessage(501332); // All friends have been removed from this house.
+
+                    break;
+                }
+            case Button.Ban: // Ban
+                {
+                    from.SendLocalizedMessage(501325); // Target the individual to ban from this house.
+                    from.Target = new HouseBanTarget(true, _house);
+
+                    break;
+                }
+            case Button.Eject: // Eject
+                {
+                    from.SendLocalizedMessage(501326); // Target the individual to eject from this house.
+                    from.Target = new HouseKickTarget(_house);
+
+                    break;
+                }
+            case Button.RemoveBans: // Remove ban
+                {
+                    var switches = info.Switches;
+
+                    if (switches.Length <= 0)
+                    {
+                        break;
+                    }
+
+                    List<Mobile> _copy = [.._house.Bans];
+
+                    for (var i = 0; i < switches.Length; ++i)
+                    {
+                        var index = switches[i];
+
+                        if (index >= 0 && index < _copy.Count)
+                        {
+                            _house.Bans.Remove(_copy[index]);
+                        }
+                    }
+
+                    from.SendGump(new HouseGump(from, _house));
+
+                    break;
+                }
+            case Button.ChangeName: // Rename sign
+                {
+                    from.Prompt = new HouseRenamePrompt(_house);
+                    from.SendLocalizedMessage(501302); // What dost thou wish the sign to say?
+
+                    break;
+                }
+            case Button.TransferOwnership: // Transfer ownership
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                        break;
+                    }
+
+                    from.SendLocalizedMessage(501309); // Target the person to whom you wish to give this house.
+                    from.Target = new HouseOwnerTarget(_house);
+
+                    break;
+                }
+            case Button.Demolish: // Demolish house
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501320); // Only the house owner may do this.
+                        break;
+                    }
+
+                    if (!Guild.NewGuildSystem && _house.FindGuildstone() != null)
+                    {
+                        from.SendLocalizedMessage(501389); // You cannot redeed a house with a guildstone inside.
+                    }
+                    else
+                    {
+                        from.SendGump(new ConfirmDemolishHouseGump(_house));
+                    }
+
+
+                    from.SendGump(new HouseGump(from, _house));
+                    break;
+                }
+            case Button.ChangePrivacy: // Declare public/private
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                        break;
+                    }
+
+                    if (_house.Public && _house.PlayerVendors.Count > 0)
+                    {
+                        from.SendLocalizedMessage(
+                            501887
+                        ); // You have vendors working out of this building. It cannot be declared private until there are no vendors in place.
+                        break;
+                    }
+
+                    _house.Public = !_house.Public;
+                    if (!_house.Public)
+                    {
+                        _house.ChangeLocks(from);
+
+                        from.SendLocalizedMessage(501888); // This house is now private.
+                        from.SendLocalizedMessage(
+                            501306
+                        ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
+                    }
+                    else
+                    {
+                        _house.RemoveKeys(from);
+                        _house.RemoveLocks();
+                        from.SendLocalizedMessage(
+                            501886
+                        ); // This house is now public. Friends of the house my now have vendors working out of this building.
+                    }
+
+                    from.SendGump(new HouseGump(from, _house));
+                    break;
+                }
+            case Button.ChangeKeys: // Change locks
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                        break;
+                    }
+
+                    if (_house.Public)
+                    {
+                        from.SendLocalizedMessage(501669); // Public houses are always unlocked.
+                    }
+                    else
+                    {
+                        _house.RemoveKeys(from);
+                        _house.ChangeLocks(from);
+
+                        from.SendLocalizedMessage(
+                            501306
+                        ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
+                    }
+
+                    from.SendGump(new HouseGump(from, _house));
+                    break;
+                }
+            case Button.ChangeSign: // Change sign type
+                {
+                    if (!isOwner)
+                    {
+                        from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                        break;
+                    }
+
+                    if (!_house.Public || info.Switches.Length <= 0)
+                    {
+                        from.SendGump(new HouseGump(from, _house));
+                        break;
+                    }
+
+                    var index = info.Switches[0] - 1;
+
+                    if (index is >= 0 and < 53)
+                    {
+                        _house.ChangeSignType(2980 + index * 2);
+                    }
+
+                    from.SendGump(new HouseGump(from, _house));
+                    break;
+                }
         }
+    }
+
+    private string GetOwnerName()
+    {
+        var m = _house.Owner;
+
+        if (m == null)
+        {
+            return "(unowned)";
+        }
+
+        string name;
+
+        if ((name = m.Name) == null || (name = name.Trim()).Length <= 0)
+        {
+            name = "(no name)";
+        }
+
+        return name;
     }
 }
 
-namespace Server.Prompts
+public class HouseRenamePrompt : Prompt
 {
-    public class RenamePrompt : Prompt
+    private readonly BaseHouse _house;
+
+    public HouseRenamePrompt(BaseHouse house) => _house = house;
+
+    public override void OnResponse(Mobile from, string text)
     {
-        private readonly BaseHouse _house;
-
-        public RenamePrompt(BaseHouse house) => _house = house;
-
-        public override void OnResponse(Mobile from, string text)
+        if (_house.IsFriend(from))
         {
-            if (_house.IsFriend(from))
+            if (_house.Sign != null)
             {
-                if (_house.Sign != null)
-                {
-                    _house.Sign.Name = text;
-                }
-
-                from.SendMessage("Sign changed.");
+                _house.Sign.Name = text;
             }
+
+            from.SendMessage("Sign changed.");
+            from.SendGump(new HouseGump(from, _house));
         }
     }
 }

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -7,20 +7,22 @@ using Server.Prompts;
 
 namespace Server.Gumps;
 
+public enum HouseGumpSection
+{
+    Info,
+    Friends,
+    Options,
+}
+
 public class HouseGump : DynamicGump
 {
-    public enum Section
-    {
-        Info,
-        Friends,
-        Options,
-    }
 
     public enum Page
     {
         One = 1,
         ShopSigns = 2,
         GuildSigns = 3,
+        // allow for 20 pages of each, page size 10, so 200 max bans, co owners, and friends?
         ListBans = 10,
         ListCoOwners = 30,
         ListFriends = 50,
@@ -59,14 +61,14 @@ public class HouseGump : DynamicGump
     private readonly bool _isCoOwner;
     private readonly bool _isFriend;
 
-    private readonly Section _section;
+    private readonly HouseGumpSection _houseGumpSection;
 
     public override bool Singleton => true;
 
-    public HouseGump(Mobile from, BaseHouse house, Section section = Section.Info) : base(50, 50)
+    public HouseGump(Mobile from, BaseHouse house, HouseGumpSection houseGumpSection = HouseGumpSection.Info) : base(50, 50)
     {
         _house = house;
-        _section = section;
+        _houseGumpSection = houseGumpSection;
 
         var isCombatRestricted = house.IsCombatRestricted(from);
 
@@ -83,18 +85,6 @@ public class HouseGump : DynamicGump
     private void AddBackButton(ref DynamicGumpBuilder builder, int buttonId)
     {
         builder.AddButton(15, 389, 0xFAE, 0xFB0, buttonId); // back button
-    }
-
-    private void AddTableOfContents(ref DynamicGumpBuilder builder)
-    {
-        builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
-        builder.AddButton(370, 20, 0x16CD, 0x16CE, (int)Button.GotoInfo);
-
-        builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
-        builder.AddButton(370, 50, 0x16CD, 0x16CE, (int)Button.GotoFriends);
-
-        builder.AddHtmlLocalized(314, 79, 75, 20, 1011235); // OPTIONS
-        builder.AddButton(370, 79, 0x16CD, 0x16CE, (int)Button.GotoOptions);
     }
 
     protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -131,21 +121,29 @@ public class HouseGump : DynamicGump
             return;
         }
 
-        AddTableOfContents(ref builder);
+        // Table of Contents
+        builder.AddHtmlLocalized(340, 17, 75, 20, 1011233); // INFO
+        builder.AddButton(374, 15, 0xFAB, 0xFAD, (int)Button.GotoInfo);
 
-        switch (_section)
+        builder.AddHtmlLocalized(319, 47, 75, 20, 1011234); // FRIENDS
+        builder.AddButton(374, 45, 0xFA8, 0xFAA, (int)Button.GotoFriends);
+
+        builder.AddHtmlLocalized(319, 77, 75, 20, 1011235); // OPTIONS
+        builder.AddButton(374, 75, 0xFBD, 0xFBF, (int)Button.GotoOptions);
+
+        switch (_houseGumpSection)
         {
-            case Section.Info:
+            case HouseGumpSection.Info:
                 {
                     BuildInfoPage(ref builder);
                     break;
                 }
-            case Section.Friends:
+            case HouseGumpSection.Friends:
                 {
                     BuildPeoplePages(ref builder);
                     break;
                 }
-            case Section.Options:
+            case HouseGumpSection.Options:
                 {
                     BuildOptionsPages(ref builder);
                     break;
@@ -245,7 +243,7 @@ public class HouseGump : DynamicGump
             {
                 if (i + pageSize < _house.Bans.Count)
                 {
-                    builder.AddButton(370, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListBans);
+                    builder.AddButton(374, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListBans);
                 }
 
                 builder.AddPage(i / pageSize + (int)Page.ListBans);
@@ -266,8 +264,8 @@ public class HouseGump : DynamicGump
                 builder.AddHtmlLocalized(260, 250, 150, 20, 1011258); // View a list of banned people
                 builder.AddButton(370, 250, 0xFBD, 0xFBF, (int)Button.Ban);
 
-                builder.AddHtmlLocalized(240, 280, 150, 20, 1011261); // Lift a ban
-                builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveBans);
+                builder.AddHtmlLocalized(245, 280, 150, 20, 1011261); // Lift a ban
+                builder.AddButton(374, 280, 0xFA2, 0xFA4, (int)Button.RemoveBans);
 
                 AddBackButton(ref builder, (int)Button.GotoFriends);
             }
@@ -316,11 +314,11 @@ public class HouseGump : DynamicGump
                     );
                 }
 
-                builder.AddHtmlLocalized(260, 250, 150, 20, 1011267); // Add a co-owner
-                builder.AddButton(370, 250, 0xFBD, 0xFBF, (int)Button.AddCoOwner);
+                builder.AddHtmlLocalized(265, 250, 150, 20, 1011267); // Add a co-owner
+                builder.AddButton(374, 250, 0xFBD, 0xFBF, (int)Button.AddCoOwner);
 
-                builder.AddHtmlLocalized(240, 280, 150, 20, 1018036); // Remove a co-owner
-                builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveCoOwners);
+                builder.AddHtmlLocalized(245, 280, 150, 20, 1018036); // Remove a co-owner
+                builder.AddButton(374, 280, 0xFA2, 0xFA4, (int)Button.RemoveCoOwners);
 
                 AddBackButton(ref builder, (int)Button.GotoFriends);
             }
@@ -351,7 +349,7 @@ public class HouseGump : DynamicGump
             {
                 if (i + pageSize < _house.Friends.Count)
                 {
-                    builder.AddButton(370, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListFriends);
+                    builder.AddButton(374, 310, 4005, 4007, 0, GumpButtonType.Page, i / pageSize + (int)Page.ListFriends);
                 }
 
                 builder.AddPage(i / pageSize + (int)Page.ListFriends);
@@ -370,10 +368,10 @@ public class HouseGump : DynamicGump
                 }
 
                 builder.AddHtmlLocalized(260, 250, 150, 20, 1011244); // Add a friend
-                builder.AddButton(370, 250, 0xFBD, 0xFBF, (int)Button.AddFriend);
+                builder.AddButton(374, 250, 0xFBD, 0xFBF, (int)Button.AddFriend);
 
                 builder.AddHtmlLocalized(240, 280, 150, 20, 1018037); // Remove a friend
-                builder.AddButton(370, 280, 0xFA2, 0xFA4, (int)Button.RemoveFriends);
+                builder.AddButton(374, 280, 0xFA2, 0xFA4, (int)Button.RemoveFriends);
 
                 AddBackButton(ref builder, (int)Button.GotoFriends);
             }
@@ -442,11 +440,11 @@ public class HouseGump : DynamicGump
             builder.AddItem(36 + i / 4 * 65, 130 + i % 4 * 35, 2980 + i * 2);
         }
 
-        builder.AddHtmlLocalized(240, 360, 129, 20, 1011254); // Guild sign choices
-        builder.AddButton(360, 359, 0xFA5, 0xFA7, 0, GumpButtonType.Page, (int)Page.GuildSigns);
+        builder.AddHtmlLocalized(254, 360, 129, 20, 1011254); // Guild sign choices
+        builder.AddButton(374, 359, 0xFA5, 0xFA7, 0, GumpButtonType.Page, (int)Page.GuildSigns);
 
-        builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
-        builder.AddButton(360, 389, 0xFB7, 0xFB9, (int)Button.ChangeSign);
+        builder.AddHtmlLocalized(254, 390, 355, 30, 1011277); // Okay that is fine.
+        builder.AddButton(374, 389, 0xFB7, 0xFB9, (int)Button.ChangeSign);
 
         builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.One);
 
@@ -458,11 +456,11 @@ public class HouseGump : DynamicGump
             builder.AddItem(36 + i / 5 * 65, 130 + i % 5 * 35, 3028 + i * 2);
         }
 
-        builder.AddHtmlLocalized(240, 360, 129, 20, 1011255); // Shop sign choices
-        builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.ShopSigns);
+        builder.AddHtmlLocalized(254, 360, 129, 20, 1011255); // Shop sign choices
+        builder.AddButton(374, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.ShopSigns);
 
-        builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
-        builder.AddButton(360, 389, 0xFB7, 0xFB9, (int)Button.ChangeSign);
+        builder.AddHtmlLocalized(254, 390, 355, 30, 1011277); // Okay that is fine.
+        builder.AddButton(374, 389, 0xFB7, 0xFB9, (int)Button.ChangeSign);
 
         builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.One);
     }
@@ -550,7 +548,7 @@ public class HouseGump : DynamicGump
                         }
                     }
 
-                    from.SendGump(new HouseGump(from, _house, Section.Friends));
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Friends));
 
                     break;
                 }
@@ -565,6 +563,8 @@ public class HouseGump : DynamicGump
                     _house.CoOwners?.Clear();
 
                     from.SendLocalizedMessage(501333); // All co-owners have been removed from this house.
+
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Friends));
 
                     break;
                 }
@@ -610,7 +610,7 @@ public class HouseGump : DynamicGump
                         }
                     }
 
-                    from.SendGump(new HouseGump(from, _house, Section.Friends));
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Friends));
 
                     break;
                 }
@@ -625,6 +625,8 @@ public class HouseGump : DynamicGump
                     _house.Friends?.Clear();
 
                     from.SendLocalizedMessage(501332); // All friends have been removed from this house.
+
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Friends));
 
                     break;
                 }
@@ -663,7 +665,7 @@ public class HouseGump : DynamicGump
                         }
                     }
 
-                    from.SendGump(new HouseGump(from, _house, Section.Friends));
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Friends));
 
                     break;
                 }
@@ -741,7 +743,7 @@ public class HouseGump : DynamicGump
                         ); // This house is now public. Friends of the house my now have vendors working out of this building.
                     }
 
-                    from.SendGump(new HouseGump(from, _house, Section.Options));
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Options));
                     break;
                 }
             case Button.ChangeKeys: // Change locks
@@ -766,7 +768,7 @@ public class HouseGump : DynamicGump
                         ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
                     }
 
-                    from.SendGump(new HouseGump(from, _house, Section.Options));
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Options));
                     break;
                 }
             case Button.ChangeSign: // Change sign type
@@ -790,17 +792,17 @@ public class HouseGump : DynamicGump
                         _house.ChangeSignType(2980 + index * 2);
                     }
 
-                    from.SendGump(new HouseGump(from, _house, Section.Options));
+                    from.SendGump(new HouseGump(from, _house, HouseGumpSection.Options));
                     break;
                 }
             case Button.GotoInfo:
                 from.SendGump(new HouseGump(from, _house));
                 break;
             case Button.GotoFriends:
-                from.SendGump(new HouseGump(from, _house, Section.Friends));
+                from.SendGump(new HouseGump(from, _house, HouseGumpSection.Friends));
                 break;
             case Button.GotoOptions:
-                from.SendGump(new HouseGump(from, _house, Section.Options));
+                from.SendGump(new HouseGump(from, _house, HouseGumpSection.Options));
                 break;
         }
     }
@@ -840,7 +842,7 @@ public class HouseRenamePrompt : Prompt
                 _house.Sign.Name = text;
             }
 
-            from.SendGump(new HouseGump(from, _house, HouseGump.Section.Options));
+            from.SendGump(new HouseGump(from, _house, HouseGumpSection.Options));
         }
     }
 }

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -224,11 +224,362 @@ namespace Server.Gumps
         }
     }
 
-    public class HouseGump : Gump
+    public class HouseSignSelectionGump : DynamicGump
     {
         private readonly BaseHouse _house;
 
         public override bool Singleton => true;
+
+        public HouseSignSelectionGump(BaseHouse house) : base(20, 30) => _house = house;
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            if (_house.Deleted)
+            {
+                return;
+            }
+
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 420, 430, 0x6DB);
+            builder.AddBackground(5, 5, 410, 420, 0xBB8);
+
+            builder.AddImage(15, 15, 100);
+
+            if (_house.Sign != null)
+            {
+                var lines = _house.Sign.GetName().Wrap(10, 6);
+
+                for (int i = 0, y = (101 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
+                {
+                    var s = lines[i];
+
+                    builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
+                }
+            }
+
+            builder.AddPage(1);
+
+            for (var i = 0; i < 24; ++i)
+            {
+                builder.AddRadio(16 + i / 4 * 65, 137 + i % 4 * 35, 210, 211, false, i + 1);
+                builder.AddItem(36 + i / 4 * 65, 130 + i % 4 * 35, 2980 + i * 2);
+            }
+
+            builder.AddHtmlLocalized(240, 360, 129, 20, 1011254); // Guild sign choices
+            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 2);
+
+            builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
+            builder.AddButton(360, 389, 0xFB7, 0xFB9, 1);
+
+            builder.AddPage(2);
+
+            for (var i = 0; i < 29; ++i)
+            {
+                builder.AddRadio(16 + i / 5 * 65, 137 + i % 5 * 35, 210, 211, false, i + 25);
+                builder.AddItem(36 + i / 5 * 65, 130 + i % 5 * 35, 3028 + i * 2);
+            }
+
+            builder.AddHtmlLocalized(240, 360, 129, 20, 1011255); // Shop sign choices
+            builder.AddButton(360, 359, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 1);
+
+            builder.AddHtmlLocalized(240, 390, 355, 30, 1011277); // Okay that is fine.
+            builder.AddButton(360, 389, 0xFB7, 0xFB9, 1);
+        }
+
+        public override void OnResponse(NetState state, in RelayInfo info)
+        {
+            if (_house.Deleted)
+            {
+                return;
+            }
+
+            var from = state.Mobile;
+
+            if (!_house.Public || info.Switches.Length <= 0 || info.ButtonID == 0)
+            {
+                from.SendGump(new HouseGump(from, _house));
+                return;
+            }
+
+            var isCombatRestricted = _house.IsCombatRestricted(from);
+
+            var isOwner = _house.IsOwner(from);
+            var isCoOwner = isOwner || _house.IsCoOwner(from);
+            var isFriend = isCoOwner || _house.IsFriend(from);
+
+            if (isCombatRestricted)
+            {
+                isFriend = isOwner = false;
+            }
+
+            if (!isFriend || !from.Alive)
+            {
+                return;
+            }
+
+            if (!isOwner)
+            {
+                from.SendLocalizedMessage(501307); // Only the house owner may do this.
+                from.SendGump(new HouseGump(from, _house));
+                return;
+            }
+
+            var index = info.Switches[0] - 1;
+
+            if (index is >= 0 and < 53)
+            {
+                _house.ChangeSignType(2980 + index * 2);
+            }
+
+            // back to HouseOptionsGump because that opened HouseSignSelectionGump
+            from.SendGump(new HouseOptionsGump(_house));
+        }
+    }
+
+    public class HouseOptionsGump : DynamicGump
+    {
+        private readonly BaseHouse _house;
+
+        public override bool Singleton => true;
+
+        public HouseOptionsGump(BaseHouse house) : base(20, 30) => _house = house;
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            if (_house.Deleted)
+            {
+                return;
+            }
+
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 420, 430, 0x6DB);
+            builder.AddBackground(5, 5, 410, 420, 0xBB8);
+
+            builder.AddImage(15, 15, 100);
+
+            if (_house.Sign != null)
+            {
+                var lines = _house.Sign.GetName().Wrap(10, 6);
+
+                for (int i = 0, y = (101 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
+                {
+                    var s = lines[i];
+
+                    builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
+                }
+            }
+
+            builder.AddItem(22, 144, 0xFBF); // scribe's pen
+            builder.AddButton(65, 146, 0x16CD, 0x16CE, 1);
+            builder.AddHtmlLocalized(95, 145, 200, 20, 1011236); // Change this house's name!
+
+            builder.AddImage(10, 165, 0x1196); // right facing arrow
+            builder.AddButton(65, 181, 0x16CD, 0x16CE, 2);
+            builder.AddHtmlLocalized(95, 180, 200, 30, 1011248); // Transfer ownership of the house
+
+            builder.AddItem(10, 211, 0x14F0); // deed
+            builder.AddButton(65, 216, 0x16CD, 0x16CE, 3);
+            builder.AddHtmlLocalized(95, 215, 300, 30, 1011249); // Demolish house and get deed back
+
+            if (!_house.Public)
+            {
+                builder.AddItem(14, 252, 0x176B); // keyring with keys
+                builder.AddButton(65, 251, 0x16CD, 0x16CE, 5);
+                builder.AddHtmlLocalized(95, 250, 355, 30, 1011247); // Change the house locks
+
+                builder.AddItem(14, 284, 0xBC4); // inn sign
+                builder.AddButton(65, 286, 0x16CD, 0x16CE, 4);
+                builder.AddHtmlLocalized(
+                    95,
+                    285,
+                    300,
+                    90,
+                    1011253
+                ); // Declare this building to be public. This will make your front door unlockable.
+            }
+            else
+            {
+                builder.AddItem(14, 247, 0xBD2); // default sign
+                builder.AddButton(65, 251, 0x16CD, 0x16CE, 4);
+                builder.AddHtmlLocalized(95, 250, 300, 30, 1011252); // Declare this building to be private.
+
+                builder.AddItem(14, 284, 0xBCA); // artist sign
+                builder.AddButton(65, 286, 0x16CD, 0x16CE, 6);
+                builder.AddHtmlLocalized(95, 285, 200, 30, 1011250); // Change the sign type
+            }
+        }
+
+        public override void OnResponse(NetState state, in RelayInfo info)
+        {
+            if (_house.Deleted)
+            {
+                return;
+            }
+
+            var from = state.Mobile;
+
+            if (info.ButtonID == 0)
+            {
+                from.SendGump(new HouseGump(from, _house));
+                return;
+            }
+
+            var isCombatRestricted = _house.IsCombatRestricted(from);
+
+            var isOwner = _house.IsOwner(from);
+            var isCoOwner = isOwner || _house.IsCoOwner(from);
+            var isFriend = isCoOwner || _house.IsFriend(from);
+
+            if (isCombatRestricted)
+            {
+                isFriend = isOwner = false;
+            }
+
+            if (!isFriend || !from.Alive)
+            {
+                return;
+            }
+
+            Item sign = _house.Sign;
+
+            if (sign == null || from.Map != sign.Map || !from.InRange(sign.GetWorldLocation(), 18))
+            {
+                return;
+            }
+
+            switch (info.ButtonID)
+            {
+                case 1: // Rename sign
+                    {
+                        from.Prompt = new RenamePrompt(_house);
+                        from.SendLocalizedMessage(501302); // What dost thou wish the sign to say?
+
+                        break;
+                    }
+                case 2: // Transfer ownership
+                    {
+                        if (!isOwner)
+                        {
+                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                            break;
+                        }
+
+                        from.SendLocalizedMessage(501309); // Target the person to whom you wish to give this house.
+                        from.Target = new HouseOwnerTarget(_house);
+
+                        break;
+                    }
+                case 3: // Demolish house
+                    {
+                        if (isOwner)
+                        {
+                            if (!Guild.NewGuildSystem && _house.FindGuildstone() != null)
+                            {
+                                from.SendLocalizedMessage(501389); // You cannot redeed a house with a guildstone inside.
+                            }
+                            else
+                            {
+                                from.SendGump(new ConfirmDemolishHouseGump(_house));
+                            }
+                        }
+                        else
+                        {
+                            from.SendLocalizedMessage(501320); // Only the house owner may do this.
+                        }
+
+                        from.SendGump(new HouseOptionsGump(_house));
+                        break;
+                    }
+                case 4: // Declare public/private
+                    {
+                        if (!isOwner)
+                        {
+                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                            break;
+                        }
+
+                        if (_house.Public && _house.PlayerVendors.Count > 0)
+                        {
+                            from.SendLocalizedMessage(
+                                501887
+                            ); // You have vendors working out of this building. It cannot be declared private until there are no vendors in place.
+                            break;
+                        }
+
+                        _house.Public = !_house.Public;
+                        if (!_house.Public)
+                        {
+                            _house.ChangeLocks(from);
+
+                            from.SendLocalizedMessage(501888); // This house is now private.
+                            from.SendLocalizedMessage(
+                                501306
+                            ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
+                        }
+                        else
+                        {
+                            _house.RemoveKeys(from);
+                            _house.RemoveLocks();
+                            from.SendLocalizedMessage(
+                                501886
+                            ); // This house is now public. Friends of the house my now have vendors working out of this building.
+                        }
+
+                        from.SendGump(new HouseOptionsGump(_house));
+                        break;
+                    }
+                case 5: // Change locks
+                    {
+                        if (!isOwner)
+                        {
+                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                            break;
+                        }
+
+                        if (_house.Public)
+                        {
+                            from.SendLocalizedMessage(501669); // Public houses are always unlocked.
+                        }
+                        else
+                        {
+                            _house.RemoveKeys(from);
+                            _house.ChangeLocks(from);
+
+                            from.SendLocalizedMessage(
+                                501306
+                            ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
+                        }
+
+                        from.SendGump(new HouseOptionsGump(_house));
+                        break;
+                    }
+                case 6: // Change sign type
+                    {
+                        if (!isOwner)
+                        {
+                            from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
+                            break;
+                        }
+
+                        from.SendGump(new HouseSignSelectionGump(_house));
+                        break;
+                    }
+            }
+        }
+    }
+
+    public class HouseGump : DynamicGump
+    {
+        private readonly BaseHouse _house;
+
+        private readonly bool _isOwner;
+        private readonly bool _isCoOwner;
+        private readonly bool _isFriend;
+
+        public override bool Singleton => true;
+
 
         public HouseGump(Mobile from, BaseHouse house) : base(20, 30)
         {
@@ -239,31 +590,39 @@ namespace Server.Gumps
 
             _house = house;
 
-            var gumps = from.GetGumps();
-
-            gumps.Close<HouseListGump>();
-            gumps.Close<HouseRemoveGump>();
+            from.CloseGump<HouseListGump>();
+            from.CloseGump<HouseRemoveGump>();
 
             var isCombatRestricted = house.IsCombatRestricted(from);
 
-            var isOwner = _house.IsOwner(from);
-            var isCoOwner = isOwner || _house.IsCoOwner(from);
-            var isFriend = isCoOwner || _house.IsFriend(from);
+            _isOwner = _house.IsOwner(from);
+            _isCoOwner = _isOwner || _house.IsCoOwner(from);
+            _isFriend = _isCoOwner || _house.IsFriend(from);
 
             if (isCombatRestricted)
             {
-                isFriend = isCoOwner = isOwner = false;
+                _isFriend = _isCoOwner = _isOwner = false;
             }
 
-            AddPage(0);
+            from.SendMessage("HouseGump");
+        }
 
-            if (isFriend)
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            if (_house.Deleted)
             {
-                AddBackground(0, 0, 420, 430, 5054);
-                AddBackground(10, 10, 400, 410, 3000);
+                return;
             }
 
-            AddImage(130, 0, 100);
+            builder.AddPage();
+
+            if (_isFriend)
+            {
+                builder.AddBackground(0, 0, 420, 430, 0x6DB);
+                builder.AddBackground(5, 5, 410, 420, 0xBB8);
+            }
+
+            builder.AddImage(15, 15, 100);
 
             if (_house.Sign != null)
             {
@@ -273,158 +632,94 @@ namespace Server.Gumps
                 {
                     var s = lines[i];
 
-                    AddLabel(130 + (143 - s.Length * 8) / 2, y, 0, s);
+                    builder.AddLabel(15 + (143 - s.Length * 8) / 2, 15 + y, 0, s);
                 }
             }
 
-            if (!isFriend)
+            if (!_isFriend)
             {
                 return;
             }
 
-            AddHtmlLocalized(55, 103, 75, 20, 1011233); // INFO
-            AddButton(20, 103, 4005, 4007, 0, GumpButtonType.Page, 1);
+            builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
+            builder.AddButton(370, 20, 0x16CD, 0x16CE, 0, GumpButtonType.Page, 1);
 
-            AddHtmlLocalized(170, 103, 75, 20, 1011234); // FRIENDS
-            AddButton(135, 103, 4005, 4007, 0, GumpButtonType.Page, 2);
+            builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
+            builder.AddButton(370, 50, 0x16CD, 0x16CE, 0, GumpButtonType.Page, 2);
 
-            AddHtmlLocalized(295, 103, 75, 20, 1011235); // OPTIONS
-            AddButton(260, 103, 4005, 4007, 0, GumpButtonType.Page, 3);
+            builder.AddHtmlLocalized(314, 79, 75, 20, 1011235); // OPTIONS
+            // builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, 3);
+            builder.AddButton(370, 79, 0x16CD, 0x16CE, 21); // HouseOptionsGump
 
-            AddHtmlLocalized(295, 390, 75, 20, 1011441); // EXIT
-            AddButton(260, 390, 4005, 4007, 0);
-
-            AddHtmlLocalized(55, 390, 200, 20, 1011236); // Change this house's name!
-            AddButton(20, 390, 4005, 4007, 1);
+            builder.AddButton(360, 389, 0xFB1, 0xFB3, 0);
+            builder.AddHtmlLocalized(320, 390, 75, 20, 1011441); // EXIT
 
             // Info page
-            AddPage(1);
+            builder.AddPage(1);
 
-            AddHtmlLocalized(20, 135, 100, 20, 1011242); // Owned by:
-            AddHtml(120, 135, 100, 20, GetOwnerName());
+            builder.AddHtmlLocalized(20, 135, 100, 20, 1011242); // Owned by:
+            builder.AddHtml(100, 135, 100, 20, GetOwnerName());
 
-            AddHtmlLocalized(20, 170, 275, 20, 1011237); // Number of locked down items:
-            AddHtml(320, 170, 50, 20, _house.LockDownCount.ToString());
+            builder.AddHtmlLocalized(20, 175, 275, 20, 1011237); // Number of locked down items:
+            builder.AddHtml(320, 175, 50, 20, _house.LockDownCount.ToString());
 
-            AddHtmlLocalized(20, 190, 275, 20, 1011238); // Maximum locked down items:
-            AddHtml(320, 190, 50, 20, _house.MaxLockDowns.ToString());
+            builder.AddHtmlLocalized(20, 200, 275, 20, 1011238); // Maximum locked down items:
+            builder.AddHtml(320, 200, 50, 20, _house.MaxLockDowns.ToString());
 
-            AddHtmlLocalized(20, 210, 275, 20, 1011239); // Number of secure containers:
-            AddHtml(320, 210, 50, 20, _house.SecureCount.ToString());
+            builder.AddHtmlLocalized(20, 225, 275, 20, 1011239); // Number of secure containers:
+            builder.AddHtml(320, 225, 50, 20, _house.SecureCount.ToString());
 
-            AddHtmlLocalized(20, 230, 275, 20, 1011240); // Maximum number of secure containers:
-            AddHtml(320, 230, 50, 20, _house.MaxSecures.ToString());
+            builder.AddHtmlLocalized(20, 250, 275, 20, 1011240); // Maximum number of secure containers:
+            builder.AddHtml(320, 250, 50, 20, _house.MaxSecures.ToString());
 
-            AddHtmlLocalized(20, 260, 400, 20, 1018032); // This house is properly placed.
-            AddHtmlLocalized(20, 280, 400, 20, 1018035); // This house is of modern design.
+            builder.AddHtmlLocalized(20, 290, 400, 20, 1018032); // This house is properly placed.
+            builder.AddHtmlLocalized(20, 310, 400, 20, 1018035); // This house is of modern design.
 
             if (_house.Public)
             {
                 // TODO: Validate exact placement
-                AddHtmlLocalized(20, 305, 275, 20, 1011241); // Number of visits this building has had
-                AddHtml(320, 305, 50, 20, _house.Visits.ToString());
+                builder.AddHtmlLocalized(20, 345, 275, 20, 1011241); // Number of visits this building has had
+                builder.AddHtml(320, 345, 50, 20, _house.Visits.ToString());
             }
 
             // Friends page
-            AddPage(2);
+            builder.AddPage(2);
 
-            AddHtmlLocalized(45, 130, 150, 20, 1011266); // List of co-owners
-            AddButton(20, 130, 2714, 2715, 2);
+            builder.AddHtmlLocalized(45, 130, 150, 20, 1011266); // List of co-owners
+            builder.AddButton(20, 130, 2714, 2715, 2);
 
-            AddHtmlLocalized(45, 150, 150, 20, 1011267); // Add a co-owner
-            AddButton(20, 150, 2714, 2715, 3);
+            builder.AddHtmlLocalized(45, 150, 150, 20, 1011267); // Add a co-owner
+            builder.AddButton(20, 150, 2714, 2715, 3);
 
-            AddHtmlLocalized(45, 170, 150, 20, 1018036); // Remove a co-owner
-            AddButton(20, 170, 2714, 2715, 4);
+            builder.AddHtmlLocalized(45, 170, 150, 20, 1018036); // Remove a co-owner
+            builder.AddButton(20, 170, 2714, 2715, 4);
 
-            AddHtmlLocalized(45, 190, 150, 20, 1011268); // Clear co-owner list
-            AddButton(20, 190, 2714, 2715, 5);
+            builder.AddHtmlLocalized(45, 190, 150, 20, 1011268); // Clear co-owner list
+            builder.AddButton(20, 190, 2714, 2715, 5);
 
-            AddHtmlLocalized(225, 130, 155, 20, 1011243); // List of Friends
-            AddButton(200, 130, 2714, 2715, 6);
+            builder.AddHtmlLocalized(225, 130, 155, 20, 1011243); // List of Friends
+            builder.AddButton(200, 130, 2714, 2715, 6);
 
-            AddHtmlLocalized(225, 150, 155, 20, 1011244); // Add a Friend
-            AddButton(200, 150, 2714, 2715, 7);
+            builder.AddHtmlLocalized(225, 150, 155, 20, 1011244); // Add a Friend
+            builder.AddButton(200, 150, 2714, 2715, 7);
 
-            AddHtmlLocalized(225, 170, 155, 20, 1018037); // Remove a Friend
-            AddButton(200, 170, 2714, 2715, 8);
+            builder.AddHtmlLocalized(225, 170, 155, 20, 1018037); // Remove a Friend
+            builder.AddButton(200, 170, 2714, 2715, 8);
 
-            AddHtmlLocalized(225, 190, 155, 20, 1011245); // Clear Friends list
-            AddButton(200, 190, 2714, 2715, 9);
+            builder.AddHtmlLocalized(225, 190, 155, 20, 1011245); // Clear Friends list
+            builder.AddButton(200, 190, 2714, 2715, 9);
 
-            AddHtmlLocalized(120, 215, 280, 20, 1011258); // Ban someone from the house
-            AddButton(95, 215, 2714, 2715, 10);
+            builder.AddHtmlLocalized(120, 215, 280, 20, 1011258); // Ban someone from the house
+            builder.AddButton(95, 215, 2714, 2715, 10);
 
-            AddHtmlLocalized(120, 235, 280, 20, 1011259); // Eject someone from the house
-            AddButton(95, 235, 2714, 2715, 11);
+            builder.AddHtmlLocalized(120, 235, 280, 20, 1011259); // Eject someone from the house
+            builder.AddButton(95, 235, 2714, 2715, 11);
 
-            AddHtmlLocalized(120, 255, 280, 20, 1011260); // View a list of banned people
-            AddButton(95, 255, 2714, 2715, 12);
+            builder.AddHtmlLocalized(120, 255, 280, 20, 1011260); // View a list of banned people
+            builder.AddButton(95, 255, 2714, 2715, 12);
 
-            AddHtmlLocalized(120, 275, 280, 20, 1011261); // Lift a ban
-            AddButton(95, 275, 2714, 2715, 13);
-
-            // Options page
-            AddPage(3);
-
-            AddHtmlLocalized(45, 150, 355, 30, 1011248); // Transfer ownership of the house
-            AddButton(20, 150, 2714, 2715, 14);
-
-            AddHtmlLocalized(45, 180, 355, 30, 1011249); // Demolish house and get deed back
-            AddButton(20, 180, 2714, 2715, 15);
-
-            if (!_house.Public)
-            {
-                AddHtmlLocalized(45, 210, 355, 30, 1011247); // Change the house locks
-                AddButton(20, 210, 2714, 2715, 16);
-
-                AddHtmlLocalized(
-                    45,
-                    240,
-                    350,
-                    90,
-                    1011253
-                ); // Declare this building to be public. This will make your front door unlockable.
-                AddButton(20, 240, 2714, 2715, 17);
-            }
-            else
-            {
-                // AddHtmlLocalized( 45, 280, 350, 30, 1011250, false, false ); // Change the sign type
-                AddHtmlLocalized(45, 210, 350, 30, 1011250); // Change the sign type
-                AddButton(20, 210, 2714, 2715, 0, GumpButtonType.Page, 4);
-
-                AddHtmlLocalized(45, 240, 350, 30, 1011252); // Declare this building to be private.
-                AddButton(20, 240, 2714, 2715, 17);
-
-                // Change the sign type
-                AddPage(4);
-
-                for (var i = 0; i < 24; ++i)
-                {
-                    AddRadio(53 + i / 4 * 50, 137 + i % 4 * 35, 210, 211, false, i + 1);
-                    AddItem(60 + i / 4 * 50, 130 + i % 4 * 35, 2980 + i * 2);
-                }
-
-                AddHtmlLocalized(200, 305, 129, 20, 1011254); // Guild sign choices
-                AddButton(350, 305, 252, 253, 0, GumpButtonType.Page, 5);
-
-                AddHtmlLocalized(200, 340, 355, 30, 1011277); // Okay that is fine.
-                AddButton(350, 340, 4005, 4007, 18);
-
-                AddPage(5);
-
-                for (var i = 0; i < 29; ++i)
-                {
-                    AddRadio(53 + i / 5 * 50, 137 + i % 5 * 35, 210, 211, false, i + 25);
-                    AddItem(60 + i / 5 * 50, 130 + i % 5 * 35, 3028 + i * 2);
-                }
-
-                AddHtmlLocalized(200, 305, 129, 20, 1011255); // Shop sign choices
-                AddButton(350, 305, 250, 251, 0, GumpButtonType.Page, 4);
-
-                AddHtmlLocalized(200, 340, 355, 30, 1011277); // Okay that is fine.
-                AddButton(350, 340, 4005, 4007, 18);
-            }
+            builder.AddHtmlLocalized(120, 275, 280, 20, 1011261); // Lift a ban
+            builder.AddButton(95, 275, 2714, 2715, 13);
         }
 
         private string GetOwnerName()
@@ -482,13 +777,6 @@ namespace Server.Gumps
 
             switch (info.ButtonID)
             {
-                case 1: // Rename sign
-                    {
-                        from.Prompt = new RenamePrompt(_house);
-                        from.SendLocalizedMessage(501302); // What dost thou wish the sign to say?
-
-                        break;
-                    }
                 case 2: // List of co-owners
                     {
                         gumps.Close<HouseGump>();
@@ -633,124 +921,11 @@ namespace Server.Gumps
 
                         break;
                     }
-                case 14: // Transfer ownership
-                    {
-                        if (isOwner)
-                        {
-                            from.SendLocalizedMessage(501309); // Target the person to whom you wish to give this house.
-                            from.Target = new HouseOwnerTarget(_house);
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501310); // Only the house owner may do this.
-                        }
 
-                        break;
-                    }
-                case 15: // Demolish house
-                    {
-                        if (isOwner)
-                        {
-                            if (!Guild.NewGuildSystem && _house.FindGuildstone() != null)
-                            {
-                                from.SendLocalizedMessage(501389); // You cannot redeed a house with a guildstone inside.
-                            }
-                            else
-                            {
-                                gumps.Send(new ConfirmDemolishHouseGump(_house));
-                            }
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501320); // Only the house owner may do this.
-                        }
-
-                        break;
-                    }
-                case 16: // Change locks
-                    {
-                        if (_house.Public)
-                        {
-                            from.SendLocalizedMessage(501669); // Public houses are always unlocked.
-                        }
-                        else
-                        {
-                            if (isOwner)
-                            {
-                                _house.RemoveKeys(from);
-                                _house.ChangeLocks(from);
-
-                                from.SendLocalizedMessage(
-                                    501306
-                                ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
-                            }
-                            else
-                            {
-                                from.SendLocalizedMessage(501303); // Only the house owner may change the house locks.
-                            }
-                        }
-
-                        break;
-                    }
-                case 17: // Declare public/private
-                    {
-                        if (isOwner)
-                        {
-                            if (_house.Public && _house.PlayerVendors.Count > 0)
-                            {
-                                from.SendLocalizedMessage(
-                                    501887
-                                ); // You have vendors working out of this building. It cannot be declared private until there are no vendors in place.
-                                break;
-                            }
-
-                            _house.Public = !_house.Public;
-                            if (!_house.Public)
-                            {
-                                _house.ChangeLocks(from);
-
-                                from.SendLocalizedMessage(501888); // This house is now private.
-                                from.SendLocalizedMessage(
-                                    501306
-                                ); // The locks on your front door have been changed, and new master keys have been placed in your bank and your backpack.
-                            }
-                            else
-                            {
-                                _house.RemoveKeys(from);
-                                _house.RemoveLocks();
-                                from.SendLocalizedMessage(
-                                    501886
-                                ); // This house is now public. Friends of the house my now have vendors working out of this building.
-                            }
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501307); // Only the house owner may do this.
-                        }
-
-                        break;
-                    }
-                case 18: // Change type
-                    {
-                        if (isOwner)
-                        {
-                            if (_house.Public && info.Switches.Length > 0)
-                            {
-                                var index = info.Switches[0] - 1;
-
-                                if (index >= 0 && index < 53)
-                                {
-                                    _house.ChangeSignType(2980 + index * 2);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            from.SendLocalizedMessage(501307); // Only the house owner may do this.
-                        }
-
-                        break;
-                    }
+                case 21:
+                    from.CloseGump<HouseGump>();
+                    from.SendGump(new HouseOptionsGump(_house));
+                    break;
             }
         }
     }
@@ -760,17 +935,17 @@ namespace Server.Prompts
 {
     public class RenamePrompt : Prompt
     {
-        private readonly BaseHouse m_House;
+        private readonly BaseHouse _house;
 
-        public RenamePrompt(BaseHouse house) => m_House = house;
+        public RenamePrompt(BaseHouse house) => _house = house;
 
         public override void OnResponse(Mobile from, string text)
         {
-            if (m_House.IsFriend(from))
+            if (_house.IsFriend(from))
             {
-                if (m_House.Sign != null)
+                if (_house.Sign != null)
                 {
-                    m_House.Sign.Name = text;
+                    _house.Sign.Name = text;
                 }
 
                 from.SendMessage("Sign changed.");

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -103,8 +103,8 @@ public class HouseGump : DynamicGump
         builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
         builder.AddButton(370, 50, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.People);
 
-        builder.AddHtmlLocalized(314, 79, 75, 20, 1011235);                                    // OPTIONS
-        builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Options); // HouseOptionsGump
+        builder.AddHtmlLocalized(314, 79, 75, 20, 1011235); // OPTIONS
+        builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Options);
 
         BuildInfoPage(ref builder);
         BuildPeoplePages(ref builder);
@@ -140,8 +140,6 @@ public class HouseGump : DynamicGump
             builder.AddHtmlLocalized(20, 345, 275, 20, 1011241); // Number of visits this building has had
             builder.AddHtml(320, 345, 50, 20, _house.Visits.ToString());
         }
-
-        builder.AddButton(360, 389, 0xFB1, 0xFB3, 0);
     }
 
     private void BuildPeoplePages(ref DynamicGumpBuilder builder)
@@ -186,11 +184,9 @@ public class HouseGump : DynamicGump
 
         builder.AddButton(15, 389, 0xFAE, 0xFB0, 0, GumpButtonType.Page, (int)Page.Info); // Back button
 
-        var pageSize = 10;
-
-        BuildBansPage(ref builder, pageSize);
-        BuildCoOwnersPage(ref builder, pageSize);
-        BuildFriendsPage(ref builder, pageSize);
+        BuildBansPage(ref builder);
+        BuildCoOwnersPage(ref builder);
+        BuildFriendsPage(ref builder);
     }
 
     private void BuildBansPage(ref DynamicGumpBuilder builder, int pageSize = 10)

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Server.Guilds;
 using Server.Multis;

--- a/Projects/UOContent/Gumps/Houses/HouseGump.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGump.cs
@@ -66,6 +66,19 @@ public class HouseGump : DynamicGump
         }
     }
 
+    private void AddTableOfContents(ref DynamicGumpBuilder builder)
+    {
+        builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
+        builder.AddButton(370, 20, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Info);
+
+        builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
+        builder.AddButton(370, 50, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.People);
+
+        builder.AddHtmlLocalized(314, 79, 75, 20, 1011235); // OPTIONS
+        builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Options);
+
+    }
+
     protected override void BuildLayout(ref DynamicGumpBuilder builder)
     {
         if (_house.Deleted)
@@ -75,8 +88,11 @@ public class HouseGump : DynamicGump
 
         builder.AddPage();
 
-        builder.AddBackground(0, 0, 420, 430, 0x6DB);
-        builder.AddBackground(5, 5, 410, 420, 0xBB8);
+        if (_isFriend)
+        {
+            builder.AddBackground(0, 0, 420, 430, 0x6DB);
+            builder.AddBackground(5, 5, 410, 420, 0xBB8);
+        }
 
         builder.AddImage(15, 15, 100);
 
@@ -97,14 +113,7 @@ public class HouseGump : DynamicGump
             return;
         }
 
-        builder.AddHtmlLocalized(335, 19, 75, 20, 1011233); // INFO
-        builder.AddButton(370, 20, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Info);
-
-        builder.AddHtmlLocalized(314, 49, 75, 20, 1011234); // FRIENDS
-        builder.AddButton(370, 50, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.People);
-
-        builder.AddHtmlLocalized(314, 79, 75, 20, 1011235); // OPTIONS
-        builder.AddButton(370, 79, 0x16CD, 0x16CE, 0, GumpButtonType.Page, (int)Page.Options);
+        AddTableOfContents(ref builder);
 
         BuildInfoPage(ref builder);
         BuildPeoplePages(ref builder);

--- a/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
@@ -5,7 +5,6 @@ using Server.Guilds;
 using Server.Mobiles;
 using Server.Multis;
 using Server.Network;
-using Server.Prompts;
 
 namespace Server.Gumps
 {

--- a/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
@@ -1392,7 +1392,7 @@ namespace Server.Gumps
                                 {
                                     if (isCoOwner)
                                     {
-                                        from.Prompt = new RenamePrompt(m_House);
+                                        from.Prompt = new HouseRenamePrompt(m_House);
                                         from.SendLocalizedMessage(501302); // What dost thou wish the sign to say?
                                     }
 


### PR DESCRIPTION
In this PR I've consolidated the `HouseListGump` and `HouseRemoveGump` into a newly-refactored, multi-page `HouseGump`.

Additionally, I added some imagery and rearranged some of the options.

I did this mostly as an exercise in creating complex gumps, but it's also a bit of an upgrade.  ~~The real question is whether or not the "paged" gump is a good thing.  I've effectively built this such that it wouldn't be prohibitively difficult to break each page into it's own gump.~~  I have since refactored to use a "sectional" gump.  Each section (`Info`, `Friends`, and `Options`) is rendered as the first page in the gump, and the paging behavior for house sign selection and people management are encompassed by section.  This means the entire gump is no longer one giant paged gump, and prevents building the layout for the people lists when a user is only viewing the info section (for example).

#### Sections

* Info
* Friends
  * Co-Owners Page
  * Friends Page
  * Bans Page
* Options
  * Sign Selection Page(s)

There are many pages and variations, so I have only included the significant stylistic changes here.

homepage
<img width="432" alt="image" src="https://github.com/user-attachments/assets/907bcc58-d6da-4e25-9246-d1c97b74d133">

private house options
<img width="440" alt="image" src="https://github.com/user-attachments/assets/c78d4155-849e-4b28-8f7d-1d9968bee722">

public house options
<img width="433" alt="image" src="https://github.com/user-attachments/assets/0602d9ad-e96b-4376-b92f-2600a72b481e">

sign selection
<img width="433" alt="image" src="https://github.com/user-attachments/assets/9d1a29b8-6a53-4694-a526-94a1ce7cffdb">

