### PR TITLE
Releasing a Talisman summon deletes your character

### DIFF
--- a/Projects/UOContent/Items/Talismans/TalismanSummons.cs
+++ b/Projects/UOContent/Items/Talismans/TalismanSummons.cs
@@ -45,7 +45,7 @@ public partial class BaseTalismanSummon : BaseCreature
 
             Effects.PlaySound(from,0x201);
 
-            from.Delete();
+            target.Delete();
         }
     }
 }


### PR DESCRIPTION
Actually reported by a player on my shard, and I can re-create...

![image](https://github.com/user-attachments/assets/8adeb7b6-062e-4e09-ac31-a755010c36aa)

Talisman such as Totem Of The Void (didn't test with anything else)