### PR TITLE
perf: Migrate Veteran Reward gumps to DynamicGump/StaticGump

### DIFF
--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
@@ -592,7 +592,7 @@ public class CharacterStatueTarget : Target
             _maker.Delete();
             statue.Sculpt(from);
 
-            from.SendGump(new CharacterStatueGump(_maker, statue, from), true);
+            CharacterStatueGump.DisplayTo(from, _maker, statue, from);
             return;
         }
 

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
@@ -592,7 +592,7 @@ public class CharacterStatueTarget : Target
             _maker.Delete();
             statue.Sculpt(from);
 
-            CharacterStatueGump.DisplayTo(from, _maker, statue, from);
+            CharacterStatueGump.DisplayTo(from, _maker, statue);
             return;
         }
 

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatuePlinth.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatuePlinth.cs
@@ -77,7 +77,7 @@ public partial class CharacterStatuePlinth : Static, IAddon
     {
         if (_statue != null)
         {
-            from.SendGump(new CharacterPlinthGump(_statue));
+            CharacterPlinthGump.DisplayTo(from, _statue);
         }
     }
 
@@ -98,31 +98,40 @@ public partial class CharacterStatuePlinth : Static, IAddon
         }
     }
 
-    private class CharacterPlinthGump : Gump
+    private class CharacterPlinthGump : DynamicGump
     {
-        public CharacterPlinthGump(CharacterStatue statue) : base(60, 30)
-        {
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+        private readonly CharacterStatue _statue;
 
-            AddPage(0);
-            AddImage(0, 0, 0x24F4);
-            AddHtml(55, 50, 150, 20, statue.Name);
-            AddHtml(55, 75, 150, 20, statue.SculptedOn.ToString());
-            AddHtmlLocalized(55, 100, 150, 20, GetTypeNumber(statue.StatueType), 0);
+        public override bool Singleton => true;
+
+        private CharacterPlinthGump(CharacterStatue statue) : base(60, 30) => _statue = statue;
+
+        public static void DisplayTo(Mobile from, CharacterStatue statue)
+        {
+            if (from?.NetState == null || statue == null || statue.Deleted)
+            {
+                return;
+            }
+
+            from.SendGump(new CharacterPlinthGump(statue));
         }
 
-        public static int GetTypeNumber(StatueType type)
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
         {
-            return type switch
+            builder.AddPage();
+            builder.AddImage(0, 0, 0x24F4);
+            builder.AddHtml(55, 50, 150, 20, _statue.Name);
+            builder.AddHtml(55, 75, 150, 20, _statue.SculptedOn.ToString());
+            builder.AddHtmlLocalized(55, 100, 150, 20, GetTypeNumber(_statue.StatueType), 0);
+        }
+
+        public static int GetTypeNumber(StatueType type) =>
+            type switch
             {
                 StatueType.Marble => 1076181,
                 StatueType.Jade   => 1076180,
                 StatueType.Bronze => 1076230,
                 _                 => 1076181
             };
-        }
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/Gumps/CharacterStatueGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/Gumps/CharacterStatueGump.cs
@@ -1,79 +1,84 @@
 using Server.Mobiles;
 using Server.Network;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public class CharacterStatueGump : DynamicGump
 {
-    public class CharacterStatueGump : Gump
+    private readonly Item _maker;
+    private readonly Mobile _owner;
+    private readonly CharacterStatue _statue;
+
+    public override bool Singleton => true;
+
+    private CharacterStatueGump(Item maker, CharacterStatue statue, Mobile owner) : base(60, 36)
     {
-        private readonly Item m_Maker;
-        private readonly Mobile m_Owner;
-        private readonly CharacterStatue m_Statue;
+        _maker = maker;
+        _statue = statue;
+        _owner = owner;
+    }
 
-        public CharacterStatueGump(Item maker, CharacterStatue statue, Mobile owner) : base(60, 36)
+    public static void DisplayTo(Mobile from, Item maker, CharacterStatue statue, Mobile owner)
+    {
+        if (from?.NetState == null || statue == null || statue.Deleted)
         {
-            m_Maker = maker;
-            m_Statue = statue;
-            m_Owner = owner;
-
-            if (m_Statue == null)
-            {
-                return;
-            }
-
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
-
-            AddPage(0);
-
-            AddBackground(0, 0, 327, 324, 0x13BE);
-            AddImageTiled(10, 10, 307, 20, 0xA40);
-            AddImageTiled(10, 40, 307, 244, 0xA40);
-            AddImageTiled(10, 294, 307, 20, 0xA40);
-            AddAlphaRegion(10, 10, 307, 304);
-            AddHtmlLocalized(14, 12, 327, 20, 1076156, 0x7FFF); // Character Statue Maker
-
-            // pose
-            AddHtmlLocalized(133, 41, 120, 20, 1076168, 0x7FFF); // Choose Pose
-            AddHtmlLocalized(133, 61, 120, 20, 1076208 + (int)m_Statue.Pose, 0x77E);
-            AddButton(163, 81, 0xFA5, 0xFA7, (int)Buttons.PoseNext);
-            AddButton(133, 81, 0xFAE, 0xFB0, (int)Buttons.PosePrev);
-
-            // direction
-            AddHtmlLocalized(133, 126, 120, 20, 1076170, 0x7FFF); // Choose Direction
-            AddHtmlLocalized(133, 146, 120, 20, GetDirectionNumber(m_Statue.Direction), 0x77E);
-            AddButton(163, 167, 0xFA5, 0xFA7, (int)Buttons.DirNext);
-            AddButton(133, 167, 0xFAE, 0xFB0, (int)Buttons.DirPrev);
-
-            // material
-            AddHtmlLocalized(133, 211, 120, 20, 1076171, 0x7FFF); // Choose Material
-            AddHtmlLocalized(133, 231, 120, 20, GetMaterialNumber(m_Statue.StatueType, m_Statue.Material), 0x77E);
-            AddButton(163, 253, 0xFA5, 0xFA7, (int)Buttons.MatNext);
-            AddButton(133, 253, 0xFAE, 0xFB0, (int)Buttons.MatPrev);
-
-            // cancel
-            AddButton(10, 294, 0xFB1, 0xFB2, (int)Buttons.Close);
-            AddHtmlLocalized(45, 294, 80, 20, 1006045, 0x7FFF); // Cancel
-
-            // sculpt
-            AddButton(234, 294, 0xFB7, 0xFB9, (int)Buttons.Sculpt);
-            AddHtmlLocalized(269, 294, 80, 20, 1076174, 0x7FFF); // Sculpt
-
-            // restore
-            if (m_Maker is CharacterStatueDeed)
-            {
-                AddButton(107, 294, 0xFAB, 0xFAD, (int)Buttons.Restore);
-                AddHtmlLocalized(142, 294, 80, 20, 1076193, 0x7FFF); // Restore
-            }
+            return;
         }
 
-        private static int GetMaterialNumber(StatueType type, StatueMaterial material)
-        {
-            switch (material)
-            {
-                case StatueMaterial.Antique:
+        from.SendGump(new CharacterStatueGump(maker, statue, owner));
+    }
 
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(0, 0, 327, 324, 0x13BE);
+        builder.AddImageTiled(10, 10, 307, 20, 0xA40);
+        builder.AddImageTiled(10, 40, 307, 244, 0xA40);
+        builder.AddImageTiled(10, 294, 307, 20, 0xA40);
+        builder.AddAlphaRegion(10, 10, 307, 304);
+        builder.AddHtmlLocalized(14, 12, 327, 20, 1076156, 0x7FFF); // Character Statue Maker
+
+        // pose
+        builder.AddHtmlLocalized(133, 41, 120, 20, 1076168, 0x7FFF); // Choose Pose
+        builder.AddHtmlLocalized(133, 61, 120, 20, 1076208 + (int)_statue.Pose, 0x77E);
+        builder.AddButton(163, 81, 0xFA5, 0xFA7, (int)Buttons.PoseNext);
+        builder.AddButton(133, 81, 0xFAE, 0xFB0, (int)Buttons.PosePrev);
+
+        // direction
+        builder.AddHtmlLocalized(133, 126, 120, 20, 1076170, 0x7FFF); // Choose Direction
+        builder.AddHtmlLocalized(133, 146, 120, 20, GetDirectionNumber(_statue.Direction), 0x77E);
+        builder.AddButton(163, 167, 0xFA5, 0xFA7, (int)Buttons.DirNext);
+        builder.AddButton(133, 167, 0xFAE, 0xFB0, (int)Buttons.DirPrev);
+
+        // material
+        builder.AddHtmlLocalized(133, 211, 120, 20, 1076171, 0x7FFF); // Choose Material
+        builder.AddHtmlLocalized(133, 231, 120, 20, GetMaterialNumber(_statue.StatueType, _statue.Material), 0x77E);
+        builder.AddButton(163, 253, 0xFA5, 0xFA7, (int)Buttons.MatNext);
+        builder.AddButton(133, 253, 0xFAE, 0xFB0, (int)Buttons.MatPrev);
+
+        // cancel
+        builder.AddButton(10, 294, 0xFB1, 0xFB2, (int)Buttons.Close);
+        builder.AddHtmlLocalized(45, 294, 80, 20, 1006045, 0x7FFF); // Cancel
+
+        // sculpt
+        builder.AddButton(234, 294, 0xFB7, 0xFB9, (int)Buttons.Sculpt);
+        builder.AddHtmlLocalized(269, 294, 80, 20, 1076174, 0x7FFF); // Sculpt
+
+        // restore
+        if (_maker is CharacterStatueDeed)
+        {
+            builder.AddButton(107, 294, 0xFAB, 0xFAD, (int)Buttons.Restore);
+            builder.AddHtmlLocalized(142, 294, 80, 20, 1076193, 0x7FFF); // Restore
+        }
+    }
+
+    private static int GetMaterialNumber(StatueType type, StatueMaterial material)
+    {
+        switch (material)
+        {
+            case StatueMaterial.Antique:
+                {
                     return type switch
                     {
                         StatueType.Bronze => 1076187,
@@ -81,127 +86,135 @@ namespace Server.Gumps
                         StatueType.Marble => 1076182,
                         _                 => 1076187
                     };
+                }
 
-                case StatueMaterial.Dark:
-
+            case StatueMaterial.Dark:
+                {
                     if (type == StatueType.Marble)
                     {
                         return 1076183;
                     }
 
                     return 1076182;
-                case StatueMaterial.Medium: return 1076184;
-                case StatueMaterial.Light:  return 1076185;
-                default:                    return 1076187;
-            }
-        }
-
-        private static int GetDirectionNumber(Direction direction)
-        {
-            return direction switch
-            {
-                Direction.North => 1075389,
-                Direction.Right => 1075388,
-                Direction.East  => 1075387,
-                Direction.Down  => 1076204,
-                Direction.South => 1075386,
-                Direction.Left  => 1075391,
-                Direction.West  => 1075390,
-                Direction.Up    => 1076205,
-                _               => 1075386
-            };
-        }
-
-        public override void OnResponse(NetState state, in RelayInfo info)
-        {
-            if (m_Statue?.Deleted != false)
-            {
-                return;
-            }
-
-            var sendGump = false;
-
-            if (info.ButtonID == (int)Buttons.Sculpt)
-            {
-                if (m_Maker is CharacterStatueDeed deed)
-                {
-                    var backup = deed.Statue;
-
-                    backup?.Delete();
                 }
-
-                m_Maker?.Delete();
-
-                m_Statue.Sculpt(state.Mobile);
-            }
-            else if (info.ButtonID == (int)Buttons.PosePrev)
-            {
-                m_Statue.Pose = (StatuePose)(((int)m_Statue.Pose + 5) % 6);
-                sendGump = true;
-            }
-            else if (info.ButtonID == (int)Buttons.PoseNext)
-            {
-                m_Statue.Pose = (StatuePose)(((int)m_Statue.Pose + 1) % 6);
-                sendGump = true;
-            }
-            else if (info.ButtonID == (int)Buttons.DirPrev)
-            {
-                m_Statue.Direction = (Direction)(((int)m_Statue.Direction + 7) % 8);
-                m_Statue.InvalidatePose();
-                sendGump = true;
-            }
-            else if (info.ButtonID == (int)Buttons.DirNext)
-            {
-                m_Statue.Direction = (Direction)(((int)m_Statue.Direction + 1) % 8);
-                m_Statue.InvalidatePose();
-                sendGump = true;
-            }
-            else if (info.ButtonID == (int)Buttons.MatPrev)
-            {
-                m_Statue.Material = (StatueMaterial)(((int)m_Statue.Material + 3) % 4);
-                sendGump = true;
-            }
-            else if (info.ButtonID == (int)Buttons.MatNext)
-            {
-                m_Statue.Material = (StatueMaterial)(((int)m_Statue.Material + 1) % 4);
-                sendGump = true;
-            }
-            else if (info.ButtonID == (int)Buttons.Restore)
-            {
-                if (m_Maker is CharacterStatueDeed deed)
+            case StatueMaterial.Medium:
                 {
-                    var backup = deed.Statue;
-
-                    if (backup != null)
-                    {
-                        m_Statue.Restore(backup);
-                    }
+                    return 1076184;
                 }
-
-                sendGump = true;
-            }
-            else // Close
-            {
-                sendGump = !m_Statue.Demolish(state.Mobile);
-            }
-
-            if (sendGump)
-            {
-                state.Mobile.SendGump(new CharacterStatueGump(m_Maker, m_Statue, m_Owner));
-            }
+            case StatueMaterial.Light:
+                {
+                    return 1076185;
+                }
+            default:
+                {
+                    return 1076187;
+                }
         }
+    }
 
-        private enum Buttons
+    private static int GetDirectionNumber(Direction direction) =>
+        direction switch
         {
-            Close,
-            Sculpt,
-            PosePrev,
-            PoseNext,
-            DirPrev,
-            DirNext,
-            MatPrev,
-            MatNext,
-            Restore
+            Direction.North => 1075389,
+            Direction.Right => 1075388,
+            Direction.East  => 1075387,
+            Direction.Down  => 1076204,
+            Direction.South => 1075386,
+            Direction.Left  => 1075391,
+            Direction.West  => 1075390,
+            Direction.Up    => 1076205,
+            _               => 1075386
+        };
+
+    public override void OnResponse(NetState state, in RelayInfo info)
+    {
+        if (_statue?.Deleted != false)
+        {
+            return;
         }
+
+        var sendGump = false;
+
+        if (info.ButtonID == (int)Buttons.Sculpt)
+        {
+            if (_maker is CharacterStatueDeed deed)
+            {
+                var backup = deed.Statue;
+
+                backup?.Delete();
+            }
+
+            _maker?.Delete();
+
+            _statue.Sculpt(state.Mobile);
+        }
+        else if (info.ButtonID == (int)Buttons.PosePrev)
+        {
+            _statue.Pose = (StatuePose)(((int)_statue.Pose + 5) % 6);
+            sendGump = true;
+        }
+        else if (info.ButtonID == (int)Buttons.PoseNext)
+        {
+            _statue.Pose = (StatuePose)(((int)_statue.Pose + 1) % 6);
+            sendGump = true;
+        }
+        else if (info.ButtonID == (int)Buttons.DirPrev)
+        {
+            _statue.Direction = (Direction)(((int)_statue.Direction + 7) % 8);
+            _statue.InvalidatePose();
+            sendGump = true;
+        }
+        else if (info.ButtonID == (int)Buttons.DirNext)
+        {
+            _statue.Direction = (Direction)(((int)_statue.Direction + 1) % 8);
+            _statue.InvalidatePose();
+            sendGump = true;
+        }
+        else if (info.ButtonID == (int)Buttons.MatPrev)
+        {
+            _statue.Material = (StatueMaterial)(((int)_statue.Material + 3) % 4);
+            sendGump = true;
+        }
+        else if (info.ButtonID == (int)Buttons.MatNext)
+        {
+            _statue.Material = (StatueMaterial)(((int)_statue.Material + 1) % 4);
+            sendGump = true;
+        }
+        else if (info.ButtonID == (int)Buttons.Restore)
+        {
+            if (_maker is CharacterStatueDeed deed)
+            {
+                var backup = deed.Statue;
+
+                if (backup != null)
+                {
+                    _statue.Restore(backup);
+                }
+            }
+
+            sendGump = true;
+        }
+        else // Close
+        {
+            sendGump = !_statue.Demolish(state.Mobile);
+        }
+
+        if (sendGump)
+        {
+            state.Mobile.SendGump(this);
+        }
+    }
+
+    private enum Buttons
+    {
+        Close,
+        Sculpt,
+        PosePrev,
+        PoseNext,
+        DirPrev,
+        DirNext,
+        MatPrev,
+        MatNext,
+        Restore
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/Gumps/CharacterStatueGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/Gumps/CharacterStatueGump.cs
@@ -6,26 +6,24 @@ namespace Server.Gumps;
 public class CharacterStatueGump : DynamicGump
 {
     private readonly Item _maker;
-    private readonly Mobile _owner;
     private readonly CharacterStatue _statue;
 
     public override bool Singleton => true;
 
-    private CharacterStatueGump(Item maker, CharacterStatue statue, Mobile owner) : base(60, 36)
+    private CharacterStatueGump(Item maker, CharacterStatue statue) : base(60, 36)
     {
         _maker = maker;
         _statue = statue;
-        _owner = owner;
     }
 
-    public static void DisplayTo(Mobile from, Item maker, CharacterStatue statue, Mobile owner)
+    public static void DisplayTo(Mobile from, Item maker, CharacterStatue statue)
     {
         if (from?.NetState == null || statue == null || statue.Deleted)
         {
             return;
         }
 
-        from.SendGump(new CharacterStatueGump(maker, statue, owner));
+        from.SendGump(new CharacterStatueGump(maker, statue));
     }
 
     protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -73,44 +71,21 @@ public class CharacterStatueGump : DynamicGump
         }
     }
 
-    private static int GetMaterialNumber(StatueType type, StatueMaterial material)
-    {
-        switch (material)
+    private static int GetMaterialNumber(StatueType type, StatueMaterial material) =>
+        material switch
         {
-            case StatueMaterial.Antique:
-                {
-                    return type switch
-                    {
-                        StatueType.Bronze => 1076187,
-                        StatueType.Jade   => 1076186,
-                        StatueType.Marble => 1076182,
-                        _                 => 1076187
-                    };
-                }
-
-            case StatueMaterial.Dark:
-                {
-                    if (type == StatueType.Marble)
-                    {
-                        return 1076183;
-                    }
-
-                    return 1076182;
-                }
-            case StatueMaterial.Medium:
-                {
-                    return 1076184;
-                }
-            case StatueMaterial.Light:
-                {
-                    return 1076185;
-                }
-            default:
-                {
-                    return 1076187;
-                }
-        }
-    }
+            StatueMaterial.Antique => type switch
+            {
+                StatueType.Bronze => 1076187,
+                StatueType.Jade   => 1076186,
+                StatueType.Marble => 1076182,
+                _                 => 1076187
+            },
+            StatueMaterial.Dark   => type == StatueType.Marble ? 1076183 : 1076182,
+            StatueMaterial.Medium => 1076184,
+            StatueMaterial.Light  => 1076185,
+            _                     => 1076187
+        };
 
     private static int GetDirectionNumber(Direction direction) =>
         direction switch

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardChoiceGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardChoiceGump.cs
@@ -74,7 +74,7 @@ public class RewardChoiceGump : DynamicGump
             35,
             500,
             70,
-            $"<B>Ultima Online Rewards Program</B><BR>Thank you for being a part of the Ultima Online community for a full {intervalAsString}.  As a token of our appreciation,  you may select from the following in-game reward items listed below.  The gift items will be attributed to the character you have logged-in with on the shard you are on when you chose the item(s).  The number of rewards you are entitled to are listed below and are for your entire account.  To read more about these rewards before making a selection, feel free to visit the uo.com site at <A HREF=\"http://www.uo.com/rewards\">http://www.uo.com/rewards</A>.",
+            $"<B>Ultima Online Rewards Program</B><BR>Thank you for being a part of the Ultima Online community for a full {intervalAsString}. As a token of our appreciation, you may select from the following in-game reward items listed below. The gift items will be attributed to the character you have logged-in with on the shard you are on when you chose the item(s). The number of rewards you are entitled to are listed below and are for your entire account. To read more about these rewards before making a selection, feel free to visit the uo.com site at <A HREF=\"https://uo.com/wiki/ultima-online-wiki/items/veteran-rewards\">https://uo.com/wiki/ultima-online-wiki/items/veteran-rewards</A>.",
             background: true,
             scrollbar: true
         );
@@ -82,10 +82,10 @@ public class RewardChoiceGump : DynamicGump
         RewardSystem.ComputeRewardInfo(_from, out var cur, out var max);
 
         builder.AddHtmlLocalized(60, 105, 300, 35, 1006006); // Your current total of rewards to choose:
-        builder.AddLabel(370, 107, 50, (max - cur).ToString());
+        builder.AddLabel(370, 107, 50, $"{max - cur}");
 
         builder.AddHtmlLocalized(60, 140, 300, 35, 1006007); // You have already chosen:
-        builder.AddLabel(370, 142, 50, cur.ToString());
+        builder.AddLabel(370, 142, 50, $"{cur}");
 
         var categories = RewardSystem.Categories;
 
@@ -93,7 +93,8 @@ public class RewardChoiceGump : DynamicGump
 
         for (var i = 0; i < categories.Length; ++i)
         {
-            if (!RewardSystem.HasAccess(_from, categories[i]))
+            var cat = categories[i];
+            if (!RewardSystem.HasAccess(_from, cat))
             {
                 page += 1;
                 continue;
@@ -101,15 +102,15 @@ public class RewardChoiceGump : DynamicGump
 
             builder.AddButton(100, 180 + i * 40, 4005, 4005, 0, GumpButtonType.Page, page);
 
-            page += PagesPerCategory(categories[i]);
+            page += PagesPerCategory(cat);
 
-            if (categories[i].NameString != null)
+            if (cat.NameString != null)
             {
-                builder.AddHtml(135, 180 + i * 40, 300, 20, categories[i].NameString);
+                builder.AddHtml(135, 180 + i * 40, 300, 20, cat.NameString);
             }
             else
             {
-                builder.AddHtmlLocalized(135, 180 + i * 40, 300, 20, categories[i].Name);
+                builder.AddHtmlLocalized(135, 180 + i * 40, 300, 20, cat.Name);
             }
         }
 

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardChoiceGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardChoiceGump.cs
@@ -2,217 +2,226 @@ using System;
 using Server.Gumps;
 using Server.Network;
 
-namespace Server.Engines.VeteranRewards
+namespace Server.Engines.VeteranRewards;
+
+public class RewardChoiceGump : DynamicGump
 {
-    public class RewardChoiceGump : Gump
+    private readonly Mobile _from;
+
+    public override bool Singleton => true;
+
+    private RewardChoiceGump(Mobile from) : base(0, 0) => _from = from;
+
+    public static void DisplayTo(Mobile from)
     {
-        private readonly Mobile m_From;
-
-        public override bool Singleton => true;
-
-        public RewardChoiceGump(Mobile from) : base(0, 0)
+        if (from?.NetState == null)
         {
-            m_From = from;
-
-            RenderBackground();
-            RenderCategories();
+            return;
         }
 
-        private void RenderBackground()
+        from.SendGump(new RewardChoiceGump(from));
+    }
+
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        RenderBackground(ref builder);
+        RenderCategories(ref builder);
+    }
+
+    private static void RenderBackground(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(10, 10, 600, 450, 2600);
+
+        builder.AddButton(530, 415, 4017, 4019, 0);
+
+        builder.AddButton(60, 415, 4014, 4016, 0, GumpButtonType.Page, 1);
+        builder.AddHtmlLocalized(95, 415, 200, 20, 1049755); // Main Menu
+    }
+
+    private void RenderCategories(ref DynamicGumpBuilder builder)
+    {
+        var rewardInterval = RewardSystem.RewardInterval;
+
+        string intervalAsString;
+
+        if (rewardInterval == TimeSpan.FromDays(30.0))
         {
-            AddPage(0);
-
-            AddBackground(10, 10, 600, 450, 2600);
-
-            AddButton(530, 415, 4017, 4019, 0);
-
-            AddButton(60, 415, 4014, 4016, 0, GumpButtonType.Page, 1);
-            AddHtmlLocalized(95, 415, 200, 20, 1049755); // Main Menu
+            intervalAsString = "month";
+        }
+        else if (rewardInterval == TimeSpan.FromDays(60.0))
+        {
+            intervalAsString = "two months";
+        }
+        else if (rewardInterval == TimeSpan.FromDays(90.0))
+        {
+            intervalAsString = "three months";
+        }
+        else if (rewardInterval == TimeSpan.FromDays(365.0))
+        {
+            intervalAsString = "year";
+        }
+        else
+        {
+            intervalAsString = $"{rewardInterval.TotalDays} day{(rewardInterval.TotalDays == 1 ? "" : "s")}";
         }
 
-        private void RenderCategories()
+        builder.AddPage(1);
+
+        builder.AddHtml(
+            60,
+            35,
+            500,
+            70,
+            $"<B>Ultima Online Rewards Program</B><BR>Thank you for being a part of the Ultima Online community for a full {intervalAsString}.  As a token of our appreciation,  you may select from the following in-game reward items listed below.  The gift items will be attributed to the character you have logged-in with on the shard you are on when you chose the item(s).  The number of rewards you are entitled to are listed below and are for your entire account.  To read more about these rewards before making a selection, feel free to visit the uo.com site at <A HREF=\"http://www.uo.com/rewards\">http://www.uo.com/rewards</A>.",
+            background: true,
+            scrollbar: true
+        );
+
+        RewardSystem.ComputeRewardInfo(_from, out var cur, out var max);
+
+        builder.AddHtmlLocalized(60, 105, 300, 35, 1006006); // Your current total of rewards to choose:
+        builder.AddLabel(370, 107, 50, (max - cur).ToString());
+
+        builder.AddHtmlLocalized(60, 140, 300, 35, 1006007); // You have already chosen:
+        builder.AddLabel(370, 142, 50, cur.ToString());
+
+        var categories = RewardSystem.Categories;
+
+        var page = 2;
+
+        for (var i = 0; i < categories.Length; ++i)
         {
-            var rewardInterval = RewardSystem.RewardInterval;
+            if (!RewardSystem.HasAccess(_from, categories[i]))
+            {
+                page += 1;
+                continue;
+            }
 
-            string intervalAsString;
+            builder.AddButton(100, 180 + i * 40, 4005, 4005, 0, GumpButtonType.Page, page);
 
-            if (rewardInterval == TimeSpan.FromDays(30.0))
+            page += PagesPerCategory(categories[i]);
+
+            if (categories[i].NameString != null)
             {
-                intervalAsString = "month";
-            }
-            else if (rewardInterval == TimeSpan.FromDays(60.0))
-            {
-                intervalAsString = "two months";
-            }
-            else if (rewardInterval == TimeSpan.FromDays(90.0))
-            {
-                intervalAsString = "three months";
-            }
-            else if (rewardInterval == TimeSpan.FromDays(365.0))
-            {
-                intervalAsString = "year";
+                builder.AddHtml(135, 180 + i * 40, 300, 20, categories[i].NameString);
             }
             else
             {
-                intervalAsString = $"{rewardInterval.TotalDays} day{(rewardInterval.TotalDays == 1 ? "" : "s")}";
+                builder.AddHtmlLocalized(135, 180 + i * 40, 300, 20, categories[i].Name);
+            }
+        }
+
+        page = 2;
+
+        for (var i = 0; i < categories.Length; ++i)
+        {
+            RenderCategory(ref builder, categories[i], i, ref page);
+        }
+    }
+
+    private int PagesPerCategory(RewardCategory category)
+    {
+        var entries = category.Entries;
+        var i = 0;
+
+        for (var j = 0; j < entries.Count; j++)
+        {
+            if (RewardSystem.HasAccess(_from, entries[j]))
+            {
+                i++;
+            }
+        }
+
+        return (int)Math.Ceiling(i / 24.0);
+    }
+
+    private static int GetButtonID(int type, int index) => 2 + index * 20 + type;
+
+    private void RenderCategory(ref DynamicGumpBuilder builder, RewardCategory category, int index, ref int page)
+    {
+        builder.AddPage(page);
+
+        var entries = category.Entries;
+
+        var i = 0;
+
+        for (var j = 0; j < entries.Count; ++j)
+        {
+            var entry = entries[j];
+
+            if (!RewardSystem.HasAccess(_from, entry))
+            {
+                continue;
             }
 
-            AddPage(1);
+            if (i == 24)
+            {
+                builder.AddButton(305, 415, 0xFA5, 0xFA7, 0, GumpButtonType.Page, ++page);
+                builder.AddHtmlLocalized(340, 415, 200, 20, 1011066); // Next page
 
-            AddHtml(
-                60,
-                35,
-                500,
-                70,
-                $"<B>Ultima Online Rewards Program</B><BR>Thank you for being a part of the Ultima Online community for a full {intervalAsString}.  As a token of our appreciation,  you may select from the following in-game reward items listed below.  The gift items will be attributed to the character you have logged-in with on the shard you are on when you chose the item(s).  The number of rewards you are entitled to are listed below and are for your entire account.  To read more about these rewards before making a selection, feel free to visit the uo.com site at <A HREF=\"http://www.uo.com/rewards\">http://www.uo.com/rewards</A>.",
-                true,
-                true
-            );
+                builder.AddPage(page);
 
-            RewardSystem.ComputeRewardInfo(m_From, out var cur, out var max);
+                builder.AddButton(270, 415, 0xFAE, 0xFB0, 0, GumpButtonType.Page, page - 1);
+                builder.AddHtmlLocalized(185, 415, 200, 20, 1011067); // Previous page
 
-            AddHtmlLocalized(60, 105, 300, 35, 1006006); // Your current total of rewards to choose:
-            AddLabel(370, 107, 50, (max - cur).ToString());
+                i = 0;
+            }
 
-            AddHtmlLocalized(60, 140, 300, 35, 1006007); // You have already chosen:
-            AddLabel(370, 142, 50, cur.ToString());
+            builder.AddButton(55 + i / 12 * 250, 80 + i % 12 * 25, 5540, 5541, GetButtonID(index, j));
+
+            if (entry.NameString != null)
+            {
+                builder.AddHtml(80 + i / 12 * 250, 80 + i % 12 * 25, 250, 20, entry.NameString);
+            }
+            else
+            {
+                builder.AddHtmlLocalized(80 + i / 12 * 250, 80 + i % 12 * 25, 250, 20, entry.Name);
+            }
+
+            ++i;
+        }
+
+        page += 1;
+    }
+
+    public override void OnResponse(NetState sender, in RelayInfo info)
+    {
+        var buttonID = info.ButtonID - 1;
+
+        if (buttonID == 0)
+        {
+            RewardSystem.ComputeRewardInfo(_from, out var cur, out var max);
+
+            if (cur < max)
+            {
+                RewardNoticeGump.DisplayTo(_from);
+            }
+        }
+        else
+        {
+            --buttonID;
+
+            var type = buttonID % 20;
+            var index = buttonID / 20;
 
             var categories = RewardSystem.Categories;
 
-            var page = 2;
-
-            for (var i = 0; i < categories.Length; ++i)
+            if (type >= 0 && type < categories.Length)
             {
-                if (!RewardSystem.HasAccess(m_From, categories[i]))
+                var category = categories[type];
+
+                if (index >= 0 && index < category.Entries.Count)
                 {
-                    page += 1;
-                    continue;
-                }
+                    var entry = category.Entries[index];
 
-                AddButton(100, 180 + i * 40, 4005, 4005, 0, GumpButtonType.Page, page);
-
-                page += PagesPerCategory(categories[i]);
-
-                if (categories[i].NameString != null)
-                {
-                    AddHtml(135, 180 + i * 40, 300, 20, categories[i].NameString);
-                }
-                else
-                {
-                    AddHtmlLocalized(135, 180 + i * 40, 300, 20, categories[i].Name);
-                }
-            }
-
-            page = 2;
-
-            for (var i = 0; i < categories.Length; ++i)
-            {
-                RenderCategory(categories[i], i, ref page);
-            }
-        }
-
-        private int PagesPerCategory(RewardCategory category)
-        {
-            var entries = category.Entries;
-            var i = 0;
-
-            for (var j = 0; j < entries.Count; j++)
-            {
-                if (RewardSystem.HasAccess(m_From, entries[j]))
-                {
-                    i++;
-                }
-            }
-
-            return (int)Math.Ceiling(i / 24.0);
-        }
-
-        private int GetButtonID(int type, int index) => 2 + index * 20 + type;
-
-        private void RenderCategory(RewardCategory category, int index, ref int page)
-        {
-            AddPage(page);
-
-            var entries = category.Entries;
-
-            var i = 0;
-
-            for (var j = 0; j < entries.Count; ++j)
-            {
-                var entry = entries[j];
-
-                if (!RewardSystem.HasAccess(m_From, entry))
-                {
-                    continue;
-                }
-
-                if (i == 24)
-                {
-                    AddButton(305, 415, 0xFA5, 0xFA7, 0, GumpButtonType.Page, ++page);
-                    AddHtmlLocalized(340, 415, 200, 20, 1011066); // Next page
-
-                    AddPage(page);
-
-                    AddButton(270, 415, 0xFAE, 0xFB0, 0, GumpButtonType.Page, page - 1);
-                    AddHtmlLocalized(185, 415, 200, 20, 1011067); // Previous page
-
-                    i = 0;
-                }
-
-                AddButton(55 + i / 12 * 250, 80 + i % 12 * 25, 5540, 5541, GetButtonID(index, j));
-
-                if (entry.NameString != null)
-                {
-                    AddHtml(80 + i / 12 * 250, 80 + i % 12 * 25, 250, 20, entry.NameString);
-                }
-                else
-                {
-                    AddHtmlLocalized(80 + i / 12 * 250, 80 + i % 12 * 25, 250, 20, entry.Name);
-                }
-
-                ++i;
-            }
-
-            page += 1;
-        }
-
-        public override void OnResponse(NetState sender, in RelayInfo info)
-        {
-            var buttonID = info.ButtonID - 1;
-
-            if (buttonID == 0)
-            {
-                RewardSystem.ComputeRewardInfo(m_From, out var cur, out var max);
-
-                if (cur < max)
-                {
-                    m_From.SendGump(new RewardNoticeGump(m_From));
-                }
-            }
-            else
-            {
-                --buttonID;
-
-                var type = buttonID % 20;
-                var index = buttonID / 20;
-
-                var categories = RewardSystem.Categories;
-
-                if (type >= 0 && type < categories.Length)
-                {
-                    var category = categories[type];
-
-                    if (index >= 0 && index < category.Entries.Count)
+                    if (!RewardSystem.HasAccess(_from, entry))
                     {
-                        var entry = category.Entries[index];
-
-                        if (!RewardSystem.HasAccess(m_From, entry))
-                        {
-                            return;
-                        }
-
-                        m_From.SendGump(new RewardConfirmGump(m_From, entry));
+                        return;
                     }
+
+                    RewardConfirmGump.DisplayTo(_from, entry);
                 }
             }
         }

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardConfirmGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardConfirmGump.cs
@@ -2,90 +2,102 @@ using Server.Gumps;
 using Server.Items;
 using Server.Network;
 
-namespace Server.Engines.VeteranRewards
+namespace Server.Engines.VeteranRewards;
+
+public class RewardConfirmGump : DynamicGump
 {
-    public class RewardConfirmGump : Gump
+    private readonly RewardEntry _entry;
+    private readonly Mobile _from;
+
+    public override bool Singleton => true;
+
+    private RewardConfirmGump(Mobile from, RewardEntry entry) : base(0, 0)
     {
-        private readonly RewardEntry m_Entry;
-        private readonly Mobile m_From;
+        _from = from;
+        _entry = entry;
+    }
 
-        public override bool Singleton => true;
-
-        public RewardConfirmGump(Mobile from, RewardEntry entry) : base(0, 0)
+    public static void DisplayTo(Mobile from, RewardEntry entry)
+    {
+        if (from?.NetState == null || entry == null)
         {
-            m_From = from;
-            m_Entry = entry;
-
-            AddPage(0);
-
-            AddBackground(10, 10, 500, 300, 2600);
-
-            AddHtmlLocalized(30, 55, 300, 35, 1006000); // You have selected:
-
-            if (entry.NameString != null)
-            {
-                AddHtml(335, 55, 150, 35, entry.NameString);
-            }
-            else
-            {
-                AddHtmlLocalized(335, 55, 150, 35, entry.Name);
-            }
-
-            AddHtmlLocalized(30, 95, 300, 35, 1006001); // This will be assigned to this character:
-            AddLabel(335, 95, 0, from.Name);
-
-            AddHtmlLocalized(
-                35,
-                160,
-                450,
-                90,
-                1006002,
-                true,
-                true
-            ); // Are you sure you wish to select this reward for this character?  You will not be able to transfer this reward to another character on another shard.  Click 'ok' below to confirm your selection or 'cancel' to go back to the selection screen.
-
-            AddButton(60, 265, 4005, 4007, 1);
-            AddHtmlLocalized(95, 266, 150, 35, 1006044); // Ok
-
-            AddButton(295, 265, 4017, 4019, 0);
-            AddHtmlLocalized(330, 266, 150, 35, 1006045); // Cancel
+            return;
         }
 
-        public override void OnResponse(NetState sender, in RelayInfo info)
+        from.SendGump(new RewardConfirmGump(from, entry));
+    }
+
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(10, 10, 500, 300, 2600);
+
+        builder.AddHtmlLocalized(30, 55, 300, 35, 1006000); // You have selected:
+
+        if (_entry.NameString != null)
         {
-            if (info.ButtonID == 1)
+            builder.AddHtml(335, 55, 150, 35, _entry.NameString);
+        }
+        else
+        {
+            builder.AddHtmlLocalized(335, 55, 150, 35, _entry.Name);
+        }
+
+        builder.AddHtmlLocalized(30, 95, 300, 35, 1006001); // This will be assigned to this character:
+        builder.AddLabel(335, 95, 0, _from.Name);
+
+        builder.AddHtmlLocalized(
+            35,
+            160,
+            450,
+            90,
+            1006002,
+            true,
+            true
+        ); // Are you sure you wish to select this reward for this character?  You will not be able to transfer this reward to another character on another shard.  Click 'ok' below to confirm your selection or 'cancel' to go back to the selection screen.
+
+        builder.AddButton(60, 265, 4005, 4007, 1);
+        builder.AddHtmlLocalized(95, 266, 150, 35, 1006044); // Ok
+
+        builder.AddButton(295, 265, 4017, 4019, 0);
+        builder.AddHtmlLocalized(330, 266, 150, 35, 1006045); // Cancel
+    }
+
+    public override void OnResponse(NetState sender, in RelayInfo info)
+    {
+        if (info.ButtonID == 1)
+        {
+            if (!RewardSystem.HasAccess(_from, _entry))
             {
-                if (!RewardSystem.HasAccess(m_From, m_Entry))
-                {
-                    return;
-                }
-
-                var item = m_Entry.Construct();
-
-                if (item != null)
-                {
-                    if (item is RedSoulstone soulstone)
-                    {
-                        soulstone.Account = m_From.Account.Username;
-                    }
-
-                    if (RewardSystem.ConsumeRewardPoint(m_From))
-                    {
-                        m_From.AddToBackpack(item);
-                    }
-                    else
-                    {
-                        item.Delete();
-                    }
-                }
+                return;
             }
 
-            RewardSystem.ComputeRewardInfo(m_From, out var cur, out var max);
+            var item = _entry.Construct();
 
-            if (cur < max)
+            if (item != null)
             {
-                m_From.SendGump(new RewardNoticeGump(m_From));
+                if (item is RedSoulstone soulstone)
+                {
+                    soulstone.Account = _from.Account.Username;
+                }
+
+                if (RewardSystem.ConsumeRewardPoint(_from))
+                {
+                    _from.AddToBackpack(item);
+                }
+                else
+                {
+                    item.Delete();
+                }
             }
+        }
+
+        RewardSystem.ComputeRewardInfo(_from, out var cur, out var max);
+
+        if (cur < max)
+        {
+            RewardNoticeGump.DisplayTo(_from);
         }
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardConfirmGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardConfirmGump.cs
@@ -45,17 +45,12 @@ public class RewardConfirmGump : DynamicGump
         }
 
         builder.AddHtmlLocalized(30, 95, 300, 35, 1006001); // This will be assigned to this character:
-        builder.AddLabel(335, 95, 0, _from.Name);
+        builder.AddLabel(335, 95, 0, _from.RawName);
 
-        builder.AddHtmlLocalized(
-            35,
-            160,
-            450,
-            90,
-            1006002,
-            true,
-            true
-        ); // Are you sure you wish to select this reward for this character?  You will not be able to transfer this reward to another character on another shard.  Click 'ok' below to confirm your selection or 'cancel' to go back to the selection screen.
+        // Are you sure you wish to select this reward for this character?
+        // You will not be able to transfer this reward to another character on another shard.
+        // Click 'ok' below to confirm your selection or 'cancel' to go back to the selection screen.
+        builder.AddHtmlLocalized(35, 160, 450, 90, 1006002, true, true);
 
         builder.AddButton(60, 265, 4005, 4007, 1);
         builder.AddHtmlLocalized(95, 266, 150, 35, 1006044); // Ok

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardDemolitionGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardDemolitionGump.cs
@@ -2,78 +2,89 @@ using Server.Items;
 using Server.Multis;
 using Server.Network;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public class RewardDemolitionGump : DynamicGump
 {
-    public class RewardDemolitionGump : Gump
+    private readonly IAddon _addon;
+    private readonly int _question;
+
+    public override bool Singleton => true;
+
+    private RewardDemolitionGump(IAddon addon, int question) : base(150, 50)
     {
-        private readonly IAddon m_Addon;
+        _addon = addon;
+        _question = question;
+    }
 
-        public override bool Singleton => true;
-
-        public RewardDemolitionGump(IAddon addon, int question) : base(150, 50)
+    public static void DisplayTo(Mobile from, IAddon addon, int question)
+    {
+        if (from?.NetState == null || addon is not Item item || item.Deleted)
         {
-            m_Addon = addon;
-
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
-
-            AddBackground(0, 0, 220, 170, 0x13BE);
-            AddBackground(10, 10, 200, 150, 0xBB8);
-
-            AddHtmlLocalized(20, 30, 180, 60, question); // Do you wish to re-deed this decoration?
-
-            AddHtmlLocalized(55, 100, 150, 25, 1011011); // CONTINUE
-            AddButton(20, 100, 0xFA5, 0xFA7, (int)Buttons.Confirm);
-
-            AddHtmlLocalized(55, 125, 150, 25, 1011012); // CANCEL
-            AddButton(20, 125, 0xFA5, 0xFA7, (int)Buttons.Cancel);
+            return;
         }
 
-        public override void OnResponse(NetState sender, in RelayInfo info)
+        from.SendGump(new RewardDemolitionGump(addon, question));
+    }
+
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(0, 0, 220, 170, 0x13BE);
+        builder.AddBackground(10, 10, 200, 150, 0xBB8);
+
+        builder.AddHtmlLocalized(20, 30, 180, 60, _question); // Do you wish to re-deed this decoration?
+
+        builder.AddHtmlLocalized(55, 100, 150, 25, 1011011); // CONTINUE
+        builder.AddButton(20, 100, 0xFA5, 0xFA7, (int)Buttons.Confirm);
+
+        builder.AddHtmlLocalized(55, 125, 150, 25, 1011012); // CANCEL
+        builder.AddButton(20, 125, 0xFA5, 0xFA7, (int)Buttons.Cancel);
+    }
+
+    public override void OnResponse(NetState sender, in RelayInfo info)
+    {
+        if (_addon is not Item item || item.Deleted)
         {
-            if (m_Addon is not Item item || item.Deleted)
-            {
-                return;
-            }
-
-            if (info.ButtonID != (int)Buttons.Confirm)
-            {
-                return;
-            }
-
-            var m = sender.Mobile;
-            var house = BaseHouse.FindHouseAt(m);
-
-            if (house?.IsOwner(m) != true)
-            {
-                // You can only re-deed this decoration if you are the house owner or originally placed the decoration.
-                m.SendLocalizedMessage(1049784);
-                return;
-            }
-
-            if (m.InRange(item.Location, 2))
-            {
-                var deed = m_Addon.Deed;
-
-                if (deed != null)
-                {
-                    m.AddToBackpack(deed);
-                    house.Addons.Remove(item);
-                    item.Delete();
-                }
-            }
-            else
-            {
-                m.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
-            }
+            return;
         }
 
-        private enum Buttons
+        if (info.ButtonID != (int)Buttons.Confirm)
         {
-            Cancel,
-            Confirm
+            return;
         }
+
+        var m = sender.Mobile;
+        var house = BaseHouse.FindHouseAt(m);
+
+        if (house?.IsOwner(m) != true)
+        {
+            // You can only re-deed this decoration if you are the house owner or originally placed the decoration.
+            m.SendLocalizedMessage(1049784);
+            return;
+        }
+
+        if (m.InRange(item.Location, 2))
+        {
+            var deed = _addon.Deed;
+
+            if (deed != null)
+            {
+                m.AddToBackpack(deed);
+                house.Addons.Remove(item);
+                item.Delete();
+            }
+        }
+        else
+        {
+            m.LocalOverheadMessage(MessageType.Regular, 0x3B2, 1019045); // I can't reach that.
+        }
+    }
+
+    private enum Buttons
+    {
+        Cancel,
+        Confirm
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardNoticeGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardNoticeGump.cs
@@ -1,40 +1,49 @@
 using Server.Gumps;
 using Server.Network;
 
-namespace Server.Engines.VeteranRewards
+namespace Server.Engines.VeteranRewards;
+
+public class RewardNoticeGump : StaticGump<RewardNoticeGump>
 {
-    public class RewardNoticeGump : Gump
+    private readonly Mobile _from;
+
+    public override bool Singleton => true;
+
+    private RewardNoticeGump(Mobile from) : base(0, 0) => _from = from;
+
+    public static void DisplayTo(Mobile from)
     {
-        private readonly Mobile m_From;
-
-        public override bool Singleton => true;
-
-        public RewardNoticeGump(Mobile from) : base(0, 0)
+        if (from?.NetState == null)
         {
-            m_From = from;
-
-            AddPage(0);
-
-            AddBackground(10, 10, 500, 135, 2600);
-
-            /* You have reward items available.
-             * Click 'ok' below to get the selection menu or 'cancel' to be prompted upon your next login.
-             */
-            AddHtmlLocalized(52, 35, 420, 55, 1006046, true, true);
-
-            AddButton(60, 95, 4005, 4007, 1);
-            AddHtmlLocalized(95, 96, 150, 35, 1006044); // Ok
-
-            AddButton(285, 95, 4017, 4019, 0);
-            AddHtmlLocalized(320, 96, 150, 35, 1006045); // Cancel
+            return;
         }
 
-        public override void OnResponse(NetState sender, in RelayInfo info)
+        from.SendGump(new RewardNoticeGump(from));
+    }
+
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(10, 10, 500, 135, 2600);
+
+        /* You have reward items available.
+         * Click 'ok' below to get the selection menu or 'cancel' to be prompted upon your next login.
+         */
+        builder.AddHtmlLocalized(52, 35, 420, 55, 1006046, true, true);
+
+        builder.AddButton(60, 95, 4005, 4007, 1);
+        builder.AddHtmlLocalized(95, 96, 150, 35, 1006044); // Ok
+
+        builder.AddButton(285, 95, 4017, 4019, 0);
+        builder.AddHtmlLocalized(320, 96, 150, 35, 1006045); // Cancel
+    }
+
+    public override void OnResponse(NetState sender, in RelayInfo info)
+    {
+        if (info.ButtonID == 1)
         {
-            if (info.ButtonID == 1)
-            {
-                m_From.SendGump(new RewardChoiceGump(m_From));
-            }
+            RewardChoiceGump.DisplayTo(_from);
         }
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardNoticeGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardNoticeGump.cs
@@ -5,11 +5,11 @@ namespace Server.Engines.VeteranRewards;
 
 public class RewardNoticeGump : StaticGump<RewardNoticeGump>
 {
-    private readonly Mobile _from;
-
     public override bool Singleton => true;
 
-    private RewardNoticeGump(Mobile from) : base(0, 0) => _from = from;
+    private RewardNoticeGump() : base(0, 0)
+    {
+    }
 
     public static void DisplayTo(Mobile from)
     {
@@ -18,7 +18,7 @@ public class RewardNoticeGump : StaticGump<RewardNoticeGump>
             return;
         }
 
-        from.SendGump(new RewardNoticeGump(from));
+        from.SendGump(new RewardNoticeGump());
     }
 
     protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -43,7 +43,7 @@ public class RewardNoticeGump : StaticGump<RewardNoticeGump>
     {
         if (info.ButtonID == 1)
         {
-            RewardChoiceGump.DisplayTo(_from);
+            RewardChoiceGump.DisplayTo(sender.Mobile);
         }
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardOptionGump.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardOptionGump.cs
@@ -1,101 +1,115 @@
 using System.Collections.Generic;
 using Server.Network;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public interface IRewardOption
 {
-    public interface IRewardOption
+    void GetOptions(RewardOptionList list);
+    void OnOptionSelected(Mobile from, int choice);
+}
+
+public class RewardOptionGump : DynamicGump
+{
+    private readonly IRewardOption _option;
+    private readonly RewardOptionList _options = new();
+    private readonly int _title;
+
+    public override bool Singleton => true;
+
+    private RewardOptionGump(IRewardOption option, int title) : base(60, 36)
     {
-        void GetOptions(RewardOptionList list);
-        void OnOptionSelected(Mobile from, int choice);
+        _option = option;
+        _title = title;
+
+        _option?.GetOptions(_options);
     }
 
-    public class RewardOptionGump : Gump
+    public static void DisplayTo(Mobile from, IRewardOption option, int title = 0)
     {
-        private readonly IRewardOption m_Option;
-        private readonly RewardOptionList m_Options = new();
-
-        public override bool Singleton => true;
-
-        public RewardOptionGump(IRewardOption option, int title = 0) : base(60, 36)
+        if (from?.NetState == null || option == null)
         {
-            m_Option = option;
-
-            m_Option?.GetOptions(m_Options);
-
-            AddPage(0);
-
-            AddBackground(0, 0, 273, 324, 0x13BE);
-            AddImageTiled(10, 10, 253, 20, 0xA40);
-            AddImageTiled(10, 40, 253, 244, 0xA40);
-            AddImageTiled(10, 294, 253, 20, 0xA40);
-            AddAlphaRegion(10, 10, 253, 304);
-
-            AddButton(10, 294, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 296, 450, 20, 1060051, 0x7FFF); // CANCEL
-
-            if (title > 0)
-            {
-                AddHtmlLocalized(14, 12, 273, 20, title, 0x7FFF);
-            }
-            else
-            {
-                AddHtmlLocalized(14, 12, 273, 20, 1080392, 0x7FFF); // Select your choice from the menu below.
-            }
-
-            AddPage(1);
-
-            for (var i = 0; i < m_Options.Count; i++)
-            {
-                AddButton(19, 49 + i * 24, 0x845, 0x846, m_Options[i].ID);
-                AddHtmlLocalized(44, 47 + i * 24, 213, 20, m_Options[i].Cliloc, 0x7FFF);
-            }
+            return;
         }
 
-        public override void OnResponse(NetState sender, in RelayInfo info)
+        from.SendGump(new RewardOptionGump(option, title));
+    }
+
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(0, 0, 273, 324, 0x13BE);
+        builder.AddImageTiled(10, 10, 253, 20, 0xA40);
+        builder.AddImageTiled(10, 40, 253, 244, 0xA40);
+        builder.AddImageTiled(10, 294, 253, 20, 0xA40);
+        builder.AddAlphaRegion(10, 10, 253, 304);
+
+        builder.AddButton(10, 294, 0xFB1, 0xFB2, 0);
+        builder.AddHtmlLocalized(45, 296, 450, 20, 1060051, 0x7FFF); // CANCEL
+
+        if (_title > 0)
         {
-            if (m_Option != null && Contains(info.ButtonID))
-            {
-                m_Option.OnOptionSelected(sender.Mobile, info.ButtonID);
-            }
+            builder.AddHtmlLocalized(14, 12, 273, 20, _title, 0x7FFF);
+        }
+        else
+        {
+            builder.AddHtmlLocalized(14, 12, 273, 20, 1080392, 0x7FFF); // Select your choice from the menu below.
         }
 
-        private bool Contains(int chosen)
+        builder.AddPage(1);
+
+        for (var i = 0; i < _options.Count; i++)
         {
-            if (m_Options == null)
-            {
-                return false;
-            }
+            builder.AddButton(19, 49 + i * 24, 0x845, 0x846, _options[i].ID);
+            builder.AddHtmlLocalized(44, 47 + i * 24, 213, 20, _options[i].Cliloc, 0x7FFF);
+        }
+    }
 
-            foreach (var option in m_Options)
-            {
-                if (option.ID == chosen)
-                {
-                    return true;
-                }
-            }
+    public override void OnResponse(NetState sender, in RelayInfo info)
+    {
+        if (_option != null && Contains(info.ButtonID))
+        {
+            _option.OnOptionSelected(sender.Mobile, info.ButtonID);
+        }
+    }
 
+    private bool Contains(int chosen)
+    {
+        if (_options == null)
+        {
             return false;
         }
-    }
 
-    public class RewardOption
-    {
-        public RewardOption(int id, int cliloc)
+        foreach (var option in _options)
         {
-            ID = id;
-            Cliloc = cliloc;
+            if (option.ID == chosen)
+            {
+                return true;
+            }
         }
 
-        public int ID { get; }
+        return false;
+    }
+}
 
-        public int Cliloc { get; }
+public class RewardOption
+{
+    public RewardOption(int id, int cliloc)
+    {
+        ID = id;
+        Cliloc = cliloc;
     }
 
-    public class RewardOptionList : List<RewardOption>
+    public int ID { get; }
+
+    public int Cliloc { get; }
+}
+
+public class RewardOptionList : List<RewardOption>
+{
+    public void Add(int id, int cliloc)
     {
-        public void Add(int id, int cliloc)
-        {
-            Add(new RewardOption(id, cliloc));
-        }
+        Add(new RewardOption(id, cliloc));
     }
 }

--- a/Projects/UOContent/Engines/Veteran Rewards/RewardSystem.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/RewardSystem.cs
@@ -595,7 +595,7 @@ namespace Server.Engines.VeteranRewards
 
             if (cur < max)
             {
-                pm.SendGump(new RewardNoticeGump(pm));
+                RewardNoticeGump.DisplayTo(pm);
             }
         }
     }

--- a/Projects/UOContent/Holiday Stuff/Christmas/2010/Addons/FireFliesDeed.cs
+++ b/Projects/UOContent/Holiday Stuff/Christmas/2010/Addons/FireFliesDeed.cs
@@ -47,7 +47,7 @@ public partial class Fireflies : Item, IAddon
         if (house?.IsOwner(from) == true)
         {
             // Do you wish to re-deed this decoration?
-            from.SendGump(new RewardDemolitionGump(this, 1049783));
+            RewardDemolitionGump.DisplayTo(from, this, 1049783);
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/AnkhOfSacrifice.cs
@@ -214,7 +214,7 @@ public partial class AnkhOfSacrificeDeed : BaseAddonDeed, IRewardItem, IRewardOp
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new RewardOptionGump(this));
+            RewardOptionGump.DisplayTo(from, this);
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/Banner.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/Banner.cs
@@ -81,7 +81,7 @@ public partial class Banner : Item, IAddon, IDyable, IRewardItem
 
         if (house?.IsOwner(from) == true)
         {
-            from.SendGump(new RewardDemolitionGump(this, 1018318)); // Do you wish to re-deed this banner?
+            RewardDemolitionGump.DisplayTo(from, this, 1018318); // Do you wish to re-deed this banner?
         }
         else
         {
@@ -128,7 +128,7 @@ public partial class BannerDeed : Item, IRewardItem
 
             if (house?.IsOwner(from) == true)
             {
-                from.SendGump(new InternalGump(this));
+                BannerGump.DisplayTo(from, this);
             }
             else
             {
@@ -141,7 +141,7 @@ public partial class BannerDeed : Item, IRewardItem
         }
     }
 
-    private class InternalGump : Gump
+    private class BannerGump : StaticGump<BannerGump>
     {
         public const int Start = 0x15AE;
         public const int End = 0x15F4;
@@ -150,41 +150,46 @@ public partial class BannerDeed : Item, IRewardItem
 
         public override bool Singleton => true;
 
-        public InternalGump(BannerDeed banner) : base(100, 200)
+        private BannerGump(BannerDeed banner) : base(100, 200) => _banner = banner;
+
+        public static void DisplayTo(Mobile from, BannerDeed banner)
         {
-            _banner = banner;
+            if (from?.NetState == null || banner?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new BannerGump(banner));
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddBackground(25, 0, 520, 230, 0xA28);
+            builder.AddBackground(25, 0, 520, 230, 0xA28);
             // TODO: Use 1152360 - <CENTER>Choose a banner:</CENTER>
-            AddLabel(70, 12, 0x3E3, "Choose a Banner:");
+            builder.AddLabel(70, 12, 0x3E3, "Choose a Banner:");
 
             var itemID = Start;
 
             for (var i = 1; i <= 4; i++)
             {
-                AddPage(i);
+                builder.AddPage(i);
 
                 for (var j = 0; j < 8; j++, itemID += 2)
                 {
-                    AddItem(50 + 60 * j, 70, itemID);
-                    AddButton(50 + 60 * j, 50, 0x845, 0x846, itemID);
+                    builder.AddItem(50 + 60 * j, 70, itemID);
+                    builder.AddButton(50 + 60 * j, 50, 0x845, 0x846, itemID);
                 }
 
                 if (i > 1)
                 {
-                    AddButton(75, 198, 0x8AF, 0x8AF, 0, GumpButtonType.Page, i - 1);
+                    builder.AddButton(75, 198, 0x8AF, 0x8AF, 0, GumpButtonType.Page, i - 1);
                 }
 
                 if (i < 4)
                 {
-                    AddButton(475, 198, 0x8B0, 0x8B0, 0, GumpButtonType.Page, i + 1);
+                    builder.AddButton(475, 198, 0x8B0, 0x8B0, 0, GumpButtonType.Page, i + 1);
                 }
             }
         }

--- a/Projects/UOContent/Items/Special/Veteran Rewards/Brazier.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/Brazier.cs
@@ -132,7 +132,7 @@ public partial class RewardBrazierDeed : Item, IRewardItem
             return;
         }
 
-        from.SendGump(new InternalGump(this));
+        BrazierGump.DisplayTo(from, this);
     }
 
     public override void GetProperties(IPropertyList list)
@@ -145,32 +145,37 @@ public partial class RewardBrazierDeed : Item, IRewardItem
         }
     }
 
-    private class InternalGump : Gump
+    private class BrazierGump : StaticGump<BrazierGump>
     {
         private readonly RewardBrazierDeed _brazier;
 
         public override bool Singleton => true;
 
-        public InternalGump(RewardBrazierDeed brazier) : base(100, 200)
+        private BrazierGump(RewardBrazierDeed brazier) : base(100, 200) => _brazier = brazier;
+
+        public static void DisplayTo(Mobile from, RewardBrazierDeed brazier)
         {
-            _brazier = brazier;
+            if (from?.NetState == null || brazier?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new BrazierGump(brazier));
+        }
 
-            AddPage(0);
-            AddBackground(0, 0, 200, 200, 2600);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
+            builder.AddBackground(0, 0, 200, 200, 2600);
 
-            AddPage(1);
-            AddLabel(45, 15, 0, "Choose a Brazier:");
+            builder.AddPage(1);
+            builder.AddLabel(45, 15, 0, "Choose a Brazier:");
 
-            AddItem(40, 75, 0x19AA);
-            AddButton(55, 50, 0x845, 0x846, 0x19AA);
+            builder.AddItem(40, 75, 0x19AA);
+            builder.AddButton(55, 50, 0x845, 0x846, 0x19AA);
 
-            AddItem(100, 75, 0x19BB);
-            AddButton(115, 50, 0x845, 0x846, 0x19BB);
+            builder.AddItem(100, 75, 0x19BB);
+            builder.AddButton(115, 50, 0x845, 0x846, 0x19BB);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/Cannon.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/Cannon.cs
@@ -142,7 +142,7 @@ public partial class CannonAddon : BaseAddon
 
             if (Validate(keg) > 0)
             {
-                from.SendGump(new InternalGump(this, keg));
+                CannonGump.DisplayTo(from, this, keg);
             }
             else
             {
@@ -309,34 +309,44 @@ public partial class CannonAddon : BaseAddon
         }
     }
 
-    private class InternalGump : Gump
+    private class CannonGump : DynamicGump
     {
         private readonly CannonAddon _cannon;
         private readonly PotionKeg _keg;
 
-        public InternalGump(CannonAddon cannon, PotionKeg keg) : base(50, 50)
+        public override bool Singleton => true;
+
+        private CannonGump(CannonAddon cannon, PotionKeg keg) : base(50, 50)
         {
             _cannon = cannon;
             _keg = keg;
+        }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+        public static void DisplayTo(Mobile from, CannonAddon cannon, PotionKeg keg)
+        {
+            if (from?.NetState == null || cannon?.Deleted != false || keg?.Deleted != false)
+            {
+                return;
+            }
 
-            AddPage(0);
+            from.SendGump(new CannonGump(cannon, keg));
+        }
 
-            AddBackground(0, 0, 291, 133, 0x13BE);
-            AddImageTiled(5, 5, 280, 100, 0xA40);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 291, 133, 0x13BE);
+            builder.AddImageTiled(5, 5, 280, 100, 0xA40);
 
             // You will need a full keg of explosion potions to recharge the cannon.  Your keg will provide ~1_CHARGES~ charges.
-            AddHtmlLocalized(9, 9, 272, 100, 1076196, cannon.Validate(keg).ToString(), 0x7FFF);
+            builder.AddHtmlLocalized(9, 9, 272, 100, 1076196, _cannon.Validate(_keg).ToString(), 0x7FFF);
 
-            AddButton(5, 107, 0xFB1, 0xFB2, (int)Buttons.Cancel);
-            AddHtmlLocalized(40, 109, 100, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddButton(5, 107, 0xFB1, 0xFB2, (int)Buttons.Cancel);
+            builder.AddHtmlLocalized(40, 109, 100, 20, 1060051, 0x7FFF); // CANCEL
 
-            AddButton(160, 107, 0xFB7, 0xFB8, (int)Buttons.Recharge);
-            AddHtmlLocalized(195, 109, 120, 20, 1076197, 0x7FFF); // Recharge
+            builder.AddButton(160, 107, 0xFB7, 0xFB8, (int)Buttons.Recharge);
+            builder.AddHtmlLocalized(195, 109, 120, 20, 1076197, 0x7FFF); // Recharge
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
@@ -420,7 +430,7 @@ public partial class CannonDeed : BaseAddonDeed, IRewardItem, IRewardOption
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new RewardOptionGump(this));
+            RewardOptionGump.DisplayTo(from, this);
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/Cannon.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/Cannon.cs
@@ -340,7 +340,7 @@ public partial class CannonAddon : BaseAddon
             builder.AddImageTiled(5, 5, 280, 100, 0xA40);
 
             // You will need a full keg of explosion potions to recharge the cannon.  Your keg will provide ~1_CHARGES~ charges.
-            builder.AddHtmlLocalized(9, 9, 272, 100, 1076196, _cannon.Validate(_keg).ToString(), 0x7FFF);
+            builder.AddHtmlLocalized(9, 9, 272, 100, 1076196, $"{_cannon.Validate(_keg)}", 0x7FFF);
 
             builder.AddButton(5, 107, 0xFB1, 0xFB2, (int)Buttons.Cancel);
             builder.AddHtmlLocalized(40, 109, 100, 20, 1060051, 0x7FFF); // CANCEL

--- a/Projects/UOContent/Items/Special/Veteran Rewards/DecorativeShield.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/DecorativeShield.cs
@@ -65,7 +65,7 @@ public partial class DecorativeShield : Item, IAddon, IRewardItem
 
         if (house?.IsOwner(from) == true)
         {
-            from.SendGump(new RewardDemolitionGump(this, 1049783)); // Do you wish to re-deed this decoration?
+            RewardDemolitionGump.DisplayTo(from, this, 1049783); // Do you wish to re-deed this decoration?
         }
         else
         {
@@ -108,7 +108,7 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new InternalGump(this));
+            DecorativeShieldGump.DisplayTo(from, this);
         }
         else
         {
@@ -128,7 +128,7 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
         };
     }
 
-    private class InternalGump : Gump
+    private class DecorativeShieldGump : StaticGump<DecorativeShieldGump>
     {
         public const int Start = 0x156C;
         public const int End = 0x1585;
@@ -137,29 +137,34 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
 
         public override bool Singleton => true;
 
-        public InternalGump(DecorativeShieldDeed shield) : base(150, 50)
+        private DecorativeShieldGump(DecorativeShieldDeed shield) : base(150, 50) => _shield = shield;
+
+        public static void DisplayTo(Mobile from, DecorativeShieldDeed shield)
         {
-            _shield = shield;
+            if (from?.NetState == null || shield?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new DecorativeShieldGump(shield));
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddBackground(25, 0, 500, 230, 0xA28);
+            builder.AddBackground(25, 0, 500, 230, 0xA28);
 
             var itemID = Start;
 
             for (var i = 1; i <= 2; i++)
             {
-                AddPage(i);
+                builder.AddPage(i);
 
                 for (var j = 0; j < 9 - i; j++)
                 {
-                    AddItem(40 + j * 60, 70, itemID);
-                    AddButton(60 + j * 60, 50, 0x845, 0x846, itemID);
+                    builder.AddItem(40 + j * 60, 70, itemID);
+                    builder.AddButton(60 + j * 60, 50, 0x845, 0x846, itemID);
 
                     if (itemID < 0x1582)
                     {
@@ -175,12 +180,12 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
                 {
                     case 1:
                         {
-                            AddButton(455, 198, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 2);
+                            builder.AddButton(455, 198, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 2);
                             break;
                         }
                     case 2:
                         {
-                            AddButton(70, 198, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 1);
+                            builder.AddButton(70, 198, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 1);
                             break;
                         }
                 }
@@ -263,7 +268,7 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
 
             if (north && west)
             {
-                from.SendGump(new FacingGump(_shield, _itemID, p3d, house));
+                DecorativeShieldFacingGump.DisplayTo(from, _shield, _itemID, p3d, house);
             }
             else if (north || west)
             {
@@ -282,7 +287,7 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
             }
         }
 
-        private class FacingGump : Gump
+        private class DecorativeShieldFacingGump : DynamicGump
         {
             private readonly BaseHouse _house;
             private readonly int _itemID;
@@ -291,26 +296,34 @@ public partial class DecorativeShieldDeed : Item, IRewardItem
 
             public override bool Singleton => true;
 
-            public FacingGump(DecorativeShieldDeed shield, int itemID, Point3D location, BaseHouse house) : base(150, 50)
+            private DecorativeShieldFacingGump(DecorativeShieldDeed shield, int itemID, Point3D location, BaseHouse house) : base(150, 50)
             {
                 _shield = shield;
                 _itemID = itemID;
                 _location = location;
                 _house = house;
+            }
 
-                Closable = true;
-                Disposable = true;
-                Draggable = true;
-                Resizable = false;
+            public static void DisplayTo(Mobile from, DecorativeShieldDeed shield, int itemID, Point3D location, BaseHouse house)
+            {
+                if (from?.NetState == null || shield?.Deleted != false || house == null)
+                {
+                    return;
+                }
 
-                AddPage(0);
-                AddBackground(0, 0, 300, 150, 0xA28);
+                from.SendGump(new DecorativeShieldFacingGump(shield, itemID, location, house));
+            }
 
-                AddItem(90, 30, GetWestItemID(itemID));
-                AddItem(180, 30, itemID);
+            protected override void BuildLayout(ref DynamicGumpBuilder builder)
+            {
+                builder.AddPage();
+                builder.AddBackground(0, 0, 300, 150, 0xA28);
 
-                AddButton(50, 35, 0x867, 0x869, (int)Buttons.East);
-                AddButton(145, 35, 0x867, 0x869, (int)Buttons.South);
+                builder.AddItem(90, 30, GetWestItemID(_itemID));
+                builder.AddItem(180, 30, _itemID);
+
+                builder.AddButton(50, 35, 0x867, 0x869, (int)Buttons.East);
+                builder.AddButton(145, 35, 0x867, 0x869, (int)Buttons.South);
             }
 
             public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/FlamingHead.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/FlamingHead.cs
@@ -79,7 +79,7 @@ public partial class FlamingHead : StoneFaceTrapNoDamage, IAddon, IRewardItem
 
         if (house?.IsOwner(from) == true)
         {
-            from.SendGump(new RewardDemolitionGump(this, 1018329)); // Do you wish to re-deed this skull?
+            RewardDemolitionGump.DisplayTo(from, this, 1018329); // Do you wish to re-deed this skull?
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/HangingSkeleton.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/HangingSkeleton.cs
@@ -69,7 +69,7 @@ public partial class HangingSkeleton : Item, IAddon, IRewardItem
 
         if (house?.IsOwner(from) == true)
         {
-            from.SendGump(new RewardDemolitionGump(this, 1049783)); // Do you wish to re-deed this decoration?
+            RewardDemolitionGump.DisplayTo(from, this, 1049783); // Do you wish to re-deed this decoration?
         }
         else
         {
@@ -124,7 +124,7 @@ public partial class HangingSkeletonDeed : Item, IRewardItem
             return;
         }
 
-        from.SendGump(new InternalGump(this));
+        HangingSkeletonGump.DisplayTo(from, this);
     }
 
     public static int GetWestItemID(int south)
@@ -137,41 +137,46 @@ public partial class HangingSkeletonDeed : Item, IRewardItem
         };
     }
 
-    private class InternalGump : Gump
+    private class HangingSkeletonGump : StaticGump<HangingSkeletonGump>
     {
         private readonly HangingSkeletonDeed _deed;
 
         public override bool Singleton => true;
 
-        public InternalGump(HangingSkeletonDeed skeleton) : base(100, 200)
+        private HangingSkeletonGump(HangingSkeletonDeed skeleton) : base(100, 200) => _deed = skeleton;
+
+        public static void DisplayTo(Mobile from, HangingSkeletonDeed deed)
         {
-            _deed = skeleton;
+            if (from?.NetState == null || deed?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new HangingSkeletonGump(deed));
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddBackground(25, 0, 500, 230, 0xA28);
+            builder.AddBackground(25, 0, 500, 230, 0xA28);
 
-            AddPage(1);
+            builder.AddPage(1);
 
-            AddItem(130, 70, 0x1A03);
-            AddButton(150, 50, 0x845, 0x846, 0x1A03);
+            builder.AddItem(130, 70, 0x1A03);
+            builder.AddButton(150, 50, 0x845, 0x846, 0x1A03);
 
-            AddItem(190, 70, 0x1A05);
-            AddButton(210, 50, 0x845, 0x846, 0x1A05);
+            builder.AddItem(190, 70, 0x1A05);
+            builder.AddButton(210, 50, 0x845, 0x846, 0x1A05);
 
-            AddItem(250, 70, 0x1A09);
-            AddButton(270, 50, 0x845, 0x846, 0x1A09);
+            builder.AddItem(250, 70, 0x1A09);
+            builder.AddButton(270, 50, 0x845, 0x846, 0x1A09);
 
-            AddItem(310, 70, 0x1B1E);
-            AddButton(330, 50, 0x845, 0x846, 0x1B1E);
+            builder.AddItem(310, 70, 0x1B1E);
+            builder.AddButton(330, 50, 0x845, 0x846, 0x1B1E);
 
-            AddItem(370, 70, 0x1B7F);
-            AddButton(390, 50, 0x845, 0x846, 0x1B7F);
+            builder.AddItem(370, 70, 0x1B7F);
+            builder.AddButton(390, 50, 0x845, 0x846, 0x1B7F);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/MiningCart.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/MiningCart.cs
@@ -368,7 +368,7 @@ public partial class MiningCartDeed : BaseAddonDeed, IRewardItem, IRewardOption
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new RewardOptionGump(this));
+            RewardOptionGump.DisplayTo(from, this);
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/MinotaurStatue.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/MinotaurStatue.cs
@@ -110,7 +110,7 @@ public partial class MinotaurStatueDeed : BaseAddonDeed, IRewardItem, IRewardOpt
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new RewardOptionGump(this));
+            RewardOptionGump.DisplayTo(from, this);
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/PottedCactus.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/PottedCactus.cs
@@ -51,7 +51,7 @@ public partial class PottedCactusDeed : Item, IRewardItem
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new InternalGump(this));
+            PottedCactusGump.DisplayTo(from, this);
         }
         else
         {
@@ -69,44 +69,49 @@ public partial class PottedCactusDeed : Item, IRewardItem
         }
     }
 
-    private class InternalGump : Gump
+    private class PottedCactusGump : StaticGump<PottedCactusGump>
     {
         private readonly PottedCactusDeed _deed;
 
         public override bool Singleton => true;
 
-        public InternalGump(PottedCactusDeed cactus) : base(100, 200)
+        private PottedCactusGump(PottedCactusDeed cactus) : base(100, 200) => _deed = cactus;
+
+        public static void DisplayTo(Mobile from, PottedCactusDeed deed)
         {
-            _deed = cactus;
+            if (from?.NetState == null || deed?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new PottedCactusGump(deed));
+        }
 
-            AddPage(0);
-            AddBackground(0, 0, 425, 250, 0xA28);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
+            builder.AddBackground(0, 0, 425, 250, 0xA28);
 
-            AddPage(1);
-            AddLabel(45, 15, 0, "Choose a Potted Cactus:");
+            builder.AddPage(1);
+            builder.AddLabel(45, 15, 0, "Choose a Potted Cactus:");
 
-            AddItem(45, 75, 0x1E0F);
-            AddButton(55, 50, 0x845, 0x846, 0x1E0F);
+            builder.AddItem(45, 75, 0x1E0F);
+            builder.AddButton(55, 50, 0x845, 0x846, 0x1E0F);
 
-            AddItem(105, 75, 0x1E10);
-            AddButton(115, 50, 0x845, 0x846, 0x1E10);
+            builder.AddItem(105, 75, 0x1E10);
+            builder.AddButton(115, 50, 0x845, 0x846, 0x1E10);
 
-            AddItem(160, 75, 0x1E14);
-            AddButton(175, 50, 0x845, 0x846, 0x1E14);
+            builder.AddItem(160, 75, 0x1E14);
+            builder.AddButton(175, 50, 0x845, 0x846, 0x1E14);
 
-            AddItem(220, 75, 0x1E11);
-            AddButton(235, 50, 0x845, 0x846, 0x1E11);
+            builder.AddItem(220, 75, 0x1E11);
+            builder.AddButton(235, 50, 0x845, 0x846, 0x1E11);
 
-            AddItem(280, 75, 0x1E12);
-            AddButton(295, 50, 0x845, 0x846, 0x1E12);
+            builder.AddItem(280, 75, 0x1E12);
+            builder.AddButton(295, 50, 0x845, 0x846, 0x1E12);
 
-            AddItem(340, 75, 0x1E13);
-            AddButton(355, 50, 0x845, 0x846, 0x1E13);
+            builder.AddItem(340, 75, 0x1E13);
+            builder.AddButton(355, 50, 0x845, 0x846, 0x1E13);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/StoneAnkh.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/StoneAnkh.cs
@@ -84,7 +84,7 @@ public partial class StoneAnkh : BaseAddon, IRewardItem
 
         if (house?.IsOwner(from) == true)
         {
-            from.SendGump(new RewardDemolitionGump(this, 1049783)); // Do you wish to re-deed this decoration?
+            RewardDemolitionGump.DisplayTo(from, this, 1049783); // Do you wish to re-deed this decoration?
         }
         else
         {
@@ -124,7 +124,7 @@ public partial class StoneAnkhDeed : BaseAddonDeed, IRewardItem
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new InternalGump(this));
+            StoneAnkhGump.DisplayTo(from, this);
         }
         else
         {
@@ -147,32 +147,37 @@ public partial class StoneAnkhDeed : BaseAddonDeed, IRewardItem
         }
     }
 
-    private class InternalGump : Gump
+    private class StoneAnkhGump : StaticGump<StoneAnkhGump>
     {
         private readonly StoneAnkhDeed _deed;
 
         public override bool Singleton => true;
 
-        public InternalGump(StoneAnkhDeed deed) : base(150, 50)
+        private StoneAnkhGump(StoneAnkhDeed deed) : base(150, 50) => _deed = deed;
+
+        public static void DisplayTo(Mobile from, StoneAnkhDeed deed)
         {
-            _deed = deed;
+            if (from?.NetState == null || deed?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new StoneAnkhGump(deed));
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddBackground(0, 0, 300, 150, 0xA28);
+            builder.AddBackground(0, 0, 300, 150, 0xA28);
 
-            AddItem(90, 30, 0x4);
-            AddItem(112, 30, 0x5);
-            AddButton(50, 35, 0x867, 0x869, (int)Buttons.South); // South
+            builder.AddItem(90, 30, 0x4);
+            builder.AddItem(112, 30, 0x5);
+            builder.AddButton(50, 35, 0x867, 0x869, (int)Buttons.South); // South
 
-            AddItem(170, 30, 0x2);
-            AddItem(192, 30, 0x3);
-            AddButton(145, 35, 0x867, 0x869, (int)Buttons.East); // East
+            builder.AddItem(170, 30, 0x2);
+            builder.AddItem(192, 30, 0x3);
+            builder.AddButton(145, 35, 0x867, 0x869, (int)Buttons.East); // East
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/TreeStump.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/TreeStump.cs
@@ -203,7 +203,7 @@ public partial class TreeStumpDeed : BaseAddonDeed, IRewardItem, IRewardOption
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new RewardOptionGump(this));
+            RewardOptionGump.DisplayTo(from, this);
         }
         else
         {

--- a/Projects/UOContent/Items/Special/Veteran Rewards/WallBanner.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/WallBanner.cs
@@ -304,7 +304,7 @@ public partial class WallBannerDeed : BaseAddonDeed, IRewardItem
 
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new InternalGump(this));
+            WallBannerGump.DisplayTo(from, this);
         }
         else
         {
@@ -319,152 +319,157 @@ public partial class WallBannerDeed : BaseAddonDeed, IRewardItem
         base.OnDoubleClick(m);
     }
 
-    private class InternalGump : Gump
+    private class WallBannerGump : StaticGump<WallBannerGump>
     {
         private readonly WallBannerDeed _wallBanner;
 
         public override bool Singleton => true;
 
-        public InternalGump(WallBannerDeed wallBanner) : base(150, 50)
+        private WallBannerGump(WallBannerDeed wallBanner) : base(150, 50) => _wallBanner = wallBanner;
+
+        public static void DisplayTo(Mobile from, WallBannerDeed wallBanner)
         {
-            _wallBanner = wallBanner;
+            if (from?.NetState == null || wallBanner?.Deleted != false)
+            {
+                return;
+            }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+            from.SendGump(new WallBannerGump(wallBanner));
+        }
 
-            AddBackground(25, 0, 500, 265, 0xA28);
-            AddLabel(70, 12, 0x3E3, "Choose a Wall Banner:");
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddBackground(25, 0, 500, 265, 0xA28);
+            builder.AddLabel(70, 12, 0x3E3, "Choose a Wall Banner:");
 
-            AddPage(1);
+            builder.AddPage(1);
 
-            AddItem(55, 110, 0x161D);
-            AddItem(75, 90, 0x161E);
-            AddItem(95, 70, 0x161F);
-            AddButton(70, 50, 0x845, 0x846, 1);
-            AddItem(105, 70, 0x1586);
-            AddItem(125, 90, 0x1587);
-            AddItem(145, 110, 0x1588);
-            AddButton(145, 50, 0x845, 0x846, 2);
-            AddItem(200, 110, 0x1620);
-            AddItem(220, 90, 0x1621);
-            AddItem(240, 70, 0x1622);
-            AddButton(220, 50, 0x845, 0x846, 3);
-            AddItem(250, 70, 0x1589);
-            AddItem(270, 90, 0x158A);
-            AddItem(290, 110, 0x158B);
-            AddButton(300, 50, 0x845, 0x846, 4);
-            AddItem(350, 110, 0x1623);
-            AddItem(370, 90, 0x1624);
-            AddItem(390, 70, 0x1625);
-            AddButton(365, 50, 0x845, 0x846, 5);
-            AddItem(400, 70, 0x158C);
-            AddItem(420, 90, 0x158D);
-            AddItem(440, 110, 0x158E);
-            AddButton(445, 50, 0x845, 0x846, 6);
-            AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 2);
+            builder.AddItem(55, 110, 0x161D);
+            builder.AddItem(75, 90, 0x161E);
+            builder.AddItem(95, 70, 0x161F);
+            builder.AddButton(70, 50, 0x845, 0x846, 1);
+            builder.AddItem(105, 70, 0x1586);
+            builder.AddItem(125, 90, 0x1587);
+            builder.AddItem(145, 110, 0x1588);
+            builder.AddButton(145, 50, 0x845, 0x846, 2);
+            builder.AddItem(200, 110, 0x1620);
+            builder.AddItem(220, 90, 0x1621);
+            builder.AddItem(240, 70, 0x1622);
+            builder.AddButton(220, 50, 0x845, 0x846, 3);
+            builder.AddItem(250, 70, 0x1589);
+            builder.AddItem(270, 90, 0x158A);
+            builder.AddItem(290, 110, 0x158B);
+            builder.AddButton(300, 50, 0x845, 0x846, 4);
+            builder.AddItem(350, 110, 0x1623);
+            builder.AddItem(370, 90, 0x1624);
+            builder.AddItem(390, 70, 0x1625);
+            builder.AddButton(365, 50, 0x845, 0x846, 5);
+            builder.AddItem(400, 70, 0x158C);
+            builder.AddItem(420, 90, 0x158D);
+            builder.AddItem(440, 110, 0x158E);
+            builder.AddButton(445, 50, 0x845, 0x846, 6);
+            builder.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 2);
 
-            AddPage(2);
+            builder.AddPage(2);
 
-            AddItem(52, 110, 0x1626);
-            AddItem(72, 90, 0x1627);
-            AddItem(95, 70, 0x1628);
-            AddButton(70, 50, 0x845, 0x846, 7);
-            AddItem(105, 70, 0x1590);
-            AddItem(125, 90, 0x1591);
-            AddItem(145, 110, 0x158F);
-            AddButton(145, 50, 0x845, 0x846, 8);
-            AddItem(197, 110, 0x1626);
-            AddItem(217, 90, 0x1629);
-            AddItem(240, 70, 0x162A);
-            AddButton(220, 50, 0x845, 0x846, 9);
-            AddItem(250, 70, 0x1592);
-            AddItem(270, 90, 0x1593);
-            AddItem(290, 110, 0x158F);
-            AddButton(300, 50, 0x845, 0x846, 10);
-            AddItem(340, 110, 0x162B);
-            AddItem(363, 90, 0x162C);
-            AddItem(385, 70, 0x162D);
-            AddButton(365, 50, 0x845, 0x846, 11);
-            AddItem(395, 70, 0x1594);
-            AddItem(417, 90, 0x1595);
-            AddItem(439, 111, 0x1596);
-            AddButton(445, 50, 0x845, 0x846, 12);
-            AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 1);
-            AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 3);
+            builder.AddItem(52, 110, 0x1626);
+            builder.AddItem(72, 90, 0x1627);
+            builder.AddItem(95, 70, 0x1628);
+            builder.AddButton(70, 50, 0x845, 0x846, 7);
+            builder.AddItem(105, 70, 0x1590);
+            builder.AddItem(125, 90, 0x1591);
+            builder.AddItem(145, 110, 0x158F);
+            builder.AddButton(145, 50, 0x845, 0x846, 8);
+            builder.AddItem(197, 110, 0x1626);
+            builder.AddItem(217, 90, 0x1629);
+            builder.AddItem(240, 70, 0x162A);
+            builder.AddButton(220, 50, 0x845, 0x846, 9);
+            builder.AddItem(250, 70, 0x1592);
+            builder.AddItem(270, 90, 0x1593);
+            builder.AddItem(290, 110, 0x158F);
+            builder.AddButton(300, 50, 0x845, 0x846, 10);
+            builder.AddItem(340, 110, 0x162B);
+            builder.AddItem(363, 90, 0x162C);
+            builder.AddItem(385, 70, 0x162D);
+            builder.AddButton(365, 50, 0x845, 0x846, 11);
+            builder.AddItem(395, 70, 0x1594);
+            builder.AddItem(417, 90, 0x1595);
+            builder.AddItem(439, 111, 0x1596);
+            builder.AddButton(445, 50, 0x845, 0x846, 12);
+            builder.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 1);
+            builder.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 3);
 
-            AddPage(3);
+            builder.AddPage(3);
 
-            AddItem(55, 110, 0x162E);
-            AddItem(75, 93, 0x1631);
-            AddItem(95, 70, 0x1632);
-            AddButton(70, 50, 0x845, 0x846, 13);
-            AddItem(118, 70, 0x1598);
-            AddItem(138, 94, 0x159B);
-            AddItem(159, 113, 0x159C);
-            AddButton(160, 50, 0x845, 0x846, 14);
-            AddItem(219, 111, 0x162F);
-            AddItem(238, 94, 0x1630);
-            AddItem(258, 70, 0x1633);
-            AddButton(240, 50, 0x845, 0x846, 15);
-            AddItem(279, 70, 0x1599);
-            AddItem(298, 93, 0x159A);
-            AddItem(319, 113, 0x159D);
-            AddButton(320, 50, 0x845, 0x846, 16);
-            AddItem(380, 90, 0x160F);
-            AddItem(400, 70, 0x1610);
-            AddButton(390, 50, 0x845, 0x846, 17);
-            AddItem(420, 70, 0x15A0);
-            AddItem(440, 90, 0x15A1);
-            AddButton(455, 50, 0x845, 0x846, 18);
-            AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 2);
-            AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 4);
+            builder.AddItem(55, 110, 0x162E);
+            builder.AddItem(75, 93, 0x1631);
+            builder.AddItem(95, 70, 0x1632);
+            builder.AddButton(70, 50, 0x845, 0x846, 13);
+            builder.AddItem(118, 70, 0x1598);
+            builder.AddItem(138, 94, 0x159B);
+            builder.AddItem(159, 113, 0x159C);
+            builder.AddButton(160, 50, 0x845, 0x846, 14);
+            builder.AddItem(219, 111, 0x162F);
+            builder.AddItem(238, 94, 0x1630);
+            builder.AddItem(258, 70, 0x1633);
+            builder.AddButton(240, 50, 0x845, 0x846, 15);
+            builder.AddItem(279, 70, 0x1599);
+            builder.AddItem(298, 93, 0x159A);
+            builder.AddItem(319, 113, 0x159D);
+            builder.AddButton(320, 50, 0x845, 0x846, 16);
+            builder.AddItem(380, 90, 0x160F);
+            builder.AddItem(400, 70, 0x1610);
+            builder.AddButton(390, 50, 0x845, 0x846, 17);
+            builder.AddItem(420, 70, 0x15A0);
+            builder.AddItem(440, 90, 0x15A1);
+            builder.AddButton(455, 50, 0x845, 0x846, 18);
+            builder.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 2);
+            builder.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 4);
 
-            AddPage(4);
+            builder.AddPage(4);
 
-            AddItem(55, 90, 0x1611);
-            AddItem(75, 70, 0x1612);
-            AddButton(70, 50, 0x845, 0x846, 19);
-            AddItem(105, 70, 0x15A2);
-            AddItem(125, 90, 0x15A3);
-            AddButton(145, 50, 0x845, 0x846, 20);
-            AddItem(200, 84, 0x1613);
-            AddItem(220, 70, 0x1614);
-            AddButton(215, 50, 0x845, 0x846, 21);
-            AddItem(250, 70, 0x15A4);
-            AddItem(270, 84, 0x15A5);
-            AddButton(290, 50, 0x845, 0x846, 22);
-            AddItem(350, 90, 0x1615);
-            AddItem(370, 70, 0x1616);
-            AddButton(365, 50, 0x845, 0x846, 23);
-            AddItem(400, 70, 0x15A6);
-            AddItem(420, 90, 0x15A7);
-            AddButton(445, 50, 0x845, 0x846, 24);
-            AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 3);
-            AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 5);
+            builder.AddItem(55, 90, 0x1611);
+            builder.AddItem(75, 70, 0x1612);
+            builder.AddButton(70, 50, 0x845, 0x846, 19);
+            builder.AddItem(105, 70, 0x15A2);
+            builder.AddItem(125, 90, 0x15A3);
+            builder.AddButton(145, 50, 0x845, 0x846, 20);
+            builder.AddItem(200, 84, 0x1613);
+            builder.AddItem(220, 70, 0x1614);
+            builder.AddButton(215, 50, 0x845, 0x846, 21);
+            builder.AddItem(250, 70, 0x15A4);
+            builder.AddItem(270, 84, 0x15A5);
+            builder.AddButton(290, 50, 0x845, 0x846, 22);
+            builder.AddItem(350, 90, 0x1615);
+            builder.AddItem(370, 70, 0x1616);
+            builder.AddButton(365, 50, 0x845, 0x846, 23);
+            builder.AddItem(400, 70, 0x15A6);
+            builder.AddItem(420, 90, 0x15A7);
+            builder.AddButton(445, 50, 0x845, 0x846, 24);
+            builder.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 3);
+            builder.AddButton(455, 205, 0x8B0, 0x8B0, 0, GumpButtonType.Page, 5);
 
-            AddPage(5);
+            builder.AddPage(5);
 
-            AddItem(55, 90, 0x1617);
-            AddItem(77, 70, 0x1618);
-            AddButton(70, 50, 0x845, 0x846, 25);
-            AddItem(105, 70, 0x15A8);
-            AddItem(127, 90, 0x15A9);
-            AddButton(145, 50, 0x845, 0x846, 26);
-            AddItem(200, 90, 0x1619);
-            AddItem(222, 70, 0x161A);
-            AddButton(220, 50, 0x845, 0x846, 27);
-            AddItem(250, 70, 0x15AA);
-            AddItem(272, 90, 0x15AB);
-            AddButton(300, 50, 0x845, 0x846, 28);
-            AddItem(350, 90, 0x161B);
-            AddItem(372, 70, 0x161C);
-            AddButton(365, 50, 0x845, 0x846, 29);
-            AddItem(400, 70, 0x15AC);
-            AddItem(422, 90, 0x15AD);
-            AddButton(445, 50, 0x845, 0x846, 30);
-            AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 4);
+            builder.AddItem(55, 90, 0x1617);
+            builder.AddItem(77, 70, 0x1618);
+            builder.AddButton(70, 50, 0x845, 0x846, 25);
+            builder.AddItem(105, 70, 0x15A8);
+            builder.AddItem(127, 90, 0x15A9);
+            builder.AddButton(145, 50, 0x845, 0x846, 26);
+            builder.AddItem(200, 90, 0x1619);
+            builder.AddItem(222, 70, 0x161A);
+            builder.AddButton(220, 50, 0x845, 0x846, 27);
+            builder.AddItem(250, 70, 0x15AA);
+            builder.AddItem(272, 90, 0x15AB);
+            builder.AddButton(300, 50, 0x845, 0x846, 28);
+            builder.AddItem(350, 90, 0x161B);
+            builder.AddItem(372, 70, 0x161C);
+            builder.AddButton(365, 50, 0x845, 0x846, 29);
+            builder.AddItem(400, 70, 0x15AC);
+            builder.AddItem(422, 90, 0x15AD);
+            builder.AddButton(445, 50, 0x845, 0x846, 30);
+            builder.AddButton(70, 205, 0x8AF, 0x8AF, 0, GumpButtonType.Page, 4);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/Veteran Rewards/WeaponEngravingTool.cs
+++ b/Projects/UOContent/Items/Special/Veteran Rewards/WeaponEngravingTool.cs
@@ -73,7 +73,7 @@ public partial class WeaponEngravingTool : Item, IUsesRemaining, IRewardItem
         }
 
         from.SendLocalizedMessage(1076163); // There are no charges left on this engraving tool.
-        from.SendGump(new ConfirmGump(this, null));
+        WeaponEngravingToolConfirmGump.DisplayTo(from, this, null);
     }
 
     public override void GetProperties(IPropertyList list)
@@ -174,7 +174,7 @@ public partial class WeaponEngravingTool : Item, IUsesRemaining, IRewardItem
 
             if (targeted is BaseWeapon item)
             {
-                from.SendGump(new InternalGump(_tool, item));
+                WeaponEngravingToolGump.DisplayTo(from, _tool, item);
             }
             else
             {
@@ -183,39 +183,47 @@ public partial class WeaponEngravingTool : Item, IUsesRemaining, IRewardItem
         }
     }
 
-    private class InternalGump : Gump
+    private class WeaponEngravingToolGump : StaticGump<WeaponEngravingToolGump>
     {
         private readonly BaseWeapon _target;
         private readonly WeaponEngravingTool _tool;
 
         public override bool Singleton => true;
 
-        public InternalGump(WeaponEngravingTool tool, BaseWeapon target) : base(0, 0)
+        private WeaponEngravingToolGump(WeaponEngravingTool tool, BaseWeapon target) : base(0, 0)
         {
             _tool = tool;
             _target = target;
+        }
 
-            Closable = true;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+        public static void DisplayTo(Mobile from, WeaponEngravingTool tool, BaseWeapon target)
+        {
+            if (from?.NetState == null || tool?.Deleted != false || target?.Deleted != false)
+            {
+                return;
+            }
 
-            AddBackground(50, 50, 400, 300, 0xA28);
+            from.SendGump(new WeaponEngravingToolGump(tool, target));
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddHtmlLocalized(50, 70, 400, 20, 1072359, 0x0); // <CENTER>Engraving Tool</CENTER>
+            builder.AddBackground(50, 50, 400, 300, 0xA28);
+
+            builder.AddHtmlLocalized(50, 70, 400, 20, 1072359, 0x0); // <CENTER>Engraving Tool</CENTER>
             // Please enter the text to add to the selected object. Leave the text area blank to remove any existing text.  Removing text does not use a charge.
-            AddHtmlLocalized(75, 95, 350, 145, 1076229, 0x0, true, true);
-            AddButton(125, 300, 0x81A, 0x81B, (int)Buttons.Okay);
-            AddButton(320, 300, 0x819, 0x818, (int)Buttons.Cancel);
-            AddImageTiled(75, 245, 350, 40, 0xDB0);
-            AddImageTiled(76, 245, 350, 2, 0x23C5);
-            AddImageTiled(75, 245, 2, 40, 0x23C3);
-            AddImageTiled(75, 285, 350, 2, 0x23C5);
-            AddImageTiled(425, 245, 2, 42, 0x23C3);
+            builder.AddHtmlLocalized(75, 95, 350, 145, 1076229, 0x0, true, true);
+            builder.AddButton(125, 300, 0x81A, 0x81B, (int)Buttons.Okay);
+            builder.AddButton(320, 300, 0x819, 0x818, (int)Buttons.Cancel);
+            builder.AddImageTiled(75, 245, 350, 40, 0xDB0);
+            builder.AddImageTiled(76, 245, 350, 2, 0x23C5);
+            builder.AddImageTiled(75, 245, 2, 40, 0x23C3);
+            builder.AddImageTiled(75, 285, 350, 2, 0x23C5);
+            builder.AddImageTiled(425, 245, 2, 42, 0x23C3);
 
-            AddTextEntry(75, 245, 350, 40, 0x0, (int)Buttons.Text, "");
+            builder.AddTextEntry(75, 245, 350, 40, 0x0, (int)Buttons.Text, "");
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
@@ -262,42 +270,54 @@ public partial class WeaponEngravingTool : Item, IUsesRemaining, IRewardItem
         }
     }
 
-    public class ConfirmGump : Gump
+    public class WeaponEngravingToolConfirmGump : DynamicGump
     {
         private readonly WeaponEngravingTool _engraver;
         private readonly Mobile _guildmaster;
 
-        public ConfirmGump(WeaponEngravingTool engraver, Mobile guildmaster) : base(200, 200)
+        public override bool Singleton => true;
+
+        private WeaponEngravingToolConfirmGump(WeaponEngravingTool engraver, Mobile guildmaster) : base(200, 200)
         {
             _engraver = engraver;
             _guildmaster = guildmaster;
+        }
 
-            Closable = false;
-            Disposable = true;
-            Draggable = true;
-            Resizable = false;
+        public static void DisplayTo(Mobile from, WeaponEngravingTool engraver, Mobile guildmaster)
+        {
+            if (from?.NetState == null || engraver?.Deleted != false)
+            {
+                return;
+            }
 
-            AddPage(0);
+            from.SendGump(new WeaponEngravingToolConfirmGump(engraver, guildmaster));
+        }
 
-            AddBackground(0, 0, 291, 133, 0x13BE);
-            AddImageTiled(5, 5, 280, 100, 0xA40);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoClose();
 
-            if (guildmaster != null)
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 291, 133, 0x13BE);
+            builder.AddImageTiled(5, 5, 280, 100, 0xA40);
+
+            if (_guildmaster != null)
             {
                 // It will cost you 100,000 gold and a blue diamond to recharge your weapon engraver with 10 charges.
-                AddHtmlLocalized(9, 9, 272, 100, 1076169, 0x7FFF);
-                AddHtmlLocalized(195, 109, 120, 20, 1076172, 0x7FFF); // Recharge it
+                builder.AddHtmlLocalized(9, 9, 272, 100, 1076169, 0x7FFF);
+                builder.AddHtmlLocalized(195, 109, 120, 20, 1076172, 0x7FFF); // Recharge it
             }
             else
             {
                 // You will need a blue diamond to repair the tip of the engraver.  A successful repair will give the engraver 10 charges.
-                AddHtmlLocalized(9, 9, 272, 100, 1076176, 0x7FFF);
-                AddHtmlLocalized(195, 109, 120, 20, 1076177, 0x7FFF); // Replace the tip.
+                builder.AddHtmlLocalized(9, 9, 272, 100, 1076176, 0x7FFF);
+                builder.AddHtmlLocalized(195, 109, 120, 20, 1076177, 0x7FFF); // Replace the tip.
             }
 
-            AddButton(160, 107, 0xFB7, 0xFB8, (int)Buttons.Confirm);
-            AddButton(5, 107, 0xFB1, 0xFB2, (int)Buttons.Cancel);
-            AddHtmlLocalized(40, 109, 100, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddButton(160, 107, 0xFB7, 0xFB8, (int)Buttons.Confirm);
+            builder.AddButton(5, 107, 0xFB1, 0xFB2, (int)Buttons.Cancel);
+            builder.AddHtmlLocalized(40, 109, 100, 20, 1060051, 0x7FFF); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)

--- a/Projects/UOContent/Mobiles/Vendors/NPC/Guildmasters/TinkerGuildmaster.cs
+++ b/Projects/UOContent/Mobiles/Vendors/NPC/Guildmasters/TinkerGuildmaster.cs
@@ -60,7 +60,7 @@ namespace Server.Mobiles
 
                 if (Banker.GetBalance(from) >= 100000)
                 {
-                    from.SendGump(new WeaponEngravingTool.ConfirmGump(tool, vendor));
+                    WeaponEngravingTool.WeaponEngravingToolConfirmGump.DisplayTo(from, tool, vendor);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Migrates 16 player-facing legacy `Gump` subclasses in the Veteran Rewards system to `DynamicGump` or `StaticGump<T>`, renames every nested `InternalGump`/`ConfirmGump` to system-prefixed names, and updates external callers to use new static `DisplayTo` entry points.

### Reward chain (Engines/Veteran Rewards)

| Gump | Base type | Reasoning |
|---|---|---|
| `RewardNoticeGump` | `StaticGump<T>` | Fixed layout |
| `RewardChoiceGump` | `DynamicGump` | Layout shape varies (per-player categories, entries, pages) |
| `RewardConfirmGump` | `DynamicGump` | `entry.Name` is a dynamic cliloc per reward (cliloc rule) |
| `RewardOptionGump` | `DynamicGump` | Title cliloc and per-option clilocs are dynamic (cliloc rule) |
| `RewardDemolitionGump` | `DynamicGump` | `question` cliloc is dynamic per caller (cliloc rule) |

### Statue (Engines/Veteran Rewards/Character Statue Maker)

| Gump | Base type | Reasoning |
|---|---|---|
| `CharacterStatueGump` | `DynamicGump` | Pose/Direction/Material labels are dynamic clilocs (cliloc rule) |
| `CharacterPlinthGump` | `DynamicGump` | `statue.Name`, sculpted-on date, and statue-type cliloc are dynamic (cliloc rule) |

### Decorations (Items/Special/Veteran Rewards) — every `InternalGump` renamed

| Original | New name | Base type | Reasoning |
|---|---|---|---|
| `Banner.InternalGump` | `BannerGump` | `StaticGump<T>` | Fully fixed item-id picker over `Start..End` range |
| `Brazier.InternalGump` | `BrazierGump` | `StaticGump<T>` | Fixed two-item picker |
| `Cannon.InternalGump` | `CannonGump` | `DynamicGump` | `keg.Validate()` value passed as `~1_CHARGES~` arg (cliloc-arg rule) |
| `DecorativeShield.InternalGump` | `DecorativeShieldGump` | `StaticGump<T>` | Fixed item picker over a constant range |
| `DecorativeShield.FacingGump` | `DecorativeShieldFacingGump` | `DynamicGump` | Item ids depend on instance state |
| `HangingSkeleton.InternalGump` | `HangingSkeletonGump` | `StaticGump<T>` | Fixed item picker (5 hard-coded ids) |
| `PottedCactus.InternalGump` | `PottedCactusGump` | `StaticGump<T>` | Fixed 6-item picker |
| `StoneAnkh.InternalGump` | `StoneAnkhGump` | `StaticGump<T>` | Fixed two-direction picker |
| `WallBanner.InternalGump` | `WallBannerGump` | `StaticGump<T>` | Fixed 30-banner picker across 5 pages |
| `WeaponEngravingTool.InternalGump` | `WeaponEngravingToolGump` | `StaticGump<T>` | Fixed text-entry dialog |
| `WeaponEngravingTool.ConfirmGump` | `WeaponEngravingToolConfirmGump` | `DynamicGump` | Layout branches on `guildmaster != null` |

### External callers updated

`RewardSystem`, `CharacterStatue`, `FireFliesDeed`, `FlamingHead`, `Banner`, `DecorativeShield`, `HangingSkeleton`, `StoneAnkh` (RewardDemolitionGump callers); `AnkhOfSacrifice`, `Cannon`, `MiningCart`, `MinotaurStatue`, `TreeStump` (RewardOptionGump callers); `TinkerGuildmaster` (engraver confirm gump).

The pre-existing `FacingGump` inside `Banner.cs` (already `DynamicGump`) was left as-is — it is private, nested inside `InternalTarget`, and never referenced outside.

## Test plan

- [x] `dotnet build Projects/UOContent/UOContent.csproj` — 0 warnings, 0 errors
- [x] `dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj` — pre-existing test-fixture NREs in `UOContentFixture..ctor` (`AOS.DisableStatInfluences`) reproduce identically against stashed code, unrelated to this PR
- [ ] In-game smoke test: trigger a reward redemption (NoticeGump -> ChoiceGump -> ConfirmGump path)
- [ ] Place each decoration deed (Banner, Brazier, Cannon, DecorativeShield, HangingSkeleton, PottedCactus, StoneAnkh, WallBanner) and exercise its menu
- [ ] Re-deed each placed decoration via demolition gump
- [ ] Sculpt and customize a Character Statue (pose / direction / material cycling, restore from deed)
- [ ] Engrave a weapon and exhaust charges to exercise `WeaponEngravingToolConfirmGump`; verify TinkerGuildmaster recharge dialog still opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
