### PR TITLE
fix: Fix FillableContainer default WeaponSmith

### DIFF
--- a/Projects/UOContent/Items/Containers/Fillable Containers/FillableContainer.cs
+++ b/Projects/UOContent/Items/Containers/Fillable Containers/FillableContainer.cs
@@ -22,7 +22,7 @@ public abstract partial class FillableContainer : LockableContainer
     public FillableContainer(int itemID) : base(itemID)
     {
         Movable = false;
-        ContentType = FillableContentType.None;
+        _contentType = FillableContentType.None;
     }
 
     public virtual int MinRespawnMinutes => 60;

--- a/Projects/UOContent/Items/Containers/Fillable Containers/FillableContainer.cs
+++ b/Projects/UOContent/Items/Containers/Fillable Containers/FillableContainer.cs
@@ -19,7 +19,11 @@ public abstract partial class FillableContainer : LockableContainer
         }
     }
 
-    public FillableContainer(int itemID) : base(itemID) => Movable = false;
+    public FillableContainer(int itemID) : base(itemID)
+    {
+        Movable = false;
+        ContentType = FillableContentType.None;
+    }
 
     public virtual int MinRespawnMinutes => 60;
     public virtual int MaxRespawnMinutes => 90;


### PR DESCRIPTION
Not sure if there is a way to set a default value when using SerializableProperty...

But FillableContentType.None is -1, whilst FillableContentType.Weaponsmith is 0, and AcquireContent doesn't do anything if the ContentType is not .None, therefore all FillableContainer's end up being Weaponsmith