### PR TITLE
fix: Fixes weapons not serializing lesser poison

### DIFF
--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -88,7 +88,7 @@ public abstract partial class BaseWeapon
 
     [SerializableFieldSaveFlag(7)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldSerializePoison() => _poison?.Level > 0;
+    private bool ShouldSerializePoison() => _poison != null;
 
     [InvalidateProperties]
     [SerializableField(8)]


### PR DESCRIPTION
### Summary

Fixes weapons not serializing lesser poison.

> [!NOTE]
> Dev Note: After applying this fix, fix weapons already in-game using the following command
> `[global set poison lesser where baseweapon poison = null poisoncharges > 0`