### PR TITLE
perf: Migrate Quest gumps to DynamicGump

### DIFF
--- a/Projects/UOContent/Engines/ML Quests/Gumps/BaseQuestGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/BaseQuestGump.cs
@@ -24,84 +24,91 @@ namespace Server.Engines.MLQuests.Gumps
         Resign = 0x2EF5
     }
 
-    public abstract class BaseQuestGump : Gump
+    public abstract class BaseMLQuestGump : DynamicGump
     {
-        private readonly List<ButtonInfo> m_Buttons;
-        private int m_Label;
-        private int m_MaxPages;
-
-        private int m_Page;
-        private string m_Title;
+        private readonly List<ButtonInfo> _buttons;
+        private readonly int _label;
+        private int _maxPages;
+        private int _page;
+        private string _title;
 
         // RunUO optimized version
-        public BaseQuestGump(int label)
-            : base(75, 25)
+        protected BaseMLQuestGump(int label) : base(75, 25)
         {
-            m_Page = 0;
-            m_MaxPages = 0;
-            m_Label = label;
-            m_Title = null;
-            m_Buttons = new List<ButtonInfo>(2);
-
-            Closable = false;
-
-            AddPage(0);
-
-            AddImageTiled(50, 20, 400, 460, 0x1404);
-            AddImageTiled(50, 29, 30, 450, 0x28DC);
-            AddImageTiled(34, 140, 17, 339, 0x242F);
-            AddImage(48, 135, 0x28AB);
-            AddImage(-16, 285, 0x28A2);
-            AddImage(0, 10, 0x28B5);
-            AddImage(25, 0, 0x28B4);
-            AddImageTiled(83, 15, 350, 15, 0x280A);
-            AddImage(34, 479, 0x2842);
-            AddImage(442, 479, 0x2840);
-            AddImageTiled(51, 479, 392, 17, 0x2775);
-            AddImageTiled(415, 29, 44, 450, 0xA2D);
-            AddImageTiled(415, 29, 30, 450, 0x28DC);
-            // AddLabel( 100, 50, 0x481, "" );
-            AddImage(370, 50, 0x589);
-            AddImage(379, 60, 0x15A9);
-            AddImage(425, 0, 0x28C9);
-            AddImage(90, 33, 0x232D);
-            AddHtmlLocalized(130, 45, 270, 16, label, 0x7FFF);
-            AddImageTiled(130, 65, 175, 1, 0x238D);
+            _label = label;
+            _page = 0;
+            _maxPages = 0;
+            _title = null;
+            _buttons = new List<ButtonInfo>(2);
         }
 
-        public void BuildPage()
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
         {
-            AddPage(++m_Page);
+            builder.SetNoClose();
 
-            if (m_Page > 1)
+            builder.AddPage();
+
+            builder.AddImageTiled(50, 20, 400, 460, 0x1404);
+            builder.AddImageTiled(50, 29, 30, 450, 0x28DC);
+            builder.AddImageTiled(34, 140, 17, 339, 0x242F);
+            builder.AddImage(48, 135, 0x28AB);
+            builder.AddImage(-16, 285, 0x28A2);
+            builder.AddImage(0, 10, 0x28B5);
+            builder.AddImage(25, 0, 0x28B4);
+            builder.AddImageTiled(83, 15, 350, 15, 0x280A);
+            builder.AddImage(34, 479, 0x2842);
+            builder.AddImage(442, 479, 0x2840);
+            builder.AddImageTiled(51, 479, 392, 17, 0x2775);
+            builder.AddImageTiled(415, 29, 44, 450, 0xA2D);
+            builder.AddImageTiled(415, 29, 30, 450, 0x28DC);
+            builder.AddImage(370, 50, 0x589);
+            builder.AddImage(379, 60, 0x15A9);
+            builder.AddImage(425, 0, 0x28C9);
+            builder.AddImage(90, 33, 0x232D);
+            builder.AddHtmlLocalized(130, 45, 270, 16, _label, 0x7FFF);
+            builder.AddImageTiled(130, 65, 175, 1, 0x238D);
+
+            // Reset paging for subclass content
+            _page = 0;
+
+            BuildContent(ref builder);
+        }
+
+        protected abstract void BuildContent(ref DynamicGumpBuilder builder);
+
+        protected void BuildPage(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage(++_page);
+
+            if (_page > 1)
             {
-                AddButton(
+                builder.AddButton(
                     130,
                     430,
                     (int)ButtonGraphic.Previous,
                     (int)ButtonGraphic.Previous + 2,
                     0,
                     GumpButtonType.Page,
-                    m_Page - 1
+                    _page - 1
                 );
             }
 
-            if (m_Page < m_MaxPages)
+            if (_page < _maxPages)
             {
-                AddButton(
+                builder.AddButton(
                     275,
                     430,
                     (int)ButtonGraphic.Continue,
                     (int)ButtonGraphic.Continue + 2,
                     0,
                     GumpButtonType.Page,
-                    m_Page + 1
+                    _page + 1
                 );
             }
 
-            foreach (var button in m_Buttons)
+            foreach (var button in _buttons)
             {
-                AddButton(
+                builder.AddButton(
                     button.Position == ButtonPosition.Left ? 95 : 313,
                     455,
                     (int)button.Graphic,
@@ -110,37 +117,37 @@ namespace Server.Engines.MLQuests.Gumps
                 );
             }
 
-            if (m_Title != null)
+            if (_title != null)
             {
-                AddHtmlLocalized(130, 68, 220, 48, 1114513, m_Title, 0x2710); // <DIV ALIGN=CENTER>~1_TOKEN~</DIV>
+                builder.AddHtmlLocalized(130, 68, 220, 48, 1114513, _title, 0x2710); // <DIV ALIGN=CENTER>~1_TOKEN~</DIV>
             }
         }
 
-        public void SetPageCount(int maxPages)
+        protected void SetPageCount(int maxPages)
         {
-            m_MaxPages = maxPages;
+            _maxPages = maxPages;
         }
 
-        public void SetTitle(TextDefinition def)
+        protected void SetTitle(TextDefinition def)
         {
             if (def.Number > 0)
             {
-                m_Title = $"#{def.Number}"; // OSI does "@@#{0}" instead, why? KR client related?
+                _title = $"#{def.Number}"; // OSI does "@@#{0}" instead, why? KR client related?
             }
             else
             {
-                m_Title = def.String;
+                _title = def.String;
             }
         }
 
-        public void RegisterButton(ButtonPosition position, ButtonGraphic graphic, int buttonID)
+        protected void RegisterButton(ButtonPosition position, ButtonGraphic graphic, int buttonID)
         {
-            m_Buttons.Add(new ButtonInfo(position, graphic, buttonID));
+            _buttons.Add(new ButtonInfo(position, graphic, buttonID));
         }
 
-        public void AddDescription(MLQuest quest)
+        protected static void AddDescription(ref DynamicGumpBuilder builder, MLQuest quest)
         {
-            AddHtmlLocalized(
+            builder.AddHtmlLocalized(
                 98,
                 140,
                 312,
@@ -149,14 +156,14 @@ namespace Server.Engines.MLQuests.Gumps
                 0x2710
             );
 
-            quest.Description.AddHtmlText(this, 98, 156, 312, 240, false, true, 0x5F90, 0xBDE784);
+            quest.Description.AddHtmlText(ref builder, 98, 156, 312, 240, false, true, 0x5F90, 0xBDE784);
         }
 
-        public void AddObjectives(MLQuest quest)
+        protected static void AddObjectives(ref DynamicGumpBuilder builder, MLQuest quest)
         {
-            AddHtmlLocalized(98, 140, 312, 16, 1049073, 0x2710); // Objective:
+            builder.AddHtmlLocalized(98, 140, 312, 16, 1049073, 0x2710); // Objective:
             // All of the following / Only one of the following
-            AddHtmlLocalized(
+            builder.AddHtmlLocalized(
                 98,
                 156,
                 312,
@@ -169,7 +176,7 @@ namespace Server.Engines.MLQuests.Gumps
 
             foreach (var objective in quest.Objectives)
             {
-                objective.WriteToGump(this, ref y);
+                objective.WriteToGump(ref builder, ref y);
 
                 if (objective.IsTimed)
                 {
@@ -178,18 +185,18 @@ namespace Server.Engines.MLQuests.Gumps
                         y -= 16;
                     }
 
-                    BaseObjectiveInstance.WriteTimeRemaining(this, ref y, objective.Duration);
+                    BaseObjectiveInstance.WriteTimeRemaining(ref builder, ref y, objective.Duration);
                 }
             }
         }
 
-        public void AddObjectivesProgress(MLQuestInstance instance)
+        protected static void AddObjectivesProgress(ref DynamicGumpBuilder builder, MLQuestInstance instance)
         {
             var quest = instance.Quest;
 
-            AddHtmlLocalized(98, 140, 312, 16, 1049073, 0x2710); // Objective:
+            builder.AddHtmlLocalized(98, 140, 312, 16, 1049073, 0x2710); // Objective:
             // All of the following / Only one of the following
-            AddHtmlLocalized(
+            builder.AddHtmlLocalized(
                 98,
                 156,
                 312,
@@ -202,55 +209,55 @@ namespace Server.Engines.MLQuests.Gumps
 
             foreach (var objInstance in instance.Objectives)
             {
-                objInstance.WriteToGump(this, ref y);
+                objInstance.WriteToGump(ref builder, ref y);
             }
         }
 
-        public void AddRewardsPage(MLQuest quest) // For the quest log/offer gumps
+        protected static void AddRewardsPage(ref DynamicGumpBuilder builder, MLQuest quest) // For the quest log/offer gumps
         {
-            AddHtmlLocalized(98, 140, 312, 16, 1072201, 0x2710); // Reward
+            builder.AddHtmlLocalized(98, 140, 312, 16, 1072201, 0x2710); // Reward
 
             var y = 162;
 
             if (quest.Rewards.Count > 1)
             {
                 // TODO: Is this what this is for? Does "Only one of the following" occur?
-                AddHtmlLocalized(98, 156, 312, 16, 1072208, 0x2710); // All of the following
+                builder.AddHtmlLocalized(98, 156, 312, 16, 1072208, 0x2710); // All of the following
                 y += 16;
             }
 
-            AddRewards(quest, 105, y, 16);
+            AddRewards(ref builder, quest, 105, y, 16);
         }
 
-        public void AddRewards(MLQuest quest) // For the claim rewards gump
+        protected static void AddRewards(ref DynamicGumpBuilder builder, MLQuest quest) // For the claim rewards gump
         {
             var y = 146;
 
             if (quest.Rewards.Count > 1)
             {
                 // TODO: Is this what this is for? Does "Only one of the following" occur?
-                AddHtmlLocalized(100, 140, 312, 16, 1072208, 0x2710); // All of the following
+                builder.AddHtmlLocalized(100, 140, 312, 16, 1072208, 0x2710); // All of the following
                 y += 16;
             }
 
-            AddRewards(quest, 107, y, 26);
+            AddRewards(ref builder, quest, 107, y, 26);
         }
 
-        public void AddRewards(MLQuest quest, int x, int y, int spacing)
+        protected static void AddRewards(ref DynamicGumpBuilder builder, MLQuest quest, int x, int y, int spacing)
         {
             var xReward = x + 28;
 
             foreach (var reward in quest.Rewards)
             {
-                AddImage(x, y + 1, 0x4B9);
-                reward.WriteToGump(this, xReward, ref y);
+                builder.AddImage(x, y + 1, 0x4B9);
+                reward.WriteToGump(ref builder, xReward, ref y);
                 y += spacing;
             }
         }
 
-        public void AddConversation(TextDefinition text)
+        protected static void AddConversation(ref DynamicGumpBuilder builder, TextDefinition text)
         {
-            text.AddHtmlText(this, 98, 140, 312, 180, false, true, 0x5F90, 0xBDE784);
+            text.AddHtmlText(ref builder, 98, 140, 312, 180, false, true, 0x5F90, 0xBDE784);
         }
 
         /* OSI gump IDs:
@@ -258,7 +265,7 @@ namespace Server.Engines.MLQuests.Gumps
          * 801 - QuestCancelConfirmGump
          * 802 - ?? (gets closed by Toggle Quest Item)
          * 803 - QuestRewardGump
-         * 804 - ?? (gets closed by Toggle Quest Item)
+         * 804 - ?? (gets closed by Toggle Quest Item and most quest gumps)
          * 805 - QuestLogGump
          * 806 - QuestConversationGump (refuse / in progress)
          * 807 - ?? (gets closed by Toggle Quest Item and most quest gumps)
@@ -277,7 +284,7 @@ namespace Server.Engines.MLQuests.Gumps
             gumps.Close<QuestCancelConfirmGump>();
         }
 
-        private struct ButtonInfo
+        private readonly struct ButtonInfo
         {
             public ButtonPosition Position { get; }
 

--- a/Projects/UOContent/Engines/ML Quests/Gumps/BaseQuestGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/BaseQuestGump.cs
@@ -106,8 +106,9 @@ namespace Server.Engines.MLQuests.Gumps
                 );
             }
 
-            foreach (var button in _buttons)
+            for (var i = 0; i < _buttons.Count; i++)
             {
+                var button = _buttons[i];
                 builder.AddButton(
                     button.Position == ButtonPosition.Left ? 95 : 313,
                     455,

--- a/Projects/UOContent/Engines/ML Quests/Gumps/InfoNPCGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/InfoNPCGump.cs
@@ -1,17 +1,40 @@
+using Server.Gumps;
+
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class InfoNPCGump : BaseQuestGump
+    public class InfoNPCGump : BaseMLQuestGump
     {
-        public InfoNPCGump(TextDefinition title, TextDefinition message)
+        private readonly TextDefinition _title;
+        private readonly TextDefinition _message;
+
+        public override bool Singleton => true;
+
+        private InfoNPCGump(TextDefinition title, TextDefinition message)
             : base(1060668) // INFORMATION
         {
+            _title = title;
+            _message = message;
+
             RegisterButton(ButtonPosition.Left, ButtonGraphic.Close, 3);
 
             SetPageCount(1);
+        }
 
-            BuildPage();
-            title.AddHtmlText(this, 160, 108, 250, 16, false, false, 0x2710, 0x4AC684);
-            message.AddHtmlText(this, 98, 156, 312, 180, false, true, 0x5F90, 0xBDE784);
+        public static void DisplayTo(Mobile from, TextDefinition title, TextDefinition message)
+        {
+            if (from?.NetState == null)
+            {
+                return;
+            }
+
+            from.SendGump(new InfoNPCGump(title, message));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            BuildPage(ref builder);
+            _title.AddHtmlText(ref builder, 160, 108, 250, 16, false, false, 0x2710, 0x4AC684);
+            _message.AddHtmlText(ref builder, 98, 156, 312, 180, false, true, 0x5F90, 0xBDE784);
         }
     }
 }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestCancelConfirmGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestCancelConfirmGump.cs
@@ -3,52 +3,66 @@ using Server.Network;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestCancelConfirmGump : Gump
+    public class QuestCancelConfirmGump : DynamicGump
     {
-        private readonly bool m_CloseGumps;
-        private readonly MLQuestInstance m_Instance;
+        private readonly bool _closeGumps;
+        private readonly MLQuestInstance _instance;
 
-        public QuestCancelConfirmGump(MLQuestInstance instance, bool closeGumps = true)
-            : base(120, 50)
+        public override bool Singleton => true;
+
+        private QuestCancelConfirmGump(MLQuestInstance instance, bool closeGumps) : base(120, 50)
         {
-            m_Instance = instance;
-            m_CloseGumps = closeGumps;
+            _instance = instance;
+            _closeGumps = closeGumps;
+        }
+
+        public static void DisplayTo(Mobile from, MLQuestInstance instance, bool closeGumps = true)
+        {
+            if (from?.NetState == null || instance == null)
+            {
+                return;
+            }
 
             if (closeGumps)
             {
-                BaseQuestGump.CloseOtherGumps(instance.Player);
+                BaseMLQuestGump.CloseOtherGumps(instance.Player);
             }
 
-            AddPage(0);
+            from.SendGump(new QuestCancelConfirmGump(instance, closeGumps));
+        }
 
-            Closable = false;
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoClose();
 
-            AddImageTiled(0, 0, 348, 262, 0xA8E);
-            AddAlphaRegion(0, 0, 348, 262);
+            builder.AddPage();
 
-            AddImage(0, 15, 0x27A8);
-            AddImageTiled(0, 30, 17, 200, 0x27A7);
-            AddImage(0, 230, 0x27AA);
+            builder.AddImageTiled(0, 0, 348, 262, 0xA8E);
+            builder.AddAlphaRegion(0, 0, 348, 262);
 
-            AddImage(15, 0, 0x280C);
-            AddImageTiled(30, 0, 300, 17, 0x280A);
-            AddImage(315, 0, 0x280E);
+            builder.AddImage(0, 15, 0x27A8);
+            builder.AddImageTiled(0, 30, 17, 200, 0x27A7);
+            builder.AddImage(0, 230, 0x27AA);
 
-            AddImage(15, 244, 0x280C);
-            AddImageTiled(30, 244, 300, 17, 0x280A);
-            AddImage(315, 244, 0x280E);
+            builder.AddImage(15, 0, 0x280C);
+            builder.AddImageTiled(30, 0, 300, 17, 0x280A);
+            builder.AddImage(315, 0, 0x280E);
 
-            AddImage(330, 15, 0x27A8);
-            AddImageTiled(330, 30, 17, 200, 0x27A7);
-            AddImage(330, 230, 0x27AA);
+            builder.AddImage(15, 244, 0x280C);
+            builder.AddImageTiled(30, 244, 300, 17, 0x280A);
+            builder.AddImage(315, 244, 0x280E);
 
-            AddImage(333, 2, 0x2716);
-            AddImage(333, 248, 0x2716);
-            AddImage(2, 248, 0x2716);
-            AddImage(2, 2, 0x2716);
+            builder.AddImage(330, 15, 0x27A8);
+            builder.AddImageTiled(330, 30, 17, 200, 0x27A7);
+            builder.AddImage(330, 230, 0x27AA);
 
-            AddHtmlLocalized(25, 22, 200, 20, 1049000, 0x7D00); // Confirm Quest Cancellation
-            AddImage(25, 40, 0xBBF);
+            builder.AddImage(333, 2, 0x2716);
+            builder.AddImage(333, 248, 0x2716);
+            builder.AddImage(2, 248, 0x2716);
+            builder.AddImage(2, 2, 0x2716);
+
+            builder.AddHtmlLocalized(25, 22, 200, 20, 1049000, 0x7D00); // Confirm Quest Cancellation
+            builder.AddImage(25, 40, 0xBBF);
 
             /*
              * This quest will give you valuable information, skills
@@ -57,28 +71,28 @@ namespace Server.Engines.MLQuests.Gumps
              * <BR>
              * Are you certain you wish to cancel at this time?
              */
-            AddHtmlLocalized(25, 55, 300, 120, 1060836, 0x7FFF);
+            builder.AddHtmlLocalized(25, 55, 300, 120, 1060836, 0x7FFF);
 
-            var quest = instance.Quest;
+            var quest = _instance.Quest;
 
             if (quest.IsChainTriggered || quest.NextQuest != null)
             {
-                AddRadio(25, 145, 0x25F8, 0x25FB, false, 2);
-                AddHtmlLocalized(60, 150, 280, 20, 1075023, 0x7FFF); // Yes, I want to quit this entire chain!
+                builder.AddRadio(25, 145, 0x25F8, 0x25FB, false, 2);
+                builder.AddHtmlLocalized(60, 150, 280, 20, 1075023, 0x7FFF); // Yes, I want to quit this entire chain!
             }
 
-            AddRadio(25, 180, 0x25F8, 0x25FB, true, 1);
-            AddHtmlLocalized(60, 185, 280, 20, 1049005, 0x7FFF); // Yes, I really want to quit this quest!
+            builder.AddRadio(25, 180, 0x25F8, 0x25FB, true, 1);
+            builder.AddHtmlLocalized(60, 185, 280, 20, 1049005, 0x7FFF); // Yes, I really want to quit this quest!
 
-            AddRadio(25, 215, 0x25F8, 0x25FB, false, 0);
-            AddHtmlLocalized(60, 220, 280, 20, 1049006, 0x7FFF); // No, I don't want to quit.
+            builder.AddRadio(25, 215, 0x25F8, 0x25FB, false, 0);
+            builder.AddHtmlLocalized(60, 220, 280, 20, 1049006, 0x7FFF); // No, I don't want to quit.
 
-            AddButton(265, 220, 0xF7, 0xF8, 7);
+            builder.AddButton(265, 220, 0xF7, 0xF8, 7);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_Instance.Removed)
+            if (_instance.Removed)
             {
                 return;
             }
@@ -89,14 +103,14 @@ namespace Server.Engines.MLQuests.Gumps
                     {
                         if (info.IsSwitched(2))
                         {
-                            m_Instance.Cancel(true);
+                            _instance.Cancel(true);
                         }
                         else if (info.IsSwitched(1))
                         {
-                            m_Instance.Cancel(false);
+                            _instance.Cancel(false);
                         }
 
-                        sender.Mobile.SendGump(new QuestLogGump(m_Instance.Player, m_CloseGumps));
+                        QuestLogGump.DisplayTo(sender.Mobile, _instance.Player, _closeGumps);
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestConversationGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestConversationGump.cs
@@ -1,21 +1,41 @@
+using Server.Gumps;
 using Server.Mobiles;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestConversationGump : BaseQuestGump
+    public class QuestConversationGump : BaseMLQuestGump
     {
-        public QuestConversationGump(MLQuest quest, PlayerMobile pm, TextDefinition text)
+        private readonly TextDefinition _text;
+
+        public override bool Singleton => true;
+
+        private QuestConversationGump(MLQuest quest, TextDefinition text)
             : base(3006156) // Quest Conversation
         {
-            CloseOtherGumps(pm);
+            _text = text;
 
             SetTitle(quest.Title);
             RegisterButton(ButtonPosition.Right, ButtonGraphic.Close, 3);
 
             SetPageCount(1);
+        }
 
-            BuildPage();
-            AddConversation(text);
+        public static void DisplayTo(PlayerMobile pm, MLQuest quest, TextDefinition text)
+        {
+            if (pm?.NetState == null || quest == null)
+            {
+                return;
+            }
+
+            CloseOtherGumps(pm);
+
+            pm.SendGump(new QuestConversationGump(quest, text));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            BuildPage(ref builder);
+            AddConversation(ref builder, _text);
         }
     }
 }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestLogDetailedGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestLogDetailedGump.cs
@@ -3,51 +3,63 @@ using Server.Network;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestLogDetailedGump : BaseQuestGump
+    public class QuestLogDetailedGump : BaseMLQuestGump
     {
-        private readonly bool m_CloseGumps;
-        private readonly MLQuestInstance m_Instance;
+        private readonly bool _closeGumps;
+        private readonly MLQuestInstance _instance;
 
         public override bool Singleton => true;
 
-        public QuestLogDetailedGump(MLQuestInstance instance, bool closeGumps = true)
+        private QuestLogDetailedGump(MLQuestInstance instance, bool closeGumps)
             : base(1046026) // Quest Log
         {
-            m_Instance = instance;
-            m_CloseGumps = closeGumps;
+            _instance = instance;
+            _closeGumps = closeGumps;
 
-            var pm = instance.Player;
-            var quest = instance.Quest;
-
-            if (closeGumps)
-            {
-                CloseOtherGumps(pm);
-            }
-
-            SetTitle(quest.Title);
+            SetTitle(instance.Quest.Title);
             RegisterButton(ButtonPosition.Left, ButtonGraphic.Resign, 1);
             RegisterButton(ButtonPosition.Right, ButtonGraphic.Okay, 2);
 
             SetPageCount(3);
+        }
 
-            BuildPage();
-            AddDescription(quest);
-
-            if (instance.Failed)                                    // only displayed on the first page
+        public static void DisplayTo(Mobile from, MLQuestInstance instance, bool closeGumps = true)
+        {
+            if (from?.NetState == null || instance == null)
             {
-                AddHtmlLocalized(160, 80, 250, 16, 500039, 0x3C00); // Failed!
+                return;
             }
 
-            BuildPage();
-            AddObjectivesProgress(instance);
+            if (closeGumps)
+            {
+                CloseOtherGumps(instance.Player);
+            }
 
-            BuildPage();
-            AddRewardsPage(quest);
+            from.SendGump(new QuestLogDetailedGump(instance, closeGumps));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            var quest = _instance.Quest;
+
+            BuildPage(ref builder);
+            AddDescription(ref builder, quest);
+
+            if (_instance.Failed)                                       // only displayed on the first page
+            {
+                builder.AddHtmlLocalized(160, 80, 250, 16, 500039, 0x3C00); // Failed!
+            }
+
+            BuildPage(ref builder);
+            AddObjectivesProgress(ref builder, _instance);
+
+            BuildPage(ref builder);
+            AddRewardsPage(ref builder, quest);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_Instance.Removed)
+            if (_instance.Removed)
             {
                 return;
             }
@@ -57,17 +69,17 @@ namespace Server.Engines.MLQuests.Gumps
                 case 1: // Resign
                     {
                         // TODO: Custom reward loss protection? OSI doesn't have this
-                        // if (m_Instance.ClaimReward)
+                        // if (_instance.ClaimReward)
                         // pm.SendMessage( "You cannot cancel a quest with rewards pending." );
                         // else
 
-                        sender.Mobile.SendGump(new QuestCancelConfirmGump(m_Instance, m_CloseGumps));
+                        QuestCancelConfirmGump.DisplayTo(sender.Mobile, _instance, _closeGumps);
 
                         break;
                     }
                 case 2: // Okay
                     {
-                        sender.Mobile.SendGump(new QuestLogGump(m_Instance.Player, m_CloseGumps));
+                        QuestLogGump.DisplayTo(sender.Mobile, _instance.Player, _closeGumps);
 
                         break;
                     }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestLogGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestLogGump.cs
@@ -4,33 +4,57 @@ using Server.Network;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestLogGump : BaseQuestGump
+    public class QuestLogGump : BaseMLQuestGump
     {
-        private readonly bool m_CloseGumps;
-        private readonly PlayerMobile m_Owner;
+        private readonly bool _closeGumps;
+        private readonly PlayerMobile _owner;
 
         public override bool Singleton => true;
 
-        public QuestLogGump(PlayerMobile pm, bool closeGumps = true)
+        private QuestLogGump(PlayerMobile pm, bool closeGumps)
             : base(1046026) // Quest Log
         {
-            m_Owner = pm;
-            m_CloseGumps = closeGumps;
+            _owner = pm;
+            _closeGumps = closeGumps;
+
+            RegisterButton(ButtonPosition.Right, ButtonGraphic.Okay, 3);
+
+            SetPageCount(1);
+        }
+
+        public static void DisplayTo(Mobile from, PlayerMobile pm, bool closeGumps = true)
+        {
+            if (from?.NetState == null || pm == null)
+            {
+                return;
+            }
 
             if (closeGumps)
             {
                 pm.CloseGump<QuestLogDetailedGump>();
             }
 
-            RegisterButton(ButtonPosition.Right, ButtonGraphic.Okay, 3);
+            from.SendGump(new QuestLogGump(pm, closeGumps));
+        }
 
-            SetPageCount(1);
+        public static void DisplayTo(PlayerMobile pm)
+        {
+            if (pm?.NetState == null)
+            {
+                return;
+            }
 
-            BuildPage();
+            pm.CloseGump<QuestLogDetailedGump>();
+            pm.SendGump(new QuestLogGump(pm, true));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            BuildPage(ref builder);
 
             int numberColor, stringColor;
 
-            var context = MLQuestSystem.GetContext(pm);
+            var context = MLQuestSystem.GetContext(_owner);
 
             if (context != null)
             {
@@ -49,7 +73,7 @@ namespace Server.Engines.MLQuests.Gumps
                     }
 
                     instances[i].Quest.Title.AddHtmlText(
-                        this,
+                        ref builder,
                         98,
                         140 + 21 * i,
                         270,
@@ -59,7 +83,7 @@ namespace Server.Engines.MLQuests.Gumps
                         numberColor,
                         stringColor
                     );
-                    AddButton(368, 140 + 21 * i, 0x26B0, 0x26B1, 6 + i, GumpButtonType.Reply, 1);
+                    builder.AddButton(368, 140 + 21 * i, 0x26B0, 0x26B1, 6 + i, GumpButtonType.Reply, 1);
                 }
             }
         }
@@ -71,7 +95,7 @@ namespace Server.Engines.MLQuests.Gumps
                 return;
             }
 
-            var context = MLQuestSystem.GetContext(m_Owner);
+            var context = MLQuestSystem.GetContext(_owner);
 
             if (context == null)
             {
@@ -86,7 +110,7 @@ namespace Server.Engines.MLQuests.Gumps
                 return;
             }
 
-            sender.Mobile.SendGump(new QuestLogDetailedGump(instances[index], m_CloseGumps));
+            QuestLogDetailedGump.DisplayTo(sender.Mobile, instances[index], _closeGumps);
         }
     }
 }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestOfferGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestOfferGump.cs
@@ -4,35 +4,48 @@ using Server.Network;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestOfferGump : BaseQuestGump
+    public class QuestOfferGump : BaseMLQuestGump
     {
-        private readonly MLQuest m_Quest;
-        private readonly IQuestGiver m_Quester;
+        private readonly MLQuest _quest;
+        private readonly IQuestGiver _quester;
 
         public override bool Singleton => true;
 
-        public QuestOfferGump(MLQuest quest, IQuestGiver quester, PlayerMobile pm)
+        private QuestOfferGump(MLQuest quest, IQuestGiver quester)
             : base(1049010) // Quest Offer
         {
-            m_Quest = quest;
-            m_Quester = quester;
-
-            CloseOtherGumps(pm);
+            _quest = quest;
+            _quester = quester;
 
             SetTitle(quest.Title);
             RegisterButton(ButtonPosition.Left, ButtonGraphic.Accept, 1);
             RegisterButton(ButtonPosition.Right, ButtonGraphic.Refuse, 2);
 
             SetPageCount(3);
+        }
 
-            BuildPage();
-            AddDescription(quest);
+        public static void DisplayTo(PlayerMobile pm, MLQuest quest, IQuestGiver quester)
+        {
+            if (pm?.NetState == null || quest == null)
+            {
+                return;
+            }
 
-            BuildPage();
-            AddObjectives(quest);
+            CloseOtherGumps(pm);
 
-            BuildPage();
-            AddRewardsPage(quest);
+            pm.SendGump(new QuestOfferGump(quest, quester));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            BuildPage(ref builder);
+            AddDescription(ref builder, _quest);
+
+            BuildPage(ref builder);
+            AddObjectives(ref builder, _quest);
+
+            BuildPage(ref builder);
+            AddRewardsPage(ref builder, _quest);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -46,12 +59,12 @@ namespace Server.Engines.MLQuests.Gumps
             {
                 case 1: // Accept
                     {
-                        m_Quest.OnAccept(m_Quester, pm);
+                        _quest.OnAccept(_quester, pm);
                         break;
                     }
                 case 2: // Refuse
                     {
-                        m_Quest.OnRefuse(m_Quester, pm);
+                        _quest.OnRefuse(_quester, pm);
                         break;
                     }
             }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestReportBackGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestReportBackGump.cs
@@ -3,36 +3,48 @@ using Server.Network;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestReportBackGump : BaseQuestGump
+    public class QuestReportBackGump : BaseMLQuestGump
     {
-        private readonly MLQuestInstance m_Instance;
+        private readonly MLQuestInstance _instance;
 
-        public QuestReportBackGump(MLQuestInstance instance)
+        public override bool Singleton => true;
+
+        private QuestReportBackGump(MLQuestInstance instance)
             : base(3006156) // Quest Conversation
         {
-            m_Instance = instance;
+            _instance = instance;
 
-            var quest = instance.Quest;
-            var pm = instance.Player;
-
-            // TODO: Check close sequence
-            CloseOtherGumps(pm);
-
-            SetTitle(quest.Title);
+            SetTitle(instance.Quest.Title);
             RegisterButton(ButtonPosition.Left, ButtonGraphic.Continue, 4);
             RegisterButton(ButtonPosition.Right, ButtonGraphic.Close, 3);
 
             SetPageCount(1);
+        }
 
-            BuildPage();
-            AddConversation(quest.CompletionMessage);
+        public static void DisplayTo(Mobile from, MLQuestInstance instance)
+        {
+            if (from?.NetState == null || instance == null)
+            {
+                return;
+            }
+
+            // TODO: Check close sequence
+            CloseOtherGumps(instance.Player);
+
+            from.SendGump(new QuestReportBackGump(instance));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            BuildPage(ref builder);
+            AddConversation(ref builder, _instance.Quest.CompletionMessage);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             if (info.ButtonID == 4)
             {
-                m_Instance.ContinueReportBack(true);
+                _instance.ContinueReportBack(true);
             }
         }
     }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/QuestRewardGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/QuestRewardGump.cs
@@ -3,34 +3,46 @@ using Server.Network;
 
 namespace Server.Engines.MLQuests.Gumps
 {
-    public class QuestRewardGump : BaseQuestGump
+    public class QuestRewardGump : BaseMLQuestGump
     {
-        private readonly MLQuestInstance m_Instance;
+        private readonly MLQuestInstance _instance;
 
-        public QuestRewardGump(MLQuestInstance instance)
+        public override bool Singleton => true;
+
+        private QuestRewardGump(MLQuestInstance instance)
             : base(1072201) // Reward
         {
-            m_Instance = instance;
+            _instance = instance;
 
-            var quest = instance.Quest;
-            var pm = instance.Player;
-
-            CloseOtherGumps(pm);
-
-            SetTitle(quest.Title);
+            SetTitle(instance.Quest.Title);
             RegisterButton(ButtonPosition.Left, ButtonGraphic.Accept, 1);
 
             SetPageCount(1);
+        }
 
-            BuildPage();
-            AddRewards(quest);
+        public static void DisplayTo(Mobile from, MLQuestInstance instance)
+        {
+            if (from?.NetState == null || instance == null)
+            {
+                return;
+            }
+
+            CloseOtherGumps(instance.Player);
+
+            from.SendGump(new QuestRewardGump(instance));
+        }
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            BuildPage(ref builder);
+            AddRewards(ref builder, _instance.Quest);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             if (info.ButtonID == 1)
             {
-                m_Instance.ClaimRewards();
+                _instance.ClaimRewards();
             }
         }
     }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/RaceChangeGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/RaceChangeGump.cs
@@ -19,41 +19,54 @@ namespace Server.Engines.MLQuests.Gumps
         void OnCancel(PlayerMobile from);
     }
 
-    public class RaceChangeConfirmGump : Gump
+    public class RaceChangeConfirmGump : DynamicGump
     {
         private static Dictionary<NetState, RaceChangeState> m_Pending;
-        private readonly PlayerMobile m_From;
+        private readonly PlayerMobile _from;
 
-        private readonly IRaceChanger m_Owner;
-        private readonly Race m_Race;
+        private readonly IRaceChanger _owner;
+        private readonly Race _race;
 
         public override bool Singleton => true;
 
-        public RaceChangeConfirmGump(IRaceChanger owner, PlayerMobile from, Race targetRace)
+        private RaceChangeConfirmGump(IRaceChanger owner, PlayerMobile from, Race targetRace)
             : base(50, 50)
         {
-            m_Owner = owner;
-            m_From = from;
-            m_Race = targetRace;
+            _owner = owner;
+            _from = from;
+            _race = targetRace;
+        }
 
-            AddPage(0);
-            AddBackground(0, 0, 240, 135, 0x2422);
-
-            if (targetRace == Race.Human)
+        public static void DisplayTo(PlayerMobile from, IRaceChanger owner, Race targetRace)
+        {
+            if (from?.NetState == null || targetRace == null)
             {
-                AddHtmlLocalized(15, 15, 210, 75, 1073643, 0); // Are you sure you wish to embrace your humanity?
+                return;
             }
-            else if (targetRace == Race.Elf)
+
+            from.SendGump(new RaceChangeConfirmGump(owner, from, targetRace));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
+            builder.AddBackground(0, 0, 240, 135, 0x2422);
+
+            if (_race == Race.Human)
             {
-                AddHtmlLocalized(15, 15, 210, 75, 1073642, 0); // Are you sure you want to follow the elven ways?
+                builder.AddHtmlLocalized(15, 15, 210, 75, 1073643, 0); // Are you sure you wish to embrace your humanity?
+            }
+            else if (_race == Race.Elf)
+            {
+                builder.AddHtmlLocalized(15, 15, 210, 75, 1073642, 0); // Are you sure you want to follow the elven ways?
             }
             else
             {
-                AddHtml(15, 15, 210, 75, $"Are you sure you want to change your race to {targetRace.Name}?");
+                builder.AddHtml(15, 15, 210, 75, $"Are you sure you want to change your race to {_race.Name}?");
             }
 
-            AddButton(160, 95, 0xF7, 0xF8, 1);
-            AddButton(90, 95, 0xF2, 0xF1, 0);
+            builder.AddButton(160, 95, 0xF7, 0xF8, 1);
+            builder.AddButton(90, 95, 0xF2, 0xF1, 0);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -62,15 +75,15 @@ namespace Server.Engines.MLQuests.Gumps
             {
                 case 0: // Cancel
                     {
-                        m_Owner?.OnCancel(m_From);
+                        _owner?.OnCancel(_from);
 
                         break;
                     }
                 case 1: // Okay
                     {
-                        if (m_Owner?.CheckComplete(m_From) != false)
+                        if (_owner?.CheckComplete(_from) != false)
                         {
-                            Offer(m_Owner, m_From, m_Race);
+                            Offer(_owner, _from, _race);
                         }
 
                         break;
@@ -329,7 +342,7 @@ namespace Server.Engines.MLQuests.Gumps
 
             if (CheckComplete(pm))
             {
-                pm.SendGump(new RaceChangeConfirmGump(this, pm, pm.Race == Race.Human ? Race.Elf : Race.Human));
+                RaceChangeConfirmGump.DisplayTo(pm, this, pm.Race == Race.Human ? Race.Elf : Race.Human);
             }
         }
     }

--- a/Projects/UOContent/Engines/ML Quests/Gumps/RaceChangeGump.cs
+++ b/Projects/UOContent/Engines/ML Quests/Gumps/RaceChangeGump.cs
@@ -22,18 +22,15 @@ namespace Server.Engines.MLQuests.Gumps
     public class RaceChangeConfirmGump : DynamicGump
     {
         private static Dictionary<NetState, RaceChangeState> m_Pending;
-        private readonly PlayerMobile _from;
 
         private readonly IRaceChanger _owner;
         private readonly Race _race;
 
         public override bool Singleton => true;
 
-        private RaceChangeConfirmGump(IRaceChanger owner, PlayerMobile from, Race targetRace)
-            : base(50, 50)
+        private RaceChangeConfirmGump(IRaceChanger owner, Race targetRace) : base(50, 50)
         {
             _owner = owner;
-            _from = from;
             _race = targetRace;
         }
 
@@ -44,7 +41,7 @@ namespace Server.Engines.MLQuests.Gumps
                 return;
             }
 
-            from.SendGump(new RaceChangeConfirmGump(owner, from, targetRace));
+            from.SendGump(new RaceChangeConfirmGump(owner, targetRace));
         }
 
         protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -71,19 +68,21 @@ namespace Server.Engines.MLQuests.Gumps
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
+            var from = sender.Mobile;
+
             switch (info.ButtonID)
             {
                 case 0: // Cancel
                     {
-                        _owner?.OnCancel(_from);
+                        _owner?.OnCancel((PlayerMobile)from);
 
                         break;
                     }
                 case 1: // Okay
                     {
-                        if (_owner?.CheckComplete(_from) != false)
+                        if (_owner?.CheckComplete((PlayerMobile)from) != false)
                         {
-                            Offer(_owner, _from, _race);
+                            Offer(_owner, (PlayerMobile)from, _race);
                         }
 
                         break;

--- a/Projects/UOContent/Engines/ML Quests/MLQuest.cs
+++ b/Projects/UOContent/Engines/ML Quests/MLQuest.cs
@@ -184,7 +184,7 @@ namespace Server.Engines.MLQuests
 
         public virtual void SendOffer(IQuestGiver quester, PlayerMobile pm)
         {
-            pm.SendGump(new QuestOfferGump(this, quester, pm));
+            QuestOfferGump.DisplayTo(pm, this, quester);
         }
 
         public virtual void OnAccept(IQuestGiver quester, PlayerMobile pm)
@@ -213,7 +213,7 @@ namespace Server.Engines.MLQuests
 
         public virtual void OnRefuse(IQuestGiver quester, PlayerMobile pm)
         {
-            pm.SendGump(new QuestConversationGump(this, pm, RefusalMessage));
+            QuestConversationGump.DisplayTo(pm, this, RefusalMessage);
         }
 
         public virtual void GetRewards(MLQuestInstance instance)

--- a/Projects/UOContent/Engines/ML Quests/MLQuestEntry.cs
+++ b/Projects/UOContent/Engines/ML Quests/MLQuestEntry.cs
@@ -234,7 +234,7 @@ namespace Server.Engines.MLQuests
 
         public void SendProgressGump()
         {
-            Player.SendGump(new QuestConversationGump(Quest, Player, Quest.InProgressMessage));
+            QuestConversationGump.DisplayTo(Player, Quest, Quest.InProgressMessage);
         }
 
         public void SendRewardOffer()
@@ -260,7 +260,7 @@ namespace Server.Engines.MLQuests
             }
             else
             {
-                Player.SendGump(new QuestRewardGump(this));
+                QuestRewardGump.DisplayTo(Player, this);
             }
         }
 
@@ -272,7 +272,7 @@ namespace Server.Engines.MLQuests
             }
             else
             {
-                Player.SendGump(new QuestReportBackGump(this));
+                QuestReportBackGump.DisplayTo(Player, this);
             }
         }
 

--- a/Projects/UOContent/Engines/ML Quests/MLQuestSystem.cs
+++ b/Projects/UOContent/Engines/ML Quests/MLQuestSystem.cs
@@ -657,7 +657,7 @@ namespace Server.Engines.MLQuests
                 return;
             }
 
-            pm.SendGump(new QuestLogGump(pm));
+            QuestLogGump.DisplayTo(pm);
         }
 
         public static MLQuest RandomStarterQuest(IQuestGiver quester, PlayerMobile pm, MLQuestContext context)
@@ -833,7 +833,7 @@ namespace Server.Engines.MLQuests
                     from,
                     $"{from.AccessLevel} {CommandLogging.Format(from)} viewing quest overview of {CommandLogging.Format(pm)}"
                 );
-                from.SendGump(new QuestLogGump(pm, false));
+                QuestLogGump.DisplayTo(from, pm, false);
             }
         }
 

--- a/Projects/UOContent/Engines/ML Quests/Mobiles/BoonCollector.cs
+++ b/Projects/UOContent/Engines/ML Quests/Mobiles/BoonCollector.cs
@@ -306,7 +306,7 @@ public partial class Darius : DoneQuestCollector
 
     public override void OnComplete(PlayerMobile from)
     {
-        from.SendGump(new RaceChangeConfirmGump(this, from, Race.Elf));
+        RaceChangeConfirmGump.DisplayTo(from, this, Race.Elf);
     }
 }
 
@@ -382,6 +382,6 @@ public partial class Nedrick : DoneQuestCollector
 
     public override void OnComplete(PlayerMobile from)
     {
-        from.SendGump(new RaceChangeConfirmGump(this, from, Race.Human));
+        RaceChangeConfirmGump.DisplayTo(from, this, Race.Human);
     }
 }

--- a/Projects/UOContent/Engines/ML Quests/Mobiles/SirHelper.cs
+++ b/Projects/UOContent/Engines/ML Quests/Mobiles/SirHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using ModernUO.Serialization;
 using Server.Engines.MLQuests.Gumps;
-using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 using Server.Network;
@@ -11,7 +10,6 @@ namespace Server.Engines.MLQuests.Mobiles;
 [SerializationGenerator(0)]
 public partial class SirHelper : Mage
 {
-    private static readonly Gump m_Gump = new InfoNPCGump(1078029, 1078028);
     private static readonly TimeSpan m_ShoutDelay = TimeSpan.FromSeconds(20);
 
     private static readonly TimeSpan
@@ -77,7 +75,7 @@ public partial class SirHelper : Mage
         }
 
         MLQuestSystem.TurnToFace(this, from);
-        from.SendGump(m_Gump);
+        InfoNPCGump.DisplayTo(from, 1078029, 1078028);
 
         // Paperdoll doesn't open
         // base.OnDoubleClick( from );

--- a/Projects/UOContent/Engines/ML Quests/Objectives/BaseObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/BaseObjective.cs
@@ -57,7 +57,7 @@ namespace Server.Engines.MLQuests.Objectives
         public static void WriteTimeRemaining(ref DynamicGumpBuilder builder, ref int y, TimeSpan timeRemaining)
         {
             builder.AddHtmlLocalized(103, y, 120, 16, 1062379, 0x5F90); // Est. time remaining:
-            builder.AddLabel(223, y, 0x481, timeRemaining.TotalSeconds.ToString("F0"));
+            builder.AddLabel(223, y, 0x481, $"{timeRemaining.TotalSeconds:F0}");
             y += 16;
         }
 

--- a/Projects/UOContent/Engines/ML Quests/Objectives/BaseObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/BaseObjective.cs
@@ -11,7 +11,7 @@ namespace Server.Engines.MLQuests.Objectives
 
         public virtual bool CanOffer(IQuestGiver quester, PlayerMobile pm, bool message) => true;
 
-        public abstract void WriteToGump(Gump g, ref int y);
+        public abstract void WriteToGump(ref DynamicGumpBuilder builder, ref int y);
 
         public virtual BaseObjectiveInstance CreateInstance(MLQuestInstance instance) => null;
     }
@@ -46,18 +46,18 @@ namespace Server.Engines.MLQuests.Objectives
 
         public virtual DataType ExtraDataType => DataType.None;
 
-        public virtual void WriteToGump(Gump g, ref int y)
+        public virtual void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
             if (IsTimed)
             {
-                WriteTimeRemaining(g, ref y, Utility.Max(EndTime - Core.Now, TimeSpan.Zero));
+                WriteTimeRemaining(ref builder, ref y, Utility.Max(EndTime - Core.Now, TimeSpan.Zero));
             }
         }
 
-        public static void WriteTimeRemaining(Gump g, ref int y, TimeSpan timeRemaining)
+        public static void WriteTimeRemaining(ref DynamicGumpBuilder builder, ref int y, TimeSpan timeRemaining)
         {
-            g.AddHtmlLocalized(103, y, 120, 16, 1062379, 0x5F90); // Est. time remaining:
-            g.AddLabel(223, y, 0x481, timeRemaining.TotalSeconds.ToString("F0"));
+            builder.AddHtmlLocalized(103, y, 120, 16, 1062379, 0x5F90); // Est. time remaining:
+            builder.AddLabel(223, y, 0x481, timeRemaining.TotalSeconds.ToString("F0"));
             y += 16;
         }
 

--- a/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
@@ -44,34 +44,34 @@ namespace Server.Engines.MLQuests.Objectives
             return label - 1078872;
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
             if (ShowDetailed)
             {
                 var amount = DesiredAmount.ToString();
 
-                g.AddHtmlLocalized(98, y, 350, 16, 1072205, 0x5F90); // Obtain
-                g.AddLabel(143, y, 0x481, amount);
+                builder.AddHtmlLocalized(98, y, 350, 16, 1072205, 0x5F90); // Obtain
+                builder.AddLabel(143, y, 0x481, amount);
 
                 if (Name.Number > 0)
                 {
-                    g.AddHtmlLocalized(143 + amount.Length * 15, y, 190, 18, Name.Number, 0x77BF);
-                    g.AddItem(350, y, LabelToItemID(Name.Number));
+                    builder.AddHtmlLocalized(143 + amount.Length * 15, y, 190, 18, Name.Number, 0x77BF);
+                    builder.AddItem(350, y, LabelToItemID(Name.Number));
                 }
                 else if (Name.String != null)
                 {
-                    g.AddLabel(143 + amount.Length * 15, y, 0x481, Name.String);
+                    builder.AddLabel(143 + amount.Length * 15, y, 0x481, Name.String);
                 }
             }
             else
             {
                 if (Name.Number > 0)
                 {
-                    g.AddHtmlLocalized(98, y, 312, 32, Name.Number, 0x5F90);
+                    builder.AddHtmlLocalized(98, y, 312, 32, Name.Number, 0x5F90);
                 }
                 else if (Name.String != null)
                 {
-                    g.AddLabel(98, y, 0x481, Name.String);
+                    builder.AddLabel(98, y, 0x481, Name.String);
                 }
             }
 
@@ -199,21 +199,21 @@ namespace Server.Engines.MLQuests.Objectives
             // No message
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
-            Objective.WriteToGump(g, ref y);
+            Objective.WriteToGump(ref builder, ref y);
             y -= 16;
 
             if (Objective.ShowDetailed)
             {
-                base.WriteToGump(g, ref y);
+                base.WriteToGump(ref builder, ref y);
 
-                g.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
-                g.AddLabel(223, y, 0x481, GetCurrentTotal().ToString());
+                builder.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
+                builder.AddLabel(223, y, 0x481, GetCurrentTotal().ToString());
                 y += 16;
 
-                g.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to
-                g.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Instance.QuesterType));
+                builder.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to
+                builder.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Instance.QuesterType));
                 y += 16;
             }
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/CollectObjective.cs
@@ -209,7 +209,7 @@ namespace Server.Engines.MLQuests.Objectives
                 base.WriteToGump(ref builder, ref y);
 
                 builder.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
-                builder.AddLabel(223, y, 0x481, GetCurrentTotal().ToString());
+                builder.AddLabel(223, y, 0x481, $"{GetCurrentTotal()}");
                 y += 16;
 
                 builder.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to

--- a/Projects/UOContent/Engines/ML Quests/Objectives/DeliverObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/DeliverObjective.cs
@@ -70,27 +70,27 @@ namespace Server.Engines.MLQuests.Objectives
             }
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
             var amount = Amount.ToString();
 
-            g.AddHtmlLocalized(98, y, 312, 16, 1072207, 0x5F90); // Deliver
-            g.AddLabel(143, y, 0x481, amount);
+            builder.AddHtmlLocalized(98, y, 312, 16, 1072207, 0x5F90); // Deliver
+            builder.AddLabel(143, y, 0x481, amount);
 
             if (Name.Number > 0)
             {
-                g.AddHtmlLocalized(143 + amount.Length * 15, y, 190, 18, Name.Number, 0x77BF);
-                g.AddItem(350, y, CollectObjective.LabelToItemID(Name.Number));
+                builder.AddHtmlLocalized(143 + amount.Length * 15, y, 190, 18, Name.Number, 0x77BF);
+                builder.AddItem(350, y, CollectObjective.LabelToItemID(Name.Number));
             }
             else if (Name.String != null)
             {
-                g.AddLabel(143 + amount.Length * 15, y, 0x481, Name.String);
+                builder.AddLabel(143 + amount.Length * 15, y, 0x481, Name.String);
             }
 
             y += 32;
 
-            g.AddHtmlLocalized(103, y, 120, 16, 1072379, 0x5F90); // Deliver to
-            g.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Destination));
+            builder.AddHtmlLocalized(103, y, 120, 16, 1072379, 0x5F90); // Deliver to
+            builder.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Destination));
 
             y += 16;
         }
@@ -225,11 +225,11 @@ namespace Server.Engines.MLQuests.Objectives
             Instance.Player.SendLocalizedMessage(1074813); // You have failed to complete your delivery.
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
-            Objective.WriteToGump(g, ref y);
+            Objective.WriteToGump(ref builder, ref y);
 
-            base.WriteToGump(g, ref y);
+            base.WriteToGump(ref builder, ref y);
 
             // No extra instance stuff printed for this objective
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/EscortObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/EscortObjective.cs
@@ -63,17 +63,17 @@ namespace Server.Engines.MLQuests.Objectives
             return true;
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
-            g.AddHtmlLocalized(98, y, 312, 16, 1072206, 0x5F90); // Escort to
+            builder.AddHtmlLocalized(98, y, 312, 16, 1072206, 0x5F90); // Escort to
 
             if (Destination.Name.Number > 0)
             {
-                g.AddHtmlLocalized(173, y, 312, 20, Destination.Name.Number, 0x7FFF);
+                builder.AddHtmlLocalized(173, y, 312, 20, Destination.Name.Number, 0x7FFF);
             }
             else if (Destination.Name.String != null)
             {
-                g.AddLabel(173, y, 0x481, Destination.Name.String);
+                builder.AddLabel(173, y, 0x481, Destination.Name.String);
             }
 
             y += 16;
@@ -275,11 +275,11 @@ namespace Server.Engines.MLQuests.Objectives
             Abandon();
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
-            m_Objective.WriteToGump(g, ref y);
+            m_Objective.WriteToGump(ref builder, ref y);
 
-            base.WriteToGump(g, ref y);
+            base.WriteToGump(ref builder, ref y);
 
             // No extra instance stuff printed for this objective
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/GainSkillObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/GainSkillObjective.cs
@@ -68,12 +68,12 @@ namespace Server.Engines.MLQuests.Objectives
             return true;
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
             var skillLabel = AosSkillBonuses.GetLabel(Skill);
             var args = $"#{skillLabel}\t{ThresholdFixed / 10.0:0.#}";
 
-            g.AddHtmlLocalized(98, y, 312, 16, 1077485, args, 0x5F90); // Increase ~1_SKILL~ to ~2_VALUE~
+            builder.AddHtmlLocalized(98, y, 312, 16, 1077485, args, 0x5F90); // Increase ~1_SKILL~ to ~2_VALUE~
             y += 16;
         }
 
@@ -150,15 +150,15 @@ namespace Server.Engines.MLQuests.Objectives
             OnQuestCancelled();
         }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
-            Objective.WriteToGump(g, ref y);
+            Objective.WriteToGump(ref builder, ref y);
 
-            base.WriteToGump(g, ref y);
+            base.WriteToGump(ref builder, ref y);
 
             if (IsCompleted())
             {
-                g.AddHtmlLocalized(113, y, 312, 20, 1055121, 0x7FFF); // Complete
+                builder.AddHtmlLocalized(113, y, 312, 20, 1055121, 0x7FFF); // Complete
                 y += 16;
             }
         }

--- a/Projects/UOContent/Engines/ML Quests/Objectives/KillObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/KillObjective.cs
@@ -23,35 +23,35 @@ namespace Server.Engines.MLQuests.Objectives
 
         public QuestArea Area { get; set; }
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
             var amount = DesiredAmount.ToString();
 
-            g.AddHtmlLocalized(98, y, 312, 16, 1072204, 0x5F90); // Slay
-            g.AddLabel(133, y, 0x481, amount);
+            builder.AddHtmlLocalized(98, y, 312, 16, 1072204, 0x5F90); // Slay
+            builder.AddLabel(133, y, 0x481, amount);
 
             if (Name.Number > 0)
             {
-                g.AddHtmlLocalized(133 + amount.Length * 15, y, 190, 18, Name.Number, 0x77BF);
+                builder.AddHtmlLocalized(133 + amount.Length * 15, y, 190, 18, Name.Number, 0x77BF);
             }
             else if (Name.String != null)
             {
-                g.AddLabel(133 + amount.Length * 15, y, 0x481, Name.String);
+                builder.AddLabel(133 + amount.Length * 15, y, 0x481, Name.String);
             }
 
             y += 16;
 
             if (Area != null)
             {
-                g.AddHtmlLocalized(103, y, 312, 20, 1018327, 0x5F90); // Location
+                builder.AddHtmlLocalized(103, y, 312, 20, 1018327, 0x5F90); // Location
 
                 if (Area.Name.Number > 0)
                 {
-                    g.AddHtmlLocalized(223, y, 312, 20, Area.Name.Number, 0x7FFF);
+                    builder.AddHtmlLocalized(223, y, 312, 20, Area.Name.Number, 0x7FFF);
                 }
                 else if (Area.Name.String != null)
                 {
-                    g.AddLabel(223, y, 0x481, Area.Name.String);
+                    builder.AddLabel(223, y, 0x481, Area.Name.String);
                 }
 
                 y += 16;
@@ -121,18 +121,18 @@ namespace Server.Engines.MLQuests.Objectives
 
         public override bool IsCompleted() => Slain >= Objective.DesiredAmount;
 
-        public override void WriteToGump(Gump g, ref int y)
+        public override void WriteToGump(ref DynamicGumpBuilder builder, ref int y)
         {
-            Objective.WriteToGump(g, ref y);
+            Objective.WriteToGump(ref builder, ref y);
 
-            base.WriteToGump(g, ref y);
+            base.WriteToGump(ref builder, ref y);
 
-            g.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
-            g.AddLabel(223, y, 0x481, Slain.ToString());
+            builder.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
+            builder.AddLabel(223, y, 0x481, Slain.ToString());
             y += 16;
 
-            g.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to
-            g.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Instance.QuesterType));
+            builder.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to
+            builder.AddLabel(223, y, 0x481, QuesterNameAttribute.GetQuesterNameFor(Instance.QuesterType));
             y += 16;
         }
 

--- a/Projects/UOContent/Engines/ML Quests/Objectives/KillObjective.cs
+++ b/Projects/UOContent/Engines/ML Quests/Objectives/KillObjective.cs
@@ -128,7 +128,7 @@ namespace Server.Engines.MLQuests.Objectives
             base.WriteToGump(ref builder, ref y);
 
             builder.AddHtmlLocalized(103, y, 120, 16, 3000087, 0x5F90); // Total
-            builder.AddLabel(223, y, 0x481, Slain.ToString());
+            builder.AddLabel(223, y, 0x481, $"{Slain}");
             y += 16;
 
             builder.AddHtmlLocalized(103, y, 120, 16, 1074782, 0x5F90); // Return to

--- a/Projects/UOContent/Engines/ML Quests/Rewards/BaseReward.cs
+++ b/Projects/UOContent/Engines/ML Quests/Rewards/BaseReward.cs
@@ -12,9 +12,9 @@ namespace Server.Engines.MLQuests.Rewards
 
         protected virtual int LabelHeight => 16;
 
-        public void WriteToGump(Gump g, int x, ref int y)
+        public void WriteToGump(ref DynamicGumpBuilder builder, int x, ref int y)
         {
-            Name.AddHtmlText(g, x, y, 280, LabelHeight, false, false, 0x5F90, 0xBDE784);
+            Name.AddHtmlText(ref builder, x, y, 280, LabelHeight, false, false, 0x5F90, 0xBDE784);
         }
 
         public abstract void AddRewardItems(PlayerMobile pm, List<Item> rewards);

--- a/Projects/UOContent/Engines/Quests/Ambitious Solen Queen/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Ambitious Solen Queen/Objectives.cs
@@ -1,3 +1,4 @@
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -9,12 +10,12 @@ namespace Server.Engines.Quests.Ambitious
 
         public override int MaxProgress => 5;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Red/Black Solen Queens killed:
-                gump.AddHtmlLocalized(
+                builder.AddHtmlLocalized(
                     70,
                     260,
                     270,
@@ -22,13 +23,13 @@ namespace Server.Engines.Quests.Ambitious
                     ((AmbitiousQueenQuest)System).RedSolen ? 1054064 : 1054065,
                     BaseQuestGump.Blue
                 );
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Ambitious Solen Queen/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Ambitious Solen Queen/Objectives.cs
@@ -23,9 +23,9 @@ namespace Server.Engines.Quests.Ambitious
                     ((AmbitiousQueenQuest)System).RedSolen ? 1054064 : 1054065,
                     BaseQuestGump.Blue
                 );
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
-                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(130, 280, 0x64, $"{MaxProgress}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Collector/Items/PaintedImage.cs
+++ b/Projects/UOContent/Engines/Quests/Collector/Items/PaintedImage.cs
@@ -40,19 +40,37 @@ public partial class PaintedImage : Item
             return;
         }
 
-        from.SendGump(new InternalGump(_image));
+        PaintedImageGump.DisplayTo(from, _image);
+    }
+}
+
+public class PaintedImageGump : DynamicGump
+{
+    private readonly ImageType _image;
+
+    public override bool Singleton => true;
+
+    private PaintedImageGump(ImageType image) : base(75, 25) => _image = image;
+
+    public static void DisplayTo(Mobile from, ImageType image)
+    {
+        if (from?.NetState == null)
+        {
+            return;
+        }
+
+        from.SendGump(new PaintedImageGump(image));
     }
 
-    private class InternalGump : Gump
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
     {
-        public InternalGump(ImageType image) : base(75, 25)
-        {
-            var info = ImageTypeInfo.Get(image);
+        builder.AddPage();
 
-            AddBackground(45, 20, 100, 100, 0xA3C);
-            AddBackground(52, 29, 86, 82, 0xBB8);
+        var info = ImageTypeInfo.Get(_image);
 
-            AddItem(info.X, info.Y, info.Figurine);
-        }
+        builder.AddBackground(45, 20, 100, 100, 0xA3C);
+        builder.AddBackground(52, 29, 86, 82, 0xBB8);
+
+        builder.AddItem(info.X, info.Y, info.Figurine);
     }
 }

--- a/Projects/UOContent/Engines/Quests/Collector/Mobiles/Impresario.cs
+++ b/Projects/UOContent/Engines/Quests/Collector/Mobiles/Impresario.cs
@@ -55,7 +55,7 @@ public partial class Impresario : BaseQuester
 
             if (obj.IsInRightTheater())
             {
-                player.SendGump(new SheetMusicOfferGump());
+                SheetMusicOfferGump.DisplayTo(player);
             }
             else
             {
@@ -69,44 +69,60 @@ public class SheetMusicOfferGump : BaseQuestGump
 {
     public override bool Singleton => true;
 
-    public SheetMusicOfferGump() : base(75, 25)
+    private SheetMusicOfferGump() : base(75, 25)
     {
-        Closable = false;
+    }
 
-        AddImage(349, 10, 0x24B0);
-        AddImageTiled(349, 130, 100, 120, 0x24B3);
-        AddImageTiled(149, 10, 200, 140, 0x24AF);
-        AddImageTiled(149, 300, 200, 140, 0x24B5);
-        AddImage(349, 300, 0x24B6);
-        AddImage(35, 10, 0x24AE);
-        AddImageTiled(35, 150, 120, 100, 0x24B1);
-        AddImage(35, 300, 0x24B4);
+    public static void DisplayTo(Mobile from)
+    {
+        if (from?.NetState == null)
+        {
+            return;
+        }
 
-        AddHtmlLocalized(110, 60, 200, 20, 1049069, White); // <STRONG>Conversation Event</STRONG>
+        from.SendGump(new SheetMusicOfferGump());
+    }
 
-        AddImage(65, 14, 0x2776);
-        AddImageTiled(81, 14, 349, 17, 0x2775);
-        AddImage(426, 14, 0x2778);
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.SetNoClose();
 
-        AddImageTiled(50, 37, 400, 376, 0xA40);
-        AddAlphaRegion(50, 37, 400, 376);
+        builder.AddPage();
 
-        AddImage(0, 0, 0x28C8);
+        builder.AddImage(349, 10, 0x24B0);
+        builder.AddImageTiled(349, 130, 100, 120, 0x24B3);
+        builder.AddImageTiled(149, 10, 200, 140, 0x24AF);
+        builder.AddImageTiled(149, 300, 200, 140, 0x24B5);
+        builder.AddImage(349, 300, 0x24B6);
+        builder.AddImage(35, 10, 0x24AE);
+        builder.AddImageTiled(35, 150, 120, 100, 0x24B1);
+        builder.AddImage(35, 300, 0x24B4);
 
-        AddImageTiled(75, 90, 200, 1, 0x238D);
-        AddImage(75, 58, 0x2635);
-        AddImage(380, 45, 0xDF);
+        builder.AddHtmlLocalized(110, 60, 200, 20, 1049069, White); // <STRONG>Conversation Event</STRONG>
+
+        builder.AddImage(65, 14, 0x2776);
+        builder.AddImageTiled(81, 14, 349, 17, 0x2775);
+        builder.AddImage(426, 14, 0x2778);
+
+        builder.AddImageTiled(50, 37, 400, 376, 0xA40);
+        builder.AddAlphaRegion(50, 37, 400, 376);
+
+        builder.AddImage(0, 0, 0x28C8);
+
+        builder.AddImageTiled(75, 90, 200, 1, 0x238D);
+        builder.AddImage(75, 58, 0x2635);
+        builder.AddImage(380, 45, 0xDF);
 
         // Sure, I have some sheet music for a Gabriel Piete song. I'd be happy to sell you a copy for 10 gold.
-        AddHtmlLocalized(98, 140, 312, 200, 1055107, LightGreen, false, true);
+        builder.AddHtmlLocalized(98, 140, 312, 200, 1055107, LightGreen, false, true);
 
-        AddRadio(85, 350, 0x25F8, 0x25FB, true, 1);
-        AddHtmlLocalized(120, 356, 280, 20, 1014088, White); // I accept.
+        builder.AddRadio(85, 350, 0x25F8, 0x25FB, true, 1);
+        builder.AddHtmlLocalized(120, 356, 280, 20, 1014088, White); // I accept.
 
-        AddRadio(85, 385, 0x25F8, 0x25FB, false, 0);
-        AddHtmlLocalized(120, 391, 280, 20, 1049012, White); // No thanks, I decline.
+        builder.AddRadio(85, 385, 0x25F8, 0x25FB, false, 0);
+        builder.AddHtmlLocalized(120, 391, 280, 20, 1049012, White); // No thanks, I decline.
 
-        AddButton(340, 390, 0xF7, 0xF8, 1);
+        builder.AddButton(340, 390, 0xF7, 0xF8, 1);
     }
 
     public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Engines/Quests/Collector/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Collector/Objectives.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Gumps;
 
 namespace Server.Engines.Quests.Collector
 {
@@ -8,20 +9,20 @@ namespace Server.Engines.Quests.Collector
 
         public override int MaxProgress => 6;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Rainbow pearls collected:
-                gump.AddHtmlObject(70, 260, 270, 100, 1055085, BaseQuestGump.Blue, false, false);
+                BaseQuestGump.AddHtmlObject(ref builder, 70, 260, 270, 100, 1055085, BaseQuestGump.Blue, false, false);
 
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 
@@ -311,7 +312,7 @@ namespace Server.Engines.Quests.Collector
             return CaptureResponse.Invalid;
         }
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
@@ -319,9 +320,10 @@ namespace Server.Engines.Quests.Collector
                 {
                     var info = ImageTypeInfo.Get(m_Images[i]);
 
-                    gump.AddHtmlObject(70, 260 + 20 * i, 200, 100, info.Name, BaseQuestGump.Blue, false, false);
-                    gump.AddLabel(200, 260 + 20 * i, 0x64, " : ");
-                    gump.AddHtmlObject(
+                    BaseQuestGump.AddHtmlObject(ref builder, 70, 260 + 20 * i, 200, 100, info.Name, BaseQuestGump.Blue, false, false);
+                    builder.AddLabel(200, 260 + 20 * i, 0x64, " : ");
+                    BaseQuestGump.AddHtmlObject(
+                        ref builder,
                         220,
                         260 + 20 * i,
                         100,
@@ -335,7 +337,7 @@ namespace Server.Engines.Quests.Collector
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Collector/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Collector/Objectives.cs
@@ -16,9 +16,9 @@ namespace Server.Engines.Quests.Collector
                 // Rainbow pearls collected:
                 BaseQuestGump.AddHtmlObject(ref builder, 70, 260, 270, 100, 1055085, BaseQuestGump.Blue, false, false);
 
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
-                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(130, 280, 0x64, $"{MaxProgress}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Core/QuestConversation.cs
+++ b/Projects/UOContent/Engines/Quests/Core/QuestConversation.cs
@@ -58,74 +58,91 @@ namespace Server.Engines.Quests
 
     public class QuestConversationsGump : BaseQuestGump
     {
-        private readonly List<QuestConversation> m_Conversations;
+        private readonly List<QuestConversation> _conversations;
 
-        public QuestConversationsGump(QuestConversation conv) : this(new List<QuestConversation> { conv })
+        private QuestConversationsGump(List<QuestConversation> conversations) : base(30, 50) =>
+            _conversations = conversations;
+
+        public static void DisplayTo(Mobile from, QuestConversation conv)
         {
+            if (from?.NetState == null || conv == null)
+            {
+                return;
+            }
+
+            from.SendGump(new QuestConversationsGump(new List<QuestConversation> { conv }));
         }
 
-        public QuestConversationsGump(List<QuestConversation> conversations) : base(30, 50)
+        public static void DisplayTo(Mobile from, List<QuestConversation> conversations)
         {
-            m_Conversations = conversations;
-
-            Closable = false;
-
-            AddPage(0);
-
-            AddImage(349, 10, 9392);
-            AddImageTiled(349, 130, 100, 120, 9395);
-            AddImageTiled(149, 10, 200, 140, 9391);
-            AddImageTiled(149, 250, 200, 140, 9397);
-            AddImage(349, 250, 9398);
-            AddImage(35, 10, 9390);
-            AddImageTiled(35, 150, 120, 100, 9393);
-            AddImage(35, 250, 9396);
-
-            AddHtmlLocalized(110, 60, 200, 20, 1049069, White); // <STRONG>Conversation Event</STRONG>
-
-            AddImage(65, 14, 10102);
-            AddImageTiled(81, 14, 349, 17, 10101);
-            AddImage(426, 14, 10104);
-
-            AddImageTiled(55, 40, 388, 323, 2624);
-            AddAlphaRegion(55, 40, 388, 323);
-
-            AddImageTiled(75, 90, 200, 1, 9101);
-            AddImage(75, 58, 9781);
-            AddImage(380, 45, 223);
-
-            AddButton(220, 335, 2313, 2312, 1);
-            AddImage(0, 0, 10440);
-
-            AddPage(1);
-
-            for (var i = 0; i < conversations.Count; ++i)
+            if (from?.NetState == null || conversations == null || conversations.Count == 0)
             {
-                var conv = conversations[conversations.Count - 1 - i];
+                return;
+            }
+
+            from.SendGump(new QuestConversationsGump(conversations));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoClose();
+
+            builder.AddPage();
+
+            builder.AddImage(349, 10, 9392);
+            builder.AddImageTiled(349, 130, 100, 120, 9395);
+            builder.AddImageTiled(149, 10, 200, 140, 9391);
+            builder.AddImageTiled(149, 250, 200, 140, 9397);
+            builder.AddImage(349, 250, 9398);
+            builder.AddImage(35, 10, 9390);
+            builder.AddImageTiled(35, 150, 120, 100, 9393);
+            builder.AddImage(35, 250, 9396);
+
+            builder.AddHtmlLocalized(110, 60, 200, 20, 1049069, White); // <STRONG>Conversation Event</STRONG>
+
+            builder.AddImage(65, 14, 10102);
+            builder.AddImageTiled(81, 14, 349, 17, 10101);
+            builder.AddImage(426, 14, 10104);
+
+            builder.AddImageTiled(55, 40, 388, 323, 2624);
+            builder.AddAlphaRegion(55, 40, 388, 323);
+
+            builder.AddImageTiled(75, 90, 200, 1, 9101);
+            builder.AddImage(75, 58, 9781);
+            builder.AddImage(380, 45, 223);
+
+            builder.AddButton(220, 335, 2313, 2312, 1);
+            builder.AddImage(0, 0, 10440);
+
+            builder.AddPage(1);
+
+            for (var i = 0; i < _conversations.Count; ++i)
+            {
+                var conv = _conversations[_conversations.Count - 1 - i];
 
                 if (i > 0)
                 {
-                    AddButton(65, 366, 9909, 9911, 0, GumpButtonType.Page, 1 + i);
-                    AddHtmlLocalized(90, 367, 50, 20, 1043354, Black); // Previous
+                    builder.AddButton(65, 366, 9909, 9911, 0, GumpButtonType.Page, 1 + i);
+                    builder.AddHtmlLocalized(90, 367, 50, 20, 1043354, Black); // Previous
 
-                    AddPage(1 + i);
+                    builder.AddPage(1 + i);
                 }
 
-                AddHtmlObject(70, 110, 365, 220, conv.Message, LightGreen, false, true);
+                AddHtmlObject(ref builder, 70, 110, 365, 220, conv.Message, LightGreen, false, true);
 
                 if (i > 0)
                 {
-                    AddButton(420, 366, 9903, 9905, 0, GumpButtonType.Page, i);
-                    AddHtmlLocalized(370, 367, 50, 20, 1043353, Black); // Next
+                    builder.AddButton(420, 366, 9903, 9905, 0, GumpButtonType.Page, i);
+                    builder.AddHtmlLocalized(370, 367, 50, 20, 1043353, Black); // Next
                 }
             }
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            for (var i = m_Conversations.Count - 1; i >= 0; --i)
+            for (var i = _conversations.Count - 1; i >= 0; --i)
             {
-                var qc = m_Conversations[i];
+                var qc = _conversations[i];
 
                 if (!qc.HasBeenRead)
                 {

--- a/Projects/UOContent/Engines/Quests/Core/QuestItemInfo.cs
+++ b/Projects/UOContent/Engines/Quests/Core/QuestItemInfo.cs
@@ -1,3 +1,5 @@
+using Server.Gumps;
+
 namespace Server.Engines.Quests
 {
     public class QuestItemInfo
@@ -15,42 +17,56 @@ namespace Server.Engines.Quests
 
     public class QuestItemInfoGump : BaseQuestGump
     {
-        public QuestItemInfoGump(QuestItemInfo[] info) : base(485, 75)
+        private readonly QuestItemInfo[] _info;
+
+        private QuestItemInfoGump(QuestItemInfo[] info) : base(485, 75) => _info = info;
+
+        public static void DisplayTo(Mobile from, QuestItemInfo[] info)
         {
-            var height = 100 + info.Length * 75;
-
-            AddPage(0);
-
-            AddBackground(5, 10, 145, height, 5054);
-
-            AddImageTiled(13, 20, 125, 10, 2624);
-            AddAlphaRegion(13, 20, 125, 10);
-
-            AddImageTiled(13, height - 10, 128, 10, 2624);
-            AddAlphaRegion(13, height - 10, 128, 10);
-
-            AddImageTiled(13, 20, 10, height - 30, 2624);
-            AddAlphaRegion(13, 20, 10, height - 30);
-
-            AddImageTiled(131, 20, 10, height - 30, 2624);
-            AddAlphaRegion(131, 20, 10, height - 30);
-
-            AddHtmlLocalized(67, 35, 120, 20, 1011233, White); // INFO
-
-            AddImage(62, 52, 9157);
-            AddImage(72, 52, 9157);
-            AddImage(82, 52, 9157);
-
-            AddButton(25, 31, 1209, 1210, 777);
-
-            AddPage(1);
-
-            for (var i = 0; i < info.Length; ++i)
+            if (from?.NetState == null || info == null || info.Length == 0)
             {
-                var cur = info[i];
+                return;
+            }
 
-                AddHtmlObject(25, 65 + i * 75, 110, 20, cur.Name, 1153, false, false);
-                AddItem(45, 85 + i * 75, cur.ItemID);
+            from.SendGump(new QuestItemInfoGump(info));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            var height = 100 + _info.Length * 75;
+
+            builder.AddPage();
+
+            builder.AddBackground(5, 10, 145, height, 5054);
+
+            builder.AddImageTiled(13, 20, 125, 10, 2624);
+            builder.AddAlphaRegion(13, 20, 125, 10);
+
+            builder.AddImageTiled(13, height - 10, 128, 10, 2624);
+            builder.AddAlphaRegion(13, height - 10, 128, 10);
+
+            builder.AddImageTiled(13, 20, 10, height - 30, 2624);
+            builder.AddAlphaRegion(13, 20, 10, height - 30);
+
+            builder.AddImageTiled(131, 20, 10, height - 30, 2624);
+            builder.AddAlphaRegion(131, 20, 10, height - 30);
+
+            builder.AddHtmlLocalized(67, 35, 120, 20, 1011233, White); // INFO
+
+            builder.AddImage(62, 52, 9157);
+            builder.AddImage(72, 52, 9157);
+            builder.AddImage(82, 52, 9157);
+
+            builder.AddButton(25, 31, 1209, 1210, 777);
+
+            builder.AddPage(1);
+
+            for (var i = 0; i < _info.Length; ++i)
+            {
+                var cur = _info[i];
+
+                AddHtmlObject(ref builder, 25, 65 + i * 75, 110, 20, cur.Name, 1153, false, false);
+                builder.AddItem(45, 85 + i * 75, cur.ItemID);
             }
         }
     }

--- a/Projects/UOContent/Engines/Quests/Core/QuestObjective.cs
+++ b/Projects/UOContent/Engines/Quests/Core/QuestObjective.cs
@@ -84,14 +84,24 @@ namespace Server.Engines.Quests
             CurProgress = MaxProgress;
         }
 
-        public virtual void RenderMessage(BaseQuestGump gump)
+        public virtual void RenderMessage(ref DynamicGumpBuilder builder)
         {
-            gump.AddHtmlObject(70, 130, 300, 100, Message, BaseQuestGump.Blue, false, false);
+            BaseQuestGump.AddHtmlObject(ref builder, 70, 130, 300, 100, Message, BaseQuestGump.Blue, false, false);
         }
 
-        public virtual void RenderProgress(BaseQuestGump gump)
+        public virtual void RenderProgress(ref DynamicGumpBuilder builder)
         {
-            gump.AddHtmlObject(70, 260, 270, 100, Completed ? 1049077 : 1049078, BaseQuestGump.Blue, false, false);
+            BaseQuestGump.AddHtmlObject(
+                ref builder,
+                70,
+                260,
+                270,
+                100,
+                Completed ? 1049077 : 1049078,
+                BaseQuestGump.Blue,
+                false,
+                false
+            );
         }
 
         public virtual void CheckCompletionStatus()
@@ -128,116 +138,142 @@ namespace Server.Engines.Quests
 
     public class QuestLogUpdatedGump : BaseQuestGump
     {
-        private readonly QuestSystem m_System;
+        private readonly QuestSystem _system;
 
         public override bool Singleton => true;
 
-        public QuestLogUpdatedGump(QuestSystem system) : base(3, 30)
+        private QuestLogUpdatedGump(QuestSystem system) : base(3, 30) => _system = system;
+
+        public static void DisplayTo(Mobile from, QuestSystem system)
         {
-            m_System = system;
+            if (from?.NetState == null || system == null)
+            {
+                return;
+            }
 
-            AddPage(0);
+            from.SendGump(new QuestLogUpdatedGump(system));
+        }
 
-            AddImage(20, 5, 1417);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddHtmlLocalized(0, 78, 120, 40, 1049079, White); // Quest Log Updated
+            builder.AddImage(20, 5, 1417);
 
-            AddImageTiled(0, 78, 120, 40, 2624);
-            AddAlphaRegion(0, 78, 120, 40);
+            builder.AddHtmlLocalized(0, 78, 120, 40, 1049079, White); // Quest Log Updated
 
-            AddButton(30, 15, 5575, 5576, 1);
+            builder.AddImageTiled(0, 78, 120, 40, 2624);
+            builder.AddAlphaRegion(0, 78, 120, 40);
+
+            builder.AddButton(30, 15, 5575, 5576, 1);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             if (info.ButtonID == 1)
             {
-                m_System.ShowQuestLog();
+                _system.ShowQuestLog();
             }
         }
     }
 
     public class QuestObjectivesGump : BaseQuestGump
     {
-        private readonly List<QuestObjective> m_Objectives;
+        private readonly List<QuestObjective> _objectives;
 
-        public QuestObjectivesGump(QuestObjective obj) : this(new List<QuestObjective> { obj })
+        private QuestObjectivesGump(List<QuestObjective> objectives) : base(90, 50) => _objectives = objectives;
+
+        public static void DisplayTo(Mobile from, QuestObjective obj)
         {
+            if (from?.NetState == null || obj == null)
+            {
+                return;
+            }
+
+            from.SendGump(new QuestObjectivesGump(new List<QuestObjective> { obj }));
         }
 
-        public QuestObjectivesGump(List<QuestObjective> objectives) : base(90, 50)
+        public static void DisplayTo(Mobile from, List<QuestObjective> objectives)
         {
-            m_Objectives = objectives;
-
-            Closable = false;
-
-            AddPage(0);
-
-            AddImage(0, 0, 3600);
-            AddImageTiled(0, 14, 15, 375, 3603);
-            AddImageTiled(380, 14, 14, 375, 3605);
-            AddImage(0, 376, 3606);
-            AddImageTiled(15, 376, 370, 16, 3607);
-            AddImageTiled(15, 0, 370, 16, 3601);
-            AddImage(380, 0, 3602);
-            AddImage(380, 376, 3608);
-
-            AddImageTiled(15, 15, 365, 365, 2624);
-            AddAlphaRegion(15, 15, 365, 365);
-
-            AddImage(20, 87, 1231);
-            AddImage(75, 62, 9307);
-
-            AddHtmlLocalized(117, 35, 230, 20, 1046026, Blue); // Quest Log
-
-            AddImage(77, 33, 9781);
-            AddImage(65, 110, 2104);
-
-            AddHtmlLocalized(79, 106, 230, 20, 1049073, Blue); // Objective:
-
-            AddImageTiled(68, 125, 120, 1, 9101);
-            AddImage(65, 240, 2104);
-
-            AddHtmlLocalized(79, 237, 230, 20, 1049076, Blue); // Progress details:
-
-            AddImageTiled(68, 255, 120, 1, 9101);
-            AddButton(175, 355, 2313, 2312, 1);
-
-            AddImage(341, 15, 10450);
-            AddImage(341, 330, 10450);
-            AddImage(15, 330, 10450);
-            AddImage(15, 15, 10450);
-
-            AddPage(1);
-
-            for (var i = 0; i < objectives.Count; ++i)
+            if (from?.NetState == null || objectives == null || objectives.Count == 0)
             {
-                var obj = objectives[objectives.Count - 1 - i];
+                return;
+            }
+
+            from.SendGump(new QuestObjectivesGump(objectives));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoClose();
+
+            builder.AddPage();
+
+            builder.AddImage(0, 0, 3600);
+            builder.AddImageTiled(0, 14, 15, 375, 3603);
+            builder.AddImageTiled(380, 14, 14, 375, 3605);
+            builder.AddImage(0, 376, 3606);
+            builder.AddImageTiled(15, 376, 370, 16, 3607);
+            builder.AddImageTiled(15, 0, 370, 16, 3601);
+            builder.AddImage(380, 0, 3602);
+            builder.AddImage(380, 376, 3608);
+
+            builder.AddImageTiled(15, 15, 365, 365, 2624);
+            builder.AddAlphaRegion(15, 15, 365, 365);
+
+            builder.AddImage(20, 87, 1231);
+            builder.AddImage(75, 62, 9307);
+
+            builder.AddHtmlLocalized(117, 35, 230, 20, 1046026, Blue); // Quest Log
+
+            builder.AddImage(77, 33, 9781);
+            builder.AddImage(65, 110, 2104);
+
+            builder.AddHtmlLocalized(79, 106, 230, 20, 1049073, Blue); // Objective:
+
+            builder.AddImageTiled(68, 125, 120, 1, 9101);
+            builder.AddImage(65, 240, 2104);
+
+            builder.AddHtmlLocalized(79, 237, 230, 20, 1049076, Blue); // Progress details:
+
+            builder.AddImageTiled(68, 255, 120, 1, 9101);
+            builder.AddButton(175, 355, 2313, 2312, 1);
+
+            builder.AddImage(341, 15, 10450);
+            builder.AddImage(341, 330, 10450);
+            builder.AddImage(15, 330, 10450);
+            builder.AddImage(15, 15, 10450);
+
+            builder.AddPage(1);
+
+            for (var i = 0; i < _objectives.Count; ++i)
+            {
+                var obj = _objectives[_objectives.Count - 1 - i];
 
                 if (i > 0)
                 {
-                    AddButton(55, 346, 9909, 9911, 0, GumpButtonType.Page, 1 + i);
-                    AddHtmlLocalized(82, 347, 50, 20, 1043354, White); // Previous
+                    builder.AddButton(55, 346, 9909, 9911, 0, GumpButtonType.Page, 1 + i);
+                    builder.AddHtmlLocalized(82, 347, 50, 20, 1043354, White); // Previous
 
-                    AddPage(1 + i);
+                    builder.AddPage(1 + i);
                 }
 
-                obj.RenderMessage(this);
-                obj.RenderProgress(this);
+                obj.RenderMessage(ref builder);
+                obj.RenderProgress(ref builder);
 
                 if (i > 0)
                 {
-                    AddButton(317, 346, 9903, 9905, 0, GumpButtonType.Page, i);
-                    AddHtmlLocalized(278, 347, 50, 20, 1043353, White); // Next
+                    builder.AddButton(317, 346, 9903, 9905, 0, GumpButtonType.Page, i);
+                    builder.AddHtmlLocalized(278, 347, 50, 20, 1043353, White); // Next
                 }
             }
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            for (var i = m_Objectives.Count - 1; i >= 0; --i)
+            for (var i = _objectives.Count - 1; i >= 0; --i)
             {
-                var obj = m_Objectives[i];
+                var obj = _objectives[i];
 
                 if (!obj.HasBeenRead)
                 {

--- a/Projects/UOContent/Engines/Quests/Core/QuestSystem.cs
+++ b/Projects/UOContent/Engines/Quests/Core/QuestSystem.cs
@@ -244,7 +244,7 @@ namespace Server.Engines.Quests
 
         public virtual void SendOffer()
         {
-            From.SendGump(new QuestOfferGump(this));
+            QuestOfferGump.DisplayTo(From, this);
         }
 
         public virtual void GetContextMenuEntries(ref PooledRefList<ContextMenuEntry> list)
@@ -264,7 +264,7 @@ namespace Server.Engines.Quests
 
         public virtual void ShowQuestLogUpdated()
         {
-            From.SendGump(new QuestLogUpdatedGump(this));
+            QuestLogUpdatedGump.DisplayTo(From, this);
         }
 
         public virtual void ShowQuestLog()
@@ -277,13 +277,13 @@ namespace Server.Engines.Quests
                 gumps.Close<QuestConversationsGump>();
                 gumps.Close<QuestObjectivesGump>();
 
-                gumps.Send(new QuestObjectivesGump(Objectives));
+                QuestObjectivesGump.DisplayTo(From, Objectives);
 
                 var last = Objectives[^1];
 
                 if (last.Info != null)
                 {
-                    gumps.Send(new QuestItemInfoGump(last.Info));
+                    QuestItemInfoGump.DisplayTo(From, last.Info);
                 }
             }
         }
@@ -298,20 +298,20 @@ namespace Server.Engines.Quests
                 gumps.Close<QuestObjectivesGump>();
                 gumps.Close<QuestConversationsGump>();
 
-                gumps.Send(new QuestConversationsGump(Conversations));
+                QuestConversationsGump.DisplayTo(From, Conversations);
 
                 var last = Conversations[^1];
 
                 if (last.Info != null)
                 {
-                    From.SendGump(new QuestItemInfoGump(last.Info));
+                    QuestItemInfoGump.DisplayTo(From, last.Info);
                 }
             }
         }
 
         public virtual void BeginCancelQuest()
         {
-            From.SendGump(new QuestCancelGump(this));
+            QuestCancelGump.DisplayTo(From, this);
         }
 
         public virtual void EndCancelQuest(bool shouldCancel)
@@ -394,11 +394,19 @@ namespace Server.Engines.Quests
             var gumps = From.GetGumps();
             gumps.Close<QuestItemInfoGump>();
             gumps.Close<QuestObjectivesGump>();
-            gumps.Send(conv.Logged ? new QuestConversationsGump(Conversations) : new QuestConversationsGump(conv));
+
+            if (conv.Logged)
+            {
+                QuestConversationsGump.DisplayTo(From, Conversations);
+            }
+            else
+            {
+                QuestConversationsGump.DisplayTo(From, conv);
+            }
 
             if (conv.Info != null)
             {
-                From.SendGump(new QuestItemInfoGump(conv.Info));
+                QuestItemInfoGump.DisplayTo(From, conv.Info);
             }
         }
 
@@ -519,142 +527,166 @@ namespace Server.Engines.Quests
 
     public class QuestCancelGump : BaseQuestGump
     {
-        private readonly QuestSystem m_System;
+        private readonly QuestSystem _system;
 
-        public QuestCancelGump(QuestSystem system) : base(120, 50)
+        public override bool Singleton => true;
+
+        private QuestCancelGump(QuestSystem system) : base(120, 50) => _system = system;
+
+        public static void DisplayTo(Mobile from, QuestSystem system)
         {
-            m_System = system;
-
-            Closable = false;
-
-            AddPage(0);
-
-            AddImageTiled(0, 0, 348, 262, 2702);
-            AddAlphaRegion(0, 0, 348, 262);
-
-            AddImage(0, 15, 10152);
-            AddImageTiled(0, 30, 17, 200, 10151);
-            AddImage(0, 230, 10154);
-
-            AddImage(15, 0, 10252);
-            AddImageTiled(30, 0, 300, 17, 10250);
-            AddImage(315, 0, 10254);
-
-            AddImage(15, 244, 10252);
-            AddImageTiled(30, 244, 300, 17, 10250);
-            AddImage(315, 244, 10254);
-
-            AddImage(330, 15, 10152);
-            AddImageTiled(330, 30, 17, 200, 10151);
-            AddImage(330, 230, 10154);
-
-            AddImage(333, 2, 10006);
-            AddImage(333, 248, 10006);
-            AddImage(2, 248, 10006);
-            AddImage(2, 2, 10006);
-
-            AddHtmlLocalized(25, 22, 200, 20, 1049000, 32000); // Confirm Quest Cancellation
-            AddImage(25, 40, 3007);
-
-            if (system.IsTutorial)
+            if (from?.NetState == null || system == null)
             {
-                AddHtmlLocalized(
+                return;
+            }
+
+            from.SendGump(new QuestCancelGump(system));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoClose();
+
+            builder.AddPage();
+
+            builder.AddImageTiled(0, 0, 348, 262, 2702);
+            builder.AddAlphaRegion(0, 0, 348, 262);
+
+            builder.AddImage(0, 15, 10152);
+            builder.AddImageTiled(0, 30, 17, 200, 10151);
+            builder.AddImage(0, 230, 10154);
+
+            builder.AddImage(15, 0, 10252);
+            builder.AddImageTiled(30, 0, 300, 17, 10250);
+            builder.AddImage(315, 0, 10254);
+
+            builder.AddImage(15, 244, 10252);
+            builder.AddImageTiled(30, 244, 300, 17, 10250);
+            builder.AddImage(315, 244, 10254);
+
+            builder.AddImage(330, 15, 10152);
+            builder.AddImageTiled(330, 30, 17, 200, 10151);
+            builder.AddImage(330, 230, 10154);
+
+            builder.AddImage(333, 2, 10006);
+            builder.AddImage(333, 248, 10006);
+            builder.AddImage(2, 248, 10006);
+            builder.AddImage(2, 2, 10006);
+
+            builder.AddHtmlLocalized(25, 22, 200, 20, 1049000, 32000); // Confirm Quest Cancellation
+            builder.AddImage(25, 40, 3007);
+
+            if (_system.IsTutorial)
+            {
+                builder.AddHtmlLocalized(
                     25,
                     55,
                     300,
                     120,
                     1060836,
-                    White
+                    BaseQuestGump.White
                 ); // This quest will give you valuable information, skills and equipment that will help you advance in the game at a quicker pace.<BR><BR>Are you certain you wish to cancel at this time?
             }
             else
             {
-                AddHtmlLocalized(25, 60, 300, 20, 1049001, White); // You have chosen to abort your quest:
-                AddImage(25, 81, 0x25E7);
-                AddHtmlObject(48, 80, 280, 20, system.Name, DarkGreen, false, false);
+                builder.AddHtmlLocalized(25, 60, 300, 20, 1049001, BaseQuestGump.White); // You have chosen to abort your quest:
+                builder.AddImage(25, 81, 0x25E7);
+                BaseQuestGump.AddHtmlObject(ref builder, 48, 80, 280, 20, _system.Name, BaseQuestGump.DarkGreen, false, false);
 
-                AddHtmlLocalized(25, 120, 280, 20, 1049002, White); // Can this quest be restarted after quitting?
-                AddImage(25, 141, 0x25E7);
-                AddHtmlLocalized(
+                builder.AddHtmlLocalized(25, 120, 280, 20, 1049002, BaseQuestGump.White); // Can this quest be restarted after quitting?
+                builder.AddImage(25, 141, 0x25E7);
+                builder.AddHtmlLocalized(
                     48,
                     140,
                     280,
                     20,
-                    system.RestartDelay < TimeSpan.MaxValue ? 1049016 : 1049017,
-                    DarkGreen
+                    _system.RestartDelay < TimeSpan.MaxValue ? 1049016 : 1049017,
+                    BaseQuestGump.DarkGreen
                 ); // Yes/No
             }
 
-            AddRadio(25, 175, 9720, 9723, true, 1);
-            AddHtmlLocalized(60, 180, 280, 20, 1049005, White); // Yes, I really want to quit!
+            builder.AddRadio(25, 175, 9720, 9723, true, 1);
+            builder.AddHtmlLocalized(60, 180, 280, 20, 1049005, BaseQuestGump.White); // Yes, I really want to quit!
 
-            AddRadio(25, 210, 9720, 9723, false, 0);
-            AddHtmlLocalized(60, 215, 280, 20, 1049006, White); // No, I don't want to quit.
+            builder.AddRadio(25, 210, 9720, 9723, false, 0);
+            builder.AddHtmlLocalized(60, 215, 280, 20, 1049006, BaseQuestGump.White); // No, I don't want to quit.
 
-            AddButton(265, 220, 247, 248, 1);
+            builder.AddButton(265, 220, 247, 248, 1);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             if (info.ButtonID == 1)
             {
-                m_System.EndCancelQuest(info.IsSwitched(1));
+                _system.EndCancelQuest(info.IsSwitched(1));
             }
         }
     }
 
     public class QuestOfferGump : BaseQuestGump
     {
-        private readonly QuestSystem m_System;
+        private readonly QuestSystem _system;
 
-        public QuestOfferGump(QuestSystem system) : base(75, 25)
+        public override bool Singleton => true;
+
+        private QuestOfferGump(QuestSystem system) : base(75, 25) => _system = system;
+
+        public static void DisplayTo(Mobile from, QuestSystem system)
         {
-            m_System = system;
+            if (from?.NetState == null || system == null)
+            {
+                return;
+            }
 
-            Closable = false;
+            from.SendGump(new QuestOfferGump(system));
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoClose();
 
-            AddImageTiled(50, 20, 400, 400, 2624);
-            AddAlphaRegion(50, 20, 400, 400);
+            builder.AddPage();
 
-            AddImage(90, 33, 9005);
-            AddHtmlLocalized(130, 45, 270, 20, 1049010, White); // Quest Offer
-            AddImageTiled(130, 65, 175, 1, 9101);
+            builder.AddImageTiled(50, 20, 400, 400, 2624);
+            builder.AddAlphaRegion(50, 20, 400, 400);
 
-            AddImage(140, 110, 1209);
-            AddHtmlObject(160, 108, 250, 20, system.Name, DarkGreen, false, false);
+            builder.AddImage(90, 33, 9005);
+            builder.AddHtmlLocalized(130, 45, 270, 20, 1049010, BaseQuestGump.White); // Quest Offer
+            builder.AddImageTiled(130, 65, 175, 1, 9101);
 
-            AddHtmlObject(98, 140, 312, 200, system.OfferMessage, LightGreen, false, true);
+            builder.AddImage(140, 110, 1209);
+            BaseQuestGump.AddHtmlObject(ref builder, 160, 108, 250, 20, _system.Name, BaseQuestGump.DarkGreen, false, false);
 
-            AddRadio(85, 350, 9720, 9723, true, 1);
-            AddHtmlLocalized(120, 356, 280, 20, 1049011, White); // I accept!
+            BaseQuestGump.AddHtmlObject(ref builder, 98, 140, 312, 200, _system.OfferMessage, BaseQuestGump.LightGreen, false, true);
 
-            AddRadio(85, 385, 9720, 9723, false, 0);
-            AddHtmlLocalized(120, 391, 280, 20, 1049012, White); // No thanks, I decline.
+            builder.AddRadio(85, 350, 9720, 9723, true, 1);
+            builder.AddHtmlLocalized(120, 356, 280, 20, 1049011, BaseQuestGump.White); // I accept!
 
-            AddButton(340, 390, 247, 248, 1);
+            builder.AddRadio(85, 385, 9720, 9723, false, 0);
+            builder.AddHtmlLocalized(120, 391, 280, 20, 1049012, BaseQuestGump.White); // No thanks, I decline.
 
-            AddImageTiled(50, 29, 30, 390, 10460);
-            AddImageTiled(34, 140, 17, 279, 9263);
+            builder.AddButton(340, 390, 247, 248, 1);
 
-            AddImage(48, 135, 10411);
-            AddImage(-16, 285, 10402);
-            AddImage(0, 10, 10421);
-            AddImage(25, 0, 10420);
+            builder.AddImageTiled(50, 29, 30, 390, 10460);
+            builder.AddImageTiled(34, 140, 17, 279, 9263);
 
-            AddImageTiled(83, 15, 350, 15, 10250);
+            builder.AddImage(48, 135, 10411);
+            builder.AddImage(-16, 285, 10402);
+            builder.AddImage(0, 10, 10421);
+            builder.AddImage(25, 0, 10420);
 
-            AddImage(34, 419, 10306);
-            AddImage(442, 419, 10304);
-            AddImageTiled(51, 419, 392, 17, 10101);
+            builder.AddImageTiled(83, 15, 350, 15, 10250);
 
-            AddImageTiled(415, 29, 44, 390, 2605);
-            AddImageTiled(415, 29, 30, 390, 10460);
-            AddImage(425, 0, 10441);
+            builder.AddImage(34, 419, 10306);
+            builder.AddImage(442, 419, 10304);
+            builder.AddImageTiled(51, 419, 392, 17, 10101);
 
-            AddImage(370, 50, 1417);
-            AddImage(379, 60, system.Picture);
+            builder.AddImageTiled(415, 29, 44, 390, 2605);
+            builder.AddImageTiled(415, 29, 30, 390, 10460);
+            builder.AddImage(425, 0, 10441);
+
+            builder.AddImage(370, 50, 1417);
+            builder.AddImage(379, 60, _system.Picture);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -663,17 +695,17 @@ namespace Server.Engines.Quests
             {
                 if (info.IsSwitched(1))
                 {
-                    m_System.Accept();
+                    _system.Accept();
                 }
                 else
                 {
-                    m_System.Decline();
+                    _system.Decline();
                 }
             }
         }
     }
 
-    public abstract class BaseQuestGump : Gump
+    public abstract class BaseQuestGump : DynamicGump
     {
         public const int Black = 0x0000;
         public const int White = 0x7FFF;
@@ -681,19 +713,29 @@ namespace Server.Engines.Quests
         public const int LightGreen = 90000;
         public const int Blue = 19777215;
 
-        public BaseQuestGump(int x, int y) : base(x, y)
+        protected BaseQuestGump(int x, int y) : base(x, y)
         {
         }
 
-        public void AddHtmlObject(int x, int y, int width, int height, object message, int color, bool back, bool scroll)
+        public static void AddHtmlObject(
+            ref DynamicGumpBuilder builder,
+            int x,
+            int y,
+            int width,
+            int height,
+            object message,
+            int color,
+            bool back,
+            bool scroll
+        )
         {
             if (message is int html)
             {
-                AddHtmlLocalized(x, y, width, height, html, color.C16216(), back, scroll);
+                builder.AddHtmlLocalized(x, y, width, height, html, color.C16216(), back, scroll);
             }
             else
             {
-                AddHtml(x, y, width, height, Html.Color($"{message}", color.C16216()), back, scroll);
+                builder.AddHtml(x, y, width, height, Html.Color($"{message}", color.C16216()), background: back, scrollbar: scroll);
             }
         }
     }

--- a/Projects/UOContent/Engines/Quests/Dark Tides/Items/ScrollOfAbraxus.cs
+++ b/Projects/UOContent/Engines/Quests/Dark Tides/Items/ScrollOfAbraxus.cs
@@ -42,7 +42,7 @@ public partial class ScrollOfAbraxus : QuestItem
     {
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new ScrollOfAbraxusGump());
+            ScrollOfAbraxusGump.DisplayTo(from);
 
             if (from is PlayerMobile pm)
             {
@@ -66,14 +66,30 @@ public partial class ScrollOfAbraxus : QuestItem
     }
 }
 
-public class ScrollOfAbraxusGump : Gump
+public class ScrollOfAbraxusGump : StaticGump<ScrollOfAbraxusGump>
 {
-    public ScrollOfAbraxusGump() : base(150, 50)
-    {
-        AddPage(0);
+    public override bool Singleton => true;
 
-        AddImage(0, 0, 1228);
-        AddImage(340, 255, 9005);
+    private ScrollOfAbraxusGump() : base(150, 50)
+    {
+    }
+
+    public static void DisplayTo(Mobile from)
+    {
+        if (from?.NetState == null)
+        {
+            return;
+        }
+
+        from.SendGump(new ScrollOfAbraxusGump());
+    }
+
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddImage(0, 0, 1228);
+        builder.AddImage(340, 255, 9005);
 
         /* Security at the Crystal Cave<BR><BR>
          *
@@ -111,6 +127,6 @@ public class ScrollOfAbraxusGump : Gump
          *
          * <I>- Frater Melkeer</I>
          */
-        AddHtmlLocalized(25, 36, 350, 210, 1060116, 1, false, true);
+        builder.AddHtmlLocalized(25, 36, 350, 210, 1060116, 1, false, true);
     }
 }

--- a/Projects/UOContent/Engines/Quests/Emino's Undertaking/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Emino's Undertaking/Objectives.cs
@@ -1,3 +1,4 @@
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -187,19 +188,19 @@ namespace Server.Engines.Quests.Ninja
 
         public override int MaxProgress => 3;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Henchmen killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063207, BaseQuestGump.Blue);
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddHtmlLocalized(70, 260, 270, 100, 1063207, BaseQuestGump.Blue);
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Emino's Undertaking/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Emino's Undertaking/Objectives.cs
@@ -194,9 +194,9 @@ namespace Server.Engines.Quests.Ninja
             {
                 // Henchmen killed:
                 builder.AddHtmlLocalized(70, 260, 270, 100, 1063207, BaseQuestGump.Blue);
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
-                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(130, 280, 0x64, $"{MaxProgress}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Solen Matriarch/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Solen Matriarch/Objectives.cs
@@ -23,9 +23,9 @@ namespace Server.Engines.Quests.Matriarch
                     ((SolenMatriarchQuest)System).RedSolen ? 1054088 : 1054087,
                     BaseQuestGump.Blue
                 );
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
-                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(130, 280, 0x64, $"{MaxProgress}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Solen Matriarch/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Solen Matriarch/Objectives.cs
@@ -1,3 +1,4 @@
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -9,12 +10,12 @@ namespace Server.Engines.Quests.Matriarch
 
         public override int MaxProgress => 7;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Black/Red Solen Infiltrators killed:
-                gump.AddHtmlLocalized(
+                builder.AddHtmlLocalized(
                     70,
                     260,
                     270,
@@ -22,13 +23,13 @@ namespace Server.Engines.Quests.Matriarch
                     ((SolenMatriarchQuest)System).RedSolen ? 1054088 : 1054087,
                     BaseQuestGump.Blue
                 );
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 
@@ -91,18 +92,18 @@ namespace Server.Engines.Quests.Matriarch
 
         public override int MaxProgress => 40;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1054093, BaseQuestGump.Blue); // Gallons of Water gathered:
-                gump.AddLabel(70, 280, 0x64, (CurProgress / 5).ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, (MaxProgress / 5).ToString());
+                builder.AddHtmlLocalized(70, 260, 270, 100, 1054093, BaseQuestGump.Blue); // Gallons of Water gathered:
+                builder.AddLabel(70, 280, 0x64, (CurProgress / 5).ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, (MaxProgress / 5).ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Study of the Solen Hive/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Study of the Solen Hive/Objectives.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Server.Gumps;
 
 namespace Server.Engines.Quests.Naturalist
 {
@@ -117,18 +118,18 @@ namespace Server.Engines.Quests.Naturalist
             }
         }
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1054055, BaseQuestGump.Blue); // Solen Nests Studied :
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddHtmlLocalized(70, 260, 270, 100, 1054055, BaseQuestGump.Blue); // Solen Nests Studied :
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 
@@ -176,14 +177,14 @@ namespace Server.Engines.Quests.Naturalist
     {
         public override int Message => 1054048;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             var count = NestArea.NonSpecialCount.ToString();
 
-            gump.AddHtmlLocalized(70, 260, 270, 100, 1054055, BaseQuestGump.Blue); // Solen Nests Studied :
-            gump.AddLabel(70, 280, 0x64, count);
-            gump.AddLabel(100, 280, 0x64, "/");
-            gump.AddLabel(130, 280, 0x64, count);
+            builder.AddHtmlLocalized(70, 260, 270, 100, 1054055, BaseQuestGump.Blue); // Solen Nests Studied :
+            builder.AddLabel(70, 280, 0x64, count);
+            builder.AddLabel(100, 280, 0x64, "/");
+            builder.AddLabel(130, 280, 0x64, count);
         }
     }
 }

--- a/Projects/UOContent/Engines/Quests/Study of the Solen Hive/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Study of the Solen Hive/Objectives.cs
@@ -123,9 +123,9 @@ namespace Server.Engines.Quests.Naturalist
             if (!Completed)
             {
                 builder.AddHtmlLocalized(70, 260, 270, 100, 1054055, BaseQuestGump.Blue); // Solen Nests Studied :
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
-                builder.AddLabel(130, 280, 0x64, MaxProgress.ToString());
+                builder.AddLabel(130, 280, 0x64, $"{MaxProgress}");
             }
             else
             {
@@ -179,12 +179,10 @@ namespace Server.Engines.Quests.Naturalist
 
         public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
-            var count = NestArea.NonSpecialCount.ToString();
-
             builder.AddHtmlLocalized(70, 260, 270, 100, 1054055, BaseQuestGump.Blue); // Solen Nests Studied :
-            builder.AddLabel(70, 280, 0x64, count);
+            builder.AddLabel(70, 280, 0x64, $"{NestArea.NonSpecialCount}");
             builder.AddLabel(100, 280, 0x64, "/");
-            builder.AddLabel(130, 280, 0x64, count);
+            builder.AddLabel(130, 280, 0x64, $"{NestArea.NonSpecialCount}");
         }
     }
 }

--- a/Projects/UOContent/Engines/Quests/Terrible Hatchlings/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Terrible Hatchlings/Objectives.cs
@@ -1,3 +1,4 @@
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -7,20 +8,20 @@ namespace Server.Engines.Quests.Zento
     {
         public override int Message => 1063316;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Deathwatch Beetle Hatchlings killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
+                builder.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
-                gump.AddLabel(70, 280, 0x64, "0");
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, "10");
+                builder.AddLabel(70, 280, 0x64, "0");
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, "10");
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 
@@ -42,20 +43,20 @@ namespace Server.Engines.Quests.Zento
     {
         public override int Message => 1063320;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Deathwatch Beetle Hatchlings killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
+                builder.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
-                gump.AddLabel(70, 280, 0x64, "1");
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, "10");
+                builder.AddLabel(70, 280, 0x64, "1");
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, "10");
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 
@@ -90,20 +91,20 @@ namespace Server.Engines.Quests.Zento
 
         public override int MaxProgress => 10;
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 // Deathwatch Beetle Hatchlings killed:
-                gump.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
+                builder.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, "10");
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, "10");
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Terrible Hatchlings/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Terrible Hatchlings/Objectives.cs
@@ -98,7 +98,7 @@ namespace Server.Engines.Quests.Zento
                 // Deathwatch Beetle Hatchlings killed:
                 builder.AddHtmlLocalized(70, 260, 270, 100, 1063318, 0xC6BF);
 
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
                 builder.AddLabel(130, 280, 0x64, "10");
             }

--- a/Projects/UOContent/Engines/Quests/The Summoning/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Objectives.cs
@@ -1,3 +1,4 @@
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -42,33 +43,33 @@ namespace Server.Engines.Quests.Doom
             }
         }
 
-        public override void RenderMessage(BaseQuestGump gump)
+        public override void RenderMessage(ref DynamicGumpBuilder builder)
         {
             if (CurProgress > 0 && CurProgress < MaxProgress)
             {
                 // Victoria has accepted the Daemon bones, but the requirement is not yet met.
-                gump.AddHtmlObject(70, 130, 300, 100, 1050028, BaseQuestGump.Blue, false, false);
+                BaseQuestGump.AddHtmlObject(ref builder, 70, 130, 300, 100, 1050028, BaseQuestGump.Blue, false, false);
             }
             else
             {
-                base.RenderMessage(gump);
+                base.RenderMessage(ref builder);
             }
         }
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (CurProgress > 0 && CurProgress < MaxProgress)
             {
                 // Number of bones collected:
-                gump.AddHtmlObject(70, 260, 270, 100, 1050019, BaseQuestGump.Blue, false, false);
+                BaseQuestGump.AddHtmlObject(ref builder, 70, 260, 270, 100, 1050019, BaseQuestGump.Blue, false, false);
 
-                gump.AddLabel(70, 280, 100, CurProgress.ToString());
-                gump.AddLabel(100, 280, 100, "/");
-                gump.AddLabel(130, 280, 100, MaxProgress.ToString());
+                builder.AddLabel(70, 280, 100, CurProgress.ToString());
+                builder.AddLabel(100, 280, 100, "/");
+                builder.AddLabel(130, 280, 100, MaxProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
     }

--- a/Projects/UOContent/Engines/Quests/The Summoning/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Objectives.cs
@@ -63,9 +63,9 @@ namespace Server.Engines.Quests.Doom
                 // Number of bones collected:
                 BaseQuestGump.AddHtmlObject(ref builder, 70, 260, 270, 100, 1050019, BaseQuestGump.Blue, false, false);
 
-                builder.AddLabel(70, 280, 100, CurProgress.ToString());
+                builder.AddLabel(70, 280, 100, $"{CurProgress}");
                 builder.AddLabel(100, 280, 100, "/");
-                builder.AddLabel(130, 280, 100, MaxProgress.ToString());
+                builder.AddLabel(130, 280, 100, $"{MaxProgress}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Objectives.cs
@@ -1,4 +1,5 @@
 using Server.Engines.Help;
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -138,16 +139,16 @@ namespace Server.Engines.Quests.Haven
             }
         }
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
-                gump.AddHtmlObject(70, 260, 270, 100, 1049090, BaseQuestGump.Blue, false, false); // Horde Minions killed:
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                BaseQuestGump.AddHtmlObject(ref builder, 70, 260, 270, 100, 1049090, BaseQuestGump.Blue, false, false); // Horde Minions killed:
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Uzeraan Turmoil/Objectives.cs
@@ -144,7 +144,7 @@ namespace Server.Engines.Quests.Haven
             if (!Completed)
             {
                 BaseQuestGump.AddHtmlObject(ref builder, 70, 260, 270, 100, 1049090, BaseQuestGump.Blue, false, false); // Horde Minions killed:
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
@@ -351,9 +351,9 @@ namespace Server.Engines.Quests.Hag
                 var info = IngredientInfo.Get(Ingredient);
 
                 builder.AddHtmlLocalized(70, 260, 270, 100, info.Name, BaseQuestGump.Blue);
-                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(70, 280, 0x64, $"{CurProgress}");
                 builder.AddLabel(100, 280, 0x64, "/");
-                builder.AddLabel(130, 280, 0x64, info.Quantity.ToString());
+                builder.AddLabel(130, 280, 0x64, $"{info.Quantity}");
             }
             else
             {

--- a/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
+++ b/Projects/UOContent/Engines/Quests/Witch Apprentice/Objectives.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;
 
@@ -343,20 +344,20 @@ namespace Server.Engines.Quests.Hag
         public int Step => Ingredients.Length;
         public bool BlackheartMet { get; private set; }
 
-        public override void RenderProgress(BaseQuestGump gump)
+        public override void RenderProgress(ref DynamicGumpBuilder builder)
         {
             if (!Completed)
             {
                 var info = IngredientInfo.Get(Ingredient);
 
-                gump.AddHtmlLocalized(70, 260, 270, 100, info.Name, BaseQuestGump.Blue);
-                gump.AddLabel(70, 280, 0x64, CurProgress.ToString());
-                gump.AddLabel(100, 280, 0x64, "/");
-                gump.AddLabel(130, 280, 0x64, info.Quantity.ToString());
+                builder.AddHtmlLocalized(70, 260, 270, 100, info.Name, BaseQuestGump.Blue);
+                builder.AddLabel(70, 280, 0x64, CurProgress.ToString());
+                builder.AddLabel(100, 280, 0x64, "/");
+                builder.AddLabel(130, 280, 0x64, info.Quantity.ToString());
             }
             else
             {
-                base.RenderProgress(gump);
+                base.RenderProgress(ref builder);
             }
         }
 

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -37,7 +37,7 @@ using Server.Spells.Sixth;
 using Server.Spells.Spellweaving;
 using Server.Systems.FeatureFlags;
 using Server.Targeting;
-using BaseQuestGump = Server.Engines.MLQuests.Gumps.BaseQuestGump;
+using BaseMLQuestGump = Server.Engines.MLQuests.Gumps.BaseMLQuestGump;
 using CalcMoves = Server.Movement.Movement;
 using QuestOfferGump = Server.Engines.MLQuests.Gumps.QuestOfferGump;
 using RankDefinition = Server.Guilds.RankDefinition;
@@ -3996,7 +3996,7 @@ namespace Server.Mobiles
         {
             if (NetState != null)
             {
-                BaseQuestGump.CloseOtherGumps(this);
+                BaseMLQuestGump.CloseOtherGumps(this);
                 var gumps = this.GetGumps();
                 gumps.Close<QuestLogDetailedGump>();
                 gumps.Close<QuestLogGump>();


### PR DESCRIPTION
## Summary

Migrates the Quest system gumps from legacy `Gump` to `DynamicGump` / `StaticGump<T>`.

**Renames** `Engines/ML Quests/Gumps/BaseQuestGump` to **`BaseMLQuestGump`** to
disambiguate from the Core quest abstract (`Engines/Quests/Core/QuestSystem.cs`).
Both abstracts now extend `DynamicGump`.

**Abstract bases**:
- `Server.Engines.Quests.BaseQuestGump` (Core) - now `abstract DynamicGump`. Holds constants and a static `AddHtmlObject(ref DynamicGumpBuilder, ...)` helper. Concrete subclasses each provide their own `BuildLayout`.
- `Server.Engines.MLQuests.Gumps.BaseMLQuestGump` (ML, renamed) - now `abstract DynamicGump` with a `protected abstract BuildContent(ref DynamicGumpBuilder)` hook. The base's `BuildLayout` draws shared chrome (background art, frame, label header) and then invokes `BuildContent`; subclasses use `BuildPage`, `SetTitle`, `RegisterButton`, `SetPageCount`, and content helpers (`AddDescription`, `AddObjectives`, `AddObjectivesProgress`, `AddRewardsPage`, `AddRewards`, `AddConversation`).

**Concrete Core gumps** migrated to `DynamicGump`:
- `QuestCancelGump`, `QuestOfferGump` (Core), `QuestObjectivesGump`, `QuestConversationsGump`, `QuestLogUpdatedGump`, `QuestItemInfoGump`, `SheetMusicOfferGump` (Impresario), `PaintedImageGump` (renamed from `PaintedImage.InternalGump`).

**Concrete ML gumps** migrated to `DynamicGump` (extending `BaseMLQuestGump` or directly):
- `InfoNPCGump`, `QuestConversationGump`, `QuestLogDetailedGump`, `QuestLogGump`, `QuestOfferGump` (ML), `QuestReportBackGump`, `QuestRewardGump`, `QuestCancelConfirmGump`, `RaceChangeConfirmGump`.

**`StaticGump<T>` migrations**:
- `ScrollOfAbraxusGump` (Dark Tides). Its layout is a single hard-coded cliloc (1060116) with no per-instance dynamic content - safe to cache.

**Cliloc rule**: Every other quest dialog bakes per-instance cliloc IDs into its layout (quest titles, NPC names, race-specific prompts, era-conditional progress messages, escort destinations). Per the cliloc rule, baking different cliloc numbers into a cached layout would defeat `StaticGump<T>` caching - so all of these are `DynamicGump`.

**Signature changes** to support the migration:
- `QuestObjective.RenderMessage`/`RenderProgress` now take `ref DynamicGumpBuilder builder` (15 overrides updated across Collector, Solen Matriarch, Ambitious Solen Queen, Study of the Solen Hive, Terrible Hatchlings, The Summoning, Uzeraan Turmoil, Witch Apprentice, Emino's Undertaking).
- ML `BaseObjective.WriteToGump` / `BaseObjectiveInstance.WriteToGump` / `BaseReward.WriteToGump` now take `ref DynamicGumpBuilder` (KillObjective, GainSkillObjective, EscortObjective, CollectObjective, DeliverObjective, BaseReward).

**Empty-gump and `Singleton` rules**: All concrete gumps now have private constructors with static `DisplayTo` entry points that null-check the player NetState before allocation. All gumps that shouldn't stack are `Singleton => true`.

**External callers updated**: `MLQuest.SendOffer`/`OnRefuse`, `MLQuestEntry.SendProgressGump`/`SendRewardGump`/`SendReportBackGump`, `MLQuestSystem.QuestGumpRequest` and `ViewQuestsCommand`, `BoonCollector` (Darius/Nedrick), `SirHelper.OnDoubleClick` (no longer caches a single shared `InfoNPCGump` instance - `DisplayTo` constructs one per click and the gump's `Singleton => true` handles deduplication), `RaceChangeDeed.OnDoubleClick`, `PaintedImage.OnDoubleClick`, `ScrollOfAbraxus.OnDoubleClick`, `Impresario.OnTalk`, and `PlayerMobile`'s `BaseQuestGump` alias is now `BaseMLQuestGump`.

**Concrete subclasses found beyond the listed entry points**: `SheetMusicOfferGump` (in Impresario.cs), `PaintedImageGump` (was `PaintedImage.InternalGump`), `QuestObjectivesGump`, `QuestConversationsGump`, `QuestLogUpdatedGump`, `QuestItemInfoGump` (the Core base has these embedded across `QuestSystem.cs`/`QuestObjective.cs`/`QuestConversation.cs`/`QuestItemInfo.cs`).

**Code-standards cleanup**: Renamed legacy `m_X` private fields to `_x` in rewritten files; braces on all control flow.

## Test plan

- [x] `dotnet build Projects/UOContent/UOContent.csproj` - 0 warnings, 0 errors.
- [x] `dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj` - 141 pre-existing failures (all `System.NullReferenceException` at `AOS.DisableStatInfluences()` from `UOContentFixture..ctor`); identical failure count on stashed/clean main, confirmed unrelated to this PR.
- [ ] In-game smoke: Take a Core collector quest (Tomas/Alberta/Gabriel) - verify offer/log/conversation gumps render, accept and complete.
- [ ] In-game smoke: Take an ML quest from a quest giver - verify offer/objective/reward gumps render and pagination works.
- [ ] In-game smoke: Cancel an in-progress ML quest from the quest log - verify resign confirmation gump appears and functions.
- [ ] In-game smoke: Use a Race Change Deed end-to-end - verify the confirmation gump appears, accepting opens the client race changer.
