### PR TITLE
fix: Fixes Spawner position finding and adds BitMask256 utility for 256-bit bitmask operations

### DIFF
--- a/Projects/Server.Tests/Tests/Maps/CanFitItemTests.cs
+++ b/Projects/Server.Tests/Tests/Maps/CanFitItemTests.cs
@@ -21,8 +21,6 @@ public class CanFitItemTests
         Skip.If(!ServerFixture.TileDataLoaded, "TileData not loaded - client files required");
     }
 
-    #region Basic Validation Tests
-
     [Fact]
     public void CanFitItem_InternalMapReturnsFalse()
     {
@@ -41,10 +39,6 @@ public class CanFitItemTests
         Assert.False(map.CanFitItem(map.Width + 1, 100, 0, 1));
         Assert.False(map.CanFitItem(100, map.Height + 1, 0, 1));
     }
-
-    #endregion
-
-    #region Land Surface Tests
 
     private const int TestLandX = 1500;
     private const int TestLandY = 1600;
@@ -71,10 +65,6 @@ public class CanFitItemTests
 
         Assert.False(result, "No surface 50 units above land");
     }
-
-    #endregion
-
-    #region Surface + Impassable Tests (Tables, Furniture)
 
     [SkippableFact]
     public void CanFitItem_SurfaceImpassableMultiIsValidSurface()
@@ -145,10 +135,6 @@ public class CanFitItemTests
         }
     }
 
-    #endregion
-
-    #region World Item Surface Tests
-
     [SkippableFact]
     public void CanFitItem_NonMovableWorldItemSurfaceWorks()
     {
@@ -215,10 +201,6 @@ public class CanFitItemTests
         }
     }
 
-    #endregion
-
-    #region Blocking Tests
-
     [SkippableFact]
     public void CanFitItem_ImpassableTileBlocksPlacement()
     {
@@ -278,10 +260,6 @@ public class CanFitItemTests
         }
     }
 
-    #endregion
-
-    #region Helper Methods and Classes
-
     private TestMulti CreateSurfaceImpassableMulti(Map map, Point3D location, int surfaceZ)
     {
         // Use SurfaceImpassableTileId - a tile that has both Surface and Impassable flags
@@ -322,6 +300,4 @@ public class CanFitItemTests
 
         public override MultiComponentList Components => _components;
     }
-
-    #endregion
 }

--- a/Projects/Server.Tests/Tests/Maps/CanSpawnMobileTests.cs
+++ b/Projects/Server.Tests/Tests/Maps/CanSpawnMobileTests.cs
@@ -9,8 +9,6 @@ namespace Server.Tests.Tests.Maps;
 [Collection("Sequential Server Tests")]
 public class CanSpawnMobileTests
 {
-    #region Basic Validation Tests
-
     [Fact]
     public void CanSpawnMobile_InternalMapReturnsFalse()
     {
@@ -30,10 +28,6 @@ public class CanSpawnMobileTests
         Assert.False(map.CanSpawnMobile(map.Width + 1, 100, -128, 127, false, false, out _));
         Assert.False(map.CanSpawnMobile(100, map.Height + 1, -128, 127, false, false, out _));
     }
-
-    #endregion
-
-    #region Land Surface Tests
 
     // Use coordinates near Britain which should be walkable land in both test and real data
     private const int TestLandX = 1500;
@@ -73,10 +67,6 @@ public class CanSpawnMobileTests
 
         Assert.False(result, "cantWalk=true should not find land as valid surface");
     }
-
-    #endregion
-
-    #region Mobile Blocking Tests
 
     [Fact]
     public void CanSpawnMobile_MobileBlocksSpawn()
@@ -162,10 +152,6 @@ public class CanSpawnMobileTests
         }
     }
 
-    #endregion
-
-    #region Helper Classes
-
     private class TestMobile : Mobile
     {
         public TestMobile()
@@ -174,6 +160,4 @@ public class CanSpawnMobileTests
             Hidden = false;
         }
     }
-
-    #endregion
 }

--- a/Projects/Server.Tests/Tests/Maps/CanSpawnMobileTileDataTests.cs
+++ b/Projects/Server.Tests/Tests/Maps/CanSpawnMobileTileDataTests.cs
@@ -23,8 +23,6 @@ public class CanSpawnMobileTileDataTests
         Skip.If(!ServerFixture.TileDataLoaded, "TileData not loaded - client files required");
     }
 
-    #region Multi-Based Tests
-
     [SkippableFact]
     public void CanSpawnMobile_FindsSurfaceOnMulti()
     {
@@ -241,10 +239,6 @@ public class CanSpawnMobileTileDataTests
         }
     }
 
-    #endregion
-
-    #region Real Map Data Tests
-
     [SkippableFact]
     public void CanSpawnMobile_MalasBuilding_FindsGroundFloor()
     {
@@ -289,10 +283,6 @@ public class CanSpawnMobileTileDataTests
         Assert.True(result);
         Assert.True(spawnZ <= -40, $"Expected lowest floor around -50, got {spawnZ}");
     }
-
-    #endregion
-
-    #region Helper Methods and Classes
 
     private TestMulti CreateFloorMulti(Map map, Point3D location, int floorZ)
     {
@@ -367,6 +357,4 @@ public class CanSpawnMobileTileDataTests
 
         public override MultiComponentList Components => _components;
     }
-
-    #endregion
 }

--- a/Projects/Server/Utilities/BitMask256.cs
+++ b/Projects/Server/Utilities/BitMask256.cs
@@ -1,0 +1,396 @@
+/*************************************************************************
+ * ModernUO                                                              *
+ * Copyright 2019-2025 - ModernUO Development Team                       *
+ * Email: hi@modernuo.com                                                *
+ * File: BitMask256.cs                                                   *
+ *                                                                       *
+ * This program is free software: you can redistribute it and/or modify  *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * You should have received a copy of the GNU General Public License     *
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *************************************************************************/
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
+
+namespace Server;
+
+/// <summary>
+/// A 256-bit bitmask stored as 4 ulongs.
+/// Useful for tracking 256 discrete states such as:
+/// - Z levels in UO (-128 to 127 = 256 values)
+/// - Sector positions (16x16 = 256 tiles)
+/// Uses BMI2 for efficient bit selection when available.
+/// </summary>
+public struct BitMask256
+{
+    public ulong Bits0, Bits1, Bits2, Bits3;
+
+    /// <summary>
+    /// Creates a mask with all 256 bits set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static BitMask256 AllSet() => new()
+    {
+        Bits0 = ulong.MaxValue,
+        Bits1 = ulong.MaxValue,
+        Bits2 = ulong.MaxValue,
+        Bits3 = ulong.MaxValue
+    };
+
+    /// <summary>
+    /// Creates a mask with all bits cleared (default state).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static BitMask256 AllClear() => default;
+
+    /// <summary>
+    /// Sets a single bit at the specified index (0-255).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetBit(int index)
+    {
+        if ((uint)index >= 256)
+        {
+            return;
+        }
+
+        var segment = index >> 6;
+        var localBit = index & 0x3F;
+        var mask = 1UL << localBit;
+
+        switch (segment)
+        {
+            case 0: Bits0 |= mask; break;
+            case 1: Bits1 |= mask; break;
+            case 2: Bits2 |= mask; break;
+            case 3: Bits3 |= mask; break;
+        }
+    }
+
+    /// <summary>
+    /// Clears a single bit at the specified index (0-255).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ClearBit(int index)
+    {
+        if ((uint)index >= 256)
+        {
+            return;
+        }
+
+        var segment = index >> 6;
+        var localBit = index & 0x3F;
+        var mask = 1UL << localBit;
+
+        switch (segment)
+        {
+            case 0: Bits0 &= ~mask; break;
+            case 1: Bits1 &= ~mask; break;
+            case 2: Bits2 &= ~mask; break;
+            case 3: Bits3 &= ~mask; break;
+        }
+    }
+
+    /// <summary>
+    /// Gets the value of a single bit at the specified index (0-255).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool GetBit(int index)
+    {
+        if ((uint)index >= 256)
+        {
+            return false;
+        }
+
+        var segment = index >> 6;
+        var localBit = index & 0x3F;
+        var mask = 1UL << localBit;
+
+        return segment switch
+        {
+            0 => (Bits0 & mask) != 0,
+            1 => (Bits1 & mask) != 0,
+            2 => (Bits2 & mask) != 0,
+            3 => (Bits3 & mask) != 0,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Sets all bits in the inclusive range [start, end].
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetRange(int start, int end)
+    {
+        if (end < 0 || start > 255 || start > end)
+        {
+            return;
+        }
+
+        start = Math.Max(0, start);
+        end = Math.Min(255, end);
+
+        Bits0 |= CreateSegmentMask(start, end, 0);
+        Bits1 |= CreateSegmentMask(start, end, 64);
+        Bits2 |= CreateSegmentMask(start, end, 128);
+        Bits3 |= CreateSegmentMask(start, end, 192);
+    }
+
+    /// <summary>
+    /// Clears all bits in the inclusive range [start, end].
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ClearRange(int start, int end)
+    {
+        if (end < 0 || start > 255 || start > end)
+        {
+            return;
+        }
+
+        start = Math.Max(0, start);
+        end = Math.Min(255, end);
+
+        Bits0 &= ~CreateSegmentMask(start, end, 0);
+        Bits1 &= ~CreateSegmentMask(start, end, 64);
+        Bits2 &= ~CreateSegmentMask(start, end, 128);
+        Bits3 &= ~CreateSegmentMask(start, end, 192);
+    }
+
+    /// <summary>
+    /// Creates a bitmask for the portion of [start, end] that falls within a 64-bit segment.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong CreateSegmentMask(int start, int end, int segmentOffset)
+    {
+        var localStart = start - segmentOffset;
+        var localEnd = end - segmentOffset;
+
+        localStart = Math.Max(0, localStart);
+        localEnd = Math.Min(63, localEnd);
+
+        if (localStart > 63 || localEnd < 0 || localStart > localEnd)
+        {
+            return 0;
+        }
+
+        var bitCount = localEnd - localStart + 1;
+        var mask = bitCount >= 64 ? ulong.MaxValue : (1UL << bitCount) - 1;
+        return mask << localStart;
+    }
+
+    /// <summary>
+    /// Returns the bitwise AND of this mask with another.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly BitMask256 And(in BitMask256 other) => new()
+    {
+        Bits0 = Bits0 & other.Bits0,
+        Bits1 = Bits1 & other.Bits1,
+        Bits2 = Bits2 & other.Bits2,
+        Bits3 = Bits3 & other.Bits3
+    };
+
+    /// <summary>
+    /// Returns the bitwise OR of this mask with another.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly BitMask256 Or(in BitMask256 other) => new()
+    {
+        Bits0 = Bits0 | other.Bits0,
+        Bits1 = Bits1 | other.Bits1,
+        Bits2 = Bits2 | other.Bits2,
+        Bits3 = Bits3 | other.Bits3
+    };
+
+    /// <summary>
+    /// Returns the bitwise XOR of this mask with another.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly BitMask256 Xor(in BitMask256 other) => new()
+    {
+        Bits0 = Bits0 ^ other.Bits0,
+        Bits1 = Bits1 ^ other.Bits1,
+        Bits2 = Bits2 ^ other.Bits2,
+        Bits3 = Bits3 ^ other.Bits3
+    };
+
+    /// <summary>
+    /// Returns the bitwise AND-NOT (this &amp; ~other).
+    /// Clears bits in this mask that are set in the other mask.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly BitMask256 AndNot(in BitMask256 other) => new()
+    {
+        Bits0 = Bits0 & ~other.Bits0,
+        Bits1 = Bits1 & ~other.Bits1,
+        Bits2 = Bits2 & ~other.Bits2,
+        Bits3 = Bits3 & ~other.Bits3
+    };
+
+    /// <summary>
+    /// Returns the bitwise NOT of this mask.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly BitMask256 Not() => new()
+    {
+        Bits0 = ~Bits0,
+        Bits1 = ~Bits1,
+        Bits2 = ~Bits2,
+        Bits3 = ~Bits3
+    };
+
+    /// <summary>
+    /// Returns the total number of bits set (population count).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly int PopCount() =>
+        BitOperations.PopCount(Bits0) +
+        BitOperations.PopCount(Bits1) +
+        BitOperations.PopCount(Bits2) +
+        BitOperations.PopCount(Bits3);
+
+    /// <summary>
+    /// Returns true if no bits are set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool IsEmpty() => (Bits0 | Bits1 | Bits2 | Bits3) == 0;
+
+    /// <summary>
+    /// Returns true if all 256 bits are set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool IsFull() =>
+        Bits0 == ulong.MaxValue &&
+        Bits1 == ulong.MaxValue &&
+        Bits2 == ulong.MaxValue &&
+        Bits3 == ulong.MaxValue;
+
+    /// <summary>
+    /// Returns the index of the lowest set bit (0-255), or -1 if no bits are set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly int LowestSetBit()
+    {
+        if (Bits0 != 0)
+        {
+            return BitOperations.TrailingZeroCount(Bits0);
+        }
+
+        if (Bits1 != 0)
+        {
+            return 64 + BitOperations.TrailingZeroCount(Bits1);
+        }
+
+        if (Bits2 != 0)
+        {
+            return 128 + BitOperations.TrailingZeroCount(Bits2);
+        }
+
+        if (Bits3 != 0)
+        {
+            return 192 + BitOperations.TrailingZeroCount(Bits3);
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Returns the index of the highest set bit (0-255), or -1 if no bits are set.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly int HighestSetBit()
+    {
+        if (Bits3 != 0)
+        {
+            return 255 - BitOperations.LeadingZeroCount(Bits3);
+        }
+
+        if (Bits2 != 0)
+        {
+            return 191 - BitOperations.LeadingZeroCount(Bits2);
+        }
+
+        if (Bits1 != 0)
+        {
+            return 127 - BitOperations.LeadingZeroCount(Bits1);
+        }
+
+        if (Bits0 != 0)
+        {
+            return 63 - BitOperations.LeadingZeroCount(Bits0);
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Returns the index of the Nth set bit (0-indexed), or -1 if fewer than N+1 bits are set.
+    /// Uses BMI2 PDEP for O(1) performance when available, otherwise O(popcount) fallback.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly int GetNthSetBit(int n)
+    {
+        if (n < 0)
+        {
+            return -1;
+        }
+
+        var count0 = BitOperations.PopCount(Bits0);
+        if (n < count0)
+        {
+            return GetNthBitInUlong(Bits0, n);
+        }
+
+        n -= count0;
+
+        var count1 = BitOperations.PopCount(Bits1);
+        if (n < count1)
+        {
+            return 64 + GetNthBitInUlong(Bits1, n);
+        }
+
+        n -= count1;
+
+        var count2 = BitOperations.PopCount(Bits2);
+        if (n < count2)
+        {
+            return 128 + GetNthBitInUlong(Bits2, n);
+        }
+
+        n -= count2;
+
+        var count3 = BitOperations.PopCount(Bits3);
+        if (n < count3)
+        {
+            return 192 + GetNthBitInUlong(Bits3, n);
+        }
+
+        return -1;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int GetNthBitInUlong(ulong bits, int n)
+    {
+        // BMI2 PDEP: O(1) - deposits the nth selector bit into the position of the nth set bit
+        if (Bmi2.X64.IsSupported)
+        {
+            var deposited = Bmi2.X64.ParallelBitDeposit(1UL << n, bits);
+            return BitOperations.TrailingZeroCount(deposited);
+        }
+
+        // Fallback: O(popcount) - clear n set bits, then find position of next one
+        while (n > 0 && bits != 0)
+        {
+            bits &= bits - 1;
+            n--;
+        }
+
+        return bits == 0 ? -1 : BitOperations.TrailingZeroCount(bits);
+    }
+}

--- a/Projects/UOContent.Tests/Tests/Engines/Spawners/SectorSpawnCacheTests.cs
+++ b/Projects/UOContent.Tests/Tests/Engines/Spawners/SectorSpawnCacheTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace UOContent.Tests;
 
-public class SectorSpawnCacheTests
+public class BitMask256Tests
 {
     [Fact]
-    public void SectorSpawnCache_InitialState_AllBitsZero()
+    public void BitMask256_InitialState_AllBitsZero()
     {
-        var cache = new SectorSpawnCache();
+        var mask = BitMask256.AllClear();
 
-        Assert.Equal(0, cache.GetCount());
+        Assert.Equal(0, mask.PopCount());
     }
 
     [Theory]
@@ -24,48 +24,48 @@ public class SectorSpawnCacheTests
     [InlineData(191)]
     [InlineData(192)]
     [InlineData(255)]
-    public void SectorSpawnCache_SetBit_SetsCorrectBit(int bitIndex)
+    public void BitMask256_SetBit_SetsCorrectBit(int bitIndex)
     {
-        var cache = new SectorSpawnCache();
+        var mask = BitMask256.AllClear();
 
-        cache.SetBit(bitIndex);
+        mask.SetBit(bitIndex);
 
-        Assert.True(cache.GetBit(bitIndex));
-        Assert.Equal(1, cache.GetCount());
+        Assert.True(mask.GetBit(bitIndex));
+        Assert.Equal(1, mask.PopCount());
     }
 
     [Fact]
-    public void SectorSpawnCache_SetMultipleBits_CountsCorrectly()
+    public void BitMask256_SetMultipleBits_CountsCorrectly()
     {
-        var cache = new SectorSpawnCache();
+        var mask = BitMask256.AllClear();
 
-        cache.SetBit(0);
-        cache.SetBit(64);
-        cache.SetBit(128);
-        cache.SetBit(192);
+        mask.SetBit(0);
+        mask.SetBit(64);
+        mask.SetBit(128);
+        mask.SetBit(192);
 
-        Assert.Equal(4, cache.GetCount());
-        Assert.True(cache.GetBit(0));
-        Assert.True(cache.GetBit(64));
-        Assert.True(cache.GetBit(128));
-        Assert.True(cache.GetBit(192));
-        Assert.False(cache.GetBit(1));
+        Assert.Equal(4, mask.PopCount());
+        Assert.True(mask.GetBit(0));
+        Assert.True(mask.GetBit(64));
+        Assert.True(mask.GetBit(128));
+        Assert.True(mask.GetBit(192));
+        Assert.False(mask.GetBit(1));
     }
 
     [Fact]
-    public void SectorSpawnCache_ClearBit_ClearsCorrectBit()
+    public void BitMask256_ClearBit_ClearsCorrectBit()
     {
-        var cache = new SectorSpawnCache();
+        var mask = BitMask256.AllClear();
 
-        cache.SetBit(50);
-        cache.SetBit(100);
-        Assert.Equal(2, cache.GetCount());
+        mask.SetBit(50);
+        mask.SetBit(100);
+        Assert.Equal(2, mask.PopCount());
 
-        cache.ClearBit(50);
+        mask.ClearBit(50);
 
-        Assert.False(cache.GetBit(50));
-        Assert.True(cache.GetBit(100));
-        Assert.Equal(1, cache.GetCount());
+        Assert.False(mask.GetBit(50));
+        Assert.True(mask.GetBit(100));
+        Assert.Equal(1, mask.PopCount());
     }
 
     [Theory]
@@ -73,31 +73,31 @@ public class SectorSpawnCacheTests
     [InlineData(1, 64)]  // First bit of second ulong
     [InlineData(2, 128)] // First bit of third ulong
     [InlineData(3, 192)] // First bit of fourth ulong
-    public void SectorSpawnCache_GetNthBitPosition_FirstBitInEachUlong(int n, int expectedPosition)
+    public void BitMask256_GetNthSetBit_FirstBitInEachUlong(int n, int expectedPosition)
     {
-        var cache = new SectorSpawnCache();
+        var mask = BitMask256.AllClear();
 
         // Set first bit in each ulong
-        cache.SetBit(0);
-        cache.SetBit(64);
-        cache.SetBit(128);
-        cache.SetBit(192);
+        mask.SetBit(0);
+        mask.SetBit(64);
+        mask.SetBit(128);
+        mask.SetBit(192);
 
-        Assert.Equal(expectedPosition, cache.GetNthBitPosition(n));
+        Assert.Equal(expectedPosition, mask.GetNthSetBit(n));
     }
 
     [Fact]
-    public void SectorSpawnCache_GetNthBitPosition_WithinSingleUlong()
+    public void BitMask256_GetNthSetBit_WithinSingleUlong()
     {
-        var cache = new SectorSpawnCache();
+        var mask = BitMask256.AllClear();
 
-        cache.SetBit(5);
-        cache.SetBit(10);
-        cache.SetBit(20);
+        mask.SetBit(5);
+        mask.SetBit(10);
+        mask.SetBit(20);
 
-        Assert.Equal(5, cache.GetNthBitPosition(0));
-        Assert.Equal(10, cache.GetNthBitPosition(1));
-        Assert.Equal(20, cache.GetNthBitPosition(2));
+        Assert.Equal(5, mask.GetNthSetBit(0));
+        Assert.Equal(10, mask.GetNthSetBit(1));
+        Assert.Equal(20, mask.GetNthSetBit(2));
     }
 }
 


### PR DESCRIPTION
### Summary

- Create BitMask256 struct with scalar operations (benchmarks showed AVX2 vectorization provides no benefit for this size)
- Refactor Map.cs to use BitMask256 for full Z range support (-128 to 127)
- Remove SectorSpawnCache struct, use BitMask256 directly in manager
- Update tests to use BitMask256 directly
- Remove unused test assertions for old 64-bit behavior