### PR TITLE
fix: Fixes Occlo so it uses the actual addon when decorations are generated.

### DIFF
--- a/Distribution/Data/Decoration/Felucca/ocllo.cfg
+++ b/Distribution/Data/Decoration/Felucca/ocllo.cfg
@@ -1060,7 +1060,7 @@ TreatiseOnAlchemy 0x0FF4
 3672 2475 4
 
 # spinning wheel
-Static 0x1019
+SpinningWheelEastAddon 0x1019
 3667 2597 0
 
 # pile of wool


### PR DESCRIPTION
Statics do not have player mobile integrations.