### PR TITLE
fix: Fixes BitArray serialization

### DIFF
--- a/Projects/Server/Serialization/IGenericWriter.cs
+++ b/Projects/Server/Serialization/IGenericWriter.cs
@@ -163,14 +163,21 @@ public interface IGenericWriter
 
     public void Write(BitArray bitArray)
     {
-        var bytesLength = (bitArray.Length - 1 + (1 << 3)) >>> 3;
-        var arrayBuffer = ArrayPool<byte>.Shared.Rent(bytesLength);
+        int bitLength = bitArray.Length;
+        int byteLength = (bitLength + 7) / 8;
 
-        WriteEncodedInt(bytesLength);
-        bitArray.CopyTo(arrayBuffer, 0);
+        WriteEncodedInt(bitLength);
 
-        Write(arrayBuffer.AsSpan(0, bytesLength));
-        ArrayPool<byte>.Shared.Return(arrayBuffer);
+        var arrayBuffer = ArrayPool<byte>.Shared.Rent(byteLength);
+        try
+        {
+            bitArray.CopyTo(arrayBuffer, 0);
+            Write(arrayBuffer.AsSpan(0, byteLength));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(arrayBuffer);
+        }
     }
 
     void Write(TextDefinition def)


### PR DESCRIPTION
### Summary

Fixes serialization/deserialization edge cases with BitArray. If you use BitArray, you will need to migrate.


### Migration

1. Change the type in the migration JSON file (if there is one) from `BitArray` to `byte[]` for all the versions you need to migrate.
2. Then in the `MigrateFrom`, use the following function to convert the field from a byte[] back to the BitArray.

```cs
public static BitArray MigrateByteArrayToBitArray(ReadOnlySpan<byte> data, int bitLength)
{
    // ReadEncodedInt
    var byteLength = 0;
    var shift = 0;
    var index = 0;
    byte b;
    do
    {
        b = data[index++];
        byteLength |= (b & 0x7F) << shift;
        shift += 7;
    }
    while (b >= 0x80);

    var buffer = ArrayPool<byte>.Shared.Rent(byteLength);
    try
    {
        data.CopyTo(buffer.AsSpan(index));
        return new BitArray(buffer) { Length = bitLength };
    }
    finally
    {
        ArrayPool<byte>.Shared.Return(buffer);
    }
}
```