### PR TITLE
fix: Ensure ShouldSerializeCrafter serializes when _crafter is not null or empty

### DIFF
--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -101,7 +101,7 @@ namespace Server.Items
         private string _crafter;
 
         [SerializableFieldSaveFlag(10)]
-        private bool ShouldSerializeCrafter() => _crafter != null;
+        private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
         [SerializableFieldSaveFlag(14)]
         private bool ShouldSerializeResource() => _resource != DefaultResource;

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -95,7 +95,7 @@ namespace Server.Items
         private string _crafter;
 
         [SerializableFieldSaveFlag(8)]
-        private bool ShouldSerializeCrafter() => _crafter != null;
+        private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
         [InvalidateProperties]
         [SerializableField(9)]

--- a/Projects/UOContent/Items/Quivers/BaseQuiver.cs
+++ b/Projects/UOContent/Items/Quivers/BaseQuiver.cs
@@ -50,7 +50,7 @@ public partial class BaseQuiver : Container, ICraftable, IAosItem
     private string _crafter;
 
     [SerializableFieldSaveFlag(4)]
-    private bool ShouldSerializeCrafter() => _crafter != null;
+    private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
     [InvalidateProperties]
     [SerializableField(5)]

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -104,7 +104,7 @@ public abstract partial class BaseWeapon : Item, IWeapon, IFactionItem, ICraftab
 
     [SerializableFieldSaveFlag(9)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldSerializeCrafter() => string.IsNullOrEmpty(_crafter);
+    private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
     [InvalidateProperties]
     [SerializableField(10)]


### PR DESCRIPTION
Fixes issue where exceptionally crafted weapons would lose makers mark after restart.