### PR TITLE
fix: Fixes empty spellbooks with EA client on Pre-AOS

### DIFF
--- a/Projects/Server/Network/Packets/OutgoingContainerPackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingContainerPackets.cs
@@ -33,7 +33,7 @@ public static class OutgoingContainerPackets
             return;
         }
 
-        if (ns.NewSpellbook)
+        if (Core.AOS && ns.NewSpellbook)
         {
             ns.SendNewSpellbookContent(book, graphic, offset, content);
         }


### PR DESCRIPTION
### Summary

- Fixes a regression of displaying spellbooks for Pre-AOS that affects EA clients.