### PR TITLE
fix: Fixes the wrong unit used for BuffIcon Timers

### DIFF
--- a/Projects/UOContent/Engines/BuffIcons/BuffIconPackets.cs
+++ b/Projects/UOContent/Engines/BuffIcons/BuffIconPackets.cs
@@ -6,7 +6,13 @@ namespace Server.Engines.BuffIcons;
 public static class BuffIconPackets
 {
     public static void SendAddBuffPacket(
-        this NetState ns, Serial mob, BuffIcon iconID, int titleCliloc, int secondaryCliloc, TextDefinition args, long ticks
+        this NetState ns,
+        Serial mob,
+        BuffIcon iconID,
+        int titleCliloc,
+        int secondaryCliloc,
+        TextDefinition args,
+        long seconds
     )
     {
         if (ns.CannotSendPackets())
@@ -28,8 +34,7 @@ public static class BuffIconPackets
         writer.Write((short)0x1); // command (0 = remove, 1 = add, 2 = data)
         writer.Write(0);
 
-        // Truncate to whole seconds - The packet should be delayed by the partial seconds and then sent "on the second"
-        writer.Write((short)(ticks / 1000));
+        writer.Write((short)seconds);
         writer.Clear(3);
         writer.Write(titleCliloc);
         writer.Write(secondaryCliloc);


### PR DESCRIPTION
### Summary

- Fixes the wrong unit sent into the BuffIcons system. Simplified this so the packet takes seconds and the conversion is done on the implementation layer.