### PR TITLE
perf: Migrate Old Guild System gumps to DynamicGump

### DIFF
--- a/Projects/Server/Buffers/SpanWriter.cs
+++ b/Projects/Server/Buffers/SpanWriter.cs
@@ -352,62 +352,62 @@ public ref struct SpanWriter
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteLittleUni(string value) => Write(value, TextEncoding.UnicodeLE);
+    public void WriteLittleUni(ReadOnlySpan<char> value) => Write(value, TextEncoding.UnicodeLE);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteLittleUniNull(string value)
+    public void WriteLittleUniNull(ReadOnlySpan<char> value)
     {
         Write(value, TextEncoding.UnicodeLE);
         Write((ushort)0);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteLittleUni(string value, int fixedLength) => Write(value, TextEncoding.UnicodeLE, fixedLength);
+    public void WriteLittleUni(ReadOnlySpan<char> value, int fixedLength) => Write(value, TextEncoding.UnicodeLE, fixedLength);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteBigUni(string value) => Write(value, TextEncoding.Unicode);
+    public void WriteBigUni(ReadOnlySpan<char> value) => Write(value, TextEncoding.Unicode);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteBigUniNull(string value)
+    public void WriteBigUniNull(ReadOnlySpan<char> value)
     {
         Write(value, TextEncoding.Unicode);
         Write((ushort)0); // '\0'
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteBigUni(string value, int fixedLength) => Write(value, TextEncoding.Unicode, fixedLength);
+    public void WriteBigUni(ReadOnlySpan<char> value, int fixedLength) => Write(value, TextEncoding.Unicode, fixedLength);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteUTF8(string value) => Write(value, TextEncoding.UTF8);
+    public void WriteUTF8(ReadOnlySpan<char> value) => Write(value, TextEncoding.UTF8);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteUTF8Null(string value)
+    public void WriteUTF8Null(ReadOnlySpan<char> value)
     {
         Write(value, TextEncoding.UTF8);
         Write((byte)0); // '\0'
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteAscii(string value) => Write(value, Encoding.ASCII);
+    public void WriteAscii(ReadOnlySpan<char> value) => Write(value, Encoding.ASCII);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteAsciiNull(string value)
+    public void WriteAsciiNull(ReadOnlySpan<char> value)
     {
         Write(value, Encoding.ASCII);
         Write((byte)0); // '\0'
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteAscii(string value, int fixedLength) => Write(value, Encoding.ASCII, fixedLength);
+    public void WriteAscii(ReadOnlySpan<char> value, int fixedLength) => Write(value, Encoding.ASCII, fixedLength);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteLatin1(string value) => Write(value, Encoding.Latin1);
+    public void WriteLatin1(ReadOnlySpan<char> value) => Write(value, Encoding.Latin1);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteLatin1(string value, int fixedLength) => Write(value, Encoding.Latin1, fixedLength);
+    public void WriteLatin1(ReadOnlySpan<char> value, int fixedLength) => Write(value, Encoding.Latin1, fixedLength);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void WriteLatin1Null(string value)
+    public void WriteLatin1Null(ReadOnlySpan<char> value)
     {
         Write(value, Encoding.Latin1);
         Write((byte)0); // '\0'

--- a/Projects/Server/Guild.cs
+++ b/Projects/Server/Guild.cs
@@ -62,7 +62,7 @@ public abstract class BaseGuild : ISerializable
 
     public abstract void OnDelete(Mobile mob);
 
-    public static BaseGuild FindByName(string name)
+    public static BaseGuild FindByName(ReadOnlySpan<char> name)
     {
         foreach (var g in World.Guilds.Values)
         {
@@ -75,7 +75,7 @@ public abstract class BaseGuild : ISerializable
         return null;
     }
 
-    public static BaseGuild FindByAbbrev(string abbr)
+    public static BaseGuild FindByAbbrev(ReadOnlySpan<char> abbr)
     {
         foreach (var g in World.Guilds.Values)
         {
@@ -88,19 +88,29 @@ public abstract class BaseGuild : ISerializable
         return null;
     }
 
-    public static HashSet<BaseGuild> Search(string find)
+    public static HashSet<BaseGuild> Search(ReadOnlySpan<char> find)
     {
-        var words = find.ToLower().Split(' ');
         var results = new HashSet<BaseGuild>();
+        find = find.Trim();
+        if (find.IsEmpty)
+        {
+            return results;
+        }
 
         foreach (var g in World.Guilds.Values)
         {
-            var name = g.Name;
+            var name = g.Name.AsSpan();
 
             var all = true;
-            foreach (var t in words)
+            foreach (var wordRange in find.Split(' '))
             {
-                if (name.InsensitiveIndexOf(t) == -1)
+                var word = find[wordRange];
+                if (word.IsEmpty)
+                {
+                    continue;
+                }
+
+                if (name.InsensitiveContains(word))
                 {
                     all = false;
                     break;

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -7809,10 +7809,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         return false;
     }
 
-    public void LaunchBrowser(string url)
-    {
-        m_NetState?.LaunchBrowser(url);
-    }
+    public void LaunchBrowser(ReadOnlySpan<char> url) => m_NetState?.LaunchBrowser(url);
 
     public void InitStats(int str, int dex, int intel)
     {

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -404,7 +404,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         HuePickers?.Clear();
     }
 
-    public void LaunchBrowser(string url)
+    public void LaunchBrowser(ReadOnlySpan<char> url)
     {
         this.SendMessageLocalized(Serial.MinusOne, -1, MessageType.Label, 0x35, 3, 501231);
         this.SendLaunchBrowser(url);

--- a/Projects/Server/Network/Packets/OutgoingPlayerPackets.cs
+++ b/Projects/Server/Network/Packets/OutgoingPlayerPackets.cs
@@ -175,14 +175,12 @@ public static class OutgoingPlayerPackets
         ns.Send(writer.Span);
     }
 
-    public static void SendLaunchBrowser(this NetState ns, string uri)
+    public static void SendLaunchBrowser(this NetState ns, ReadOnlySpan<char> uri)
     {
         if (ns.CannotSendPackets())
         {
             return;
         }
-
-        uri ??= "";
 
         var length = 4 + uri.Length;
         var writer = new SpanWriter(stackalloc byte[length]);

--- a/Projects/UOContent/Gumps/Guilds/DeclareFealtyGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/DeclareFealtyGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class DeclareFealtyGump : GuildMobileListGump
     {
-        private DeclareFealtyGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
+        private DeclareFealtyGump(Guild guild) : base(guild, true, guild.Members)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new DeclareFealtyGump(from, guild));
+            from.SendGump(new DeclareFealtyGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(_mobile, _guild))
+            var from = state.Mobile;
+            if (info.ButtonID == 0 || GuildGump.BadMember(from, _guild))
             {
                 return;
             }
@@ -58,7 +59,7 @@ namespace Server.Gumps
                 }
             }
 
-            GuildGump.DisplayTo(_mobile, _guild);
+            GuildGump.DisplayTo(from, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/DeclareFealtyGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/DeclareFealtyGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class DeclareFealtyGump : GuildMobileListGump
     {
-        public DeclareFealtyGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
+        private DeclareFealtyGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011097); // Declare your fealty
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 250, 35, 1011098); // I have selected my new lord.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new DeclareFealtyGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 0);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011097); // Declare your fealty
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 250, 35, 1011098); // I have selected my new lord.
+
+            builder.AddButton(300, 400, 4005, 4007, 0);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(m_Mobile, m_Guild))
+            if (GuildGump.BadMember(_mobile, _guild))
             {
                 return;
             }
@@ -35,9 +46,9 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var m = m_List[index];
+                        var m = _list[index];
 
                         if (m?.Deleted == false)
                         {
@@ -47,8 +58,7 @@ namespace Server.Gumps
                 }
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
+            GuildGump.DisplayTo(_mobile, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GrantGuildTitleGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GrantGuildTitleGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GrantGuildTitleGump : GuildMobileListGump
     {
-        private GrantGuildTitleGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
+        private GrantGuildTitleGump(Guild guild) : base(guild, true, guild.Members)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GrantGuildTitleGump(from, guild));
+            from.SendGump(new GrantGuildTitleGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (info.ButtonID == 0 || GuildGump.BadMember(from, _guild))
             {
                 return;
             }
@@ -52,15 +53,15 @@ namespace Server.Gumps
 
                         if (m?.Deleted == false)
                         {
-                            _mobile.SendLocalizedMessage(1013074); // New title (20 characters max):
-                            _mobile.Prompt = new GuildTitlePrompt(_mobile, m, _guild);
+                            from.SendLocalizedMessage(1013074); // New title (20 characters max):
+                            from.Prompt = new GuildTitlePrompt(m, _guild);
                         }
                     }
                 }
             }
             else if (info.ButtonID == 2)
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GrantGuildTitleGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GrantGuildTitleGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class GrantGuildTitleGump : GuildMobileListGump
     {
-        public GrantGuildTitleGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
+        private GrantGuildTitleGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011118); // Grant a title to another member.
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011127); // I dub thee...
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GrantGuildTitleGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011118); // Grant a title to another member.
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011127); // I dub thee...
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -35,22 +46,21 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var m = m_List[index];
+                        var m = _list[index];
 
                         if (m?.Deleted == false)
                         {
-                            m_Mobile.SendLocalizedMessage(1013074); // New title (20 characters max):
-                            m_Mobile.Prompt = new GuildTitlePrompt(m_Mobile, m, m_Guild);
+                            _mobile.SendLocalizedMessage(1013074); // New title (20 characters max):
+                            _mobile.Prompt = new GuildTitlePrompt(_mobile, m, _guild);
                         }
                     }
                 }
             }
             else if (info.ButtonID == 2)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildAbbrvPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildAbbrvPrompt.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Guilds;
 using Server.Prompts;
 
@@ -5,53 +6,49 @@ namespace Server.Gumps
 {
     public class GuildAbbrvPrompt : Prompt
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
 
-        public GuildAbbrvPrompt(Mobile m, Guild g)
-        {
-            m_Mobile = m;
-            m_Guild = g;
-        }
+        public GuildAbbrvPrompt(Guild g) => _guild = g;
 
         public override void OnCancel(Mobile from)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
 
         public override void OnResponse(Mobile from, string text)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            text = text.Trim();
+            var textSpan = text.AsSpan().Trim();
 
-            if (text.Length > 3)
+            if (textSpan.Length > 3)
             {
-                text = text[..3];
+                textSpan = textSpan[..3];
             }
 
-            if (text.Length > 0)
+            if (textSpan.Length > 0)
             {
-                if (BaseGuild.FindByAbbrev(text) != null)
+                if (BaseGuild.FindByAbbrev(textSpan) != null)
                 {
-                    m_Mobile.SendMessage($"{text} conflicts with the abbreviation of an existing guild.");
+                    from.SendMessage($"{textSpan} conflicts with the abbreviation of an existing guild.");
                 }
                 else
                 {
-                    m_Guild.Abbreviation = text;
-                    m_Guild.GuildMessage(1018025, true, text); // Your guild abbreviation has changed:
+                    text = textSpan.ToString();
+                    _guild.Abbreviation = text;
+                    _guild.GuildMessage(1018025, true, text); // Your guild abbreviation has changed:
                 }
             }
 
-            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildAbbrvPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildAbbrvPrompt.cs
@@ -21,8 +21,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
@@ -52,8 +51,7 @@ namespace Server.Gumps
                 }
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildAcceptWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildAcceptWarGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class GuildAcceptWarGump : GuildListGump
     {
-        public GuildAcceptWarGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarInvitations)
+        private GuildAcceptWarGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarInvitations)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011147); // Select the guild to accept the invitations:
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011100); // Accept war invitations.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildAcceptWarGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011147); // Select the guild to accept the invitations:
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011100); // Accept war invitations.
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -35,27 +46,25 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var g = m_List[index];
+                        var g = _list[index];
 
                         if (g != null)
                         {
-                            m_Guild.WarInvitations.Remove(g);
-                            g.WarDeclarations.Remove(m_Guild);
+                            _guild.WarInvitations.Remove(g);
+                            g.WarDeclarations.Remove(_guild);
 
-                            m_Guild.AddEnemy(g);
-                            m_Guild.GuildMessage(1018020, true, $"{g.Name} ({g.Abbreviation})");
+                            _guild.AddEnemy(g);
+                            _guild.GuildMessage(1018020, true, $"{g.Name} ({g.Abbreviation})");
 
-                            GuildGump.EnsureClosed(m_Mobile);
-
-                            if (m_Guild.WarInvitations.Count > 0)
+                            if (_guild.WarInvitations.Count > 0)
                             {
-                                m_Mobile.SendGump(new GuildAcceptWarGump(m_Mobile, m_Guild));
+                                DisplayTo(_mobile, _guild);
                             }
                             else
                             {
-                                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                GuildmasterGump.DisplayTo(_mobile, _guild);
                             }
                         }
                     }
@@ -63,8 +72,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildAcceptWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildAcceptWarGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildAcceptWarGump : GuildListGump
     {
-        private GuildAcceptWarGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarInvitations)
+        private GuildAcceptWarGump(Guild guild) : base(guild, true, guild.WarInvitations)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildAcceptWarGump(from, guild));
+            from.SendGump(new GuildAcceptWarGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -60,11 +61,11 @@ namespace Server.Gumps
 
                             if (_guild.WarInvitations.Count > 0)
                             {
-                                DisplayTo(_mobile, _guild);
+                                DisplayTo(from, _guild);
                             }
                             else
                             {
-                                GuildmasterGump.DisplayTo(_mobile, _guild);
+                                GuildmasterGump.DisplayTo(from, _guild);
                             }
                         }
                     }
@@ -72,7 +73,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildAdminCandidatesGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildAdminCandidatesGump.cs
@@ -6,24 +6,35 @@ namespace Server.Gumps
 {
     public class GuildAdminCandidatesGump : GuildMobileListGump
     {
-        public GuildAdminCandidatesGump(Mobile from, Guild guild) : base(from, guild, true, guild.Candidates)
+        private GuildAdminCandidatesGump(Mobile from, Guild guild) : base(from, guild, true, guild.Candidates)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1013075); // Accept or Refuse candidates for membership
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1013076); // Accept
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildAdminCandidatesGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1013077); // Refuse
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1013075); // Accept or Refuse candidates for membership
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1013076); // Accept
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1013077); // Refuse
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -32,9 +43,7 @@ namespace Server.Gumps
             {
                 case 0:
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
-
+                        GuildmasterGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 1: // Accept
@@ -45,13 +54,13 @@ namespace Server.Gumps
                         {
                             var index = switches[0];
 
-                            if (index >= 0 && index < m_List.Count)
+                            if (index >= 0 && index < _list.Count)
                             {
-                                var m = m_List[index];
+                                var m = _list[index];
 
                                 if (m?.Deleted == false)
                                 {
-                                    var guildState = PlayerState.Find(m_Guild.Leader);
+                                    var guildState = PlayerState.Find(_guild.Leader);
                                     var targetState = PlayerState.Find(m);
 
                                     var guildFaction = guildState?.Faction;
@@ -61,21 +70,18 @@ namespace Server.Gumps
                                     {
                                         if (guildFaction == null)
                                         {
-                                            m_Mobile.SendLocalizedMessage(
-                                                1013027
-                                            ); // That player cannot join a non-faction guild.
+                                            // That player cannot join a non-faction guild.
+                                            _mobile.SendLocalizedMessage(1013027);
                                         }
                                         else if (targetFaction == null)
                                         {
-                                            m_Mobile.SendLocalizedMessage(
-                                                1013026
-                                            ); // That player must be in a faction before joining this guild.
+                                            // That player must be in a faction before joining this guild.
+                                            _mobile.SendLocalizedMessage(1013026);
                                         }
                                         else
                                         {
-                                            m_Mobile.SendLocalizedMessage(
-                                                1013028
-                                            ); // That person has a different faction affiliation.
+                                            // That person has a different faction affiliation.
+                                            _mobile.SendLocalizedMessage(1013028);
                                         }
 
                                         break;
@@ -84,24 +90,22 @@ namespace Server.Gumps
                                     if (targetState?.IsLeaving == true)
                                     {
                                         // OSI does this quite strangely, so we'll just do it this way
-                                        m_Mobile.SendMessage(
+                                        _mobile.SendMessage(
                                             "That person is quitting their faction and so you may not recruit them."
                                         );
                                         break;
                                     }
 
-                                    m_Guild.Candidates.Remove(m);
-                                    m_Guild.Accepted.Add(m);
+                                    _guild.Candidates.Remove(m);
+                                    _guild.Accepted.Add(m);
 
-                                    GuildGump.EnsureClosed(m_Mobile);
-
-                                    if (m_Guild.Candidates.Count > 0)
+                                    if (_guild.Candidates.Count > 0)
                                     {
-                                        m_Mobile.SendGump(new GuildAdminCandidatesGump(m_Mobile, m_Guild));
+                                        DisplayTo(_mobile, _guild);
                                     }
                                     else
                                     {
-                                        m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                        GuildmasterGump.DisplayTo(_mobile, _guild);
                                     }
                                 }
                             }
@@ -117,23 +121,21 @@ namespace Server.Gumps
                         {
                             var index = switches[0];
 
-                            if (index >= 0 && index < m_List.Count)
+                            if (index >= 0 && index < _list.Count)
                             {
-                                var m = m_List[index];
+                                var m = _list[index];
 
                                 if (m?.Deleted == false)
                                 {
-                                    m_Guild.Candidates.Remove(m);
+                                    _guild.Candidates.Remove(m);
 
-                                    GuildGump.EnsureClosed(m_Mobile);
-
-                                    if (m_Guild.Candidates.Count > 0)
+                                    if (_guild.Candidates.Count > 0)
                                     {
-                                        m_Mobile.SendGump(new GuildAdminCandidatesGump(m_Mobile, m_Guild));
+                                        DisplayTo(_mobile, _guild);
                                     }
                                     else
                                     {
-                                        m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                        GuildmasterGump.DisplayTo(_mobile, _guild);
                                     }
                                 }
                             }

--- a/Projects/UOContent/Gumps/Guilds/GuildAdminCandidatesGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildAdminCandidatesGump.cs
@@ -6,7 +6,7 @@ namespace Server.Gumps
 {
     public class GuildAdminCandidatesGump : GuildMobileListGump
     {
-        private GuildAdminCandidatesGump(Mobile from, Guild guild) : base(from, guild, true, guild.Candidates)
+        private GuildAdminCandidatesGump(Guild guild) : base(guild, true, guild.Candidates)
         {
         }
 
@@ -18,7 +18,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildAdminCandidatesGump(from, guild));
+            from.SendGump(new GuildAdminCandidatesGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -34,7 +34,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -43,7 +44,7 @@ namespace Server.Gumps
             {
                 case 0:
                     {
-                        GuildmasterGump.DisplayTo(_mobile, _guild);
+                        GuildmasterGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 1: // Accept
@@ -71,17 +72,17 @@ namespace Server.Gumps
                                         if (guildFaction == null)
                                         {
                                             // That player cannot join a non-faction guild.
-                                            _mobile.SendLocalizedMessage(1013027);
+                                            from.SendLocalizedMessage(1013027);
                                         }
                                         else if (targetFaction == null)
                                         {
                                             // That player must be in a faction before joining this guild.
-                                            _mobile.SendLocalizedMessage(1013026);
+                                            from.SendLocalizedMessage(1013026);
                                         }
                                         else
                                         {
                                             // That person has a different faction affiliation.
-                                            _mobile.SendLocalizedMessage(1013028);
+                                            from.SendLocalizedMessage(1013028);
                                         }
 
                                         break;
@@ -90,7 +91,7 @@ namespace Server.Gumps
                                     if (targetState?.IsLeaving == true)
                                     {
                                         // OSI does this quite strangely, so we'll just do it this way
-                                        _mobile.SendMessage(
+                                        from.SendMessage(
                                             "That person is quitting their faction and so you may not recruit them."
                                         );
                                         break;
@@ -101,11 +102,11 @@ namespace Server.Gumps
 
                                     if (_guild.Candidates.Count > 0)
                                     {
-                                        DisplayTo(_mobile, _guild);
+                                        DisplayTo(from, _guild);
                                     }
                                     else
                                     {
-                                        GuildmasterGump.DisplayTo(_mobile, _guild);
+                                        GuildmasterGump.DisplayTo(from, _guild);
                                     }
                                 }
                             }
@@ -131,11 +132,11 @@ namespace Server.Gumps
 
                                     if (_guild.Candidates.Count > 0)
                                     {
-                                        DisplayTo(_mobile, _guild);
+                                        DisplayTo(from, _guild);
                                     }
                                     else
                                     {
-                                        GuildmasterGump.DisplayTo(_mobile, _guild);
+                                        GuildmasterGump.DisplayTo(from, _guild);
                                     }
                                 }
                             }

--- a/Projects/UOContent/Gumps/Guilds/GuildCandidatesGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildCandidatesGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildCandidatesGump : GuildMobileListGump
     {
-        private GuildCandidatesGump(Mobile from, Guild guild) : base(from, guild, false, guild.Candidates)
+        private GuildCandidatesGump(Guild guild) : base(guild, false, guild.Candidates)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildCandidatesGump(from, guild));
+            from.SendGump(new GuildCandidatesGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -30,14 +30,15 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadMember(from, _guild))
             {
                 return;
             }
 
             if (info.ButtonID == 1)
             {
-                GuildGump.DisplayTo(_mobile, _guild);
+                GuildGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildCandidatesGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildCandidatesGump.cs
@@ -5,29 +5,39 @@ namespace Server.Gumps
 {
     public class GuildCandidatesGump : GuildMobileListGump
     {
-        public GuildCandidatesGump(Mobile from, Guild guild) : base(from, guild, false, guild.Candidates)
+        private GuildCandidatesGump(Mobile from, Guild guild) : base(from, guild, false, guild.Candidates)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 500, 35, 1013030); // <center> Candidates </center>
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 300, 35, 1011120); // Return to the main menu.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildCandidatesGump(from, guild));
+        }
+
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 500, 35, 1013030); // <center> Candidates </center>
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 300, 35, 1011120); // Return to the main menu.
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(m_Mobile, m_Guild))
+            if (GuildGump.BadMember(_mobile, _guild))
             {
                 return;
             }
 
             if (info.ButtonID == 1)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
+                GuildGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildChangeTypeGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildChangeTypeGump.cs
@@ -5,45 +5,61 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildChangeTypeGump : Gump
+    public class GuildChangeTypeGump : DynamicGump
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
+        private readonly Mobile _mobile;
 
-        public GuildChangeTypeGump(Mobile from, Guild guild) : base(20, 30)
+        public override bool Singleton => true;
+
+        private GuildChangeTypeGump(Mobile from, Guild guild) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+        }
 
-            Draggable = false;
+        public static void DisplayTo(Mobile from, Guild guild)
+        {
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 400, 5054);
-            AddBackground(10, 10, 530, 380, 3000);
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildChangeTypeGump(from, guild));
+        }
 
-            AddHtmlLocalized(20, 15, 510, 30, 1013062); // <center>Change Guild Type Menu</center>
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            AddHtmlLocalized(50, 50, 450, 30, 1013066); // Please select the type of guild you would like to change to
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 400, 5054);
+            builder.AddBackground(10, 10, 530, 380, 3000);
 
-            AddButton(20, 100, 4005, 4007, 1);
-            AddHtmlLocalized(85, 100, 300, 30, 1013063); // Standard guild
+            builder.AddHtmlLocalized(20, 15, 510, 30, 1013062); // <center>Change Guild Type Menu</center>
 
-            AddButton(20, 150, 4005, 4007, 2);
-            AddItem(50, 143, 7109);
-            AddHtmlLocalized(85, 150, 300, 300, 1013064); // Order guild
+            builder.AddHtmlLocalized(50, 50, 450, 30, 1013066); // Please select the type of guild you would like to change to
 
-            AddButton(20, 200, 4005, 4007, 3);
-            AddItem(45, 200, 7107);
-            AddHtmlLocalized(85, 200, 300, 300, 1013065); // Chaos guild
+            builder.AddButton(20, 100, 4005, 4007, 1);
+            builder.AddHtmlLocalized(85, 100, 300, 30, 1013063); // Standard guild
 
-            AddButton(300, 360, 4005, 4007, 4);
-            AddHtmlLocalized(335, 360, 150, 30, 1011012); // CANCEL
+            builder.AddButton(20, 150, 4005, 4007, 2);
+            builder.AddItem(50, 143, 7109);
+            builder.AddHtmlLocalized(85, 150, 300, 300, 1013064); // Order guild
+
+            builder.AddButton(20, 200, 4005, 4007, 3);
+            builder.AddItem(45, 200, 7107);
+            builder.AddHtmlLocalized(85, 200, 300, 300, 1013065); // Chaos guild
+
+            builder.AddButton(300, 360, 4005, 4007, 4);
+            builder.AddHtmlLocalized(335, 360, 150, 30, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (Guild.NewGuildSystem && !BaseGuildGump.IsLeader(m_Mobile, m_Guild) ||
-                !Guild.NewGuildSystem && GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (Guild.NewGuildSystem && !BaseGuildGump.IsLeader(_mobile, _guild) ||
+                !Guild.NewGuildSystem && GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -53,41 +69,40 @@ namespace Server.Gumps
                 1 => GuildType.Regular,
                 2 => GuildType.Order,
                 3 => GuildType.Chaos,
-                _ => m_Guild.Type
+                _ => _guild.Type
             };
 
-            if (m_Guild.Type != newType)
+            if (_guild.Type != newType)
             {
-                var pl = PlayerState.Find(m_Mobile);
+                var pl = PlayerState.Find(_mobile);
 
                 if (pl != null)
                 {
-                    m_Mobile.SendLocalizedMessage(1010405); // You cannot change guild types while in a Faction!
+                    _mobile.SendLocalizedMessage(1010405); // You cannot change guild types while in a Faction!
                 }
-                else if (m_Guild.TypeLastChange.AddDays(7) > Core.Now)
+                else if (_guild.TypeLastChange.AddDays(7) > Core.Now)
                 {
-                    m_Mobile.SendLocalizedMessage(1011142); // You have already changed your guild type recently.
+                    _mobile.SendLocalizedMessage(1011142); // You have already changed your guild type recently.
                     // TODO: Clilocs 1011142-1011145 suggest a timer for pending changes
                 }
                 else
                 {
-                    m_Guild.Type = newType;
-                    m_Guild.GuildMessage(1018022, true, newType.ToString()); // Guild Message: Your guild type has changed:
+                    _guild.Type = newType;
+                    _guild.GuildMessage(1018022, true, newType.ToString()); // Guild Message: Your guild type has changed:
                 }
             }
 
             if (Guild.NewGuildSystem)
             {
-                if (m_Mobile is PlayerMobile mobile)
+                if (_mobile is PlayerMobile mobile)
                 {
-                    mobile.SendGump(new GuildInfoGump(mobile, m_Guild));
+                    mobile.SendGump(new GuildInfoGump(mobile, _guild));
                 }
 
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(_mobile, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildChangeTypeGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildChangeTypeGump.cs
@@ -5,18 +5,13 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildChangeTypeGump : DynamicGump
+    public class GuildChangeTypeGump : StaticGump<GuildChangeTypeGump>
     {
         private readonly Guild _guild;
-        private readonly Mobile _mobile;
 
         public override bool Singleton => true;
 
-        private GuildChangeTypeGump(Mobile from, Guild guild) : base(20, 30)
-        {
-            _mobile = from;
-            _guild = guild;
-        }
+        private GuildChangeTypeGump(Guild guild) : base(20, 30) => _guild = guild;
 
         public static void DisplayTo(Mobile from, Guild guild)
         {
@@ -26,10 +21,10 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildChangeTypeGump(from, guild));
+            from.SendGump(new GuildChangeTypeGump(guild));
         }
 
-        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
         {
             builder.SetNoMove();
 
@@ -58,8 +53,9 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (Guild.NewGuildSystem && !BaseGuildGump.IsLeader(_mobile, _guild) ||
-                !Guild.NewGuildSystem && GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (Guild.NewGuildSystem && !BaseGuildGump.IsLeader(from, _guild) ||
+                !Guild.NewGuildSystem && GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -74,15 +70,15 @@ namespace Server.Gumps
 
             if (_guild.Type != newType)
             {
-                var pl = PlayerState.Find(_mobile);
+                var pl = PlayerState.Find(from);
 
                 if (pl != null)
                 {
-                    _mobile.SendLocalizedMessage(1010405); // You cannot change guild types while in a Faction!
+                    from.SendLocalizedMessage(1010405); // You cannot change guild types while in a Faction!
                 }
                 else if (_guild.TypeLastChange.AddDays(7) > Core.Now)
                 {
-                    _mobile.SendLocalizedMessage(1011142); // You have already changed your guild type recently.
+                    from.SendLocalizedMessage(1011142); // You have already changed your guild type recently.
                     // TODO: Clilocs 1011142-1011145 suggest a timer for pending changes
                 }
                 else
@@ -94,7 +90,7 @@ namespace Server.Gumps
 
             if (Guild.NewGuildSystem)
             {
-                if (_mobile is PlayerMobile mobile)
+                if (from is PlayerMobile mobile)
                 {
                     mobile.SendGump(new GuildInfoGump(mobile, _guild));
                 }
@@ -102,7 +98,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildmasterGump.DisplayTo(_mobile, _guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildCharterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildCharterGump.cs
@@ -3,53 +3,69 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildCharterGump : Gump
+    public class GuildCharterGump : DynamicGump
     {
         private const string DefaultWebsite = "https://www.modernuo.com";
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
+        private readonly Mobile _mobile;
 
-        public GuildCharterGump(Mobile from, Guild guild) : base(20, 30)
+        public override bool Singleton => true;
+
+        private GuildCharterGump(Mobile from, Guild guild) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+        }
 
-            Draggable = false;
+        public static void DisplayTo(Mobile from, Guild guild)
+        {
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 400, 5054);
-            AddBackground(10, 10, 530, 380, 3000);
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildCharterGump(from, guild));
+        }
 
-            AddButton(20, 360, 4005, 4007, 1);
-            AddHtmlLocalized(55, 360, 300, 35, 1011120); // Return to the main menu.
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
+
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 400, 5054);
+            builder.AddBackground(10, 10, 530, 380, 3000);
+
+            builder.AddButton(20, 360, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 360, 300, 35, 1011120); // Return to the main menu.
 
             string charter;
 
-            if ((charter = guild.Charter) == null || (charter = charter.Trim()).Length <= 0)
+            if ((charter = _guild.Charter) == null || (charter = charter.Trim()).Length <= 0)
             {
-                AddHtmlLocalized(20, 20, 400, 35, 1013032); // No charter has been defined.
+                builder.AddHtmlLocalized(20, 20, 400, 35, 1013032); // No charter has been defined.
             }
             else
             {
-                AddHtml(20, 20, 510, 75, charter, true, true);
+                builder.AddHtml(20, 20, 510, 75, charter, background: true, scrollbar: true);
             }
 
-            AddButton(20, 200, 4005, 4007, 2);
-            AddHtmlLocalized(55, 200, 300, 20, 1011122); // Visit the guild website :
+            builder.AddButton(20, 200, 4005, 4007, 2);
+            builder.AddHtmlLocalized(55, 200, 300, 20, 1011122); // Visit the guild website :
 
             string website;
 
-            if ((website = guild.Website) == null || (website = website.Trim()).Length <= 0)
+            if ((website = _guild.Website) == null || (website = website.Trim()).Length <= 0)
             {
                 website = DefaultWebsite;
             }
 
-            AddHtml(55, 220, 300, 20, website);
+            builder.AddHtml(55, 220, 300, 20, website);
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(m_Mobile, m_Guild))
+            if (GuildGump.BadMember(_mobile, _guild))
             {
                 return;
             }
@@ -62,24 +78,23 @@ namespace Server.Gumps
                     }
                 case 1:
                     {
-                        break;  // Return to main menu
+                        break; // Return to main menu
                     }
                 case 2:
                     {
                         string website;
 
-                        if ((website = m_Guild.Website) == null || (website = website.Trim()).Length <= 0)
+                        if ((website = _guild.Website) == null || (website = website.Trim()).Length <= 0)
                         {
                             website = DefaultWebsite;
                         }
 
-                        m_Mobile.LaunchBrowser(website);
+                        _mobile.LaunchBrowser(website);
                         break;
                     }
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
+            GuildGump.DisplayTo(_mobile, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildCharterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildCharterGump.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Guilds;
 using Server.Network;
 
@@ -7,15 +8,10 @@ namespace Server.Gumps
     {
         private const string DefaultWebsite = "https://www.modernuo.com";
         private readonly Guild _guild;
-        private readonly Mobile _mobile;
 
         public override bool Singleton => true;
 
-        private GuildCharterGump(Mobile from, Guild guild) : base(20, 30)
-        {
-            _mobile = from;
-            _guild = guild;
-        }
+        private GuildCharterGump(Guild guild) : base(20, 30) => _guild = guild;
 
         public static void DisplayTo(Mobile from, Guild guild)
         {
@@ -25,7 +21,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildCharterGump(from, guild));
+            from.SendGump(new GuildCharterGump(guild));
         }
 
         protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -53,9 +49,8 @@ namespace Server.Gumps
             builder.AddButton(20, 200, 4005, 4007, 2);
             builder.AddHtmlLocalized(55, 200, 300, 20, 1011122); // Visit the guild website :
 
-            string website;
-
-            if ((website = _guild.Website) == null || (website = website.Trim()).Length <= 0)
+            var website = _guild.Website != null ? _guild.Website.AsSpan().Trim() : "";
+            if (website.Length <= 0)
             {
                 website = DefaultWebsite;
             }
@@ -65,36 +60,24 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(_mobile, _guild))
+            var from = state.Mobile;
+            if (info.ButtonID == 0 || GuildGump.BadMember(from, _guild))
             {
                 return;
             }
 
-            switch (info.ButtonID)
+            if (info.ButtonID == 2)
             {
-                case 0:
-                    {
-                        return; // Close
-                    }
-                case 1:
-                    {
-                        break; // Return to main menu
-                    }
-                case 2:
-                    {
-                        string website;
+                var website = _guild.Website != null ? _guild.Website.AsSpan().Trim() : "";
+                if (website.Length <= 0)
+                {
+                    website = DefaultWebsite;
+                }
 
-                        if ((website = _guild.Website) == null || (website = website.Trim()).Length <= 0)
-                        {
-                            website = DefaultWebsite;
-                        }
-
-                        _mobile.LaunchBrowser(website);
-                        break;
-                    }
+                from.LaunchBrowser(website);
             }
 
-            GuildGump.DisplayTo(_mobile, _guild);
+            GuildGump.DisplayTo(from, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildCharterPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildCharterPrompt.cs
@@ -21,8 +21,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
@@ -47,8 +46,7 @@ namespace Server.Gumps
             m_Mobile.SendLocalizedMessage(1013072); // Enter the new website for the guild (50 characters max):
             m_Mobile.Prompt = new GuildWebsitePrompt(m_Mobile, m_Guild);
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildCharterPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildCharterPrompt.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Guilds;
 using Server.Prompts;
 
@@ -5,48 +6,43 @@ namespace Server.Gumps
 {
     public class GuildCharterPrompt : Prompt
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
 
-        public GuildCharterPrompt(Mobile m, Guild g)
-        {
-            m_Mobile = m;
-            m_Guild = g;
-        }
+        public GuildCharterPrompt(Guild g) => _guild = g;
 
         public override void OnCancel(Mobile from)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
 
         public override void OnResponse(Mobile from, string text)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            text = text.Trim();
+            var textSpan = text.AsSpan().Trim();
 
-            if (text.Length > 50)
+            if (textSpan.Length > 50)
             {
-                text = text[..50];
+                textSpan = textSpan[..50];
             }
 
-            if (text.Length > 0)
+            if (textSpan.Length > 0)
             {
-                m_Guild.Charter = text;
+                _guild.Charter = textSpan.ToString();
             }
 
-            m_Mobile.SendLocalizedMessage(1013072); // Enter the new website for the guild (50 characters max):
-            m_Mobile.Prompt = new GuildWebsitePrompt(m_Mobile, m_Guild);
+            from.SendLocalizedMessage(1013072); // Enter the new website for the guild (50 characters max):
+            from.Prompt = new GuildWebsitePrompt(from, _guild);
 
-            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclarePeaceGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclarePeaceGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class GuildDeclarePeaceGump : GuildListGump
     {
-        public GuildDeclarePeaceGump(Mobile from, Guild guild) : base(from, guild, true, guild.Enemies)
+        private GuildDeclarePeaceGump(Mobile from, Guild guild) : base(from, guild, true, guild.Enemies)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011137); // Select the guild you wish to declare peace with.
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011138); // Send the olive branch.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildDeclarePeaceGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011137); // Select the guild you wish to declare peace with.
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011138); // Send the olive branch.
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -35,25 +46,23 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var g = m_List[index];
+                        var g = _list[index];
 
                         if (g != null)
                         {
-                            m_Guild.RemoveEnemy(g);
+                            _guild.RemoveEnemy(g);
                             // Guild Message: You are now at peace with this guild:
-                            m_Guild.GuildMessage(1018018, true, $"{g.Name} ({g.Abbreviation})");
+                            _guild.GuildMessage(1018018, true, $"{g.Name} ({g.Abbreviation})");
 
-                            GuildGump.EnsureClosed(m_Mobile);
-
-                            if (m_Guild.Enemies.Count > 0)
+                            if (_guild.Enemies.Count > 0)
                             {
-                                m_Mobile.SendGump(new GuildDeclarePeaceGump(m_Mobile, m_Guild));
+                                DisplayTo(_mobile, _guild);
                             }
                             else
                             {
-                                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                GuildmasterGump.DisplayTo(_mobile, _guild);
                             }
                         }
                     }
@@ -61,8 +70,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclarePeaceGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclarePeaceGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildDeclarePeaceGump : GuildListGump
     {
-        private GuildDeclarePeaceGump(Mobile from, Guild guild) : base(from, guild, true, guild.Enemies)
+        private GuildDeclarePeaceGump(Guild guild) : base(guild, true, guild.Enemies)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildDeclarePeaceGump(from, guild));
+            from.SendGump(new GuildDeclarePeaceGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -58,11 +59,11 @@ namespace Server.Gumps
 
                             if (_guild.Enemies.Count > 0)
                             {
-                                DisplayTo(_mobile, _guild);
+                                DisplayTo(from, _guild);
                             }
                             else
                             {
-                                GuildmasterGump.DisplayTo(_mobile, _guild);
+                                GuildmasterGump.DisplayTo(from, _guild);
                             }
                         }
                     }
@@ -70,7 +71,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclareWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclareWarGump.cs
@@ -7,20 +7,19 @@ namespace Server.Gumps
 {
     public class GuildDeclareWarGump : GuildListGump
     {
-        private GuildDeclareWarGump(Mobile from, Guild guild, List<Guild> list)
-            : base(from, guild, true, list)
+        private GuildDeclareWarGump(Guild guild, List<Guild> list) : base(guild, true, list)
         {
         }
 
         public static void DisplayTo(Mobile from, Guild guild, List<Guild> list)
         {
-            if (from?.NetState == null || guild == null || list == null)
+            if (from?.NetState == null || guild == null || list == null || list.Count == 0)
             {
                 return;
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildDeclareWarGump(from, guild, list));
+            from.SendGump(new GuildDeclareWarGump(guild, list));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -36,7 +35,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -57,16 +57,16 @@ namespace Server.Gumps
                         {
                             if (g == _guild)
                             {
-                                _mobile.SendLocalizedMessage(501184); // You cannot declare war against yourself!
+                                from.SendLocalizedMessage(501184); // You cannot declare war against yourself!
                             }
                             else if (g.WarInvitations.Contains(_guild) && _guild.WarDeclarations.Contains(g) ||
                                      _guild.IsWar(g))
                             {
-                                _mobile.SendLocalizedMessage(501183); // You are already at war with that guild.
+                                from.SendLocalizedMessage(501183); // You are already at war with that guild.
                             }
                             else if (Faction.Find(_guild.Leader) != null)
                             {
-                                _mobile.SendLocalizedMessage(1005288); // You cannot declare war while you are in a faction
+                                from.SendLocalizedMessage(1005288); // You cannot declare war while you are in a faction
                             }
                             else
                             {
@@ -85,14 +85,14 @@ namespace Server.Gumps
                                 }
                             }
 
-                            GuildWarAdminGump.DisplayTo(_mobile, _guild);
+                            GuildWarAdminGump.DisplayTo(from, _guild);
                         }
                     }
                 }
             }
             else if (info.ButtonID == 2)
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclareWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclareWarGump.cs
@@ -7,25 +7,36 @@ namespace Server.Gumps
 {
     public class GuildDeclareWarGump : GuildListGump
     {
-        public GuildDeclareWarGump(Mobile from, Guild guild, List<Guild> list)
+        private GuildDeclareWarGump(Mobile from, Guild guild, List<Guild> list)
             : base(from, guild, true, list)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild, List<Guild> list)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011065); // Select the guild you wish to declare war on.
+            if (from?.NetState == null || guild == null || list == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011068); // Send the challenge!
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildDeclareWarGump(from, guild, list));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011065); // Select the guild you wish to declare war on.
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011068); // Send the challenge!
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -38,52 +49,50 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var g = m_List[index];
+                        var g = _list[index];
 
                         if (g != null)
                         {
-                            if (g == m_Guild)
+                            if (g == _guild)
                             {
-                                m_Mobile.SendLocalizedMessage(501184); // You cannot declare war against yourself!
+                                _mobile.SendLocalizedMessage(501184); // You cannot declare war against yourself!
                             }
-                            else if (g.WarInvitations.Contains(m_Guild) && m_Guild.WarDeclarations.Contains(g) ||
-                                     m_Guild.IsWar(g))
+                            else if (g.WarInvitations.Contains(_guild) && _guild.WarDeclarations.Contains(g) ||
+                                     _guild.IsWar(g))
                             {
-                                m_Mobile.SendLocalizedMessage(501183); // You are already at war with that guild.
+                                _mobile.SendLocalizedMessage(501183); // You are already at war with that guild.
                             }
-                            else if (Faction.Find(m_Guild.Leader) != null)
+                            else if (Faction.Find(_guild.Leader) != null)
                             {
-                                m_Mobile.SendLocalizedMessage(1005288); // You cannot declare war while you are in a faction
+                                _mobile.SendLocalizedMessage(1005288); // You cannot declare war while you are in a faction
                             }
                             else
                             {
-                                if (!m_Guild.WarDeclarations.Contains(g))
+                                if (!_guild.WarDeclarations.Contains(g))
                                 {
-                                    m_Guild.WarDeclarations.Add(g);
+                                    _guild.WarDeclarations.Add(g);
                                     // Guild Message: Your guild has sent an invitation for war:
-                                    m_Guild.GuildMessage(1018019, true, $"{g.Name} ({g.Abbreviation})");
+                                    _guild.GuildMessage(1018019, true, $"{g.Name} ({g.Abbreviation})");
                                 }
 
-                                if (!g.WarInvitations.Contains(m_Guild))
+                                if (!g.WarInvitations.Contains(_guild))
                                 {
-                                    g.WarInvitations.Add(m_Guild);
+                                    g.WarInvitations.Add(_guild);
                                     // Guild Message: Your guild has received an invitation to war:
-                                    g.GuildMessage(1018021, true, $"{m_Guild.Name} ({m_Guild.Abbreviation})");
+                                    g.GuildMessage(1018021, true, $"{_guild.Name} ({_guild.Abbreviation})");
                                 }
                             }
 
-                            GuildGump.EnsureClosed(m_Mobile);
-                            m_Mobile.SendGump(new GuildWarAdminGump(m_Mobile, m_Guild));
+                            GuildWarAdminGump.DisplayTo(_mobile, _guild);
                         }
                     }
                 }
             }
             else if (info.ButtonID == 2)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclareWarPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclareWarPrompt.cs
@@ -5,51 +5,46 @@ namespace Server.Gumps
 {
     public class GuildDeclareWarPrompt : Prompt
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
 
-        public GuildDeclareWarPrompt(Mobile m, Guild g)
-        {
-            m_Mobile = m;
-            m_Guild = g;
-        }
+        public GuildDeclareWarPrompt(Guild g) => _guild = g;
 
         public override void OnCancel(Mobile from)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            GuildWarAdminGump.DisplayTo(m_Mobile, m_Guild);
+            GuildWarAdminGump.DisplayTo(from, _guild);
         }
 
         public override void OnResponse(Mobile from, string text)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            text = text.Trim();
+            var textSpan = text.Trim();
 
-            if (text.Length >= 3)
+            if (textSpan.Length >= 3)
             {
-                var guilds = BaseGuild.Search(text).SafeConvertList<BaseGuild, Guild>();
+                var guilds = BaseGuild.Search(textSpan).SafeConvertList<BaseGuild, Guild>();
 
                 if (guilds.Count > 0)
                 {
-                    GuildDeclareWarGump.DisplayTo(m_Mobile, m_Guild, guilds);
+                    GuildDeclareWarGump.DisplayTo(from, _guild, guilds);
                 }
                 else
                 {
-                    GuildWarAdminGump.DisplayTo(m_Mobile, m_Guild);
-                    m_Mobile.SendLocalizedMessage(1018003); // No guilds found matching - try another name in the search
+                    GuildWarAdminGump.DisplayTo(from, _guild);
+                    from.SendLocalizedMessage(1018003); // No guilds found matching - try another name in the search
                 }
             }
             else
             {
-                m_Mobile.SendMessage("Search string must be at least three letters in length.");
+                from.SendMessage("Search string must be at least three letters in length.");
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildDeclareWarPrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDeclareWarPrompt.cs
@@ -21,8 +21,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildWarAdminGump(m_Mobile, m_Guild));
+            GuildWarAdminGump.DisplayTo(m_Mobile, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
@@ -38,15 +37,13 @@ namespace Server.Gumps
             {
                 var guilds = BaseGuild.Search(text).SafeConvertList<BaseGuild, Guild>();
 
-                GuildGump.EnsureClosed(m_Mobile);
-
                 if (guilds.Count > 0)
                 {
-                    m_Mobile.SendGump(new GuildDeclareWarGump(m_Mobile, m_Guild, guilds));
+                    GuildDeclareWarGump.DisplayTo(m_Mobile, m_Guild, guilds);
                 }
                 else
                 {
-                    m_Mobile.SendGump(new GuildWarAdminGump(m_Mobile, m_Guild));
+                    GuildWarAdminGump.DisplayTo(m_Mobile, m_Guild);
                     m_Mobile.SendLocalizedMessage(1018003); // No guilds found matching - try another name in the search
                 }
             }

--- a/Projects/UOContent/Gumps/Guilds/GuildDismissGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDismissGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildDismissGump : GuildMobileListGump
     {
-        private GuildDismissGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
+        private GuildDismissGump(Guild guild) : base(guild, true, guild.Members)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildDismissGump(from, guild));
+            from.SendGump(new GuildDismissGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -54,17 +55,17 @@ namespace Server.Gumps
                         {
                             _guild.RemoveMember(m);
 
-                            if (_mobile.AccessLevel >= AccessLevel.GameMaster || _mobile == _guild.Leader)
+                            if (from.AccessLevel >= AccessLevel.GameMaster || from == _guild.Leader)
                             {
-                                GuildmasterGump.DisplayTo(_mobile, _guild);
+                                GuildmasterGump.DisplayTo(from, _guild);
                             }
                         }
                     }
                 }
             }
-            else if (info.ButtonID == 2 && (_mobile.AccessLevel >= AccessLevel.GameMaster || _mobile == _guild.Leader))
+            else if (info.ButtonID == 2 && (from.AccessLevel >= AccessLevel.GameMaster || from == _guild.Leader))
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildDismissGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildDismissGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class GuildDismissGump : GuildMobileListGump
     {
-        public GuildDismissGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
+        private GuildDismissGump(Mobile from, Guild guild) : base(from, guild, true, guild.Members)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011124); // Whom do you wish to dismiss?
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011125); // Kick them out!
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildDismissGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011124); // Whom do you wish to dismiss?
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011125); // Kick them out!
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -35,27 +46,25 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var m = m_List[index];
+                        var m = _list[index];
 
                         if (m?.Deleted == false)
                         {
-                            m_Guild.RemoveMember(m);
+                            _guild.RemoveMember(m);
 
-                            if (m_Mobile.AccessLevel >= AccessLevel.GameMaster || m_Mobile == m_Guild.Leader)
+                            if (_mobile.AccessLevel >= AccessLevel.GameMaster || _mobile == _guild.Leader)
                             {
-                                GuildGump.EnsureClosed(m_Mobile);
-                                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                GuildmasterGump.DisplayTo(_mobile, _guild);
                             }
                         }
                     }
                 }
             }
-            else if (info.ButtonID == 2 && (m_Mobile.AccessLevel >= AccessLevel.GameMaster || m_Mobile == m_Guild.Leader))
+            else if (info.ButtonID == 2 && (_mobile.AccessLevel >= AccessLevel.GameMaster || _mobile == _guild.Leader))
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildGump.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Guilds;
 using Server.Network;
 
@@ -41,9 +42,10 @@ namespace Server.Gumps
 
             if (leader != null)
             {
-                var leadTitle = leader.GuildTitle?.Trim();
-                var leadName = (leader.Name?.Trim()).DefaultIfNullOrEmpty("(empty)");
-                var text = leadTitle?.Length > 0 ? $"{leadTitle}: {leadName}" : leadName;
+                var leadTitle = leader.GuildTitle != null ? leader.GuildTitle.AsSpan().Trim() : ReadOnlySpan<char>.Empty;
+                var leadName = leader.Name;
+                var leadNameSpan = leadName != null ? leadName.AsSpan().Trim() : ReadOnlySpan<char>.Empty;
+                var text = leadTitle.Length > 0 ? $"{leadTitle}: {leadNameSpan}" : leadNameSpan;
 
                 builder.AddHtml(220, 15, 250, 35, text);
             }
@@ -60,15 +62,14 @@ namespace Server.Gumps
 
             fealty ??= _mobile;
 
-            var fealtyName = (fealty.Name?.Trim()).DefaultIfNullOrEmpty("(empty)");
-
             if (_mobile == fealty)
             {
                 builder.AddHtmlLocalized(55, 70, 470, 20, 1018002); // yourself
             }
             else
             {
-                builder.AddHtml(55, 70, 470, 20, fealtyName);
+                var fealtyName = fealty.Name;
+                builder.AddHtml(55, 70, 470, 20, fealtyName != null ? fealtyName.AsSpan().Trim() : "(empty)");
             }
 
             builder.AddButton(215, 50, 4005, 4007, 2);

--- a/Projects/UOContent/Gumps/Guilds/GuildGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildGump.cs
@@ -3,25 +3,41 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildGump : Gump
+    public class GuildGump : DynamicGump
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
+        private readonly Mobile _mobile;
 
-        public GuildGump(Mobile beholder, Guild guild) : base(20, 30)
+        public override bool Singleton => true;
+
+        private GuildGump(Mobile beholder, Guild guild) : base(20, 30)
         {
-            m_Mobile = beholder;
-            m_Guild = guild;
+            _mobile = beholder;
+            _guild = guild;
+        }
 
-            Draggable = false;
+        public static void DisplayTo(Mobile from, Guild guild)
+        {
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 400, 5054);
-            AddBackground(10, 10, 530, 380, 3000);
+            EnsureClosed(from);
+            from.SendGump(new GuildGump(from, guild));
+        }
 
-            AddHtml(20, 15, 200, 35, guild.Name);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            var leader = guild.Leader;
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 400, 5054);
+            builder.AddBackground(10, 10, 530, 380, 3000);
+
+            builder.AddHtml(20, 15, 200, 35, _guild.Name);
+
+            var leader = _guild.Leader;
 
             if (leader != null)
             {
@@ -29,75 +45,75 @@ namespace Server.Gumps
                 var leadName = (leader.Name?.Trim()).DefaultIfNullOrEmpty("(empty)");
                 var text = leadTitle?.Length > 0 ? $"{leadTitle}: {leadName}" : leadName;
 
-                AddHtml(220, 15, 250, 35, text);
+                builder.AddHtml(220, 15, 250, 35, text);
             }
 
-            AddButton(20, 50, 4005, 4007, 1);
-            AddHtmlLocalized(55, 50, 100, 20, 1013022); // Loyal to
+            builder.AddButton(20, 50, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 50, 100, 20, 1013022); // Loyal to
 
-            var fealty = beholder.GuildFealty;
+            var fealty = _mobile.GuildFealty;
 
-            if (fealty == null || !guild.IsMember(fealty))
+            if (fealty == null || !_guild.IsMember(fealty))
             {
                 fealty = leader;
             }
 
-            fealty ??= beholder;
+            fealty ??= _mobile;
 
             var fealtyName = (fealty.Name?.Trim()).DefaultIfNullOrEmpty("(empty)");
 
-            if (beholder == fealty)
+            if (_mobile == fealty)
             {
-                AddHtmlLocalized(55, 70, 470, 20, 1018002); // yourself
+                builder.AddHtmlLocalized(55, 70, 470, 20, 1018002); // yourself
             }
             else
             {
-                AddHtml(55, 70, 470, 20, fealtyName);
+                builder.AddHtml(55, 70, 470, 20, fealtyName);
             }
 
-            AddButton(215, 50, 4005, 4007, 2);
-            AddHtmlLocalized(250, 50, 170, 20, 1013023);                                       // Display guild abbreviation
-            AddHtmlLocalized(250, 70, 50, 20, beholder.DisplayGuildTitle ? 1011262 : 1011263); // on/off
+            builder.AddButton(215, 50, 4005, 4007, 2);
+            builder.AddHtmlLocalized(250, 50, 170, 20, 1013023);                                       // Display guild abbreviation
+            builder.AddHtmlLocalized(250, 70, 50, 20, _mobile.DisplayGuildTitle ? 1011262 : 1011263); // on/off
 
-            AddButton(20, 100, 4005, 4007, 3);
-            AddHtmlLocalized(55, 100, 470, 30, 1011086); // View the current roster.
+            builder.AddButton(20, 100, 4005, 4007, 3);
+            builder.AddHtmlLocalized(55, 100, 470, 30, 1011086); // View the current roster.
 
-            AddButton(20, 130, 4005, 4007, 4);
-            AddHtmlLocalized(55, 130, 470, 30, 1011085); // Recruit someone into the guild.
+            builder.AddButton(20, 130, 4005, 4007, 4);
+            builder.AddHtmlLocalized(55, 130, 470, 30, 1011085); // Recruit someone into the guild.
 
-            if (guild.Candidates.Count > 0)
+            if (_guild.Candidates.Count > 0)
             {
-                AddButton(20, 160, 4005, 4007, 5);
-                AddHtmlLocalized(55, 160, 470, 30, 1011093); // View list of candidates who have been sponsored to the guild.
+                builder.AddButton(20, 160, 4005, 4007, 5);
+                builder.AddHtmlLocalized(55, 160, 470, 30, 1011093); // View list of candidates who have been sponsored to the guild.
             }
             else
             {
-                AddImage(20, 160, 4020);
-                AddHtmlLocalized(55, 160, 470, 30, 1013031); // There are currently no candidates for membership.
+                builder.AddImage(20, 160, 4020);
+                builder.AddHtmlLocalized(55, 160, 470, 30, 1013031); // There are currently no candidates for membership.
             }
 
-            AddButton(20, 220, 4005, 4007, 6);
-            AddHtmlLocalized(55, 220, 470, 30, 1011087); // View the guild's charter.
+            builder.AddButton(20, 220, 4005, 4007, 6);
+            builder.AddHtmlLocalized(55, 220, 470, 30, 1011087); // View the guild's charter.
 
-            AddButton(20, 250, 4005, 4007, 7);
-            AddHtmlLocalized(55, 250, 470, 30, 1011092); // Resign from the guild.
+            builder.AddButton(20, 250, 4005, 4007, 7);
+            builder.AddHtmlLocalized(55, 250, 470, 30, 1011092); // Resign from the guild.
 
-            AddButton(20, 280, 4005, 4007, 8);
-            AddHtmlLocalized(55, 280, 470, 30, 1011095); // View list of guilds you are at war with.
+            builder.AddButton(20, 280, 4005, 4007, 8);
+            builder.AddHtmlLocalized(55, 280, 470, 30, 1011095); // View list of guilds you are at war with.
 
-            if (beholder.AccessLevel >= AccessLevel.GameMaster || beholder == leader)
+            if (_mobile.AccessLevel >= AccessLevel.GameMaster || _mobile == leader)
             {
-                AddButton(20, 310, 4005, 4007, 9);
-                AddHtmlLocalized(55, 310, 470, 30, 1011094); // Access guildmaster functions.
+                builder.AddButton(20, 310, 4005, 4007, 9);
+                builder.AddHtmlLocalized(55, 310, 470, 30, 1011094); // Access guildmaster functions.
             }
             else
             {
-                AddImage(20, 310, 4020);
-                AddHtmlLocalized(55, 310, 470, 30, 1018013); // Reserved for guildmaster
+                builder.AddImage(20, 310, 4020);
+                builder.AddHtmlLocalized(55, 310, 470, 30, 1018013); // Reserved for guildmaster
             }
 
-            AddButton(20, 360, 4005, 4007, 0);
-            AddHtmlLocalized(55, 360, 470, 30, 1011441); // EXIT
+            builder.AddButton(20, 360, 4005, 4007, 0);
+            builder.AddHtmlLocalized(55, 360, 470, 30, 1011441); // EXIT
         }
 
         public static void EnsureClosed(Mobile m)
@@ -143,7 +159,7 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (BadMember(m_Mobile, m_Guild))
+            if (BadMember(_mobile, _guild))
             {
                 return;
             }
@@ -152,66 +168,50 @@ namespace Server.Gumps
             {
                 case 1: // Loyalty
                     {
-                        EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new DeclareFealtyGump(m_Mobile, m_Guild));
-
+                        DeclareFealtyGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 2: // Toggle display abbreviation
                     {
-                        m_Mobile.DisplayGuildTitle = !m_Mobile.DisplayGuildTitle;
-
-                        EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
-
+                        _mobile.DisplayGuildTitle = !_mobile.DisplayGuildTitle;
+                        DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 3: // View the current roster
                     {
-                        EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildRosterGump(m_Mobile, m_Guild));
-
+                        GuildRosterGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 4: // Recruit
                     {
-                        m_Mobile.Target = new GuildRecruitTarget(m_Mobile, m_Guild);
-
+                        _mobile.Target = new GuildRecruitTarget(_mobile, _guild);
                         break;
                     }
                 case 5: // Membership candidates
                     {
-                        EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildCandidatesGump(m_Mobile, m_Guild));
-
+                        GuildCandidatesGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 6: // View charter
                     {
-                        EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildCharterGump(m_Mobile, m_Guild));
-
+                        GuildCharterGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 7: // Resign
                     {
-                        m_Guild.RemoveMember(m_Mobile);
-
+                        _guild.RemoveMember(_mobile);
                         break;
                     }
                 case 8: // View wars
                     {
-                        EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildWarGump(m_Mobile, m_Guild));
-
+                        GuildWarGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 9: // Guildmaster functions
                     {
-                        if (m_Mobile.AccessLevel >= AccessLevel.GameMaster || m_Guild.Leader == m_Mobile)
+                        if (_mobile.AccessLevel >= AccessLevel.GameMaster || _guild.Leader == _mobile)
                         {
-                            EnsureClosed(m_Mobile);
-                            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                            GuildmasterGump.DisplayTo(_mobile, _guild);
                         }
 
                         break;

--- a/Projects/UOContent/Gumps/Guilds/GuildListGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildListGump.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Server.Guilds;
 
@@ -7,14 +8,12 @@ namespace Server.Gumps
     {
         protected Guild _guild;
         protected List<Guild> _list;
-        protected Mobile _mobile;
         private readonly bool _radio;
 
         public override bool Singleton => true;
 
-        protected GuildListGump(Mobile from, Guild guild, bool radio, List<Guild> list) : base(20, 30)
+        protected GuildListGump(Guild guild, bool radio, List<Guild> list) : base(20, 30)
         {
-            _mobile = from;
             _guild = guild;
             _radio = radio;
             _list = list;
@@ -56,8 +55,8 @@ namespace Server.Gumps
 
                 var g = _list[i];
 
-                var name = g.Name?.Trim().DefaultIfNullOrEmpty("(empty)");
-                builder.AddLabel(_radio ? 55 : 20, 35 + i % 11 * 30, 0, name);
+                var name = g.Name;
+                builder.AddLabel(_radio ? 55 : 20, 35 + i % 11 * 30, 0, name != null ? name.AsSpan().Trim() : "(empty)");
             }
         }
 

--- a/Projects/UOContent/Gumps/Guilds/GuildListGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildListGump.cs
@@ -3,60 +3,64 @@ using Server.Guilds;
 
 namespace Server.Gumps
 {
-    public abstract class GuildListGump : Gump
+    public abstract class GuildListGump : DynamicGump
     {
-        protected Guild m_Guild;
-        protected List<Guild> m_List;
-        protected Mobile m_Mobile;
+        protected Guild _guild;
+        protected List<Guild> _list;
+        protected Mobile _mobile;
+        private readonly bool _radio;
 
-        public GuildListGump(Mobile from, Guild guild, bool radio, List<Guild> list) : base(20, 30)
+        public override bool Singleton => true;
+
+        protected GuildListGump(Mobile from, Guild guild, bool radio, List<Guild> list) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+            _radio = radio;
+            _list = list;
+        }
 
-            Draggable = false;
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 440, 5054);
-            AddBackground(10, 10, 530, 420, 3000);
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 440, 5054);
+            builder.AddBackground(10, 10, 530, 420, 3000);
 
-            Design();
+            BuildHeader(ref builder);
 
-            m_List = list;
-
-            for (var i = 0; i < m_List.Count; ++i)
+            for (var i = 0; i < _list.Count; ++i)
             {
                 if (i % 11 == 0)
                 {
                     if (i != 0)
                     {
-                        AddButton(300, 370, 4005, 4007, 0, GumpButtonType.Page, i / 11 + 1);
-                        AddHtmlLocalized(335, 370, 300, 35, 1011066); // Next page
+                        builder.AddButton(300, 370, 4005, 4007, 0, GumpButtonType.Page, i / 11 + 1);
+                        builder.AddHtmlLocalized(335, 370, 300, 35, 1011066); // Next page
                     }
 
-                    AddPage(i / 11 + 1);
+                    builder.AddPage(i / 11 + 1);
 
                     if (i != 0)
                     {
-                        AddButton(20, 370, 4014, 4016, 0, GumpButtonType.Page, i / 11);
-                        AddHtmlLocalized(55, 370, 300, 35, 1011067); // Previous page
+                        builder.AddButton(20, 370, 4014, 4016, 0, GumpButtonType.Page, i / 11);
+                        builder.AddHtmlLocalized(55, 370, 300, 35, 1011067); // Previous page
                     }
                 }
 
-                if (radio)
+                if (_radio)
                 {
-                    AddRadio(20, 35 + i % 11 * 30, 208, 209, false, i);
+                    builder.AddRadio(20, 35 + i % 11 * 30, 208, 209, false, i);
                 }
 
-                var g = m_List[i];
+                var g = _list[i];
 
                 var name = g.Name?.Trim().DefaultIfNullOrEmpty("(empty)");
-                AddLabel(radio ? 55 : 20, 35 + i % 11 * 30, 0, name);
+                builder.AddLabel(_radio ? 55 : 20, 35 + i % 11 * 30, 0, name);
             }
         }
 
-        protected virtual void Design()
-        {
-        }
+        protected abstract void BuildHeader(ref DynamicGumpBuilder builder);
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildMobileListGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildMobileListGump.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Server.Guilds;
 
@@ -7,14 +8,12 @@ namespace Server.Gumps
     {
         protected Guild _guild;
         protected List<Mobile> _list;
-        protected Mobile _mobile;
         private readonly bool _radio;
 
         public override bool Singleton => true;
 
-        protected GuildMobileListGump(Mobile from, Guild guild, bool radio, List<Mobile> list) : base(20, 30)
+        protected GuildMobileListGump(Guild guild, bool radio, List<Mobile> list) : base(20, 30)
         {
-            _mobile = from;
             _guild = guild;
             _radio = radio;
             _list = new List<Mobile>(list);
@@ -56,8 +55,8 @@ namespace Server.Gumps
 
                 var m = _list[i];
 
-                var name = m.Name?.Trim().DefaultIfNullOrEmpty("(empty)");
-                builder.AddLabel(_radio ? 55 : 20, 35 + i % 11 * 30, 0, name);
+                var name = m.Name;
+                builder.AddLabel(_radio ? 55 : 20, 35 + i % 11 * 30, 0, name != null ? name.AsSpan().Trim() : "(empty)");
             }
         }
 

--- a/Projects/UOContent/Gumps/Guilds/GuildMobileListGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildMobileListGump.cs
@@ -3,61 +3,64 @@ using Server.Guilds;
 
 namespace Server.Gumps
 {
-    public abstract class GuildMobileListGump : Gump
+    public abstract class GuildMobileListGump : DynamicGump
     {
-        protected Guild m_Guild;
-        protected List<Mobile> m_List;
-        protected Mobile m_Mobile;
+        protected Guild _guild;
+        protected List<Mobile> _list;
+        protected Mobile _mobile;
+        private readonly bool _radio;
 
-        public GuildMobileListGump(Mobile from, Guild guild, bool radio, List<Mobile> list)
-            : base(20, 30)
+        public override bool Singleton => true;
+
+        protected GuildMobileListGump(Mobile from, Guild guild, bool radio, List<Mobile> list) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+            _radio = radio;
+            _list = new List<Mobile>(list);
+        }
 
-            Draggable = false;
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 440, 5054);
-            AddBackground(10, 10, 530, 420, 3000);
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 440, 5054);
+            builder.AddBackground(10, 10, 530, 420, 3000);
 
-            Design();
+            BuildHeader(ref builder);
 
-            m_List = new List<Mobile>(list);
-
-            for (var i = 0; i < m_List.Count; ++i)
+            for (var i = 0; i < _list.Count; ++i)
             {
                 if (i % 11 == 0)
                 {
                     if (i != 0)
                     {
-                        AddButton(300, 370, 4005, 4007, 0, GumpButtonType.Page, i / 11 + 1);
-                        AddHtmlLocalized(335, 370, 300, 35, 1011066); // Next page
+                        builder.AddButton(300, 370, 4005, 4007, 0, GumpButtonType.Page, i / 11 + 1);
+                        builder.AddHtmlLocalized(335, 370, 300, 35, 1011066); // Next page
                     }
 
-                    AddPage(i / 11 + 1);
+                    builder.AddPage(i / 11 + 1);
 
                     if (i != 0)
                     {
-                        AddButton(20, 370, 4014, 4016, 0, GumpButtonType.Page, i / 11);
-                        AddHtmlLocalized(55, 370, 300, 35, 1011067); // Previous page
+                        builder.AddButton(20, 370, 4014, 4016, 0, GumpButtonType.Page, i / 11);
+                        builder.AddHtmlLocalized(55, 370, 300, 35, 1011067); // Previous page
                     }
                 }
 
-                if (radio)
+                if (_radio)
                 {
-                    AddRadio(20, 35 + i % 11 * 30, 208, 209, false, i);
+                    builder.AddRadio(20, 35 + i % 11 * 30, 208, 209, false, i);
                 }
 
-                var m = m_List[i];
+                var m = _list[i];
 
                 var name = m.Name?.Trim().DefaultIfNullOrEmpty("(empty)");
-                AddLabel(radio ? 55 : 20, 35 + i % 11 * 30, 0, name);
+                builder.AddLabel(_radio ? 55 : 20, 35 + i % 11 * 30, 0, name);
             }
         }
 
-        protected virtual void Design()
-        {
-        }
+        protected abstract void BuildHeader(ref DynamicGumpBuilder builder);
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildNamePrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildNamePrompt.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Guilds;
 using Server.Prompts;
 
@@ -5,53 +6,49 @@ namespace Server.Gumps
 {
     public class GuildNamePrompt : Prompt
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
 
-        public GuildNamePrompt(Mobile m, Guild g)
-        {
-            m_Mobile = m;
-            m_Guild = g;
-        }
+        public GuildNamePrompt(Mobile m, Guild g) => _guild = g;
 
         public override void OnCancel(Mobile from)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
 
         public override void OnResponse(Mobile from, string text)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
 
-            text = text.Trim();
+            var textSpan = text.AsSpan().Trim();
 
-            if (text.Length > 40)
+            if (textSpan.Length > 40)
             {
-                text = text[..40];
+                textSpan = textSpan[..40];
             }
 
-            if (text.Length > 0)
+            if (textSpan.Length > 0)
             {
-                if (BaseGuild.FindByName(text) != null)
+                if (BaseGuild.FindByName(textSpan) != null)
                 {
-                    m_Mobile.SendMessage($"{text} conflicts with the name of an existing guild.");
+                    from.SendMessage($"{textSpan} conflicts with the name of an existing guild.");
                 }
                 else
                 {
-                    m_Guild.Name = text;
-                    m_Guild.GuildMessage(1018024, true, text); // The name of your guild has changed:
+                    text = textSpan.ToString();
+                    _guild.Name = text;
+                    _guild.GuildMessage(1018024, true, text); // The name of your guild has changed:
                 }
             }
 
-            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
+            GuildmasterGump.DisplayTo(from, _guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildNamePrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildNamePrompt.cs
@@ -21,8 +21,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
@@ -52,8 +51,7 @@ namespace Server.Gumps
                 }
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildRejectWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildRejectWarGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class GuildRejectWarGump : GuildListGump
     {
-        public GuildRejectWarGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarInvitations)
+        private GuildRejectWarGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarInvitations)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011148); // Select the guild to reject their invitations:
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011101); // Reject war invitations.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildRejectWarGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011148); // Select the guild to reject their invitations:
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011101); // Reject war invitations.
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -35,24 +46,22 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var g = m_List[index];
+                        var g = _list[index];
 
                         if (g != null)
                         {
-                            m_Guild.WarInvitations.Remove(g);
-                            g.WarDeclarations.Remove(m_Guild);
+                            _guild.WarInvitations.Remove(g);
+                            g.WarDeclarations.Remove(_guild);
 
-                            GuildGump.EnsureClosed(m_Mobile);
-
-                            if (m_Guild.WarInvitations.Count > 0)
+                            if (_guild.WarInvitations.Count > 0)
                             {
-                                m_Mobile.SendGump(new GuildRejectWarGump(m_Mobile, m_Guild));
+                                DisplayTo(_mobile, _guild);
                             }
                             else
                             {
-                                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                GuildmasterGump.DisplayTo(_mobile, _guild);
                             }
                         }
                     }
@@ -60,8 +69,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildRejectWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildRejectWarGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildRejectWarGump : GuildListGump
     {
-        private GuildRejectWarGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarInvitations)
+        private GuildRejectWarGump(Guild guild) : base(guild, true, guild.WarInvitations)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildRejectWarGump(from, guild));
+            from.SendGump(new GuildRejectWarGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -57,11 +58,11 @@ namespace Server.Gumps
 
                             if (_guild.WarInvitations.Count > 0)
                             {
-                                DisplayTo(_mobile, _guild);
+                                DisplayTo(from, _guild);
                             }
                             else
                             {
-                                GuildmasterGump.DisplayTo(_mobile, _guild);
+                                GuildmasterGump.DisplayTo(from, _guild);
                             }
                         }
                     }
@@ -69,7 +70,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildRescindDeclarationGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildRescindDeclarationGump.cs
@@ -5,24 +5,35 @@ namespace Server.Gumps
 {
     public class GuildRescindDeclarationGump : GuildListGump
     {
-        public GuildRescindDeclarationGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarDeclarations)
+        private GuildRescindDeclarationGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarDeclarations)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtmlLocalized(20, 10, 400, 35, 1011150); // Select the guild to rescind our invitations:
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 245, 30, 1011102); // Rescind your war declarations.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildRescindDeclarationGump(from, guild));
+        }
 
-            AddButton(300, 400, 4005, 4007, 2);
-            AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtmlLocalized(20, 10, 400, 35, 1011150); // Select the guild to rescind our invitations:
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 245, 30, 1011102); // Rescind your war declarations.
+
+            builder.AddButton(300, 400, 4005, 4007, 2);
+            builder.AddHtmlLocalized(335, 400, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -35,24 +46,22 @@ namespace Server.Gumps
                 {
                     var index = switches[0];
 
-                    if (index >= 0 && index < m_List.Count)
+                    if (index >= 0 && index < _list.Count)
                     {
-                        var g = m_List[index];
+                        var g = _list[index];
 
                         if (g != null)
                         {
-                            m_Guild.WarDeclarations.Remove(g);
-                            g.WarInvitations.Remove(m_Guild);
+                            _guild.WarDeclarations.Remove(g);
+                            g.WarInvitations.Remove(_guild);
 
-                            GuildGump.EnsureClosed(m_Mobile);
-
-                            if (m_Guild.WarDeclarations.Count > 0)
+                            if (_guild.WarDeclarations.Count > 0)
                             {
-                                m_Mobile.SendGump(new GuildRescindDeclarationGump(m_Mobile, m_Guild));
+                                DisplayTo(_mobile, _guild);
                             }
                             else
                             {
-                                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                                GuildmasterGump.DisplayTo(_mobile, _guild);
                             }
                         }
                     }
@@ -60,8 +69,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+                GuildmasterGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildRescindDeclarationGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildRescindDeclarationGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildRescindDeclarationGump : GuildListGump
     {
-        private GuildRescindDeclarationGump(Mobile from, Guild guild) : base(from, guild, true, guild.WarDeclarations)
+        private GuildRescindDeclarationGump(Guild guild) : base(guild, true, guild.WarDeclarations)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildRescindDeclarationGump(from, guild));
+            from.SendGump(new GuildRescindDeclarationGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -33,7 +33,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -57,11 +58,11 @@ namespace Server.Gumps
 
                             if (_guild.WarDeclarations.Count > 0)
                             {
-                                DisplayTo(_mobile, _guild);
+                                DisplayTo(from, _guild);
                             }
                             else
                             {
-                                GuildmasterGump.DisplayTo(_mobile, _guild);
+                                GuildmasterGump.DisplayTo(from, _guild);
                             }
                         }
                     }
@@ -69,7 +70,7 @@ namespace Server.Gumps
             }
             else if (info.ButtonID == 2)
             {
-                GuildmasterGump.DisplayTo(_mobile, _guild);
+                GuildmasterGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildRosterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildRosterGump.cs
@@ -5,7 +5,7 @@ namespace Server.Gumps
 {
     public class GuildRosterGump : GuildMobileListGump
     {
-        private GuildRosterGump(Mobile from, Guild guild) : base(from, guild, false, guild.Members)
+        private GuildRosterGump(Guild guild) : base(guild, false, guild.Members)
         {
         }
 
@@ -17,7 +17,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildRosterGump(from, guild));
+            from.SendGump(new GuildRosterGump(guild));
         }
 
         protected override void BuildHeader(ref DynamicGumpBuilder builder)
@@ -30,14 +30,15 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadMember(from, _guild))
             {
                 return;
             }
 
             if (info.ButtonID == 1)
             {
-                GuildGump.DisplayTo(_mobile, _guild);
+                GuildGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildRosterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildRosterGump.cs
@@ -5,29 +5,39 @@ namespace Server.Gumps
 {
     public class GuildRosterGump : GuildMobileListGump
     {
-        public GuildRosterGump(Mobile from, Guild guild) : base(from, guild, false, guild.Members)
+        private GuildRosterGump(Mobile from, Guild guild) : base(from, guild, false, guild.Members)
         {
         }
 
-        protected override void Design()
+        public static void DisplayTo(Mobile from, Guild guild)
         {
-            AddHtml(20, 10, 500, 35, $"<center>{m_Guild.Name}</center>");
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 300, 35, 1011120); // Return to the main menu.
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildRosterGump(from, guild));
+        }
+
+        protected override void BuildHeader(ref DynamicGumpBuilder builder)
+        {
+            builder.AddHtml(20, 10, 500, 35, $"<center>{_guild.Name}</center>");
+
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 300, 35, 1011120); // Return to the main menu.
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(m_Mobile, m_Guild))
+            if (GuildGump.BadMember(_mobile, _guild))
             {
                 return;
             }
 
             if (info.ButtonID == 1)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
+                GuildGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildTitlePrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildTitlePrompt.cs
@@ -1,3 +1,4 @@
+using System;
 using Server.Guilds;
 using Server.Prompts;
 
@@ -6,19 +7,17 @@ namespace Server.Gumps
     public class GuildTitlePrompt : Prompt
     {
         private readonly Guild m_Guild;
-        private readonly Mobile m_Leader;
         private readonly Mobile m_Target;
 
-        public GuildTitlePrompt(Mobile leader, Mobile target, Guild g)
+        public GuildTitlePrompt(Mobile target, Guild g)
         {
-            m_Leader = leader;
             m_Target = target;
             m_Guild = g;
         }
 
         public override void OnCancel(Mobile from)
         {
-            if (GuildGump.BadLeader(m_Leader, m_Guild))
+            if (GuildGump.BadLeader(from, m_Guild))
             {
                 return;
             }
@@ -28,12 +27,12 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildmasterGump.DisplayTo(m_Leader, m_Guild);
+            GuildmasterGump.DisplayTo(from, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
         {
-            if (GuildGump.BadLeader(m_Leader, m_Guild))
+            if (GuildGump.BadLeader(from, m_Guild))
             {
                 return;
             }
@@ -43,19 +42,19 @@ namespace Server.Gumps
                 return;
             }
 
-            text = text.Trim();
+            var textSpan = text.AsSpan().Trim();
 
-            if (text.Length > 20)
+            if (textSpan.Length > 20)
             {
-                text = text[..20];
+                textSpan = textSpan[..20];
             }
 
-            if (text.Length > 0)
+            if (textSpan.Length > 0)
             {
-                m_Target.GuildTitle = text;
+                m_Target.GuildTitle = textSpan.ToString();
             }
 
-            GuildmasterGump.DisplayTo(m_Leader, m_Guild);
+            GuildmasterGump.DisplayTo(from, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildTitlePrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildTitlePrompt.cs
@@ -28,8 +28,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Leader);
-            m_Leader.SendGump(new GuildmasterGump(m_Leader, m_Guild));
+            GuildmasterGump.DisplayTo(m_Leader, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
@@ -56,8 +55,7 @@ namespace Server.Gumps
                 m_Target.GuildTitle = text;
             }
 
-            GuildGump.EnsureClosed(m_Leader);
-            m_Leader.SendGump(new GuildmasterGump(m_Leader, m_Guild));
+            GuildmasterGump.DisplayTo(m_Leader, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildWarAdminGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildWarAdminGump.cs
@@ -6,15 +6,10 @@ namespace Server.Gumps
     public class GuildWarAdminGump : DynamicGump
     {
         private readonly Guild _guild;
-        private readonly Mobile _mobile;
 
         public override bool Singleton => true;
 
-        private GuildWarAdminGump(Mobile from, Guild guild) : base(20, 30)
-        {
-            _mobile = from;
-            _guild = guild;
-        }
+        private GuildWarAdminGump(Guild guild) : base(20, 30) => _guild = guild;
 
         public static void DisplayTo(Mobile from, Guild guild)
         {
@@ -24,7 +19,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildWarAdminGump(from, guild));
+            from.SendGump(new GuildWarAdminGump(guild));
         }
 
         protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -40,39 +35,37 @@ namespace Server.Gumps
             builder.AddButton(20, 40, 4005, 4007, 1);
             builder.AddHtmlLocalized(55, 40, 400, 30, 1011099); // Declare war through guild name search.
 
-            var count = 0;
-
             if (_guild.Enemies.Count > 0)
             {
-                builder.AddButton(20, 160 + count * 30, 4005, 4007, 2);
-                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011103); // Declare peace.
+                builder.AddButton(20, 160 + 30, 4005, 4007, 2);
+                builder.AddHtmlLocalized(55, 160, 400, 30, 1011103); // Declare peace.
             }
             else
             {
-                builder.AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1013033); // No current wars
+                builder.AddHtmlLocalized(20, 160, 400, 30, 1013033); // No current wars
             }
 
             if (_guild.WarInvitations.Count > 0)
             {
-                builder.AddButton(20, 160 + count * 30, 4005, 4007, 3);
-                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011100); // Accept war invitations.
+                builder.AddButton(20, 190, 4005, 4007, 3);
+                builder.AddHtmlLocalized(55, 190, 400, 30, 1011100); // Accept war invitations.
 
-                builder.AddButton(20, 160 + count * 30, 4005, 4007, 4);
-                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011101); // Reject war invitations.
+                builder.AddButton(20, 190, 4005, 4007, 4);
+                builder.AddHtmlLocalized(55, 190, 400, 30, 1011101); // Reject war invitations.
             }
             else
             {
-                builder.AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1018012); // No current invitations received for war.
+                builder.AddHtmlLocalized(20, 190, 400, 30, 1018012); // No current invitations received for war.
             }
 
             if (_guild.WarDeclarations.Count > 0)
             {
-                builder.AddButton(20, 160 + count * 30, 4005, 4007, 5);
-                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011102); // Rescind your war declarations.
+                builder.AddButton(20, 220, 4005, 4007, 5);
+                builder.AddHtmlLocalized(55, 220, 400, 30, 1011102); // Rescind your war declarations.
             }
             else
             {
-                builder.AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1013055); // No current war declarations
+                builder.AddHtmlLocalized(20, 220, 400, 30, 1013055); // No current war declarations
             }
 
             builder.AddButton(20, 400, 4005, 4007, 6);
@@ -81,7 +74,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -90,33 +84,33 @@ namespace Server.Gumps
             {
                 case 1: // Declare war
                     {
-                        _mobile.SendLocalizedMessage(1018001); // Declare war through search - Enter Guild Name:
-                        _mobile.Prompt = new GuildDeclareWarPrompt(_mobile, _guild);
+                        from.SendLocalizedMessage(1018001); // Declare war through search - Enter Guild Name:
+                        from.Prompt = new GuildDeclareWarPrompt(_guild);
                         break;
                     }
                 case 2: // Declare peace
                     {
-                        GuildDeclarePeaceGump.DisplayTo(_mobile, _guild);
+                        GuildDeclarePeaceGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 3: // Accept war
                     {
-                        GuildAcceptWarGump.DisplayTo(_mobile, _guild);
+                        GuildAcceptWarGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 4: // Reject war
                     {
-                        GuildRejectWarGump.DisplayTo(_mobile, _guild);
+                        GuildRejectWarGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 5: // Rescind declarations
                     {
-                        GuildRescindDeclarationGump.DisplayTo(_mobile, _guild);
+                        GuildRescindDeclarationGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 6: // Return
                     {
-                        GuildmasterGump.DisplayTo(_mobile, _guild);
+                        GuildmasterGump.DisplayTo(from, _guild);
                         break;
                     }
             }

--- a/Projects/UOContent/Gumps/Guilds/GuildWarAdminGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildWarAdminGump.cs
@@ -3,69 +3,85 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildWarAdminGump : Gump
+    public class GuildWarAdminGump : DynamicGump
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
+        private readonly Mobile _mobile;
 
-        public GuildWarAdminGump(Mobile from, Guild guild) : base(20, 30)
+        public override bool Singleton => true;
+
+        private GuildWarAdminGump(Mobile from, Guild guild) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+        }
 
-            Draggable = false;
+        public static void DisplayTo(Mobile from, Guild guild)
+        {
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 440, 5054);
-            AddBackground(10, 10, 530, 420, 3000);
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildWarAdminGump(from, guild));
+        }
 
-            AddHtmlLocalized(20, 10, 510, 35, 1011105); // <center>WAR FUNCTIONS</center>
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            AddButton(20, 40, 4005, 4007, 1);
-            AddHtmlLocalized(55, 40, 400, 30, 1011099); // Declare war through guild name search.
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 440, 5054);
+            builder.AddBackground(10, 10, 530, 420, 3000);
+
+            builder.AddHtmlLocalized(20, 10, 510, 35, 1011105); // <center>WAR FUNCTIONS</center>
+
+            builder.AddButton(20, 40, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 40, 400, 30, 1011099); // Declare war through guild name search.
 
             var count = 0;
 
-            if (guild.Enemies.Count > 0)
+            if (_guild.Enemies.Count > 0)
             {
-                AddButton(20, 160 + count * 30, 4005, 4007, 2);
-                AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011103); // Declare peace.
+                builder.AddButton(20, 160 + count * 30, 4005, 4007, 2);
+                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011103); // Declare peace.
             }
             else
             {
-                AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1013033); // No current wars
+                builder.AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1013033); // No current wars
             }
 
-            if (guild.WarInvitations.Count > 0)
+            if (_guild.WarInvitations.Count > 0)
             {
-                AddButton(20, 160 + count * 30, 4005, 4007, 3);
-                AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011100); // Accept war invitations.
+                builder.AddButton(20, 160 + count * 30, 4005, 4007, 3);
+                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011100); // Accept war invitations.
 
-                AddButton(20, 160 + count * 30, 4005, 4007, 4);
-                AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011101); // Reject war invitations.
+                builder.AddButton(20, 160 + count * 30, 4005, 4007, 4);
+                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011101); // Reject war invitations.
             }
             else
             {
-                AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1018012); // No current invitations received for war.
+                builder.AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1018012); // No current invitations received for war.
             }
 
-            if (guild.WarDeclarations.Count > 0)
+            if (_guild.WarDeclarations.Count > 0)
             {
-                AddButton(20, 160 + count * 30, 4005, 4007, 5);
-                AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011102); // Rescind your war declarations.
+                builder.AddButton(20, 160 + count * 30, 4005, 4007, 5);
+                builder.AddHtmlLocalized(55, 160 + count++ * 30, 400, 30, 1011102); // Rescind your war declarations.
             }
             else
             {
-                AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1013055); // No current war declarations
+                builder.AddHtmlLocalized(20, 160 + count++ * 30, 400, 30, 1013055); // No current war declarations
             }
 
-            AddButton(20, 400, 4005, 4007, 6);
-            AddHtmlLocalized(55, 400, 400, 35, 1011104); // Return to the previous menu.
+            builder.AddButton(20, 400, 4005, 4007, 6);
+            builder.AddHtmlLocalized(55, 400, 400, 35, 1011104); // Return to the previous menu.
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -74,44 +90,33 @@ namespace Server.Gumps
             {
                 case 1: // Declare war
                     {
-                        m_Mobile.SendLocalizedMessage(1018001); // Declare war through search - Enter Guild Name:
-                        m_Mobile.Prompt = new GuildDeclareWarPrompt(m_Mobile, m_Guild);
-
+                        _mobile.SendLocalizedMessage(1018001); // Declare war through search - Enter Guild Name:
+                        _mobile.Prompt = new GuildDeclareWarPrompt(_mobile, _guild);
                         break;
                     }
                 case 2: // Declare peace
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildDeclarePeaceGump(m_Mobile, m_Guild));
-
+                        GuildDeclarePeaceGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 3: // Accept war
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildAcceptWarGump(m_Mobile, m_Guild));
-
+                        GuildAcceptWarGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 4: // Reject war
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildRejectWarGump(m_Mobile, m_Guild));
-
+                        GuildRejectWarGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 5: // Rescind declarations
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildRescindDeclarationGump(m_Mobile, m_Guild));
-
+                        GuildRescindDeclarationGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 6: // Return
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
-
+                        GuildmasterGump.DisplayTo(_mobile, _guild);
                         break;
                     }
             }

--- a/Projects/UOContent/Gumps/Guilds/GuildWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildWarGump.cs
@@ -6,15 +6,10 @@ namespace Server.Gumps
     public class GuildWarGump : DynamicGump
     {
         private readonly Guild _guild;
-        private readonly Mobile _mobile;
 
         public override bool Singleton => true;
 
-        private GuildWarGump(Mobile from, Guild guild) : base(20, 30)
-        {
-            _mobile = from;
-            _guild = guild;
-        }
+        private GuildWarGump(Guild guild) : base(20, 30) => _guild = guild;
 
         public static void DisplayTo(Mobile from, Guild guild)
         {
@@ -24,7 +19,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildWarGump(from, guild));
+            from.SendGump(new GuildWarGump(guild));
         }
 
         protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -57,9 +52,7 @@ namespace Server.Gumps
             {
                 for (var i = 0; i < enemies.Count; ++i)
                 {
-                    var g = enemies[i];
-
-                    builder.AddHtml(20, 65 + i * 20, 300, 20, g.Name);
+                    builder.AddHtml(20, 65 + i * 20, 300, 20, enemies[i].Name);
                 }
             }
 
@@ -83,9 +76,7 @@ namespace Server.Gumps
             {
                 for (var i = 0; i < declared.Count; ++i)
                 {
-                    var g = declared[i];
-
-                    builder.AddHtml(20, 65 + i * 20, 300, 20, g.Name);
+                    builder.AddHtml(20, 65 + i * 20, 300, 20, declared[i].Name);
                 }
             }
 
@@ -106,23 +97,22 @@ namespace Server.Gumps
             {
                 for (var i = 0; i < invites.Count; ++i)
                 {
-                    var g = invites[i];
-
-                    builder.AddHtml(20, 65 + i * 20, 300, 20, g.Name);
+                    builder.AddHtml(20, 65 + i * 20, 300, 20, invites[i].Name);
                 }
             }
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadMember(from, _guild))
             {
                 return;
             }
 
             if (info.ButtonID == 1)
             {
-                GuildGump.DisplayTo(_mobile, _guild);
+                GuildGump.DisplayTo(from, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildWarGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildWarGump.cs
@@ -3,39 +3,55 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildWarGump : Gump
+    public class GuildWarGump : DynamicGump
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
+        private readonly Mobile _mobile;
 
-        public GuildWarGump(Mobile from, Guild guild) : base(20, 30)
+        public override bool Singleton => true;
+
+        private GuildWarGump(Mobile from, Guild guild) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+        }
 
-            Draggable = false;
+        public static void DisplayTo(Mobile from, Guild guild)
+        {
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 440, 5054);
-            AddBackground(10, 10, 530, 420, 3000);
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildWarGump(from, guild));
+        }
 
-            AddHtmlLocalized(20, 10, 500, 35, 1011133); // <center>WARFARE STATUS</center>
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            AddButton(20, 400, 4005, 4007, 1);
-            AddHtmlLocalized(55, 400, 300, 35, 1011120); // Return to the main menu.
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 440, 5054);
+            builder.AddBackground(10, 10, 530, 420, 3000);
 
-            AddPage(1);
+            builder.AddHtmlLocalized(20, 10, 500, 35, 1011133); // <center>WARFARE STATUS</center>
 
-            AddButton(375, 375, 5224, 5224, 0, GumpButtonType.Page, 2);
-            AddHtmlLocalized(410, 373, 100, 25, 1011066); // Next page
+            builder.AddButton(20, 400, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 400, 300, 35, 1011120); // Return to the main menu.
 
-            AddHtmlLocalized(20, 45, 400, 20, 1011134); // We are at war with:
+            builder.AddPage(1);
 
-            var enemies = guild.Enemies;
+            builder.AddButton(375, 375, 5224, 5224, 0, GumpButtonType.Page, 2);
+            builder.AddHtmlLocalized(410, 373, 100, 25, 1011066); // Next page
+
+            builder.AddHtmlLocalized(20, 45, 400, 20, 1011134); // We are at war with:
+
+            var enemies = _guild.Enemies;
 
             if (enemies.Count == 0)
             {
-                AddHtmlLocalized(20, 65, 400, 20, 1013033); // No current wars
+                builder.AddHtmlLocalized(20, 65, 400, 20, 1013033); // No current wars
             }
             else
             {
@@ -43,25 +59,25 @@ namespace Server.Gumps
                 {
                     var g = enemies[i];
 
-                    AddHtml(20, 65 + i * 20, 300, 20, g.Name);
+                    builder.AddHtml(20, 65 + i * 20, 300, 20, g.Name);
                 }
             }
 
-            AddPage(2);
+            builder.AddPage(2);
 
-            AddButton(375, 375, 5224, 5224, 0, GumpButtonType.Page, 3);
-            AddHtmlLocalized(410, 373, 100, 25, 1011066); // Next page
+            builder.AddButton(375, 375, 5224, 5224, 0, GumpButtonType.Page, 3);
+            builder.AddHtmlLocalized(410, 373, 100, 25, 1011066); // Next page
 
-            AddButton(30, 375, 5223, 5223, 0, GumpButtonType.Page, 1);
-            AddHtmlLocalized(65, 373, 150, 25, 1011067); // Previous page
+            builder.AddButton(30, 375, 5223, 5223, 0, GumpButtonType.Page, 1);
+            builder.AddHtmlLocalized(65, 373, 150, 25, 1011067); // Previous page
 
-            AddHtmlLocalized(20, 45, 400, 20, 1011136); // Guilds that we have declared war on:
+            builder.AddHtmlLocalized(20, 45, 400, 20, 1011136); // Guilds that we have declared war on:
 
-            var declared = guild.WarDeclarations;
+            var declared = _guild.WarDeclarations;
 
             if (declared.Count == 0)
             {
-                AddHtmlLocalized(20, 65, 400, 20, 1018012); // No current invitations received for war.
+                builder.AddHtmlLocalized(20, 65, 400, 20, 1018012); // No current invitations received for war.
             }
             else
             {
@@ -69,22 +85,22 @@ namespace Server.Gumps
                 {
                     var g = declared[i];
 
-                    AddHtml(20, 65 + i * 20, 300, 20, g.Name);
+                    builder.AddHtml(20, 65 + i * 20, 300, 20, g.Name);
                 }
             }
 
-            AddPage(3);
+            builder.AddPage(3);
 
-            AddButton(30, 375, 5223, 5223, 0, GumpButtonType.Page, 2);
-            AddHtmlLocalized(65, 373, 150, 25, 1011067); // Previous page
+            builder.AddButton(30, 375, 5223, 5223, 0, GumpButtonType.Page, 2);
+            builder.AddHtmlLocalized(65, 373, 150, 25, 1011067); // Previous page
 
-            AddHtmlLocalized(20, 45, 400, 20, 1011135); // Guilds that have declared war on us:
+            builder.AddHtmlLocalized(20, 45, 400, 20, 1011135); // Guilds that have declared war on us:
 
-            var invites = guild.WarInvitations;
+            var invites = _guild.WarInvitations;
 
             if (invites.Count == 0)
             {
-                AddHtmlLocalized(20, 65, 400, 20, 1013055); // No current war declarations
+                builder.AddHtmlLocalized(20, 65, 400, 20, 1013055); // No current war declarations
             }
             else
             {
@@ -92,22 +108,21 @@ namespace Server.Gumps
                 {
                     var g = invites[i];
 
-                    AddHtml(20, 65 + i * 20, 300, 20, g.Name);
+                    builder.AddHtml(20, 65 + i * 20, 300, 20, g.Name);
                 }
             }
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadMember(m_Mobile, m_Guild))
+            if (GuildGump.BadMember(_mobile, _guild))
             {
                 return;
             }
 
             if (info.ButtonID == 1)
             {
-                GuildGump.EnsureClosed(m_Mobile);
-                m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
+                GuildGump.DisplayTo(_mobile, _guild);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/GuildWebsitePrompt.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildWebsitePrompt.cs
@@ -21,8 +21,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
 
         public override void OnResponse(Mobile from, string text)
@@ -44,8 +43,7 @@ namespace Server.Gumps
                 m_Guild.Website = text;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
+            GuildmasterGump.DisplayTo(m_Mobile, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Gumps/Guilds/GuildmasterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildmasterGump.cs
@@ -4,93 +4,109 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class GuildmasterGump : Gump
+    public class GuildmasterGump : DynamicGump
     {
-        private readonly Guild m_Guild;
-        private readonly Mobile m_Mobile;
+        private readonly Guild _guild;
+        private readonly Mobile _mobile;
 
-        public GuildmasterGump(Mobile from, Guild guild) : base(20, 30)
+        public override bool Singleton => true;
+
+        private GuildmasterGump(Mobile from, Guild guild) : base(20, 30)
         {
-            m_Mobile = from;
-            m_Guild = guild;
+            _mobile = from;
+            _guild = guild;
+        }
 
-            Draggable = false;
+        public static void DisplayTo(Mobile from, Guild guild)
+        {
+            if (from?.NetState == null || guild == null)
+            {
+                return;
+            }
 
-            AddPage(0);
-            AddBackground(0, 0, 550, 400, 5054);
-            AddBackground(10, 10, 530, 380, 3000);
+            GuildGump.EnsureClosed(from);
+            from.SendGump(new GuildmasterGump(from, guild));
+        }
 
-            AddHtmlLocalized(20, 15, 510, 35, 1011121); // <center>GUILDMASTER FUNCTIONS</center>
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.SetNoMove();
 
-            AddButton(20, 40, 4005, 4007, 2);
-            AddHtmlLocalized(55, 40, 470, 30, 1011107); // Set the guild name.
+            builder.AddPage();
+            builder.AddBackground(0, 0, 550, 400, 5054);
+            builder.AddBackground(10, 10, 530, 380, 3000);
 
-            AddButton(20, 70, 4005, 4007, 3);
-            AddHtmlLocalized(55, 70, 470, 30, 1011109); // Set the guild's abbreviation.
+            builder.AddHtmlLocalized(20, 15, 510, 35, 1011121); // <center>GUILDMASTER FUNCTIONS</center>
+
+            builder.AddButton(20, 40, 4005, 4007, 2);
+            builder.AddHtmlLocalized(55, 40, 470, 30, 1011107); // Set the guild name.
+
+            builder.AddButton(20, 70, 4005, 4007, 3);
+            builder.AddHtmlLocalized(55, 70, 470, 30, 1011109); // Set the guild's abbreviation.
 
             if (Guild.OrderChaos)
             {
-                AddButton(20, 100, 4005, 4007, 4);
+                builder.AddButton(20, 100, 4005, 4007, 4);
 
-                switch (m_Guild.Type)
+                switch (_guild.Type)
                 {
                     case GuildType.Regular:
                         {
-                            AddHtmlLocalized(55, 100, 470, 30, 1013059); // Change guild type: Currently Standard
+                            builder.AddHtmlLocalized(55, 100, 470, 30, 1013059); // Change guild type: Currently Standard
                             break;
                         }
                     case GuildType.Order:
                         {
-                            AddHtmlLocalized(55, 100, 470, 30, 1013057); // Change guild type: Currently Order
+                            builder.AddHtmlLocalized(55, 100, 470, 30, 1013057); // Change guild type: Currently Order
                             break;
                         }
                     case GuildType.Chaos:
                         {
-                            AddHtmlLocalized(55, 100, 470, 30, 1013058); // Change guild type: Currently Chaos
+                            builder.AddHtmlLocalized(55, 100, 470, 30, 1013058); // Change guild type: Currently Chaos
                             break;
                         }
                 }
             }
 
-            AddButton(20, 130, 4005, 4007, 5);
-            AddHtmlLocalized(55, 130, 470, 30, 1011112); // Set the guild's charter.
+            builder.AddButton(20, 130, 4005, 4007, 5);
+            builder.AddHtmlLocalized(55, 130, 470, 30, 1011112); // Set the guild's charter.
 
-            AddButton(20, 160, 4005, 4007, 6);
-            AddHtmlLocalized(55, 160, 470, 30, 1011113); // Dismiss a member.
+            builder.AddButton(20, 160, 4005, 4007, 6);
+            builder.AddHtmlLocalized(55, 160, 470, 30, 1011113); // Dismiss a member.
 
-            AddButton(20, 190, 4005, 4007, 7);
-            AddHtmlLocalized(55, 190, 470, 30, 1011114); // Go to the WAR menu.
+            builder.AddButton(20, 190, 4005, 4007, 7);
+            builder.AddHtmlLocalized(55, 190, 470, 30, 1011114); // Go to the WAR menu.
 
-            if (m_Guild.Candidates.Count > 0)
+            if (_guild.Candidates.Count > 0)
             {
-                AddButton(20, 220, 4005, 4007, 8);
-                AddHtmlLocalized(55, 220, 470, 30, 1013056); // Administer the list of candidates
+                builder.AddButton(20, 220, 4005, 4007, 8);
+                builder.AddHtmlLocalized(55, 220, 470, 30, 1013056); // Administer the list of candidates
             }
             else
             {
-                AddImage(20, 220, 4020);
-                AddHtmlLocalized(55, 220, 470, 30, 1013031); // There are currently no candidates for membership.
+                builder.AddImage(20, 220, 4020);
+                builder.AddHtmlLocalized(55, 220, 470, 30, 1013031); // There are currently no candidates for membership.
             }
 
-            AddButton(20, 250, 4005, 4007, 9);
-            AddHtmlLocalized(55, 250, 470, 30, 1011117); // Set the guildmaster's title.
+            builder.AddButton(20, 250, 4005, 4007, 9);
+            builder.AddHtmlLocalized(55, 250, 470, 30, 1011117); // Set the guildmaster's title.
 
-            AddButton(20, 280, 4005, 4007, 10);
-            AddHtmlLocalized(55, 280, 470, 30, 1011118); // Grant a title to another member.
+            builder.AddButton(20, 280, 4005, 4007, 10);
+            builder.AddHtmlLocalized(55, 280, 470, 30, 1011118); // Grant a title to another member.
 
-            AddButton(20, 310, 4005, 4007, 11);
-            AddHtmlLocalized(55, 310, 470, 30, 1011119); // Move this guildstone.
+            builder.AddButton(20, 310, 4005, 4007, 11);
+            builder.AddHtmlLocalized(55, 310, 470, 30, 1011119); // Move this guildstone.
 
-            AddButton(20, 360, 4005, 4007, 1);
-            AddHtmlLocalized(55, 360, 245, 30, 1011120); // Return to the main menu.
+            builder.AddButton(20, 360, 4005, 4007, 1);
+            builder.AddHtmlLocalized(55, 360, 245, 30, 1011120); // Return to the main menu.
 
-            AddButton(300, 360, 4005, 4007, 0);
-            AddHtmlLocalized(335, 360, 100, 30, 1011441); // EXIT
+            builder.AddButton(300, 360, 4005, 4007, 0);
+            builder.AddHtmlLocalized(335, 360, 100, 30, 1011441); // EXIT
         }
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(m_Mobile, m_Guild))
+            if (GuildGump.BadLeader(_mobile, _guild))
             {
                 return;
             }
@@ -99,23 +115,19 @@ namespace Server.Gumps
             {
                 case 1: // Main menu
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
-
+                        GuildGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 2: // Set guild name
                     {
-                        m_Mobile.SendLocalizedMessage(1013060); // Enter new guild name (40 characters max):
-                        m_Mobile.Prompt = new GuildNamePrompt(m_Mobile, m_Guild);
-
+                        _mobile.SendLocalizedMessage(1013060); // Enter new guild name (40 characters max):
+                        _mobile.Prompt = new GuildNamePrompt(_mobile, _guild);
                         break;
                     }
                 case 3: // Set guild abbreviation
                     {
-                        m_Mobile.SendLocalizedMessage(1013061); // Enter new guild abbreviation (3 characters max):
-                        m_Mobile.Prompt = new GuildAbbrvPrompt(m_Mobile, m_Guild);
-
+                        _mobile.SendLocalizedMessage(1013061); // Enter new guild abbreviation (3 characters max):
+                        _mobile.Prompt = new GuildAbbrvPrompt(_mobile, _guild);
                         break;
                     }
                 case 4: // Change guild type
@@ -125,72 +137,57 @@ namespace Server.Gumps
                             return;
                         }
 
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildChangeTypeGump(m_Mobile, m_Guild));
-
+                        GuildChangeTypeGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 5: // Set charter
                     {
-                        m_Mobile.SendLocalizedMessage(1013071); // Enter the new guild charter (50 characters max):
-                        m_Mobile.Prompt = new GuildCharterPrompt(m_Mobile, m_Guild);
-
+                        _mobile.SendLocalizedMessage(1013071); // Enter the new guild charter (50 characters max):
+                        _mobile.Prompt = new GuildCharterPrompt(_mobile, _guild);
                         break;
                     }
                 case 6: // Dismiss member
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildDismissGump(m_Mobile, m_Guild));
-
+                        GuildDismissGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 7: // War menu
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildWarAdminGump(m_Mobile, m_Guild));
-
+                        GuildWarAdminGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 8: // Administer candidates
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildAdminCandidatesGump(m_Mobile, m_Guild));
-
+                        GuildAdminCandidatesGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 9: // Set guildmaster's title
                     {
-                        m_Mobile.SendLocalizedMessage(1013073); // Enter new guildmaster title (20 characters max):
-                        m_Mobile.Prompt = new GuildTitlePrompt(m_Mobile, m_Mobile, m_Guild);
-
+                        _mobile.SendLocalizedMessage(1013073); // Enter new guildmaster title (20 characters max):
+                        _mobile.Prompt = new GuildTitlePrompt(_mobile, _mobile, _guild);
                         break;
                     }
                 case 10: // Grant title
                     {
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GrantGuildTitleGump(m_Mobile, m_Guild));
-
+                        GrantGuildTitleGump.DisplayTo(_mobile, _guild);
                         break;
                     }
                 case 11: // Move guildstone
                     {
-                        if (m_Guild.Guildstone != null)
+                        if (_guild.Guildstone != null)
                         {
-                            var item = new GuildTeleporter(m_Guild.Guildstone);
+                            var item = new GuildTeleporter(_guild.Guildstone);
 
-                            m_Guild.Teleporter?.Delete();
+                            _guild.Teleporter?.Delete();
 
-                            m_Mobile.SendLocalizedMessage(
-                                501133
-                            ); // Use the teleporting object placed in your backpack to move this guildstone.
+                            // Use the teleporting object placed in your backpack to move this guildstone.
+                            _mobile.SendLocalizedMessage(501133);
 
-                            m_Mobile.AddToBackpack(item);
-                            m_Guild.Teleporter = item;
+                            _mobile.AddToBackpack(item);
+                            _guild.Teleporter = item;
                         }
 
-                        GuildGump.EnsureClosed(m_Mobile);
-                        m_Mobile.SendGump(new GuildmasterGump(m_Mobile, m_Guild));
-
+                        DisplayTo(_mobile, _guild);
                         break;
                     }
             }

--- a/Projects/UOContent/Gumps/Guilds/GuildmasterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/GuildmasterGump.cs
@@ -7,15 +7,10 @@ namespace Server.Gumps
     public class GuildmasterGump : DynamicGump
     {
         private readonly Guild _guild;
-        private readonly Mobile _mobile;
 
         public override bool Singleton => true;
 
-        private GuildmasterGump(Mobile from, Guild guild) : base(20, 30)
-        {
-            _mobile = from;
-            _guild = guild;
-        }
+        private GuildmasterGump(Guild guild) : base(20, 30) => _guild = guild;
 
         public static void DisplayTo(Mobile from, Guild guild)
         {
@@ -25,7 +20,7 @@ namespace Server.Gumps
             }
 
             GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildmasterGump(from, guild));
+            from.SendGump(new GuildmasterGump(guild));
         }
 
         protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -106,7 +101,8 @@ namespace Server.Gumps
 
         public override void OnResponse(NetState state, in RelayInfo info)
         {
-            if (GuildGump.BadLeader(_mobile, _guild))
+            var from = state.Mobile;
+            if (GuildGump.BadLeader(from, _guild))
             {
                 return;
             }
@@ -115,19 +111,19 @@ namespace Server.Gumps
             {
                 case 1: // Main menu
                     {
-                        GuildGump.DisplayTo(_mobile, _guild);
+                        GuildGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 2: // Set guild name
                     {
-                        _mobile.SendLocalizedMessage(1013060); // Enter new guild name (40 characters max):
-                        _mobile.Prompt = new GuildNamePrompt(_mobile, _guild);
+                        from.SendLocalizedMessage(1013060); // Enter new guild name (40 characters max):
+                        from.Prompt = new GuildNamePrompt(from, _guild);
                         break;
                     }
                 case 3: // Set guild abbreviation
                     {
-                        _mobile.SendLocalizedMessage(1013061); // Enter new guild abbreviation (3 characters max):
-                        _mobile.Prompt = new GuildAbbrvPrompt(_mobile, _guild);
+                        from.SendLocalizedMessage(1013061); // Enter new guild abbreviation (3 characters max):
+                        from.Prompt = new GuildAbbrvPrompt(_guild);
                         break;
                     }
                 case 4: // Change guild type
@@ -137,39 +133,39 @@ namespace Server.Gumps
                             return;
                         }
 
-                        GuildChangeTypeGump.DisplayTo(_mobile, _guild);
+                        GuildChangeTypeGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 5: // Set charter
                     {
-                        _mobile.SendLocalizedMessage(1013071); // Enter the new guild charter (50 characters max):
-                        _mobile.Prompt = new GuildCharterPrompt(_mobile, _guild);
+                        from.SendLocalizedMessage(1013071); // Enter the new guild charter (50 characters max):
+                        from.Prompt = new GuildCharterPrompt(_guild);
                         break;
                     }
                 case 6: // Dismiss member
                     {
-                        GuildDismissGump.DisplayTo(_mobile, _guild);
+                        GuildDismissGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 7: // War menu
                     {
-                        GuildWarAdminGump.DisplayTo(_mobile, _guild);
+                        GuildWarAdminGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 8: // Administer candidates
                     {
-                        GuildAdminCandidatesGump.DisplayTo(_mobile, _guild);
+                        GuildAdminCandidatesGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 9: // Set guildmaster's title
                     {
-                        _mobile.SendLocalizedMessage(1013073); // Enter new guildmaster title (20 characters max):
-                        _mobile.Prompt = new GuildTitlePrompt(_mobile, _mobile, _guild);
+                        from.SendLocalizedMessage(1013073); // Enter new guildmaster title (20 characters max):
+                        from.Prompt = new GuildTitlePrompt(from, _guild);
                         break;
                     }
                 case 10: // Grant title
                     {
-                        GrantGuildTitleGump.DisplayTo(_mobile, _guild);
+                        GrantGuildTitleGump.DisplayTo(from, _guild);
                         break;
                     }
                 case 11: // Move guildstone
@@ -181,13 +177,13 @@ namespace Server.Gumps
                             _guild.Teleporter?.Delete();
 
                             // Use the teleporting object placed in your backpack to move this guildstone.
-                            _mobile.SendLocalizedMessage(501133);
+                            from.SendLocalizedMessage(501133);
 
-                            _mobile.AddToBackpack(item);
+                            from.AddToBackpack(item);
                             _guild.Teleporter = item;
                         }
 
-                        DisplayTo(_mobile, _guild);
+                        DisplayTo(from, _guild);
                         break;
                     }
             }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/GuildInfoGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/GuildInfoGump.cs
@@ -158,7 +158,7 @@ namespace Server.Guilds
                         // Guild Faction
                         if (Guild.OrderChaos && IsLeader(pm, guild))
                         {
-                            pm.SendGump(new GuildChangeTypeGump(pm, guild), true);
+                            GuildChangeTypeGump.DisplayTo(pm, guild);
                         }
 
                         break;

--- a/Projects/UOContent/Gumps/Guilds/RecruitTarget.cs
+++ b/Projects/UOContent/Gumps/Guilds/RecruitTarget.cs
@@ -96,8 +96,7 @@ namespace Server.Gumps
                 return;
             }
 
-            GuildGump.EnsureClosed(m_Mobile);
-            m_Mobile.SendGump(new GuildGump(m_Mobile, m_Guild));
+            GuildGump.DisplayTo(m_Mobile, m_Guild);
         }
     }
 }

--- a/Projects/UOContent/Items/Guilds/Guildstone.cs
+++ b/Projects/UOContent/Items/Guilds/Guildstone.cs
@@ -187,8 +187,7 @@ public partial class Guildstone : Item, IAddon, IChoppable
             _guild.Accepted.Remove(from);
             _guild.AddMember(from);
 
-            GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildGump(from, Guild));
+            GuildGump.DisplayTo(from, Guild);
         }
         else if (from.AccessLevel < AccessLevel.GameMaster && !_guild.IsMember(from))
         {
@@ -197,8 +196,7 @@ public partial class Guildstone : Item, IAddon, IChoppable
         }
         else
         {
-            GuildGump.EnsureClosed(from);
-            from.SendGump(new GuildGump(from, _guild));
+            GuildGump.DisplayTo(from, _guild);
         }
     }
 }


### PR DESCRIPTION
## Summary

Migrates the Old Guild System (pre-AOS guild stones) gumps from the legacy `Gump` class to `DynamicGump`, following the same pattern used for the Quest gump migration in #2416. All concrete gumps now have private constructors gated by static `DisplayTo` entry points (empty-gump rule), and `Singleton => true` is set across the board so reopening a sibling dialog automatically closes the previous one.

**Migrated gumps:**
- `GuildGump` - main guild dialog
- `GuildmasterGump` - guildmaster functions
- `GuildCharterGump` - charter and website display
- `GuildWarGump` - warfare status (kept as player-facing)
- `GuildWarAdminGump` - war menu (retained as player-facing - reachable from `GuildmasterGump`'s WAR button by guildmasters)
- `GuildChangeTypeGump` - Standard/Order/Chaos selection

**Abstract bases:** `GuildListGump` and `GuildMobileListGump` keep their shared list-rendering chrome inside a single concrete `BuildLayout` on the abstract class and expose a `protected abstract void BuildHeader(ref DynamicGumpBuilder builder)` hook for subclasses (replacing the old `Design()` override). This mirrors the abstract-base treatment used for the ML quest base in the quest-gump migration PR.

**Concrete subclasses migrated alongside the abstract bases:**
- `GuildListGump` subclasses: `GuildAcceptWarGump`, `GuildDeclarePeaceGump`, `GuildDeclareWarGump`, `GuildRejectWarGump`, `GuildRescindDeclarationGump`
- `GuildMobileListGump` subclasses: `DeclareFealtyGump`, `GrantGuildTitleGump`, `GuildAdminCandidatesGump`, `GuildCandidatesGump`, `GuildDismissGump`, `GuildRosterGump`

**Cliloc rule:** Every gump bakes per-instance dynamic content (guild names, member names, war declarations, candidate lists), which would defeat `StaticGump<T>` caching. Per the cliloc rule, all are `DynamicGump`.

**External callers updated:** the prompt files (`GuildAbbrvPrompt`, `GuildCharterPrompt`, `GuildDeclareWarPrompt`, `GuildNamePrompt`, `GuildTitlePrompt`, `GuildWebsitePrompt`), `RecruitTarget`, the `Guildstone` item, and the New Guild System `GuildInfoGump`'s Order/Chaos handler all now go through static `DisplayTo` entry points instead of `new XGump(...)`.

## Test plan

- [x] `dotnet build Projects/UOContent/UOContent.csproj` - 0 warnings, 0 errors
- [ ] In-game smoke (Old Guild System era - `Guild.NewGuildSystem == false`):
  - [ ] Form a guild via guildstone deed; open the main `GuildGump` from the stone
  - [ ] Toggle "Display guild abbreviation" - verify gump refreshes
  - [ ] View roster, candidates, charter, war list - verify navigation back to main gump
  - [ ] Open guildmaster functions; rename guild and abbreviation via prompts; verify return to guildmaster gump
  - [ ] Set/view charter and website; declare war on another guild via search; accept/reject incoming war invitations; declare peace; rescind declarations
  - [ ] Change guild type Standard/Order/Chaos (Order/Chaos era only)
  - [ ] Dismiss a member; grant title to a member
  - [ ] Recruit target; verify "Loyal to" fealty selection
- [ ] Old Guild System: confirm all dialogs close and reopen as singletons (no stacking)
- [ ] New Guild System path: verify `GuildChangeTypeGump.DisplayTo` still works from `GuildInfoGump` button 100 (Order/Chaos)
