### PR TITLE
fix: Fixes ObjectPropertyList double return issue

### DIFF
--- a/Projects/Server/Buffers/STArrayPool.cs
+++ b/Projects/Server/Buffers/STArrayPool.cs
@@ -53,7 +53,7 @@ public class STArrayPool<T> : ArrayPool<T>
 #if DEBUG_ARRAYPOOL
                 _rentedArrays.AddOrUpdate(
                     buffer,
-                    new RentReturnStatus { IsRented = true, StackTrace = Environment.StackTrace }
+                    new RentReturnStatus { IsRented = true }
                 );
 #endif
                 return buffer;
@@ -72,7 +72,7 @@ public class STArrayPool<T> : ArrayPool<T>
 #if DEBUG_ARRAYPOOL
                     _rentedArrays.AddOrUpdate(
                         buffer,
-                        new RentReturnStatus { IsRented = true, StackTrace = Environment.StackTrace }
+                        new RentReturnStatus { IsRented = true }
                     );
 #endif
                     return buffer;

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -1,6 +1,6 @@
 /*************************************************************************
  * ModernUO                                                              *
- * Copyright 2019-2023 - ModernUO Development Team                       *
+ * Copyright 2019-2024 - ModernUO Development Team                       *
  * Email: hi@modernuo.com                                                *
  * File: ObjectPropertyList.cs                                           *
  *                                                                       *
@@ -79,8 +79,9 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
         _stringNumbersIndex = 0;
         Header = 0;
         HeaderArgs = null;
-        STArrayPool<char>.Shared.Return(_arrayToReturnToPool);
         _pos = 0;
+
+        Dispose();
     }
 
     private void Flush()
@@ -499,13 +500,19 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void Dispose()
     {
-        STArrayPool<char>.Shared.Return(_arrayToReturnToPool);
-        _arrayToReturnToPool = null;
+        if (_arrayToReturnToPool != null)
+        {
+            STArrayPool<char>.Shared.Return(_arrayToReturnToPool);
+            _arrayToReturnToPool = null;
+        }
     }
 
     ~ObjectPropertyList()
     {
-        STArrayPool<char>.Shared.Return(_arrayToReturnToPool);
-        _arrayToReturnToPool = null;
+        if (_arrayToReturnToPool != null)
+        {
+            STArrayPool<char>.Shared.Return(_arrayToReturnToPool);
+            _arrayToReturnToPool = null;
+        }
     }
 }

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -1460,4 +1460,12 @@ public static partial class Utility
 
         return (r << 10) | (g << 5) | b;
     }
+
+    public static void AddOrUpdate<TKey, TValue>(this ConditionalWeakTable<TKey, TValue> table, TKey key, TValue value)
+        where TKey : class
+        where TValue : class
+    {
+        table.Remove(key);
+        table.Add(key, value);
+    }
 }


### PR DESCRIPTION
### Summary

- Fixes double return issue with object property list that is causing corruption.
- Adds DEBUG_ARRAYPOOL define constant which will crash on double return or invalid return scenarios.


> [!IMPORTANT]
> **Developer Notes**
> STArrayPool rented arrays **MUST NOT** be returned **ONLY ONCE** otherwise there will be corruption from double-use.
> Use `DEBUG_ARRAYPOOL` to test potential broken STArrayPool use cases.


> [!NOTE]
> **Why can't I enable the debug all the time?**
> Other than the fact that it will crash due to bad code, the actual tracking system is highly detrimental/problematic for performance and memory consumption by creating objects that have a stack trace.