### PR TITLE
Fix missing CopyTo in FixHtmlFormattable

### DIFF
--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -237,6 +237,8 @@ public static class Utility
     {
         var chars = STArrayPool<char>.Shared.Rent(str.Length);
         var span = chars.AsSpan(0, str.Length);
+        str.CopyTo(span);
+
         var formattable = new PooledArraySpanFormattable(chars, str.Length);
 
         if (!str.IsNullOrWhiteSpace())


### PR DESCRIPTION
Assuming this is correct like in FixHtml, without it my guild abbreviation becomes whatever is left over the in the shared buffer.