### PR TITLE
Fix HolidayTree not serializing components

### DIFF
--- a/Projects/UOContent/Items/Special/Holiday/Christmas/HolidayTree.cs
+++ b/Projects/UOContent/Items/Special/Holiday/Christmas/HolidayTree.cs
@@ -9,13 +9,14 @@ public enum HolidayTreeType
     Modern
 }
 
-[SerializationGenerator(2, false)]
+[SerializationGenerator(3, false)]
 public partial class HolidayTree : Item, IAddon
 {
     [SerializableField(0)]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private Mobile _placer;
 
+    [SerializableField(1)]
     private Item[] _components;
 
     public HolidayTree(Mobile from, HolidayTreeType type, Point3D loc) : base(1)
@@ -107,6 +108,11 @@ public partial class HolidayTree : Item, IAddon
 
     public override void OnAfterDelete()
     {
+        if (_components == null)
+        {
+            return;
+        }
+
         for (var i = 0; i < _components.Length; ++i)
         {
             _components[i]?.Delete();
@@ -155,6 +161,11 @@ public partial class HolidayTree : Item, IAddon
             deed.MoveToWorld(Location, Map);
             Delete();
         }
+    }
+
+    private void MigrateFrom(V2Content content)
+    {
+        Placer = content.Placer;
     }
 
     public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Migrations/Server.Items.HolidayTree.v3.json
+++ b/Projects/UOContent/Migrations/Server.Items.HolidayTree.v3.json
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "type": "Server.Items.HolidayTree",
+  "properties": [
+    {
+      "name": "Placer",
+      "type": "Server.Mobile",
+      "rule": "SerializableInterfaceMigrationRule"
+    },
+    {
+      "name": "Components",
+      "type": "Server.Item[]",
+      "rule": "ArrayMigrationRule",
+      "ruleArguments": [
+        "Server.Item",
+        "SerializableInterfaceMigrationRule"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Components isn't serialized in V2...

Without the null check in OnAfterDelete, existing HolidayTree's will crash the server when being redeed'd after server restart.