### PR TITLE
fix: Bumps IORingGroup to fix excessive syscalls

### DIFF
--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,7 +34,7 @@
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Logger\Logger.csproj" />
-        <PackageReference Include="IORingGroup" Version="1.0.1" />
+        <PackageReference Include="IORingGroup" Version="1.0.4" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.2.120" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.2" />


### PR DESCRIPTION
### Summary

Bumps IORingGroup to 1.0.4:
* Fixes excessive syscalls in windows.
* Switches from a C implementation for windows (v1.0.3) to pure C# because the performance is the same or better.