### PR TITLE
fix: Do not add an extraneous Open Paperdoll context menu entry

### DIFF
--- a/Projects/UOContent/Mobiles/Hireables/BaseHire.cs
+++ b/Projects/UOContent/Mobiles/Hireables/BaseHire.cs
@@ -228,11 +228,6 @@ public partial class BaseHire : BaseCreature
 
         if (!Controlled)
         {
-            if (CanPaperdollBeOpenedBy(from))
-            {
-                list.Add(new PaperdollEntry());
-            }
-
             list.Add(new HireEntry());
         }
         else


### PR DESCRIPTION
There was a duplicate 'Open Paperdoll' context menu entry in all hireables, being added in BaseHire:

![screenshot-2025-06-28-18-47-57](https://github.com/user-attachments/assets/fa26ec61-e2bb-47bf-a675-d9b8238a7aec)

I've removed it.