### PR TITLE
fix: Fixes EVs/BSs attacking players in Pre-AOS

### DIFF
--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -387,6 +387,12 @@ namespace Server.Misc
                 return Notoriety.Invulnerable;
             }
 
+            // Moved above AccessLevel check so staff summons are red
+            if (bcTarg?.AlwaysMurderer == true)
+            {
+                return Notoriety.Murderer;
+            }
+
             var pmFrom = source as PlayerMobile;
             var pmTarg = target as PlayerMobile;
 
@@ -434,7 +440,7 @@ namespace Server.Misc
 
             if (target.Kills >= 5 ||
                 target.Body.IsMonster && IsSummoned(bcTarg) && target is not BaseFamiliar && target is not ArcaneFey &&
-                target is not Golem || bcTarg?.AlwaysMurderer == true || bcTarg?.IsAnimatedDead == true)
+                target is not Golem || bcTarg?.IsAnimatedDead == true)
             {
                 return Notoriety.Murderer;
             }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -448,6 +448,8 @@ namespace Server.Mobiles
         [CommandProperty(AccessLevel.GameMaster)]
         public bool IsPrisoner { get; set; }
 
+        public virtual bool FollowsAcquireRules => true;
+
         protected DateTime SummonEnd { get; set; }
 
         public virtual Faction FactionAllegiance => null;

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/BladeSpirits.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/BladeSpirits.cs
@@ -45,7 +45,7 @@ namespace Server.Mobiles
 
         public override string CorpseName => "a blade spirit corpse";
         public override string DefaultName => "a blade spirit";
-        
+
         public override bool DeleteCorpseOnDeath => Core.AOS;
         public override bool IsHouseSummonable => true;
 
@@ -54,6 +54,8 @@ namespace Server.Mobiles
 
         public override bool BleedImmune => true;
         public override Poison PoisonImmune => Poison.Lethal;
+
+        public override bool FollowsAcquireRules => Core.AOS || !Summoned || SummonMaster?.Player != true || Map != Map.Felucca;
 
         public override double GetFightModeRanking(Mobile m, FightMode acqType, bool bPlayerOnly) =>
             (m.Str + m.Skills.Tactics.Value) / Math.Max(GetDistanceToSqrt(m), 1.0);

--- a/Projects/UOContent/Mobiles/Monsters/Misc/Melee/EnergyVortex.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Misc/Melee/EnergyVortex.cs
@@ -63,6 +63,8 @@ namespace Server.Mobiles
         public override bool BleedImmune => true;
         public override Poison PoisonImmune => Poison.Lethal;
 
+        public override bool FollowsAcquireRules => Core.AOS || !Summoned || SummonMaster?.Player != true || Map != Map.Felucca;
+
         public override double GetFightModeRanking(Mobile m, FightMode acqType, bool bPlayerOnly) =>
             (m.Int + m.Skills.Magery.Value) / Math.Max(GetDistanceToSqrt(m), 1.0);
 


### PR DESCRIPTION
### Summary

At some point EVs and BSs changed from attacking players (and their caster) to following normal spell casting rules of not attacking blues. We will assume it was at AOS+.

Introduced a new overridable property `BaseCreature.FollowsAcquireRules` to mediate this.