### PR TITLE
fix: Allow guildstone movement within the same house

### DIFF
--- a/Projects/UOContent/Items/Guilds/GuildTeleporter.cs
+++ b/Projects/UOContent/Items/Guilds/GuildTeleporter.cs
@@ -51,7 +51,7 @@ public partial class GuildTeleporter : Item
         {
             from.SendLocalizedMessage(501141); // You can only place a guildstone in a house you own!
         }
-        else if (house.FindGuildstone() != null)
+        else if (house.FindGuildstone() != null && house.FindGuildstone() != _stone)
         {
             from.SendLocalizedMessage(501142); // Only one guildstone may reside in a given house.
         }


### PR DESCRIPTION
- Adjusted condition to prevent unnecessary "one guildstone per house" restriction when moving the guildstone inside the same house since the guildstone does not disappear after teleporter generation.

Refactors the teleportation logic for improved user experience.