### PR TITLE
fix: Fixes console clobbering when prompted to add an owner account

### DIFF
--- a/Projects/UOContent/Misc/AccountPrompt.cs
+++ b/Projects/UOContent/Misc/AccountPrompt.cs
@@ -12,18 +12,18 @@ public static class AccountPrompt
     {
         if (Accounts.Count == 0)
         {
-            Console.WriteLine("This server has no accounts.");
-            Console.Write("Do you want to create the owner account now? (y/n): ");
+            logger.Warning("This server has no accounts.");
+            logger.Information("Do you want to create the owner account now? (y/n): ");
 
             var answer = ConsoleInputHandler.ReadLine();
             if (answer.InsensitiveEquals("y"))
             {
-                Console.WriteLine();
+                logger.Information("");
 
-                Console.Write("Username: ");
+                logger.Information("Input Username: ");
                 var username = ConsoleInputHandler.ReadLine();
 
-                Console.Write("Password: ");
+                logger.Information("Input Password: ");
                 var password = ConsoleInputHandler.ReadLine();
 
                 var a = new Account(username, password)

--- a/Projects/UOContent/Misc/AccountPrompt.cs
+++ b/Projects/UOContent/Misc/AccountPrompt.cs
@@ -1,4 +1,3 @@
-using System;
 using Server.Accounting;
 using Server.Logging;
 

--- a/Projects/UOContent/Misc/AccountPrompt.cs
+++ b/Projects/UOContent/Misc/AccountPrompt.cs
@@ -13,17 +13,15 @@ public static class AccountPrompt
         if (Accounts.Count == 0)
         {
             logger.Warning("This server has no accounts.");
-            logger.Information("Do you want to create the owner account now? (y/n): ");
+            logger.Information("Do you want to create the owner account now? (y/n):");
 
             var answer = ConsoleInputHandler.ReadLine();
             if (answer.InsensitiveEquals("y"))
             {
-                logger.Information("");
-
-                logger.Information("Input Username: ");
+                logger.Information("Input Username:");
                 var username = ConsoleInputHandler.ReadLine();
 
-                logger.Information("Input Password: ");
+                logger.Information("Input Password:");
                 var password = ConsoleInputHandler.ReadLine();
 
                 var a = new Account(username, password)


### PR DESCRIPTION
### Summary
- Updates AccountPrompt to use `logger` to avoid console clobbering

### Screenshot
![image](https://github.com/user-attachments/assets/8bfbaccc-3c23-4d05-ab49-a656e6a8803f)
