### PR TITLE
feat: Fixes beneficial notoriety checks and adds better young restrictions/messaging

### DIFF
--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -7105,22 +7105,16 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return false;
         }
 
-        if (item.Parent != null)
+        if (item.Parent is Item parent)
         {
-            if (item.Parent is Item parent)
+            if (!(CanSee(parent) && parent.IsChildVisibleTo(this, item)))
             {
-                if (!(CanSee(parent) && parent.IsChildVisibleTo(this, item)))
-                {
-                    return false;
-                }
+                return false;
             }
-            else if (item.Parent is Mobile mobile)
-            {
-                if (!CanSee(mobile))
-                {
-                    return false;
-                }
-            }
+        }
+        else if (item.Parent is Mobile mobile && !CanSee(mobile))
+        {
+            return false;
         }
 
         if (item is BankBox box && m_AccessLevel <= AccessLevel.Counselor && (box.Owner != this || !box.Opened))

--- a/Projects/UOContent/Items/Skill Items/Misc/Bandage.cs
+++ b/Projects/UOContent/Items/Skill Items/Misc/Bandage.cs
@@ -466,6 +466,10 @@ public class BandageContext : Timer
         {
             healer.SendLocalizedMessage(501042); // Target cannot be resurrected at that location.
         }
+        else if ((healer as PlayerMobile)?.Young == true && (patient as PlayerMobile)?.Young == false)
+        {
+            healer.SendLocalizedMessage(500952); // As a young player, you may not use beneficial skills on older players.
+        }
         else if (healer.CanBeBeneficial(patient, true, true))
         {
             healer.DoBeneficial(patient);

--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -44,15 +44,8 @@ namespace Server.Misc
             return GuildStatus.Waring;
         }
 
-        private static bool CheckBeneficialStatus(GuildStatus from, GuildStatus target)
-        {
-            if (from == GuildStatus.Waring || target == GuildStatus.Waring)
-            {
-                return false;
-            }
-
-            return true;
-        }
+        private static bool CheckBeneficialStatus(GuildStatus from, GuildStatus target) =>
+            from != GuildStatus.Waring && target != GuildStatus.Waring;
 
         /*private static bool CheckHarmfulStatus( GuildStatus from, GuildStatus target )
         {
@@ -239,13 +232,9 @@ namespace Server.Misc
             if (!from.Player && !(from is BaseCreature bc && bc.GetMaster() != null &&
                                   bc.GetMaster().AccessLevel == AccessLevel.Player))
             {
-                if (!CheckAggressor(from.Aggressors, target) && !CheckAggressed(from.Aggressed, target) &&
-                    pmTarg?.CheckYoungProtection(from) == true)
-                {
-                    return false;
-                }
-
-                return true; // Uncontrolled NPCs are only restricted by the young system
+                // Uncontrolled NPCs are only restricted by the young system
+                return CheckAggressor(from.Aggressors, target) || CheckAggressed(from.Aggressed, target) ||
+                       pmTarg?.CheckYoungProtection(from) != true;
             }
 
             var fromGuild = GetGuildFor(from.Guild as Guild, from);

--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -137,7 +137,7 @@ namespace Server.Misc
                 return false; // Players cannot heal uncontrolled mobiles
             }
 
-            if (pmFrom?.Young == true && pmTarg?.Young != true)
+            if (pmFrom?.Young == true && pmTarg?.Young == false)
             {
                 return false; // Young players cannot perform beneficial actions towards non-young players or pets
             }

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -2621,12 +2621,9 @@ namespace Server.Mobiles
                 }
             }
 
-            if (Young && DuelContext == null)
+            if (Young && DuelContext == null && YoungDeathTeleport())
             {
-                if (YoungDeathTeleport())
-                {
-                    Timer.StartTimer(TimeSpan.FromSeconds(2.5), SendYoungDeathNotice);
-                }
+                Timer.StartTimer(TimeSpan.FromSeconds(2.5), SendYoungDeathNotice);
             }
 
             if (DuelContext?.Registered != true || !DuelContext.Started || m_DuelPlayer?.Eliminated != false)

--- a/Projects/UOContent/Skills/Stealing.cs
+++ b/Projects/UOContent/Skills/Stealing.cs
@@ -82,7 +82,6 @@ namespace Server.SkillHandlers
                 var root = toSteal.RootParent;
                 var mobRoot = root as Mobile;
                 var rootIsPlayer = mobRoot?.Player == true;
-                var vendor = root as BaseVendor;
 
                 StealableArtifacts.StealableInstance si = toSteal.Parent == null || !toSteal.Movable
                     ? StealableArtifacts.GetStealableInstance(toSteal)
@@ -96,7 +95,7 @@ namespace Server.SkillHandlers
                 {
                     m_Thief.SendMessage("You may not steal in this area.");
                 }
-                else if ((m_Thief as PlayerMobile)?.Young == true && (rootIsPlayer || vendor == null && mobRoot is BaseCreature))
+                else if ((m_Thief as PlayerMobile)?.Young == true && (rootIsPlayer || mobRoot is BaseCreature))
                 {
                     m_Thief.SendLocalizedMessage(502700); // You cannot steal from people or monsters right now.  Practice on chests and barrels.
                 }
@@ -112,7 +111,7 @@ namespace Server.SkillHandlers
                 {
                     m_Thief.SendLocalizedMessage(502699); // You cannot steal from the Young.
                 }
-                else if (vendor?.IsInvulnerable == true)
+                else if ((root as BaseVendor)?.IsInvulnerable == true)
                 {
                     m_Thief.SendLocalizedMessage(1005598); // You can't steal from shopkeepers.
                 }

--- a/Projects/UOContent/Skills/Stealing.cs
+++ b/Projects/UOContent/Skills/Stealing.cs
@@ -18,6 +18,7 @@ namespace Server.SkillHandlers
     {
         public static readonly bool ClassicMode = false;
         public static readonly bool SuspendOnMurder = false;
+        private const int MaxWeightToSteal = 10;
 
         public static void Initialize()
         {
@@ -80,6 +81,8 @@ namespace Server.SkillHandlers
 
                 var root = toSteal.RootParent;
                 var mobRoot = root as Mobile;
+                var rootIsPlayer = mobRoot?.Player == true;
+                var vendor = root as BaseVendor;
 
                 StealableArtifacts.StealableInstance si = toSteal.Parent == null || !toSteal.Movable
                     ? StealableArtifacts.GetStealableInstance(toSteal)
@@ -93,16 +96,23 @@ namespace Server.SkillHandlers
                 {
                     m_Thief.SendMessage("You may not steal in this area.");
                 }
-                else if (mobRoot?.Player == true && !IsInGuild(m_Thief))
+                else if ((m_Thief as PlayerMobile)?.Young == true && (rootIsPlayer || vendor == null && mobRoot is BaseCreature))
+                {
+                    m_Thief.SendLocalizedMessage(502700); // You cannot steal from people or monsters right now.  Practice on chests and barrels.
+                }
+                else if (rootIsPlayer && !IsInGuild(m_Thief))
                 {
                     m_Thief.SendLocalizedMessage(1005596); // You must be in the thieves guild to steal from other players.
                 }
-                else if (SuspendOnMurder && mobRoot?.Player == true && IsInGuild(m_Thief) &&
-                         m_Thief.Kills > 0)
+                else if (SuspendOnMurder && rootIsPlayer && IsInGuild(m_Thief) && m_Thief.Kills > 0)
                 {
                     m_Thief.SendLocalizedMessage(502706); // You are currently suspended from the thieves guild.
                 }
-                else if (root is BaseVendor vendor && vendor.IsInvulnerable)
+                else if ((mobRoot as PlayerMobile)?.Young == true)
+                {
+                    m_Thief.SendLocalizedMessage(502699); // You cannot steal from the Young.
+                }
+                else if (vendor?.IsInvulnerable == true)
                 {
                     m_Thief.SendLocalizedMessage(1005598); // You can't steal from shopkeepers.
                 }
@@ -113,10 +123,6 @@ namespace Server.SkillHandlers
                 else if (!m_Thief.CanSee(toSteal))
                 {
                     m_Thief.SendLocalizedMessage(500237); // Target can not be seen.
-                }
-                else if (m_Thief.Backpack?.CheckHold(m_Thief, toSteal, false, true) != true)
-                {
-                    m_Thief.SendLocalizedMessage(1048147); // Your backpack can't hold anything else.
                 }
                 else if (toSteal is Sigil sig)
                 {
@@ -206,6 +212,10 @@ namespace Server.SkillHandlers
                         m_Thief.SendLocalizedMessage(1005588); // You must join a faction to do that
                     }
                 }
+                else if (m_Thief.Backpack?.CheckHold(m_Thief, toSteal, false, true) != true)
+                {
+                    m_Thief.SendLocalizedMessage(1048147); // Your backpack can't hold anything else.
+                }
                 else if (si == null && (toSteal.Parent == null || !toSteal.Movable))
                 {
                     m_Thief.SendLocalizedMessage(502710); // You can't steal that!
@@ -250,9 +260,10 @@ namespace Server.SkillHandlers
                 {
                     var w = toSteal.Weight + toSteal.TotalWeight;
 
-                    if (w > 10)
+                    if (w > MaxWeightToSteal)
                     {
-                        m_Thief.SendMessage("That is too heavy to steal.");
+                        // This item is too heavy to steal from someone's backpack.
+                        m_Thief.SendLocalizedMessage(502722);
                     }
                     else
                     {

--- a/Projects/UOContent/Spells/Base/Spell.cs
+++ b/Projects/UOContent/Spells/Base/Spell.cs
@@ -831,6 +831,12 @@ namespace Server.Spells
                 return false;
             }
 
+            if ((Caster as PlayerMobile)?.Young == true && (target as PlayerMobile)?.Young == false)
+            {
+                Caster.SendLocalizedMessage(500278); // As a young player, you may not cast beneficial spells onto older players.
+                return false;
+            }
+
             if (Caster.CanBeBeneficial(target, true, allowDead) && CheckSequence())
             {
                 Caster.DoBeneficial(target);


### PR DESCRIPTION
### Summary
* Adds `As a young player, you may not use beneficial skills on older players.` for healing.
* Adds `You cannot steal from people or monsters right now. Practice on chests and barrels.` for stealing.
* Adds fix to prevent stealing from young players with the message `You cannot steal from the Young.`
* Adds `As a young player, you may not cast beneficial spells onto older players.` for beneficial spells.
* Fixes stealing heavy items error message to `This item is too heavy to steal from someone's backpack.`
* Fixes notoriety issue where young players cannot heal their own horse.
* Fixes notoriety issue where pets bypass beneficial checks in some circumstances.