### PR TITLE
add "headless" mode where server does not write back to Configuration

### DIFF
--- a/Projects/Server/Configuration/ServerConfiguration.cs
+++ b/Projects/Server/Configuration/ServerConfiguration.cs
@@ -32,6 +32,7 @@ public static class ServerConfiguration
     private static ServerSettings _settings;
     private static bool m_Mocked;
 
+    public static bool Headless => _settings.Headless;
     public static List<string> AssemblyDirectories => _settings.AssemblyDirectories;
 
     public static HashSet<string> DataDirectories => _settings.DataDirectories;
@@ -287,7 +288,7 @@ public static class ServerConfiguration
 
         Core.Expansion = currentExpansion;
 
-        if (updated)
+        if (updated && !Headless)
         {
             Save();
             Console.Write("Server configuration saved to ");

--- a/Projects/Server/Configuration/ServerSettings.cs
+++ b/Projects/Server/Configuration/ServerSettings.cs
@@ -22,6 +22,9 @@ namespace Server;
 
 public class ServerSettings
 {
+    [JsonPropertyName("headless")]
+    public bool Headless { get; set; } = false;
+
     [JsonPropertyName("assemblyDirectories")]
     public List<string> AssemblyDirectories { get; set; } = new();
 

--- a/Projects/Server/Main.cs
+++ b/Projects/Server/Main.cs
@@ -447,7 +447,7 @@ public static class Core
 #if DEBUG
             const bool idleCPU = true;
 #else
-            var idleCPU = ServerConfiguration.GetOrUpdateSetting("core.enableIdleCPU", false);
+            var idleCPU = ServerConfiguration.Headless ? ServerConfiguration.GetSetting("core.enableIdleCPU", false) : ServerConfiguration.GetOrUpdateSetting("core.enableIdleCPU", false);
 #endif
 
             var cycleCount = _cyclesPerSecond.Length;

--- a/Projects/Server/Network/PacketHandler.cs
+++ b/Projects/Server/Network/PacketHandler.cs
@@ -40,7 +40,8 @@ public unsafe class PacketHandler
 
     public int PacketID { get; }
 
-    public virtual int GetLength(NetState ns) => _length;
+    public virtual int GetLength() => _length;
+    public virtual int GetLength(NetState ns) => GetLength();
 
     public delegate*<NetState, SpanReader, void> OnReceive { get; }
 

--- a/Projects/UOContent/Misc/PacketThrottles.cs
+++ b/Projects/UOContent/Misc/PacketThrottles.cs
@@ -53,7 +53,10 @@ public static class PacketThrottles
             }
         }
 
-        SaveDelays();
+        if (!ServerConfiguration.Headless)
+        {
+            SaveDelays();
+        }
     }
 
     [Usage("GetThrottle <packetID>")]

--- a/Projects/UOContent/Misc/ServerAccess.cs
+++ b/Projects/UOContent/Misc/ServerAccess.cs
@@ -49,7 +49,7 @@ public static class ServerAccess
     {
         var path = Path.Join(Core.BaseDirectory, _serverAccessConfigurationPath);
 
-        if (!File.Exists(path))
+        if (!File.Exists(path) && !ServerConfiguration.Headless)
         {
             SaveConfiguration();
             return;

--- a/Projects/UOContent/Misc/ServerList.cs
+++ b/Projects/UOContent/Misc/ServerList.cs
@@ -36,6 +36,7 @@ namespace Server.Misc
         private static readonly ILogger logger = LogFactory.GetLogger(typeof(ServerList));
 
         private static IPAddress _publicAddress;
+        public static IPAddress PublicAddress => _publicAddress;
         public static string Address { get; private set; }
         public static string ServerName { get; private set; }
 

--- a/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
+++ b/Projects/UOContent/Network/Packets/IncomingAccountPackets.cs
@@ -346,6 +346,11 @@ public static class IncomingAccountPackets
 
     private static int GenerateAuthID(this NetState state)
     {
+        return GenerateAuthID(state.Version);
+    }
+
+    public static int GenerateAuthID(ClientVersion version)
+    {
         if (_authIDWindow.Count == _authIDWindowSize)
         {
             var oldestID = 0;
@@ -375,7 +380,7 @@ public static class IncomingAccountPackets
             }
         } while (_authIDWindow.ContainsKey(authID));
 
-        _authIDWindow[authID] = new AuthIDPersistence(state.Version);
+        _authIDWindow[authID] = new AuthIDPersistence(version);
 
         return authID;
     }


### PR DESCRIPTION
tl;dr I encountered an issue where the server is writing back to a read only directory in my deployment.  I'm providing the configs up front, and don't need them to change.  In this PR I have added a "headless" mode gate around the places where the configs are written back to the `Configuration` files.  I am open to suggestions for the name because it's not _great_.