### PR TITLE
Fix Lord/Lady title display in paperdoll when Karma >= 10000

### DIFF
--- a/Projects/UOContent/Misc/Titles.cs
+++ b/Projects/UOContent/Misc/Titles.cs
@@ -291,7 +291,7 @@ namespace Server.Misc
 
                             if (karma <= ke.m_Karma || j == karmaEntries.Length - 1)
                             {
-                                if (karma >= 10000)
+                                if (fame >= 10000)
                                 {
                                     if (beheld.Female)
                                     {


### PR DESCRIPTION
Lord/Lady title should display when fame >= 10000, not karma