### PR TITLE
perf: Migrate Virtue gumps to DynamicGump/StaticGump

### DIFF
--- a/Projects/UOContent/Engines/Virtues/VirtueGump.cs
+++ b/Projects/UOContent/Engines/Virtues/VirtueGump.cs
@@ -7,7 +7,7 @@ namespace Server.Engines.Virtues;
 
 public delegate void OnVirtueUsed(PlayerMobile from);
 
-public class VirtueGump : Gump
+public class VirtueGump : DynamicGump
 {
     private static readonly Dictionary<int, OnVirtueUsed> _callbacks = new();
 
@@ -23,6 +23,19 @@ public class VirtueGump : Gump
         0x0543, 0x0547, 0x0061
     };
 
+    private readonly PlayerMobile _beheld;
+    private readonly PlayerMobile _beholder;
+
+    public override bool Singleton => true;
+
+    private VirtueGump(PlayerMobile beholder, PlayerMobile beheld) : base(0, 0)
+    {
+        _beholder = beholder;
+        _beheld = beheld;
+
+        Serial = beheld.Serial;
+    }
+
     public static void Register(int gumpID, OnVirtueUsed callback)
     {
         _callbacks[gumpID] = callback;
@@ -36,7 +49,7 @@ public class VirtueGump : Gump
         }
         else if (beholder.Map == beheld.Map && beholder.InRange(beheld, 12))
         {
-            beholder.SendGump(new VirtueGump(beholder, beheld), true);
+            beholder.SendGump(new VirtueGump(beholder, beheld));
         }
     }
 
@@ -78,35 +91,27 @@ public class VirtueGump : Gump
         RequestVirtueItem(beholder, beholder, virtueID);
     }
 
-    private readonly PlayerMobile _beheld;
-    private readonly PlayerMobile _beholder;
-
-    public VirtueGump(PlayerMobile beholder, PlayerMobile beheld) : base(0, 0)
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
     {
-        _beholder = beholder;
-        _beheld = beheld;
+        builder.AddPage();
 
-        Serial = beheld.Serial;
+        builder.AddImage(30, 40, 104);
 
-        AddPage(0);
+        builder.AddPage(1);
 
-        AddImage(30, 40, 104);
-
-        AddPage(1);
-
-        Add(new VirtueGumpItem(61, 71, 108, GetHueFor(0)));   // Humility
-        Add(new VirtueGumpItem(123, 46, 112, GetHueFor(4)));  // Valor
-        Add(new VirtueGumpItem(187, 70, 107, GetHueFor(5)));  // Honor
-        Add(new VirtueGumpItem(35, 135, 110, GetHueFor(1)));  // Sacrifice
-        Add(new VirtueGumpItem(211, 133, 105, GetHueFor(2))); // Compassion
-        Add(new VirtueGumpItem(61, 195, 111, GetHueFor(3)));  // Spirituality
-        Add(new VirtueGumpItem(186, 195, 109, GetHueFor(6))); // Justice
-        Add(new VirtueGumpItem(121, 221, 106, GetHueFor(7))); // Honesty
+        builder.AddImage(61, 71, 108, GetHueFor(0), "VirtueGumpItem");   // Humility
+        builder.AddImage(123, 46, 112, GetHueFor(4), "VirtueGumpItem");  // Valor
+        builder.AddImage(187, 70, 107, GetHueFor(5), "VirtueGumpItem");  // Honor
+        builder.AddImage(35, 135, 110, GetHueFor(1), "VirtueGumpItem");  // Sacrifice
+        builder.AddImage(211, 133, 105, GetHueFor(2), "VirtueGumpItem"); // Compassion
+        builder.AddImage(61, 195, 111, GetHueFor(3), "VirtueGumpItem");  // Spirituality
+        builder.AddImage(186, 195, 109, GetHueFor(6), "VirtueGumpItem"); // Justice
+        builder.AddImage(121, 221, 106, GetHueFor(7), "VirtueGumpItem"); // Honesty
 
         if (_beholder == _beheld)
         {
-            AddButton(57, 269, 2027, 2027, 1);
-            AddButton(186, 269, 2071, 2071, 2);
+            builder.AddButton(57, 269, 2027, 2027, 1);
+            builder.AddButton(186, 269, 2071, 2071, 2);
         }
     }
 
@@ -140,14 +145,7 @@ public class VirtueGump : Gump
     {
         if (info.ButtonID == 1 && _beholder == _beheld)
         {
-            _beholder.SendGump(new VirtueStatusGump(_beholder));
-        }
-    }
-
-    private class VirtueGumpItem : GumpImage
-    {
-        public VirtueGumpItem(int x, int y, int gumpID, int hue) : base(x, y, gumpID, hue, "VirtueGumpItem")
-        {
+            VirtueStatusGump.DisplayTo(_beholder);
         }
     }
 }

--- a/Projects/UOContent/Engines/Virtues/VirtueInfoGump.cs
+++ b/Projects/UOContent/Engines/Virtues/VirtueInfoGump.cs
@@ -4,32 +4,47 @@ using Server.Network;
 
 namespace Server.Engines.Virtues;
 
-public class VirtueInfoGump : Gump
+public class VirtueInfoGump : DynamicGump
 {
     private readonly PlayerMobile _beholder;
     private readonly int _desc;
     private readonly string _site;
     private readonly VirtueName _virtue;
 
-    public VirtueInfoGump(PlayerMobile beholder, VirtueName virtue, int description, string webPage = null) : base(0, 0)
+    public override bool Singleton => true;
+
+    private VirtueInfoGump(PlayerMobile beholder, VirtueName virtue, int description, string webPage) : base(0, 0)
     {
         _beholder = beholder;
         _virtue = virtue;
         _desc = description;
         _site = webPage;
+    }
 
-        var value = VirtueSystem.GetVirtues(beholder)?.GetValue((int)virtue) ?? 0;
+    public static void DisplayTo(PlayerMobile beholder, VirtueName virtue, int description, string webPage = null)
+    {
+        if (beholder?.NetState == null)
+        {
+            return;
+        }
 
-        AddPage(0);
+        beholder.SendGump(new VirtueInfoGump(beholder, virtue, description, webPage));
+    }
 
-        AddImage(30, 40, 2080);
-        AddImage(47, 77, 2081);
-        AddImage(47, 147, 2081);
-        AddImage(47, 217, 2081);
-        AddImage(47, 267, 2083);
-        AddImage(70, 213, 2091);
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        var value = VirtueSystem.GetVirtues(_beholder)?.GetValue((int)_virtue) ?? 0;
 
-        AddPage(1);
+        builder.AddPage();
+
+        builder.AddImage(30, 40, 2080);
+        builder.AddImage(47, 77, 2081);
+        builder.AddImage(47, 147, 2081);
+        builder.AddImage(47, 217, 2081);
+        builder.AddImage(47, 267, 2083);
+        builder.AddImage(70, 213, 2091);
+
+        builder.AddPage(1);
 
         var maxValue = VirtueSystem.GetMaxAmount(_virtue);
 
@@ -55,7 +70,7 @@ public class VirtueInfoGump : Gump
 
         for (var i = 0; i < 10; ++i)
         {
-            AddImage(95 + i * 17, 50, i < dots ? 2362 : 2360);
+            builder.AddImage(95 + i * 17, 50, i < dots ? 2362 : 2360);
         }
 
         if (value < 1)
@@ -95,16 +110,16 @@ public class VirtueInfoGump : Gump
             valueDesc = 1052050; // You have achieved the highest path in this Virtue.
         }
 
-        AddHtmlLocalized(157, 73, 200, 40, 1051000 + (int)virtue);
-        AddHtmlLocalized(75, 95, 220, 140, description);
-        AddHtmlLocalized(70, 224, 229, 60, valueDesc);
+        builder.AddHtmlLocalized(157, 73, 200, 40, 1051000 + (int)_virtue);
+        builder.AddHtmlLocalized(75, 95, 220, 140, _desc);
+        builder.AddHtmlLocalized(70, 224, 229, 60, valueDesc);
 
-        AddButton(65, 277, 1209, 1209, 1);
+        builder.AddButton(65, 277, 1209, 1209, 1);
 
-        AddButton(280, 43, 4014, 4014, 2);
+        builder.AddButton(280, 43, 4014, 4014, 2);
 
         // This virtue is not yet defined. OR -click to learn more (opens webpage)
-        AddHtmlLocalized(83, 275, 400, 40, webPage == null ? 1052055 : 1052052);
+        builder.AddHtmlLocalized(83, 275, 400, 40, _site == null ? 1052055 : 1052052);
     }
 
     public override void OnResponse(NetState state, in RelayInfo info)
@@ -113,7 +128,7 @@ public class VirtueInfoGump : Gump
         {
             case 1:
                 {
-                    _beholder.SendGump(new VirtueInfoGump(_beholder, _virtue, _desc, _site));
+                    _beholder.SendGump(this);
 
                     if (_site != null)
                     {
@@ -124,7 +139,7 @@ public class VirtueInfoGump : Gump
                 }
             case 2:
                 {
-                    _beholder.SendGump(new VirtueStatusGump(_beholder));
+                    VirtueStatusGump.DisplayTo(_beholder);
                     break;
                 }
         }

--- a/Projects/UOContent/Engines/Virtues/VirtueStatusGump.cs
+++ b/Projects/UOContent/Engines/Virtues/VirtueStatusGump.cs
@@ -4,48 +4,63 @@ using Server.Network;
 
 namespace Server.Engines.Virtues;
 
-public class VirtueStatusGump : Gump
+public class VirtueStatusGump : StaticGump<VirtueStatusGump>
 {
     private readonly PlayerMobile _beholder;
 
-    public VirtueStatusGump(PlayerMobile beholder) : base(0, 0)
+    public override bool Singleton => true;
+
+    private VirtueStatusGump(PlayerMobile beholder) : base(0, 0)
     {
         _beholder = beholder;
+    }
 
-        AddPage(0);
+    public static void DisplayTo(PlayerMobile beholder)
+    {
+        if (beholder?.NetState == null)
+        {
+            return;
+        }
 
-        AddImage(30, 40, 2080);
-        AddImage(47, 77, 2081);
-        AddImage(47, 147, 2081);
-        AddImage(47, 217, 2081);
-        AddImage(47, 267, 2083);
-        AddImage(70, 213, 2091);
+        beholder.SendGump(new VirtueStatusGump(beholder));
+    }
 
-        AddPage(1);
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage();
 
-        AddHtmlLocalized(140, 73, 200, 20, 1077972); // The Virtues
+        builder.AddImage(30, 40, 2080);
+        builder.AddImage(47, 77, 2081);
+        builder.AddImage(47, 147, 2081);
+        builder.AddImage(47, 217, 2081);
+        builder.AddImage(47, 267, 2083);
+        builder.AddImage(70, 213, 2091);
 
-        AddHtmlLocalized(80, 100, 100, 40, 1051000);  // Humility
-        AddHtmlLocalized(80, 129, 100, 40, 1051001);  // Sacrifice
-        AddHtmlLocalized(80, 159, 100, 40, 1051002);  // Compassion
-        AddHtmlLocalized(80, 189, 100, 40, 1051003);  // Spirituality
-        AddHtmlLocalized(200, 100, 200, 40, 1051004); // Valor
-        AddHtmlLocalized(200, 129, 200, 40, 1051005); // Honor
-        AddHtmlLocalized(200, 159, 200, 40, 1051006); // Justice
-        AddHtmlLocalized(200, 189, 200, 40, 1051007); // Honesty
+        builder.AddPage(1);
 
-        AddHtmlLocalized(75, 224, 220, 60, 1052062); // Click on a blue gem to view your status in that virtue.
+        builder.AddHtmlLocalized(140, 73, 200, 20, 1077972); // The Virtues
 
-        AddButton(60, 100, 1210, 1210, 1);  // Humility
-        AddButton(60, 129, 1210, 1210, 2);  // Sacrifice
-        AddButton(60, 159, 1210, 1210, 3);  // Compassion
-        AddButton(60, 189, 1210, 1210, 4);  // Spirituality
-        AddButton(180, 100, 1210, 1210, 5); // Valor
-        AddButton(180, 129, 1210, 1210, 6); // Honor
-        AddButton(180, 159, 1210, 1210, 7); // Justice
-        AddButton(180, 189, 1210, 1210, 8); // Honesty
+        builder.AddHtmlLocalized(80, 100, 100, 40, 1051000);  // Humility
+        builder.AddHtmlLocalized(80, 129, 100, 40, 1051001);  // Sacrifice
+        builder.AddHtmlLocalized(80, 159, 100, 40, 1051002);  // Compassion
+        builder.AddHtmlLocalized(80, 189, 100, 40, 1051003);  // Spirituality
+        builder.AddHtmlLocalized(200, 100, 200, 40, 1051004); // Valor
+        builder.AddHtmlLocalized(200, 129, 200, 40, 1051005); // Honor
+        builder.AddHtmlLocalized(200, 159, 200, 40, 1051006); // Justice
+        builder.AddHtmlLocalized(200, 189, 200, 40, 1051007); // Honesty
 
-        AddButton(280, 43, 4014, 4014, 9);
+        builder.AddHtmlLocalized(75, 224, 220, 60, 1052062); // Click on a blue gem to view your status in that virtue.
+
+        builder.AddButton(60, 100, 1210, 1210, 1);  // Humility
+        builder.AddButton(60, 129, 1210, 1210, 2);  // Sacrifice
+        builder.AddButton(60, 159, 1210, 1210, 3);  // Compassion
+        builder.AddButton(60, 189, 1210, 1210, 4);  // Spirituality
+        builder.AddButton(180, 100, 1210, 1210, 5); // Valor
+        builder.AddButton(180, 129, 1210, 1210, 6); // Honor
+        builder.AddButton(180, 159, 1210, 1210, 7); // Justice
+        builder.AddButton(180, 189, 1210, 1210, 8); // Honesty
+
+        builder.AddButton(280, 43, 4014, 4014, 9);
     }
 
     private static int GetVirtueDescription(VirtueName virtue) =>
@@ -66,7 +81,7 @@ public class VirtueStatusGump : Gump
     {
         if (info.ButtonID == 9)
         {
-            _beholder.SendGump(new VirtueGump(_beholder, _beholder));
+            VirtueGump.RequestVirtueGump(_beholder, _beholder);
             return;
         }
 
@@ -77,11 +92,11 @@ public class VirtueStatusGump : Gump
 
         var virtue = (VirtueName)(info.ButtonID - 1);
 
-        _beholder.SendGump(new VirtueInfoGump(
+        VirtueInfoGump.DisplayTo(
             _beholder,
             virtue,
             GetVirtueDescription(virtue),
             @$"https://uo.com/wiki/ultima-online-wiki/gameplay/the-virtues/#{VirtueSystem.GetLowerCaseName(virtue)}"
-        ));
+        );
     }
 }


### PR DESCRIPTION
## Summary

First PR in a multi-PR migration of player-facing legacy `Gump` subclasses to the modern `DynamicGump` / `StaticGump<T>` system. Plan covers ~95 files across ~14 PRs by system; this PR is the foundation (smallest, isolated, no cross-refs).

- `VirtueGump` → `DynamicGump`: per-instance virtue hues from `GetHueFor()` and the conditional self/other button block prevent layout caching.
- `VirtueStatusGump` → `StaticGump<VirtueStatusGump>`: layout is identical for every player; only used as a navigation hub.
- `VirtueInfoGump` → `DynamicGump`: dynamic cliloc IDs (`1051000 + (int)virtue`, the description cliloc, and the conditional `1052055`/`1052052` footer) cannot be cached by `StaticGump<T>` — cliloc *numbers* are baked into layout bytes, only HTML/label *text* can be deferred to placeholders.

All three:

- `Singleton => true` (replaces previous instance instead of stacking)
- Constructors made `private`; entry points are static (`RequestVirtueGump`, `DisplayTo`) per the empty-gump rule (CLAUDE.md §13)
- `OnResponse` updated to `in RelayInfo info` modern signature
- `VirtueInfoGump` self-refresh button now uses `_beholder.SendGump(this)` instead of allocating a new instance
- Removed the unused `VirtueGumpItem : GumpImage` nested class — replaced with direct `builder.AddImage(...)` calls; preserves the legacy `class=VirtueGumpItem` attribute for packet parity

The special-cased TypeID for VirtueGump (`BaseGump.cs:86`) is preserved because the type's full name (`Server.Engines.Virtues.VirtueGump`) is unchanged.

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — 301/301 passing
- [ ] In-game: open the virtue book on yourself, click each gem, click "back" and "learn more", invoke `RequestVirtueGump` on another player
- [ ] Verify the virtue gump auto-replaces on repeat invocation (no stacking)
