### PR TITLE
Add Pre-AOS single click support for items

### DIFF
--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Server.Collections;
 using Server.ContextMenus;
 using Server.Items;
@@ -4121,6 +4122,20 @@ public class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropertyListEnt
                 opl.HeaderArgs
             );
         }
+    }
+
+    public static void AppendWithSpace(StringBuilder builder, string text)
+    {
+        if (!string.IsNullOrEmpty(text))
+        {
+            if (builder.Length > 0) builder.Append(" ");
+            builder.Append(text);
+        }
+    }
+
+    public virtual void OnSingleClickPreAOS(Mobile from)
+    {
+        return;
     }
 
     public virtual void OnSingleClick(Mobile from)

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -907,6 +907,11 @@ namespace Server.Items
 
         public override void OnSingleClick(Mobile from)
         {
+            if (!Core.AOS)
+            {
+                OnSingleClickPreAOS(from);
+                return;
+            }
             var attrs = new List<EquipInfoAttribute>();
 
             AddEquipInfoAttributes(from, attrs);
@@ -929,6 +934,37 @@ namespace Server.Items
             }
 
             from.NetState.SendDisplayEquipmentInfo(Serial, number, _crafter, false, attrs);
+        }
+
+        public override void OnSingleClickPreAOS(Mobile from)
+        {
+            var qualityText = Quality != ClothingQuality.Regular
+                ? Localization.GetText(1018305 - (int)Quality, from.Language)?.ToLowerInvariant() ?? "" : "";
+
+            // Add any unique name
+            if (Name != null)
+            {
+                LabelTo(from, Name);
+            }
+
+            // Add label
+            if (qualityText.Length > 0)
+            {
+                LabelTo(from, 1151757, $"{qualityText}\t#{LabelNumber}"); // ~1_PREFIX~ ~2_ITEM~
+            }
+            else
+            {
+                LabelTo(from, LabelNumber);
+            }
+
+            // Add maker's mark
+            if (PlayerConstructed)
+            {
+                if (Crafter != null)
+                {
+                    LabelTo(from, 1050043, Crafter.ToString()); // crafted by ~1_NAME~
+                }
+            }
         }
 
         public virtual void AddEquipInfoAttributes(Mobile from, List<EquipInfoAttribute> attrs)

--- a/Projects/UOContent/Items/Wands/BaseWand.cs
+++ b/Projects/UOContent/Items/Wands/BaseWand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using ModernUO.Serialization;
 using Server.Network;
 using Server.Spells;
@@ -168,6 +169,12 @@ public abstract partial class BaseWand : BaseBashing
 
     public override void OnSingleClick(Mobile from)
     {
+        if (!Core.AOS)
+        {
+            OnSingleClickPreAOS(from);
+            return;
+        }
+
         var attrs = new List<EquipInfoAttribute>();
 
         if (DisplayLootType)
@@ -228,6 +235,78 @@ public abstract partial class BaseWand : BaseBashing
         }
 
         from.NetState.SendDisplayEquipmentInfo(Serial, number, Crafter, false, attrs);
+    }
+
+    public override void OnSingleClickPreAOS(Mobile from)
+    {
+        string prefix = null;
+        string suffix = null;
+
+        // Construct suffix
+        var suffixBuilder = new StringBuilder();
+
+        if (!Identified)
+        {
+            prefix = Localization.GetText(1038000, from.Language)?.ToLowerInvariant();
+        }
+        else
+        {
+            var num = _wandEffect switch
+            {
+                WandEffect.Clumsiness => 3002011,
+                WandEffect.Identification => 1044063,
+                WandEffect.Healing => 3002014,
+                WandEffect.Feeblemindedness => 3002013,
+                WandEffect.Weakness => 3002018,
+                WandEffect.MagicArrow => 3002015,
+                WandEffect.Harming => 3002022,
+                WandEffect.Fireball => 3002028,
+                WandEffect.GreaterHealing => 3002039,
+                WandEffect.Lightning => 3002040,
+                WandEffect.ManaDraining => 3002041,
+                _ => 0
+            };
+
+            var wandText = Localization.GetText(num, from.Language)?.ToLowerInvariant();
+
+            // Append wand effect text
+            AppendWithSpace(suffixBuilder, wandText);
+
+            // Append charges
+            AppendWithSpace(suffixBuilder, "with");
+            AppendWithSpace(suffixBuilder, _charges.ToString());
+            if (_charges == 1)
+            {
+                AppendWithSpace(suffixBuilder, "charge");
+            }
+            else
+            {
+                AppendWithSpace(suffixBuilder, "charges");
+            }
+
+            // Convert to string
+            suffix = suffixBuilder.Length > 0 ? suffixBuilder.ToString() : null;
+        }
+
+        // Add any unique name
+        if (Name != null && Identified)
+        {
+            LabelTo(from, Name);
+        }
+
+        // Add label
+        if (prefix != null) // ~1_PREFIX~ ~2_ITEM~
+        {
+            LabelTo(from, 1151757, $"{prefix}\t#{LabelNumber}");
+        }
+        else if (suffix != null)
+        {
+            LabelTo(from, 1151758, $"#{LabelNumber}\t{suffix}");
+        }
+        else
+        {
+            LabelTo(from, LabelNumber);
+        }
     }
 
     public void Cast(Spell spell)

--- a/Projects/UOContent/Items/Weapons/SlayerName.cs
+++ b/Projects/UOContent/Items/Weapons/SlayerName.cs
@@ -31,4 +31,47 @@ namespace Server.Items
         ElementalBan, // Bane?
         Fey
     }
+
+    public static class SlayerNameExtensions
+    {
+        public static string GetSlayerNamePreAOS(this SlayerName slayerName, Mobile from)
+        {
+            if (slayerName == SlayerName.None)
+            {
+                return "none";
+            }
+
+            return slayerName switch
+            {
+                SlayerName.Silver => Localization.GetText(1017384, from.Language).ToLowerInvariant(),
+                SlayerName.OrcSlaying => Localization.GetText(1017385, from.Language).ToLowerInvariant(),
+                SlayerName.TrollSlaughter => Localization.GetText(1017386, from.Language).ToLowerInvariant(),
+                SlayerName.OgreTrashing => Localization.GetText(1017387, from.Language).ToLowerInvariant(),
+                SlayerName.Repond => Localization.GetText(1017388, from.Language).ToLowerInvariant(),
+                SlayerName.DragonSlaying => Localization.GetText(1017389, from.Language).ToLowerInvariant(),
+                SlayerName.Terathan => Localization.GetText(1017390, from.Language).ToLowerInvariant(),
+                SlayerName.SnakesBane => Localization.GetText(1017391, from.Language).ToLowerInvariant(),
+                SlayerName.LizardmanSlaughter => Localization.GetText(1017392, from.Language).ToLowerInvariant(),
+                SlayerName.ReptilianDeath => Localization.GetText(1017393, from.Language).ToLowerInvariant(),
+                SlayerName.DaemonDismissal => Localization.GetText(1017394, from.Language).ToLowerInvariant(),
+                SlayerName.GargoylesFoe => Localization.GetText(1017395, from.Language).ToLowerInvariant(),
+                SlayerName.BalronDamnation => Localization.GetText(1017396, from.Language).ToLowerInvariant(),
+                SlayerName.Exorcism => Localization.GetText(1017397, from.Language).ToLowerInvariant(),
+                SlayerName.Ophidian => Localization.GetText(1017398, from.Language).ToLowerInvariant(),
+                SlayerName.SpidersDeath => Localization.GetText(1017399, from.Language).ToLowerInvariant(),
+                SlayerName.ScorpionsBane => Localization.GetText(1017400, from.Language).ToLowerInvariant(),
+                SlayerName.ArachnidDoom => Localization.GetText(1017401, from.Language).ToLowerInvariant(),
+                SlayerName.FlameDousing => Localization.GetText(1017402, from.Language).ToLowerInvariant(),
+                SlayerName.WaterDissipation => Localization.GetText(1017403, from.Language).ToLowerInvariant(),
+                SlayerName.Vacuum => Localization.GetText(1017404, from.Language).ToLowerInvariant(),
+                SlayerName.ElementalHealth => Localization.GetText(1017405, from.Language).ToLowerInvariant(),
+                SlayerName.EarthShatter => Localization.GetText(1017406, from.Language).ToLowerInvariant(),
+                SlayerName.BloodDrinking => Localization.GetText(1017407, from.Language).ToLowerInvariant(),
+                SlayerName.SummerWind => Localization.GetText(1017408, from.Language).ToLowerInvariant(),
+                SlayerName.ElementalBan => Localization.GetText(1017409, from.Language).ToLowerInvariant(),
+                SlayerName.Fey => Localization.GetText(1070855, from.Language).ToLowerInvariant(),
+                _ => "unknown slayer"
+            };
+        }
+    }
 }


### PR DESCRIPTION
- Implemented `OnSingleClickPreAOS` in base item classes to handle single-click display logic for preAOS clients
- Added helper method `AppendWithSpace` to streamline string construction with proper spacing
- Enhanced `BaseArmor`, `BaseClothing`, `BaseWeapon`, and `BaseWand` to support Pre-AOS label generation with localized strings
- Improved modularity and clarity of single-click behavior by separating AOS and Pre-AOS logic
- Updated `SlayerName` extensions to provide localized Pre-AOS slayer descriptions
- Refactored label generation to include maker’s mark and enhanced prefix/suffix logic for improved readability