### PR TITLE
feat: Replaces params array with params ReadOnlySpan

### DIFF
--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -423,7 +423,7 @@ public partial class Container : Item
         return false;
     }
 
-    public virtual bool TryDropItems(Mobile from, bool sendFullMessage, params Item[] droppedItems)
+    public virtual bool TryDropItems(Mobile from, bool sendFullMessage, params ReadOnlySpan<Item> droppedItems)
     {
         var dropItems = new List<Item>();
         var stackItems = new List<ItemStackEntry>();

--- a/Projects/Server/Regions/Region.cs
+++ b/Projects/Server/Regions/Region.cs
@@ -127,7 +127,7 @@ public class Region : IComparable<Region>, IValueLinkListNode<Region>
     public const int MinZ = sbyte.MinValue;
     public const int MaxZ = sbyte.MaxValue + 1;
 
-    public Region(string name, Map map, int priority, params Rectangle2D[] area) : this(
+    public Region(string name, Map map, int priority, params ReadOnlySpan<Rectangle2D> area) : this(
         name,
         map,
         priority,
@@ -147,7 +147,7 @@ public class Region : IComparable<Region>, IValueLinkListNode<Region>
     public Region(string name, Map map, Region parent, int priority, params Rectangle3D[] area) : this(name, map, parent, area) =>
         Priority = priority;
 
-    public Region(string name, Map map, Region parent, params Rectangle2D[] area) : this(
+    public Region(string name, Map map, Region parent, params ReadOnlySpan<Rectangle2D> area) : this(
         name,
         map,
         parent,
@@ -314,7 +314,7 @@ public class Region : IComparable<Region>, IValueLinkListNode<Region>
     public static Rectangle3D ConvertTo3D(Rectangle2D rect) =>
         new(new Point3D(rect.Start, MinZ), new Point3D(rect.End, MaxZ));
 
-    public static Rectangle3D[] ConvertTo3D(Rectangle2D[] rects)
+    public static Rectangle3D[] ConvertTo3D(ReadOnlySpan<Rectangle2D> rects)
     {
         var ret = new Rectangle3D[rects.Length];
 

--- a/Projects/Server/Utilities/Utility.cs
+++ b/Projects/Server/Utilities/Utility.cs
@@ -745,7 +745,7 @@ public static partial class Utility
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T RandomList<T>(params T[] list) => list.RandomElement();
+    public static T RandomList<T>(params ReadOnlySpan<T> list) => list.RandomElement();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T RandomElement<T>(this ReadOnlySpan<T> list) => list.Length == 0 ? default : list[Random(list.Length)];
@@ -1305,15 +1305,15 @@ public static partial class Utility
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T[] Combine<T>(this IList<T> source, params IList<T>[] arrays) =>
+    public static T[] Combine<T>(this IList<T> source, params ReadOnlySpan<IList<T>> arrays) =>
         source.Combine(false, arrays);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T[] CombinePooled<T>(this IList<T> source, params IList<T>[] arrays) =>
+    public static T[] CombinePooled<T>(this IList<T> source, params ReadOnlySpan<IList<T>> arrays) =>
         source.Combine(true, arrays);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T[] Combine<T>(this IList<T> source, bool pooled, params IList<T>[] arrays)
+    public static T[] Combine<T>(this IList<T> source, bool pooled, params ReadOnlySpan<IList<T>> arrays)
     {
         var totalLength = source.Count;
         foreach (var arr in arrays)

--- a/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
@@ -85,7 +85,7 @@ public abstract partial class BaseSpawner : Item, ISpawner
 
     public BaseSpawner(
         int amount, int minDelay, int maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : this(
         amount,
         TimeSpan.FromMinutes(minDelay),
@@ -99,7 +99,7 @@ public abstract partial class BaseSpawner : Item, ISpawner
 
     public BaseSpawner(
         int amount, TimeSpan minDelay, TimeSpan maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : base(0x1f13)
     {
         _guid = Guid.NewGuid();

--- a/Projects/UOContent/Engines/Spawners/ProximitySpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/ProximitySpawner.cs
@@ -66,7 +66,7 @@ public partial class ProximitySpawner : Spawner
     [Constructible(AccessLevel.Developer)]
     public ProximitySpawner(
         int amount, TimeSpan minDelay, TimeSpan maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : base(amount, minDelay, maxDelay, team, homeRange, spawnedNames)
     {
     }
@@ -74,7 +74,7 @@ public partial class ProximitySpawner : Spawner
     [Constructible(AccessLevel.Developer)]
     public ProximitySpawner(
         int amount, TimeSpan minDelay, TimeSpan maxDelay, int team, int homeRange, int triggerRange,
-        TextDefinition spawnMessage, bool instantFlag, params string[] spawnedNames
+        TextDefinition spawnMessage, bool instantFlag, params ReadOnlySpan<string> spawnedNames
     ) : base(amount, minDelay, maxDelay, team, homeRange, spawnedNames)
     {
         TriggerRange = triggerRange;

--- a/Projects/UOContent/Engines/Spawners/RegionSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/RegionSpawner.cs
@@ -42,7 +42,7 @@ public partial class RegionSpawner : Spawner
     [Constructible(AccessLevel.Developer)]
     public RegionSpawner(
         int amount, int minDelay, int maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : this(
         amount,
         TimeSpan.FromMinutes(minDelay),
@@ -57,7 +57,7 @@ public partial class RegionSpawner : Spawner
     [Constructible(AccessLevel.Developer)]
     public RegionSpawner(
         int amount, TimeSpan minDelay, TimeSpan maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : base(amount, minDelay, maxDelay, team, homeRange, spawnedNames)
     {
     }

--- a/Projects/UOContent/Engines/Spawners/Spawner.cs
+++ b/Projects/UOContent/Engines/Spawners/Spawner.cs
@@ -21,7 +21,7 @@ public partial class Spawner : BaseSpawner
     [Constructible(AccessLevel.Developer)]
     public Spawner(
         int amount, int minDelay, int maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : this(
         amount,
         TimeSpan.FromMinutes(minDelay),
@@ -36,7 +36,7 @@ public partial class Spawner : BaseSpawner
     [Constructible(AccessLevel.Developer)]
     public Spawner(
         int amount, TimeSpan minDelay, TimeSpan maxDelay, int team, int homeRange,
-        params string[] spawnedNames
+        params ReadOnlySpan<string> spawnedNames
     ) : base(amount, minDelay, maxDelay, team, homeRange, spawnedNames)
     {
     }

--- a/Projects/UOContent/Gumps/AdminGump.cs
+++ b/Projects/UOContent/Gumps/AdminGump.cs
@@ -1313,7 +1313,7 @@ namespace Server.Gumps
 
         public void AddPageButton(
             int x, int y, int buttonID, string text, AdminGumpPage page,
-            params AdminGumpPage[] subPages
+            params ReadOnlySpan<AdminGumpPage> subPages
         )
         {
             var isSelection = m_PageType == page;

--- a/Projects/UOContent/Items/Misc/FlippableAddonAttribute.cs
+++ b/Projects/UOContent/Items/Misc/FlippableAddonAttribute.cs
@@ -6,7 +6,7 @@ namespace Server.Items;
 [AttributeUsage(AttributeTargets.Class)]
 public class FlippableAddonAttribute : Attribute
 {
-    private static readonly string m_MethodName = "Flip";
+    private const string MethodName = "Flip";
 
     private static readonly Type[] m_Params =
     {
@@ -26,7 +26,7 @@ public class FlippableAddonAttribute : Attribute
 
         try
         {
-            var flipMethod = addon.GetType().GetMethod(m_MethodName, m_Params);
+            var flipMethod = addon.GetType().GetMethod(MethodName, m_Params);
 
             if (flipMethod == null)
             {

--- a/Projects/UOContent/Misc/InhumanSpeech.cs
+++ b/Projects/UOContent/Misc/InhumanSpeech.cs
@@ -360,10 +360,10 @@ namespace Server.Misc
             return sentence.ToString();
         }
 
-        public void SayRandomTranslate(Mobile mob, params string[] sentancesInEnglish)
+        public void SayRandomTranslate(Mobile mob, params ReadOnlySpan<string> sentencesInEnglish)
         {
             SaySentance(mob, Utility.RandomMinMax(2, 3));
-            mob.Say(sentancesInEnglish.RandomElement());
+            mob.Say(sentencesInEnglish.RandomElement());
         }
 
         private string GetRandomResponseWord(List<string> keywordsFound)

--- a/Projects/UOContent/Misc/Loot.cs
+++ b/Projects/UOContent/Misc/Loot.cs
@@ -766,15 +766,15 @@ namespace Server
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Item Construct(params Type[] types) => Construct<Item>(types.RandomElement());
+        public static Item Construct(params ReadOnlySpan<Type> types) => Construct<Item>(types.RandomElement());
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T Construct<T>(params Type[] types) where T : Item => Construct<T>(types.RandomElement());
+        public static T Construct<T>(params ReadOnlySpan<Type> types) where T : Item => Construct<T>(types.RandomElement());
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Item Construct(Type[] types, int index) => Construct<Item>(types, index);
+        public static Item Construct(ReadOnlySpan<Type> types, int index) => Construct<Item>(types, index);
 
-        public static T Construct<T>(Type[] types, int index) where T : Item
+        public static T Construct<T>(ReadOnlySpan<Type> types, int index) where T : Item
         {
             if (index >= 0 && index < types.Length)
             {

--- a/Projects/UOContent/Misc/Weather.cs
+++ b/Projects/UOContent/Misc/Weather.cs
@@ -15,14 +15,14 @@ namespace Server.Misc
         private int m_Stage;
 
         public Weather(
-            Map facet, Rectangle2D[] area, int temperature, int chanceOfPercipitation, int chanceOfExtremeTemperature,
+            Map facet, Rectangle2D[] area, int temperature, int chanceOfPrecipitation, int chanceOfExtremeTemperature,
             TimeSpan interval
         )
         {
             Facet = facet;
             Area = area;
             Temperature = temperature;
-            ChanceOfPercipitation = chanceOfPercipitation;
+            ChanceOfPrecipitation = chanceOfPrecipitation;
             ChanceOfExtremeTemperature = chanceOfExtremeTemperature;
 
             var list = GetWeatherList(facet);
@@ -42,7 +42,7 @@ namespace Server.Misc
 
         public int Temperature { get; set; }
 
-        public int ChanceOfPercipitation { get; set; }
+        public int ChanceOfPrecipitation { get; set; }
 
         public int ChanceOfExtremeTemperature { get; set; }
 
@@ -298,7 +298,7 @@ namespace Server.Misc
         {
             if (m_Stage == 0)
             {
-                m_Active = ChanceOfPercipitation > Utility.Random(100);
+                m_Active = ChanceOfPrecipitation > Utility.Random(100);
                 m_ExtremeTemperature = ChanceOfExtremeTemperature > Utility.Random(100);
 
                 if (MoveSpeed > 0)

--- a/Projects/UOContent/Mobiles/AI/HealerAI.cs
+++ b/Projects/UOContent/Mobiles/AI/HealerAI.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Spells;
 using Server.Spells.First;
 using Server.Spells.Fourth;
@@ -132,7 +133,7 @@ public class HealerAI : BaseAI
         }
     }
 
-    private Mobile Find(params NeedDelegate[] funcs)
+    private Mobile Find(params ReadOnlySpan<NeedDelegate> funcs)
     {
         if (m_Mobile.Deleted)
         {

--- a/Projects/UOContent/Multis/ComponentVerification.cs
+++ b/Projects/UOContent/Multis/ComponentVerification.cs
@@ -147,17 +147,17 @@ namespace Server.Multis
             return table;
         }
 
-        private void LoadItems(string path, params string[] itemColumns)
+        private void LoadItems(string path, params ReadOnlySpan<string> itemColumns)
         {
             LoadSpreadsheet(m_ItemTable, path, itemColumns);
         }
 
-        private void LoadMultis(string path, params string[] multiColumns)
+        private void LoadMultis(string path, params ReadOnlySpan<string> multiColumns)
         {
             LoadSpreadsheet(m_MultiTable, path, multiColumns);
         }
 
-        private void LoadSpreadsheet(int[] table, string path, params string[] tileColumns)
+        private void LoadSpreadsheet(int[] table, string path, params ReadOnlySpan<string> tileColumns)
         {
             var ss = new Spreadsheet(path);
 

--- a/Projects/UOContent/Regions/BaseRegion.cs
+++ b/Projects/UOContent/Regions/BaseRegion.cs
@@ -12,7 +12,7 @@ public class BaseRegion : Region
     private static readonly List<Rectangle3D> m_RectBuffer1 = new();
     private static readonly List<Rectangle3D> m_RectBuffer2 = new();
 
-    public BaseRegion(string name, Map map, int priority, params Rectangle2D[] area) : base(name, map, priority, area)
+    public BaseRegion(string name, Map map, int priority, params ReadOnlySpan<Rectangle2D> area) : base(name, map, priority, area)
     {
     }
 
@@ -26,7 +26,7 @@ public class BaseRegion : Region
     {
     }
 
-    public BaseRegion(string name, Map map, Region parent, params Rectangle2D[] area) : base(name, map, parent, area)
+    public BaseRegion(string name, Map map, Region parent, params ReadOnlySpan<Rectangle2D> area) : base(name, map, parent, area)
     {
     }
 


### PR DESCRIPTION
### Summary

If you don't need to use the array built by `params`, then changing `params T[]` to `params ReadOnlySpan<T>` will hint to the compiler to make a global static array and to not allocate the input as an array.