### PR TITLE
fix: Fixes skill cooldown for some target skills

### DIFF
--- a/Projects/UOContent/Skills/DetectHidden.cs
+++ b/Projects/UOContent/Skills/DetectHidden.cs
@@ -114,7 +114,13 @@ namespace Server.SkillHandlers
                     src.SendLocalizedMessage(500817); // You can see nothing hidden there.
                 }
 
-                src.NextSkillTime = Core.TickCount + 6000; // 6 seconds cooldown
+                const int TargeterCooldown = 30000; // 30s
+                const int SkillCooldown = 10000;    // 10s
+
+                // Calculate how much time has passed since the targeter was opened
+                int ticksSinceTargeter = (int)(Core.TickCount - (src.NextSkillTime - TargeterCooldown));
+                int remainingCooldown = Math.Max(0, SkillCooldown - ticksSinceTargeter);
+                src.NextSkillTime = Core.TickCount + remainingCooldown;
             }
         }
     }

--- a/Projects/UOContent/Skills/Stealing.cs
+++ b/Projects/UOContent/Skills/Stealing.cs
@@ -410,7 +410,13 @@ public static class Stealing
                 pm.Delta(MobileDelta.Noto);
             }
 
-            from.NextSkillTime = Core.TickCount + 10000; // 10 seconds cooldown
+            const int TargeterCooldown = 30000; // 30s
+            const int SkillCooldown = 10000;    // 10s
+
+            // Calculate how much time has passed since the targeter was opened
+            int ticksSinceTargeter = (int)(Core.TickCount - (from.NextSkillTime - TargeterCooldown));
+            int remainingCooldown = Math.Max(0, SkillCooldown - ticksSinceTargeter);
+            from.NextSkillTime = Core.TickCount + remainingCooldown;
         }
     }
 }


### PR DESCRIPTION
### Summary

Stealing, Detect Hidden, and Begging will now give credit for the time it took the player to use the targeter against the total skill cooldown. So if the player takes longer than 10s to target, then they can use a skill again immediately.

> [!NOTE]
> This does not change the requirement that players can no longer stack target these skills.