### PR TITLE
fix: Fixes race condition with world save snapshot request

### DIFF
--- a/Projects/Server/Main.cs
+++ b/Projects/Server/Main.cs
@@ -517,10 +517,11 @@ public static class Core
         DoKill(_restartOnKill);
     }
 
+    // This is generally called from background threads during Preserialize
     internal static void RequestSnapshot(string snapshotPath)
     {
-        _performSnapshot = true;
         _snapshotPath = snapshotPath;
+        _performSnapshot = true; // Set this after the path so race conditions do not occur
     }
 
     public static void VerifySerialization()

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -324,6 +324,11 @@ public static class World
         {
             _serializationStart = Core.Now;
 
+            if (string.IsNullOrEmpty(snapshotPath))
+            {
+                throw new ArgumentException("Snapshot path cannot be null or empty", nameof(snapshotPath));
+            }
+
             Persistence.SerializeAll();
             PauseSerializationThreads();
             EventSink.InvokeWorldSave();


### PR DESCRIPTION
### Summary

* Fixes a race condition where the snapshot path isn't between the request snapshot being set on a background thread, and the main loop consuming that flag.


Closes #2102 