### PR TITLE
fix: Ensure server listing address is used when set in config

### DIFF
--- a/Projects/UOContent/Misc/ServerList.cs
+++ b/Projects/UOContent/Misc/ServerList.cs
@@ -63,7 +63,7 @@ namespace Server.Misc
             {
                 Resolve(Address, out _publicAddress);
 
-                if (_publicAddress is not null)
+                if (_publicAddress != null)
                 {
                     _useServerListingAddressConfig = true;
 

--- a/Projects/UOContent/Misc/ServerList.cs
+++ b/Projects/UOContent/Misc/ServerList.cs
@@ -41,6 +41,8 @@ namespace Server.Misc
 
         public static bool AutoDetect { get; private set; }
 
+        private static bool _useServerListingAddressConfig { get; set; }
+
         public static void Configure()
         {
             Address = ServerConfiguration.GetOrUpdateSetting("serverListing.address", null);
@@ -60,6 +62,13 @@ namespace Server.Misc
             else
             {
                 Resolve(Address, out _publicAddress);
+
+                if (_publicAddress is not null)
+                {
+                    _useServerListingAddressConfig = true;
+
+                    logger.Information("Server listing address set from config: {address}", _publicAddress);
+                }
             }
         }
 
@@ -79,9 +88,14 @@ namespace Server.Misc
                 var localAddress = ipep.Address;
                 var localPort = ipep.Port;
 
-                if (IsPrivateNetwork(localAddress))
+                if (_useServerListingAddressConfig)
+                {
+                    localAddress = _publicAddress;
+                }
+                else if (IsPrivateNetwork(localAddress))
                 {
                     ipep = (IPEndPoint)ns.Connection.RemoteEndPoint;
+
                     if (ipep == null || !IsPrivateNetwork(ipep.Address) && _publicAddress != null)
                     {
                         localAddress = _publicAddress;


### PR DESCRIPTION
This is important for container management hosts where the server container doesn't have access to the host IP.

The following scenarios were tested:

| scenario                                                   | public ip | private ip |
|:-----------------------------------------------------------|:---------:|:----------:|
| Docker and client on same host                          | Y         | Y          |
| Docker and client on different hosts, same network      | Y         | Y          |
| Docker and client on different hosts, different network | Y         | N/A        |