### PR TITLE
fix: Adjusts spell ranges to match OSI

### DIFF
--- a/Projects/UOContent/Spells/Fifth/DispelField.cs
+++ b/Projects/UOContent/Spells/Fifth/DispelField.cs
@@ -22,6 +22,8 @@ namespace Server.Spells.Fifth
 
         public override SpellCircle Circle => SpellCircle.Fifth;
 
+        public int TargetRange => Core.T2A ? 15 : 18;
+
         public void Target(Item item)
         {
             if (!item.GetType().IsDefined(typeof(DispellableFieldAttribute), false))

--- a/Projects/UOContent/Spells/Fifth/PoisonField.cs
+++ b/Projects/UOContent/Spells/Fifth/PoisonField.cs
@@ -26,6 +26,8 @@ public class PoisonFieldSpell : MagerySpell, ITargetingSpell<IPoint3D>
 
     public override SpellCircle Circle => SpellCircle.Fifth;
 
+    public int TargetRange => Core.T2A ? 15 : 18;
+
     public void Target(IPoint3D p)
     {
         if (SpellHelper.CheckTown(p, Caster) && CheckSequence())

--- a/Projects/UOContent/Spells/Fourth/FireField.cs
+++ b/Projects/UOContent/Spells/Fourth/FireField.cs
@@ -26,6 +26,8 @@ public class FireFieldSpell : MagerySpell, ITargetingSpell<IPoint3D>
 
     public override SpellCircle Circle => SpellCircle.Fourth;
 
+    public int TargetRange => Core.T2A ? 15 : 18;
+
     public void Target(IPoint3D p)
     {
         if (SpellHelper.CheckTown(p, Caster) && CheckSequence())

--- a/Projects/UOContent/Spells/Seventh/EnergyField.cs
+++ b/Projects/UOContent/Spells/Seventh/EnergyField.cs
@@ -26,6 +26,8 @@ public class EnergyFieldSpell : MagerySpell, ITargetingSpell<IPoint3D>
 
     public override SpellCircle Circle => SpellCircle.Seventh;
 
+    public int TargetRange => Core.T2A ? 15 : 18;
+
     public void Target(IPoint3D p)
     {
         if (SpellHelper.CheckTown(p, Caster) && CheckSequence())

--- a/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
+++ b/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
@@ -25,7 +25,7 @@ public class ParalyzeFieldSpell : MagerySpell, ITargetingSpell<IPoint3D>
 
     public override SpellCircle Circle => SpellCircle.Sixth;
 
-    public int TargetRange => 15;
+    public int TargetRange => Core.T2A ? 15 : 18;
 
     public void Target(IPoint3D p)
     {

--- a/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
+++ b/Projects/UOContent/Spells/Sixth/ParalyzeField.cs
@@ -25,6 +25,8 @@ public class ParalyzeFieldSpell : MagerySpell, ITargetingSpell<IPoint3D>
 
     public override SpellCircle Circle => SpellCircle.Sixth;
 
+    public int TargetRange => 15;
+
     public void Target(IPoint3D p)
     {
         if (SpellHelper.CheckTown(p, Caster) && CheckSequence())

--- a/Projects/UOContent/Spells/Targeting/ITargetingSpell.cs
+++ b/Projects/UOContent/Spells/Targeting/ITargetingSpell.cs
@@ -4,7 +4,8 @@ public interface IRangedSpell
 {
     Mobile Caster { get; }
 
-    int TargetRange => Core.ML ? 10 : 12;
+    // https://uo.com/wiki/ultima-online-wiki/technical/previous-publishes/1999-2/1999-06-14th-april/
+    int TargetRange => Core.T2A ? 10 : 12;
     void FinishSequence();
 }
 

--- a/Projects/UOContent/Spells/Third/WallOfStone.cs
+++ b/Projects/UOContent/Spells/Third/WallOfStone.cs
@@ -23,6 +23,8 @@ public class WallOfStoneSpell : MagerySpell, ITargetingSpell<IPoint3D>
 
     public override SpellCircle Circle => SpellCircle.Third;
 
+    public int TargetRange => Core.T2A ? 15 : 18;
+
     public void Target(IPoint3D p)
     {
         if (SpellHelper.CheckTown(p, Caster) && CheckSequence())


### PR DESCRIPTION
### Summary

Adjusts spell ranges according to OSI. Specifically, the [April 14, 1999 patch](https://uo.com/wiki/ultima-online-wiki/technical/previous-publishes/1999-2/1999-06-14th-april/) changed spell ranges to 10 tiles, and 15 tiles for fields.