### PR TITLE
Set VendorItem Valid AfterDeserialize

### DIFF
--- a/Projects/UOContent/Mobiles/Vendors/VendorItem.cs
+++ b/Projects/UOContent/Mobiles/Vendors/VendorItem.cs
@@ -60,5 +60,7 @@ public partial class VendorItem
         {
             _price = 100000000;
         }
+
+        Valid = true;
     }
 }


### PR DESCRIPTION
Valid is set to true in the VendorItem ctor...

![image](https://github.com/user-attachments/assets/17654590-448c-415f-b914-e33170ed5a20)

But nothing sets it back to Valid after deserialization, and it's checked in PlayerVendorBuyGump and will display the message 'You can't buy that' if not valid...

![image](https://github.com/user-attachments/assets/eb76c399-0af5-441a-9c38-dbd2fa5ea8b0)

Therefore will set Valid to true AfterDeserialization, the alternative is to serialize the property?