### PR TITLE
perf: Migrate SoulStone and TMap chest gumps to DynamicGump

### DIFF
--- a/Projects/UOContent/Items/Containers/TreasureMapChest.cs
+++ b/Projects/UOContent/Items/Containers/TreasureMapChest.cs
@@ -447,15 +447,10 @@ public partial class TreasureMapChest : LockableContainer
     private class RemoveGump : StaticGump<RemoveGump>
     {
         private readonly TreasureMapChest _chest;
-        private readonly Mobile _from;
 
         public override bool Singleton => true;
 
-        private RemoveGump(Mobile from, TreasureMapChest chest) : base(15, 15)
-        {
-            _from = from;
-            _chest = chest;
-        }
+        private RemoveGump(TreasureMapChest chest) : base(15, 15) => _chest = chest;
 
         public static void DisplayTo(Mobile from, TreasureMapChest chest)
         {
@@ -464,7 +459,7 @@ public partial class TreasureMapChest : LockableContainer
                 return;
             }
 
-            from.SendGump(new RemoveGump(from, chest));
+            from.SendGump(new RemoveGump(chest));
         }
 
         protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -492,7 +487,7 @@ public partial class TreasureMapChest : LockableContainer
         {
             if (info.ButtonID == 1)
             {
-                _chest.EndRemove(_from);
+                _chest.EndRemove(sender.Mobile);
             }
         }
     }

--- a/Projects/UOContent/Items/Containers/TreasureMapChest.cs
+++ b/Projects/UOContent/Items/Containers/TreasureMapChest.cs
@@ -430,12 +430,7 @@ public partial class TreasureMapChest : LockableContainer
 
     public void BeginRemove(Mobile from)
     {
-        if (!from.Alive)
-        {
-            return;
-        }
-
-        from.SendGump(new RemoveGump(from, this));
+        RemoveGump.DisplayTo(from, this);
     }
 
     public void EndRemove(Mobile from)
@@ -449,35 +444,48 @@ public partial class TreasureMapChest : LockableContainer
         Delete();
     }
 
-    private class RemoveGump : Gump
+    private class RemoveGump : StaticGump<RemoveGump>
     {
         private readonly TreasureMapChest _chest;
         private readonly Mobile _from;
 
         public override bool Singleton => true;
 
-        public RemoveGump(Mobile from, TreasureMapChest chest) : base(15, 15)
+        private RemoveGump(Mobile from, TreasureMapChest chest) : base(15, 15)
         {
             _from = from;
             _chest = chest;
+        }
 
-            Closable = false;
-            Disposable = false;
+        public static void DisplayTo(Mobile from, TreasureMapChest chest)
+        {
+            if (from?.NetState == null || !from.Alive || chest == null || chest.Deleted)
+            {
+                return;
+            }
 
-            AddPage(0);
+            from.SendGump(new RemoveGump(from, chest));
+        }
 
-            AddBackground(30, 0, 240, 240, 2620);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
+
+            builder.SetNoClose();
+            builder.SetNoDispose();
+
+            builder.AddBackground(30, 0, 240, 240, 2620);
 
             // When this treasure chest is removed, any items still inside of it will be lost.
-            AddHtmlLocalized(45, 15, 200, 80, 1048125, 0x7FFF);
+            builder.AddHtmlLocalized(45, 15, 200, 80, 1048125, 0x7FFF);
             // Are you certain you're ready to remove this chest?
-            AddHtmlLocalized(45, 95, 200, 60, 1048126, 0x7FFF);
+            builder.AddHtmlLocalized(45, 95, 200, 60, 1048126, 0x7FFF);
 
-            AddButton(40, 153, 4005, 4007, 1);
-            AddHtmlLocalized(75, 155, 180, 40, 1048127, 0x7FFF); // Remove the Treasure Chest
+            builder.AddButton(40, 153, 4005, 4007, 1);
+            builder.AddHtmlLocalized(75, 155, 180, 40, 1048127, 0x7FFF); // Remove the Treasure Chest
 
-            AddButton(40, 195, 4005, 4007, 2);
-            AddHtmlLocalized(75, 197, 180, 35, 1006045, 0x7FFF); // Cancel
+            builder.AddButton(40, 195, 4005, 4007, 2);
+            builder.AddHtmlLocalized(75, 197, 180, 35, 1006045, 0x7FFF); // Cancel
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -352,12 +352,7 @@ public partial class SoulStone : Item, ISecurable
             }
 
             var skill = from.Skills[iSkill];
-            if (skill.Base <= 0.0)
-            {
-                return;
-            }
-
-            if (!_stone.CheckUse(from))
+            if (skill.Base <= 0.0 || !_stone.CheckUse(from))
             {
                 return;
             }

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -236,11 +236,11 @@ public partial class SoulStone : Item, ISecurable
 
         if (IsEmpty)
         {
-            gumps.Send(new SelectSkillGump(this, from));
+            SelectSkillGump.DisplayTo(from, this);
         }
         else
         {
-            gumps.Send(new ConfirmTransferGump(this, from));
+            ConfirmTransferGump.DisplayTo(from, this);
         }
     }
 
@@ -257,32 +257,50 @@ public partial class SoulStone : Item, ISecurable
         _skillValue = reader.ReadDouble();
     }
 
-    private class SelectSkillGump : Gump
+    private class SelectSkillGump : DynamicGump
     {
         private readonly SoulStone _stone;
+        private readonly Mobile _from;
 
-        public SelectSkillGump(SoulStone stone, Mobile from) : base(50, 50)
+        public override bool Singleton => true;
+
+        private SelectSkillGump(SoulStone stone, Mobile from) : base(50, 50)
         {
             _stone = stone;
+            _from = from;
+        }
 
-            AddPage(0);
-
-            AddBackground(0, 0, 520, 440, 0x13BE);
-
-            AddImageTiled(10, 10, 500, 20, 0xA40);
-            AddImageTiled(10, 40, 500, 360, 0xA40);
-            AddImageTiled(10, 410, 500, 20, 0xA40);
-
-            AddAlphaRegion(10, 10, 500, 420);
-
-            AddHtmlLocalized(10, 12, 500, 20, 1061087, 0x7FFF); // Which skill do you wish to transfer to the Soulstone?
-
-            AddButton(10, 410, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
-
-            for (int i = 0, n = 0; i < from.Skills.Length; i++)
+        public static void DisplayTo(Mobile from, SoulStone stone)
+        {
+            if (from?.NetState == null || stone == null || stone.Deleted || !stone.IsEmpty)
             {
-                var skill = from.Skills[i];
+                return;
+            }
+
+            from.SendGump(new SelectSkillGump(stone, from));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 520, 440, 0x13BE);
+
+            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+            builder.AddImageTiled(10, 40, 500, 360, 0xA40);
+            builder.AddImageTiled(10, 410, 500, 20, 0xA40);
+
+            builder.AddAlphaRegion(10, 10, 500, 420);
+
+            // Which skill do you wish to transfer to the Soulstone?
+            builder.AddHtmlLocalized(10, 12, 500, 20, 1061087, 0x7FFF);
+
+            builder.AddButton(10, 410, 0xFB1, 0xFB2, 0);
+            builder.AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
+
+            for (int i = 0, n = 0; i < _from.Skills.Length; i++)
+            {
+                var skill = _from.Skills[i];
 
                 if (skill.Base > 0.0)
                 {
@@ -294,24 +312,24 @@ public partial class SoulStone : Item, ISecurable
 
                         if (page > 0)
                         {
-                            AddButton(260, 380, 0xFA5, 0xFA6, 0, GumpButtonType.Page, page + 1);
-                            AddHtmlLocalized(305, 382, 200, 20, 1011066, 0x7FFF); // Next page
+                            builder.AddButton(260, 380, 0xFA5, 0xFA6, 0, GumpButtonType.Page, page + 1);
+                            builder.AddHtmlLocalized(305, 382, 200, 20, 1011066, 0x7FFF); // Next page
                         }
 
-                        AddPage(page + 1);
+                        builder.AddPage(page + 1);
 
                         if (page > 0)
                         {
-                            AddButton(10, 380, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page);
-                            AddHtmlLocalized(55, 382, 200, 20, 1011067, 0x7FFF); // Previous page
+                            builder.AddButton(10, 380, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page);
+                            builder.AddHtmlLocalized(55, 382, 200, 20, 1011067, 0x7FFF); // Previous page
                         }
                     }
 
                     var x = p % 2 == 0 ? 10 : 260;
                     var y = p / 2 * 20 + 40;
 
-                    AddButton(x, y, 0xFA5, 0xFA6, i + 1);
-                    AddHtmlLocalized(x + 45, y + 2, 200, 20, AosSkillBonuses.GetLabel(skill.SkillName), 0x7FFF);
+                    builder.AddButton(x, y, 0xFA5, 0xFA6, i + 1);
+                    builder.AddHtmlLocalized(x + 45, y + 2, 200, 20, AosSkillBonuses.GetLabel(skill.SkillName), 0x7FFF);
 
                     n++;
                 }
@@ -344,29 +362,47 @@ public partial class SoulStone : Item, ISecurable
                 return;
             }
 
-            from.SendGump(new ConfirmSkillGump(_stone, skill));
+            ConfirmSkillGump.DisplayTo(from, _stone, skill);
         }
     }
 
-    private class ConfirmSkillGump : Gump
+    private class ConfirmSkillGump : DynamicGump
     {
         private readonly Skill _skill;
         private readonly SoulStone _stone;
 
-        public ConfirmSkillGump(SoulStone stone, Skill skill) : base(50, 50)
+        public override bool Singleton => true;
+
+        private ConfirmSkillGump(SoulStone stone, Skill skill) : base(50, 50)
         {
             _stone = stone;
             _skill = skill;
+        }
 
-            AddBackground(0, 0, 520, 440, 0x13BE);
+        public static void DisplayTo(Mobile from, SoulStone stone, Skill skill)
+        {
+            if (from?.NetState == null || stone == null || stone.Deleted || !stone.IsEmpty || skill == null)
+            {
+                return;
+            }
 
-            AddImageTiled(10, 10, 500, 20, 0xA40);
-            AddImageTiled(10, 40, 500, 360, 0xA40);
-            AddImageTiled(10, 410, 500, 20, 0xA40);
+            from.SendGump(new ConfirmSkillGump(stone, skill));
+        }
 
-            AddAlphaRegion(10, 10, 500, 420);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddHtmlLocalized(10, 12, 500, 20, 1070709, 0x7FFF); // <CENTER>Confirm Soulstone Transfer</CENTER>
+            builder.AddBackground(0, 0, 520, 440, 0x13BE);
+
+            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+            builder.AddImageTiled(10, 40, 500, 360, 0xA40);
+            builder.AddImageTiled(10, 410, 500, 20, 0xA40);
+
+            builder.AddAlphaRegion(10, 10, 500, 420);
+
+            // <CENTER>Confirm Soulstone Transfer</CENTER>
+            builder.AddHtmlLocalized(10, 12, 500, 20, 1070709, 0x7FFF);
 
             /* <CENTER>Soulstone</CENTER><BR>
              * You are using a Soulstone.  This powerful artifact allows you to remove skill points
@@ -383,30 +419,30 @@ public partial class SoulStone : Item, ISecurable
              * This is an Account Bound Soulstone.  Skill pointsstored inside can be retrieved by any
              * character on the same account as the character who placed them into the stone.
              */
-            AddHtmlLocalized(10, 42, 500, 110, 1061067, 0x7FFF, false, true);
+            builder.AddHtmlLocalized(10, 42, 500, 110, 1061067, 0x7FFF, false, true);
 
-            AddHtmlLocalized(10, 200, 390, 20, 1062297, 0x7FFF); // Skill Chosen:
-            AddHtmlLocalized(210, 200, 390, 20, AosSkillBonuses.GetLabel(skill.SkillName), 0x7FFF);
+            builder.AddHtmlLocalized(10, 200, 390, 20, 1062297, 0x7FFF); // Skill Chosen:
+            builder.AddHtmlLocalized(210, 200, 390, 20, AosSkillBonuses.GetLabel(_skill.SkillName), 0x7FFF);
 
-            AddHtmlLocalized(10, 220, 390, 20, 1062298, 0x7FFF); // Current Value:
-            AddLabel(210, 220, 0x481, skill.Base.ToString("F1"));
+            builder.AddHtmlLocalized(10, 220, 390, 20, 1062298, 0x7FFF); // Current Value:
+            builder.AddLabel(210, 220, 0x481, $"{_skill.Base:F1}");
 
-            AddHtmlLocalized(10, 240, 390, 20, 1062299, 0x7FFF); // Current Cap:
-            AddLabel(210, 240, 0x481, skill.Cap.ToString("F1"));
+            builder.AddHtmlLocalized(10, 240, 390, 20, 1062299, 0x7FFF); // Current Cap:
+            builder.AddLabel(210, 240, 0x481, $"{_skill.Cap:F1}");
 
-            AddHtmlLocalized(10, 260, 390, 20, 1062300, 0x7FFF); // New Value:
-            AddLabel(210, 260, 0x481, "0.0");
+            builder.AddHtmlLocalized(10, 260, 390, 20, 1062300, 0x7FFF); // New Value:
+            builder.AddLabel(210, 260, 0x481, "0.0");
 
-            AddButton(10, 360, 0xFA5, 0xFA6, 2);
+            builder.AddButton(10, 360, 0xFA5, 0xFA6, 2);
 
             // Activate the stone.  I am ready to transfer the skill points to it.
-            AddHtmlLocalized(45, 362, 450, 20, 1070720, 0x7FFF);
+            builder.AddHtmlLocalized(45, 362, 450, 20, 1070720, 0x7FFF);
 
-            AddButton(10, 380, 0xFA5, 0xFA6, 1);
-            AddHtmlLocalized(45, 382, 450, 20, 1062279, 0x7FFF); // No, let me make another selection.
+            builder.AddButton(10, 380, 0xFA5, 0xFA6, 1);
+            builder.AddHtmlLocalized(45, 382, 450, 20, 1062279, 0x7FFF); // No, let me make another selection.
 
-            AddButton(10, 410, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddButton(10, 410, 0xFB1, 0xFB2, 0);
+            builder.AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -425,7 +461,7 @@ public partial class SoulStone : Item, ISecurable
 
             if (info.ButtonID == 1) // Is asking for another selection
             {
-                from.SendGump(new SelectSkillGump(_stone, from));
+                SelectSkillGump.DisplayTo(from, _stone);
                 return;
             }
 
@@ -445,7 +481,7 @@ public partial class SoulStone : Item, ISecurable
                  * the selected skill at this time, click "Cancel".
                  */
 
-                from.SendGump(new ErrorGump(_stone, 1070710, 1070711));
+                ErrorGump.DisplayTo(from, _stone, 1070710, 1070711);
                 return;
             }
 
@@ -492,23 +528,43 @@ public partial class SoulStone : Item, ISecurable
         }
     }
 
-    private class ConfirmTransferGump : Gump
+    private class ConfirmTransferGump : DynamicGump
     {
         private readonly SoulStone _stone;
+        private readonly Mobile _from;
 
-        public ConfirmTransferGump(SoulStone stone, Mobile from) : base(50, 50)
+        public override bool Singleton => true;
+
+        private ConfirmTransferGump(SoulStone stone, Mobile from) : base(50, 50)
         {
             _stone = stone;
+            _from = from;
+        }
 
-            AddBackground(0, 0, 520, 440, 0x13BE);
+        public static void DisplayTo(Mobile from, SoulStone stone)
+        {
+            if (from?.NetState == null || stone == null || stone.Deleted || stone.IsEmpty)
+            {
+                return;
+            }
 
-            AddImageTiled(10, 10, 500, 20, 0xA40);
-            AddImageTiled(10, 40, 500, 360, 0xA40);
-            AddImageTiled(10, 410, 500, 20, 0xA40);
+            from.SendGump(new ConfirmTransferGump(stone, from));
+        }
 
-            AddAlphaRegion(10, 10, 500, 420);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddHtmlLocalized(10, 12, 500, 20, 1070709, 0x7FFF); // <CENTER>Confirm Soulstone Transfer</CENTER>
+            builder.AddBackground(0, 0, 520, 440, 0x13BE);
+
+            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+            builder.AddImageTiled(10, 40, 500, 360, 0xA40);
+            builder.AddImageTiled(10, 410, 500, 20, 0xA40);
+
+            builder.AddAlphaRegion(10, 10, 500, 420);
+
+            // <CENTER>Confirm Soulstone Transfer</CENTER>
+            builder.AddHtmlLocalized(10, 12, 500, 20, 1070709, 0x7FFF);
 
             /* <CENTER>Soulstone</CENTER><BR>
              * You are using a Soulstone.  This powerful artifact allows you to remove skill points
@@ -525,34 +581,34 @@ public partial class SoulStone : Item, ISecurable
              * This is an Account Bound Soulstone.  Skill pointsstored inside can be retrieved by any
              * character on the same account as the character who placed them into the stone.
              */
-            AddHtmlLocalized(10, 42, 500, 110, 1061067, 0x7FFF, false, true);
+            builder.AddHtmlLocalized(10, 42, 500, 110, 1061067, 0x7FFF, false, true);
 
-            AddHtmlLocalized(10, 200, 390, 20, 1070718, 0x7FFF); // Skill Stored:
-            AddHtmlLocalized(210, 200, 390, 20, AosSkillBonuses.GetLabel(stone.Skill), 0x7FFF);
+            builder.AddHtmlLocalized(10, 200, 390, 20, 1070718, 0x7FFF); // Skill Stored:
+            builder.AddHtmlLocalized(210, 200, 390, 20, AosSkillBonuses.GetLabel(_stone.Skill), 0x7FFF);
 
-            var fromSkill = from.Skills[stone.Skill];
+            var fromSkill = _from.Skills[_stone.Skill];
 
-            AddHtmlLocalized(10, 220, 390, 20, 1062298, 0x7FFF); // Current Value:
-            AddLabel(210, 220, 0x481, fromSkill.Base.ToString("F1"));
+            builder.AddHtmlLocalized(10, 220, 390, 20, 1062298, 0x7FFF); // Current Value:
+            builder.AddLabel(210, 220, 0x481, $"{fromSkill.Base:F1}");
 
-            AddHtmlLocalized(10, 240, 390, 20, 1062299, 0x7FFF); // Current Cap:
-            AddLabel(210, 240, 0x481, fromSkill.Cap.ToString("F1"));
+            builder.AddHtmlLocalized(10, 240, 390, 20, 1062299, 0x7FFF); // Current Cap:
+            builder.AddLabel(210, 240, 0x481, $"{fromSkill.Cap:F1}");
 
-            AddHtmlLocalized(10, 260, 390, 20, 1062300, 0x7FFF); // New Value:
-            AddLabel(210, 260, 0x481, stone.SkillValue.ToString("F1"));
+            builder.AddHtmlLocalized(10, 260, 390, 20, 1062300, 0x7FFF); // New Value:
+            builder.AddLabel(210, 260, 0x481, $"{_stone.SkillValue:F1}");
 
-            AddButton(10, 360, 0xFA5, 0xFA6, 2);
+            builder.AddButton(10, 360, 0xFA5, 0xFA6, 2);
 
             // Activate the stone.  I am ready to retrieve the skill points from it.
-            AddHtmlLocalized(45, 362, 450, 20, 1070719, 0x7FFF);
+            builder.AddHtmlLocalized(45, 362, 450, 20, 1070719, 0x7FFF);
 
-            AddButton(10, 380, 0xFA5, 0xFA6, 1);
+            builder.AddButton(10, 380, 0xFA5, 0xFA6, 1);
 
             // Remove all skill points from this stone and DO NOT absorb them.
-            AddHtmlLocalized(45, 382, 450, 20, 1070723, 0x7FFF);
+            builder.AddHtmlLocalized(45, 382, 450, 20, 1070723, 0x7FFF);
 
-            AddButton(10, 410, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddButton(10, 410, 0xFB1, 0xFB2, 0);
+            builder.AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -571,7 +627,7 @@ public partial class SoulStone : Item, ISecurable
 
             if (info.ButtonID == 1) // Remove skill points
             {
-                from.SendGump(new ConfirmRemovalGump(_stone));
+                ConfirmRemovalGump.DisplayTo(from, _stone);
                 return;
             }
 
@@ -622,7 +678,7 @@ public partial class SoulStone : Item, ISecurable
                  * time, click "Cancel".
                  */
 
-                from.SendGump(new ErrorGump(_stone, 1070717, 1070716));
+                ErrorGump.DisplayTo(from, _stone, 1070717, 1070716);
                 return;
             }
 
@@ -636,7 +692,7 @@ public partial class SoulStone : Item, ISecurable
                  * skill cap.  You cannot currently retrieve the skill points stored in this stone.
                  */
 
-                from.SendGump(new ErrorGump(_stone, 1070717, 1070715));
+                ErrorGump.DisplayTo(from, _stone, 1070717, 1070715);
                 return;
             }
 
@@ -650,7 +706,7 @@ public partial class SoulStone : Item, ISecurable
 
                 // Wrong message?!
 
-                from.SendGump(new ErrorGump(_stone, 1070717, 1070802));
+                ErrorGump.DisplayTo(from, _stone, 1070717, 1070802);
                 return;
             }
 
@@ -662,7 +718,7 @@ public partial class SoulStone : Item, ISecurable
 
                 // Wrong message?!
 
-                from.SendGump(new ErrorGump(_stone, 1070717, 1078115));
+                ErrorGump.DisplayTo(from, _stone, 1070717, 1078115);
                 return;
             }
 
@@ -736,23 +792,41 @@ public partial class SoulStone : Item, ISecurable
         }
     }
 
-    private class ConfirmRemovalGump : Gump
+    private class ConfirmRemovalGump : StaticGump<ConfirmRemovalGump>
     {
         private readonly SoulStone _stone;
 
-        public ConfirmRemovalGump(SoulStone stone) : base(50, 50)
+        public override bool Singleton => true;
+
+        private ConfirmRemovalGump(SoulStone stone) : base(50, 50)
         {
             _stone = stone;
+        }
 
-            AddBackground(0, 0, 520, 440, 0x13BE);
+        public static void DisplayTo(Mobile from, SoulStone stone)
+        {
+            if (from?.NetState == null || stone == null || stone.Deleted || stone.IsEmpty)
+            {
+                return;
+            }
 
-            AddImageTiled(10, 10, 500, 20, 0xA40);
-            AddImageTiled(10, 40, 500, 360, 0xA40);
-            AddImageTiled(10, 410, 500, 20, 0xA40);
+            from.SendGump(new ConfirmRemovalGump(stone));
+        }
 
-            AddAlphaRegion(10, 10, 500, 420);
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddHtmlLocalized(10, 12, 500, 20, 1070725, 0x7FFF); // <CENTER>Confirm Soulstone Skill Removal</CENTER>
+            builder.AddBackground(0, 0, 520, 440, 0x13BE);
+
+            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+            builder.AddImageTiled(10, 40, 500, 360, 0xA40);
+            builder.AddImageTiled(10, 410, 500, 20, 0xA40);
+
+            builder.AddAlphaRegion(10, 10, 500, 420);
+
+            // <CENTER>Confirm Soulstone Skill Removal</CENTER>
+            builder.AddHtmlLocalized(10, 12, 500, 20, 1070725, 0x7FFF);
 
             /* WARNING!<BR><BR>
              *
@@ -761,13 +835,13 @@ public partial class SoulStone : Item, ISecurable
              *
              * Are you sure you wish to do this?  If not, press the Cancel button.
              */
-            AddHtmlLocalized(10, 42, 500, 110, 1070724, 0x7FFF, false, true);
+            builder.AddHtmlLocalized(10, 42, 500, 110, 1070724, 0x7FFF, false, true);
 
-            AddButton(10, 380, 0xFA5, 0xFA6, 1);
-            AddHtmlLocalized(45, 382, 450, 20, 1052072, 0x7FFF); // Continue
+            builder.AddButton(10, 380, 0xFA5, 0xFA6, 1);
+            builder.AddHtmlLocalized(45, 382, 450, 20, 1052072, 0x7FFF); // Continue
 
-            AddButton(10, 410, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddButton(10, 410, 0xFB1, 0xFB2, 0);
+            builder.AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -789,31 +863,52 @@ public partial class SoulStone : Item, ISecurable
         }
     }
 
-    private class ErrorGump : Gump
+    private class ErrorGump : DynamicGump
     {
         private readonly SoulStone _stone;
+        private readonly int _title;
+        private readonly int _message;
 
-        public ErrorGump(SoulStone stone, int title, int message) : base(50, 50)
+        public override bool Singleton => true;
+
+        private ErrorGump(SoulStone stone, int title, int message) : base(50, 50)
         {
             _stone = stone;
+            _title = title;
+            _message = message;
+        }
 
-            AddBackground(0, 0, 520, 440, 0x13BE);
+        public static void DisplayTo(Mobile from, SoulStone stone, int title, int message)
+        {
+            if (from?.NetState == null || stone == null || stone.Deleted)
+            {
+                return;
+            }
 
-            AddImageTiled(10, 10, 500, 20, 0xA40);
-            AddImageTiled(10, 40, 500, 360, 0xA40);
-            AddImageTiled(10, 410, 500, 20, 0xA40);
+            from.SendGump(new ErrorGump(stone, title, message));
+        }
 
-            AddAlphaRegion(10, 10, 500, 420);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddHtmlLocalized(10, 12, 500, 20, title, 0x7FFF);
+            builder.AddBackground(0, 0, 520, 440, 0x13BE);
 
-            AddHtmlLocalized(10, 42, 500, 110, message, 0x7FFF, false, true);
+            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+            builder.AddImageTiled(10, 40, 500, 360, 0xA40);
+            builder.AddImageTiled(10, 410, 500, 20, 0xA40);
 
-            AddButton(10, 380, 0xFA5, 0xFA6, 1);
-            AddHtmlLocalized(45, 382, 450, 20, 1052072, 0x7FFF); // Continue
+            builder.AddAlphaRegion(10, 10, 500, 420);
 
-            AddButton(10, 410, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddHtmlLocalized(10, 12, 500, 20, _title, 0x7FFF);
+
+            builder.AddHtmlLocalized(10, 42, 500, 110, _message, 0x7FFF, false, true);
+
+            builder.AddButton(10, 380, 0xFA5, 0xFA6, 1);
+            builder.AddHtmlLocalized(45, 382, 450, 20, 1052072, 0x7FFF); // Continue
+
+            builder.AddButton(10, 410, 0xFB1, 0xFB2, 0);
+            builder.AddHtmlLocalized(45, 412, 450, 20, 1060051, 0x7FFF); // CANCEL
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -832,11 +927,11 @@ public partial class SoulStone : Item, ISecurable
 
             if (_stone.IsEmpty)
             {
-                from.SendGump(new SelectSkillGump(_stone, from));
+                SelectSkillGump.DisplayTo(from, _stone);
             }
             else
             {
-                from.SendGump(new ConfirmTransferGump(_stone, from));
+                ConfirmTransferGump.DisplayTo(from, _stone);
             }
         }
     }


### PR DESCRIPTION
## Summary

Migrates the five-step SoulStone wizard and the TreasureMapChest remove-confirmation dialog from legacy `Gump` to the modern builder API.

Per-gump base type:

- **`SelectSkillGump` -> `DynamicGump`** -- the skill picker iterates the player's skill list and emits one button per non-zero skill, so the layout shape varies per instance.
- **`ConfirmSkillGump` -> `DynamicGump`** -- skill name uses `AosSkillBonuses.GetLabel(...)` which returns dynamic clilocs in the `1044060 + (int)skill` range, plus current/cap skill values rendered as text labels.
- **`ConfirmTransferGump` -> `DynamicGump`** -- same dynamic skill cliloc plus per-instance Base/Cap/Stored values.
- **`ConfirmRemovalGump` -> `StaticGump<ConfirmRemovalGump>`** -- only fixed clilocs (warning text, Continue, Cancel), so the layout caches.
- **`ErrorGump` -> `DynamicGump`** -- title and message clilocs are constructor parameters that vary per call site.
- **`TreasureMapChest.RemoveGump` -> `StaticGump<RemoveGump>`** -- fixed-cliloc confirmation prompt (no item list, despite the name); `Closable=false`/`Disposable=false` are now `builder.SetNoClose()`/`builder.SetNoDispose()`.

All six gumps are now `Singleton => true`, have private constructors, and expose a static `DisplayTo` entry point that validates `from`, `NetState`, and the underlying entity before constructing -- prevents the empty-gump leak. Wizard navigation between steps now goes through `DisplayTo` (e.g. `ConfirmSkillGump.DisplayTo(from, _stone, skill)` from the skill picker, `ErrorGump.DisplayTo(...)` from absorption pre-checks, `SelectSkillGump.DisplayTo(...)` from the "make another selection" button on `ConfirmSkillGump` and from `ErrorGump` bounce-back). Because each gump is Singleton, sending the same type again automatically closes any prior instance instead of stacking; the explicit `gumps.Close<T>()` chain on `OnDoubleClick` is preserved so opening the soulstone still resets any orphaned step from another wizard.

`OnResponse` now uses `in RelayInfo info`. All inline `AddX(...)` calls move to `builder.AddX(...)` inside `BuildLayout`. `Skill.Base.ToString("F1")` etc. are converted to `$"{value:F1}"` interpolation passed to `AddLabel(ReadOnlySpan<char>)`. Skill picker pagination still uses client-side `AddPage` / `GumpButtonType.Page` -- no server-state pagination to migrate.

## Test plan

- [x] `dotnet build Projects/UOContent/UOContent.csproj` -- 0 warnings, 0 errors.
- [ ] In-game: load a soulstone, double-click while empty, page through the skill picker, pick a skill -> confirm transfer -> verify points move into the stone.
- [ ] In-game: double-click a loaded soulstone, absorb skill points back -> verify points return.
- [ ] In-game: trigger an absorb error path (skill lock = down, or skill below stored value) -> verify ErrorGump shows and the Continue button bounces back to the appropriate prior step.
- [ ] In-game: double-click a loaded soulstone, choose "Remove all skill points" -> ConfirmRemovalGump -> Continue -> verify points are deleted.
- [ ] In-game: open a treasure map chest you own, use the context menu Remove option -> Cancel and Remove buttons both behave; the dialog cannot be right-clicked away (NoClose).
