### PR TITLE
fix: Fixes door monster LOS exploit & AOS House Gump NPE

### DIFF
--- a/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
@@ -115,11 +115,14 @@ namespace Server.Gumps
             {
                 var lines = m_House.Sign.GetName().Wrap(10, 6);
 
-                for (int i = 0, y = (114 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
+                if (lines != null)
                 {
-                    var s = lines[i];
+                    for (int i = 0, y = (114 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
+                    {
+                        var s = lines[i];
 
-                    AddLabel(10 + (160 - s.Length * 8) / 2, y, 0, s);
+                        AddLabel(10 + (160 - s.Length * 8) / 2, y, 0, s);
+                    }
                 }
             }
 

--- a/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
+++ b/Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs
@@ -111,18 +111,15 @@ namespace Server.Gumps
 
             AddImage(10, 10, 100);
 
-            if (m_House.Sign != null)
+            var lines = m_House.Sign?.GetName().Wrap(10, 6);
+
+            if (lines != null)
             {
-                var lines = m_House.Sign.GetName().Wrap(10, 6);
-
-                if (lines != null)
+                for (int i = 0, y = (114 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
                 {
-                    for (int i = 0, y = (114 - lines.Count * 14) / 2; i < lines.Count; ++i, y += 14)
-                    {
-                        var s = lines[i];
+                    var s = lines[i];
 
-                        AddLabel(10 + (160 - s.Length * 8) / 2, y, 0, s);
-                    }
+                    AddLabel(10 + (160 - s.Length * 8) / 2, y, 0, s);
                 }
             }
 


### PR DESCRIPTION
It's an old school RunUO bug that people squirreled away to day 1 balron/boss monsters. Essentially by standing on a door way, the HasLineOfSight() of sight check returns false and the monster just stands there, doing nothing, not even returning melee swings