### PR TITLE
fix: Prevent cascading deletes during world deserialization

### DIFF
--- a/Projects/Server/Serialization/GenericEntityPersistence.cs
+++ b/Projects/Server/Serialization/GenericEntityPersistence.cs
@@ -345,7 +345,20 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
         _entities.Clear();
         _entities.TrimExcess();
         _entities = null;
+
+        if (_toDelete != null)
+        {
+            foreach (var t in _toDelete)
+            {
+                t.Delete();
+            }
+
+            _toDelete.Clear();
+            _toDelete = null;
+        }
     }
+
+    private static List<T> _toDelete;
 
     private unsafe void InternalDeserialize(string filePath, int index, Dictionary<ulong, string> typesDb)
     {
@@ -415,7 +428,8 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
                     }
                 }
 
-                t.Delete();
+                _toDelete ??= [];
+                _toDelete.Add(t);
             }
         }
 


### PR DESCRIPTION
### Summary

Fixes an issue where deleting entities during world load can cause cascading delete failures when the world is not fully loaded.