### PR TITLE
feat: events for Help system

### DIFF
--- a/Projects/UOContent/Engines/Help/HelpEvents.cs
+++ b/Projects/UOContent/Engines/Help/HelpEvents.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
-using Server.Engines.Help;
 
-namespace Server;
+namespace Server.Engines.Help;
 
 public static class HelpEvents
 {

--- a/Projects/UOContent/Engines/Help/HelpEvents.cs
+++ b/Projects/UOContent/Engines/Help/HelpEvents.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.CompilerServices;
+using Server.Engines.Help;
+
+namespace Server;
+
+public static class HelpEvents
+{
+    public static event Action<PageEntry> PageEnqueued;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokePageEnqueued(PageEntry e) => PageEnqueued?.Invoke(e);
+
+    public static event Action<PageEntry> PageRemoved;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokePageRemoved(PageEntry e) => PageRemoved?.Invoke(e);
+
+    public static event Action<Mobile, Mobile, PageEntry> PageHandlerChanged;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokePageHandlerChanged(Mobile old, Mobile value, PageEntry e) => PageHandlerChanged?.Invoke(old, value, e);
+
+    public static event Action<PageEntry> PageWaiting;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokePageWaiting(PageEntry e) => PageWaiting?.Invoke(e);
+
+    public static event Action<Mobile> StuckMenu;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokeStuckMenu(Mobile m) => StuckMenu?.Invoke(m);
+}

--- a/Projects/UOContent/Engines/Help/PageQueue.cs
+++ b/Projects/UOContent/Engines/Help/PageQueue.cs
@@ -103,6 +103,8 @@ namespace Server.Engines.Help
                     {
                         m_Entry.Handler = null;
                     }
+
+                    HelpEvents.InvokePageWaiting(m_Entry);
                 }
                 else
                 {
@@ -171,6 +173,13 @@ namespace Server.Engines.Help
             {
                 m_KeyedByHandler[value] = entry;
             }
+
+            if (old == null || value == null)
+            {
+                return;
+            }
+
+            HelpEvents.InvokePageHandlerChanged(old, value, entry);
         }
 
         [Usage("Pages"), Description("Opens the page queue menu.")]
@@ -212,6 +221,8 @@ namespace Server.Engines.Help
             {
                 m_KeyedByHandler.Remove(e.Handler);
             }
+
+            HelpEvents.InvokePageRemoved(e);
         }
 
         public static PageEntry GetEntry(Mobile sender)
@@ -258,6 +269,8 @@ namespace Server.Engines.Help
             {
                 Email.SendQueueEmail(entry, GetPageTypeName(entry.Type));
             }
+
+            HelpEvents.InvokePageEnqueued(entry);
         }
     }
 }

--- a/Projects/UOContent/Engines/Help/StuckMenu.cs
+++ b/Projects/UOContent/Engines/Help/StuckMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Engines.Help;
 using Server.Factions;
 using Server.Gumps;
 using Server.Mobiles;

--- a/Projects/UOContent/Engines/Help/StuckMenu.cs
+++ b/Projects/UOContent/Engines/Help/StuckMenu.cs
@@ -194,16 +194,16 @@ namespace Server.Menus.Questions
                     m_Mobile.SendLocalizedMessage(1010588); // You choose not to go to any city.
                 }
             }
-            else
-            {
-                var index = info.ButtonID - 1;
-                var entries = IsInSecondAgeArea(m_Mobile) ? m_T2AEntries : m_Entries;
 
-                if (index >= 0 && index < entries.Length)
-                {
-                    Teleport(entries[index]);
-                }
+            var index = info.ButtonID - 1;
+            var entries = IsInSecondAgeArea(m_Mobile) ? m_T2AEntries : m_Entries;
+
+            if (index >= 0 && index < entries.Length)
+            {
+                Teleport(entries[index]);
             }
+
+            HelpEvents.InvokeStuckMenu(m_Mobile);
         }
 
         private void Teleport(StuckMenuEntry entry)


### PR DESCRIPTION
It would be much simpler to expose pages to external webhooks such as Discord or Slack without significantly modifying the core codebase if we adopt some simple `event`s for actions taken by players and staff.  Given this addition an ambitious ModernUO developer (probably me) could [create an addon](https://github.com/modernuo/ModernUO/tree/addon-tutorial/Projects/AddonExample) that implements the aforementioned webhook behavior by adding delegates to the events in this PR.

This PR is a suggested approach, it includes the following events:
* `PageEnqueued`
* `PageRemoved`
* `PageHandlerChanged`
* `PageWaiting`
* `StuckMenu`

