### PR TITLE
fix: Fixes networking issues

### DIFF
--- a/Projects/Server/Events/SocketConnectionEvent.cs
+++ b/Projects/Server/Events/SocketConnectionEvent.cs
@@ -1,0 +1,41 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2023 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: SocketConnectionEvent.cs                                        *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+
+namespace Server;
+
+public class SocketConnectEventArgs
+{
+    public SocketConnectEventArgs(Socket c)
+    {
+        Connection = c;
+        AllowConnection = true;
+    }
+
+    public Socket Connection { get; }
+
+    public bool AllowConnection { get; set; }
+}
+
+public static partial class EventSink
+{
+    public static event Action<SocketConnectEventArgs> SocketConnect;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokeSocketConnect(SocketConnectEventArgs e) => SocketConnect?.Invoke(e);
+}

--- a/Projects/Server/Main.cs
+++ b/Projects/Server/Main.cs
@@ -336,6 +336,8 @@ public static class Core
 
         World.WaitForWriteCompletion();
         World.ExitSerializationThreads();
+        PingServer.Shutdown();
+        TcpServer.Shutdown();
 
         if (!_crashed)
         {

--- a/Projects/Server/Network/PingServer.cs
+++ b/Projects/Server/Network/PingServer.cs
@@ -16,7 +16,6 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using System.Threading;
 using Server.Logging;
 
 namespace Server.Network;
@@ -47,8 +46,8 @@ public static class PingServer
             return;
         }
 
-        HashSet<IPEndPoint> listeningAddresses = new HashSet<IPEndPoint>();
-        List<UdpClient> listeners = new List<UdpClient>();
+        HashSet<IPEndPoint> listeningAddresses = [];
+        List<UdpClient> listeners = [];
 
         foreach (var serverIpep in ServerConfiguration.Listeners)
         {
@@ -70,7 +69,7 @@ public static class PingServer
             }
 
             listeners.Add(listener);
-            new Thread(BeginAcceptingUdpRequest).Start(listener);
+            BeginAcceptingUdpRequest(listener);
         }
 
         foreach (var ipep in listeningAddresses)
@@ -138,6 +137,14 @@ public static class PingServer
             {
                 // ignored
             }
+        }
+    }
+
+    public static void Shutdown()
+    {
+        foreach (var listener in Listeners)
+        {
+            listener.Close();
         }
     }
 }

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -169,7 +169,7 @@ namespace Server.Gumps
                         AddLabel(150, 150, LabelHue, banned.ToString());
 
                         AddLabel(20, 170, LabelHue, "Firewalled:");
-                        AddLabel(150, 170, LabelHue, AdminFirewall.Set.Count.ToString());
+                        AddLabel(150, 170, LabelHue, Firewall.FirewallSet.Count.ToString());
 
                         AddLabel(20, 190, LabelHue, "Clients:");
                         AddLabel(150, 190, LabelHue, NetState.Instances.Count.ToString());
@@ -1161,7 +1161,7 @@ namespace Server.Gumps
                     {
                         AddFirewallHeader();
 
-                        m_List ??= AdminFirewall.Set.ToList<object>();
+                        m_List ??= Firewall.FirewallSet.ToList<object>();
 
                         AddLabelCropped(12, 120, 358, 20, LabelHue, "IP Address");
 
@@ -3464,7 +3464,7 @@ namespace Server.Gumps
                                     }
                                     else
                                     {
-                                        foreach (var check in AdminFirewall.Set)
+                                        foreach (var check in Firewall.FirewallSet)
                                         {
                                             var checkStr = check.ToString();
 

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.13.5"
+  "version": "0.13.6"
 }


### PR DESCRIPTION
### Summary
- Puts back `EventSink.SocketConnect`.
- Reverts networking change to push the networking to a separate thread.
- Reverts changes to the firewall by removing the firewall queue.
- Fixes listeners not shutting down with the server.
- Fixes race condition causing connections to get stuck even after they are disposed.

> [!NOTE]
> **Developer Note**
> Networking has been reverted back to using the main thread instead of a background thread. This alleviated complexity and the requirement for concurrent queues all over the place.