### PR TITLE
Fix missing LabelNumber on DisguiseKit

### DIFF
--- a/Projects/UOContent/Items/Skill Items/Thief/DisguiseKit.cs
+++ b/Projects/UOContent/Items/Skill Items/Thief/DisguiseKit.cs
@@ -14,6 +14,8 @@ namespace Server.Items;
 [SerializationGenerator(0, false)]
 public partial class DisguiseKit : Item
 {
+    public override int LabelNumber => 1041078; // a disguise kit
+
     [Constructible]
     public DisguiseKit() : base(0xE05) => Weight = 1.0;
 


### PR DESCRIPTION
Would previously display as 'Wig Stand'