### PR TITLE
perf: Migrate Item Interaction gumps to DynamicGump/StaticGump

### DIFF
--- a/Projects/UOContent/Gumps/ConfirmHeritageGump.cs
+++ b/Projects/UOContent/Gumps/ConfirmHeritageGump.cs
@@ -1,37 +1,55 @@
 using System;
 using Server.Items;
+using Server.Logging;
 using Server.Network;
 
 namespace Server.Gumps
 {
-    public class ConfirmHeritageGump : Gump
+    public class ConfirmHeritageGump : DynamicGump
     {
-        private readonly Type[] m_Selected;
-        private readonly HeritageToken m_Token;
+        private static readonly ILogger _logger = LogFactory.GetLogger(typeof(ConfirmHeritageGump));
+
+        private readonly Type[] _selected;
+        private readonly HeritageToken _token;
+        private readonly int _cliloc;
 
         public override bool Singleton => true;
 
-        public ConfirmHeritageGump(HeritageToken token, Type[] selected, int cliloc) : base(60, 36)
+        private ConfirmHeritageGump(HeritageToken token, Type[] selected, int cliloc) : base(60, 36)
         {
-            m_Token = token;
-            m_Selected = selected;
+            _token = token;
+            _selected = selected;
+            _cliloc = cliloc;
+        }
 
-            AddPage(0);
+        public static void DisplayTo(Mobile from, HeritageToken token, Type[] selected, int cliloc)
+        {
+            if (from?.NetState == null || token?.Deleted != false || selected == null || selected.Length == 0)
+            {
+                return;
+            }
 
-            AddBackground(0, 0, 291, 99, 0x13BE);
-            AddImageTiled(5, 6, 280, 20, 0xA40);
-            AddHtmlLocalized(9, 8, 280, 20, 1070972, 0x7FFF); // Click "OKAY" to redeem the following promotional item:
-            AddImageTiled(5, 31, 280, 40, 0xA40);
-            AddHtmlLocalized(9, 35, 272, 40, cliloc, 0x7FFF);
-            AddButton(180, 73, 0xFB7, 0xFB8, (int)Buttons.Okay);
-            AddHtmlLocalized(215, 75, 100, 20, 1011036, 0x7FFF); // OKAY
-            AddButton(5, 73, 0xFB1, 0xFB2, (int)Buttons.Cancel);
-            AddHtmlLocalized(40, 75, 100, 20, 1060051, 0x7FFF); // CANCEL
+            from.SendGump(new ConfirmHeritageGump(token, selected, cliloc));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 291, 99, 0x13BE);
+            builder.AddImageTiled(5, 6, 280, 20, 0xA40);
+            builder.AddHtmlLocalized(9, 8, 280, 20, 1070972, 0x7FFF); // Click "OKAY" to redeem the following promotional item:
+            builder.AddImageTiled(5, 31, 280, 40, 0xA40);
+            builder.AddHtmlLocalized(9, 35, 272, 40, _cliloc, 0x7FFF);
+            builder.AddButton(180, 73, 0xFB7, 0xFB8, (int)Buttons.Okay);
+            builder.AddHtmlLocalized(215, 75, 100, 20, 1011036, 0x7FFF); // OKAY
+            builder.AddButton(5, 73, 0xFB1, 0xFB2, (int)Buttons.Cancel);
+            builder.AddHtmlLocalized(40, 75, 100, 20, 1060051, 0x7FFF); // CANCEL
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_Token?.Deleted != false)
+            if (_token?.Deleted != false)
             {
                 return;
             }
@@ -42,7 +60,7 @@ namespace Server.Gumps
                     {
                         Item item = null;
 
-                        foreach (var type in m_Selected)
+                        foreach (var type in _selected)
                         {
                             try
                             {
@@ -50,13 +68,12 @@ namespace Server.Gumps
                             }
                             catch (Exception ex)
                             {
-                                Console.WriteLine(ex.Message);
-                                Console.WriteLine(ex.StackTrace);
+                                _logger.Error(ex, "Failed to create heritage item of type {Type}", type);
                             }
 
                             if (item != null)
                             {
-                                m_Token.Delete();
+                                _token.Delete();
                                 sender.Mobile.AddToBackpack(item);
                             }
                         }
@@ -66,7 +83,7 @@ namespace Server.Gumps
 
                 case (int)Buttons.Cancel:
                     {
-                        sender.Mobile.SendGump(new HeritageTokenGump(m_Token));
+                        HeritageTokenGump.DisplayTo(sender.Mobile, _token);
                         break;
                     }
             }

--- a/Projects/UOContent/Gumps/HeritageTokenGump.cs
+++ b/Projects/UOContent/Gumps/HeritageTokenGump.cs
@@ -3,396 +3,224 @@ using System.Collections.Generic;
 using Server.Items;
 using Server.Network;
 
-namespace Server.Gumps
+namespace Server.Gumps;
+
+public class HeritageTokenGump : StaticGump<HeritageTokenGump>
 {
-    public class HeritageTokenGump : StaticGump<HeritageTokenGump>
+    private static readonly Dictionary<int, (Type[] Types, int CliLoc, int Tooltip, int ItemID, int Hue, int Width, int Height)> ButtonLookup = new()
     {
-        private static readonly Dictionary<int, (Type[] Types, int CliLoc)> ButtonLookup = new()
+        // 7th anniversary
+        { 0x64, ([typeof(LeggingsOfEmbers)], 1078147, 1062912, 0x1411, 0x2C, 18, 8) },
+        { 0x65, ([typeof(RoseOfTrinsic)], 1062913, 1062914, 0x234D, 0x0, 18, 12) },
+        { 0x66, ([typeof(ShaminoCrossbow)], 1062915, 1062916, 0x26C3, 0x504, 18, 8) },
+        { 0x67, ([typeof(TapestryOfSosaria)], 1062917, 1062918, 0x3F1D, 0x0, 18, 8) },
+        { 0x68, ([typeof(HearthOfHomeFireDeed)], 1062919, 1062920, 0x3F14, 0x0, 18, 8) },
+        { 0x69, ([typeof(HolySword)], 1062921, 1062922, 0xF60, 0x482, -1, 10) },
+        { 0x6A, ([typeof(SamuraiHelm)], 1062923, 1062924, 0x236C, 0x0, 18, 6) },
+
+        // 8th anniversary
+        { 0x6B, ([typeof(SpiritualityHelm)], 1075188, 1075223, 0x2B10, 0x226, 18, 11) },
+        { 0x6C, ([typeof(ValorGauntlets)], 1075192, 1075224, 0x2B0C, 0x226, 18, 15) },
+        { 0x6D, ([typeof(DupresShield)], 1075196, 1075225, 0x2B01, 0x0, 18, 9) },
+        { 0x6E, ([typeof(FountainOfLifeDeed)], 1075197, 1075226, 0x2AC6, 0x0, 29, 0) },
+        { 0x6F, ([typeof(DawnsMusicBox)], 1075198, 1075227, 0x2AF9, 0x0, -4, -5) },
+        { 0x70, ([typeof(OssianGrimoire)], 1078148, 1075228, 0x2253, 0x0, 18, 12) },
+        { 0x71, ([typeof(FerretFormTalisman)], 1078142, 1078527, 0x2D98, 0x0, 19, 13) },
+        { 0x72, ([typeof(SquirrelFormTalisman)], 1078143, 1078528, 0x2D97, 0x0, 19, 13) },
+        { 0x73, ([typeof(CuSidheFormTalisman)], 1078144, 1078529, 0x2D96, 0x0, 19, 8) },
+        { 0x74, ([typeof(ReptalonFormTalisman)], 1078145, 1078530, 0x2D95, 0x0, -4, 2) },
+        { 0x75, ([typeof(QuiverOfInfinity)], 1075201, 1078526, 0x2B02, 0x0, -2, 9) },
+
+        // evil home decor
+        { 0x76, (
+            [typeof(BoneThroneDeed), typeof(BoneCouchDeed), typeof(BoneTableDeed)],
+            1074797, 1075986, 0x2A91, 0x0, 25, 5
+        ) },
+        { 0x77, (
+            [typeof(CreepyPortraitDeed), typeof(DisturbingPortraitDeed), typeof(UnsettlingPortraitDeed)],
+            1078146, 1075987, 0x2A99, 0x0, 18, 1
+        ) },
+        { 0x78, (
+            [
+                typeof(MountedPixieBlueDeed), typeof(MountedPixieGreenDeed), typeof(MountedPixieLimeDeed),
+                typeof(MountedPixieOrangeDeed), typeof(MountedPixieWhiteDeed)
+            ],
+            1074799, 1075988, 0x2A71, 0x0, 13, 5
+        ) },
+        { 0x79, ([typeof(HaunterMirrorDeed)], 1074800, 1075990, 0x2A98, 0x0, 26, 1) },
+        { 0x7A, ([typeof(BedOfNailsDeed)], 1074801, 1075989, 0x2A92, 0x0, 18, 1) },
+        { 0x7B, ([typeof(SacrificialAltarDeed)], 1074818, 1075991, 0x2AB8, 0x0, 18, 1) },
+
+        // broken furniture
+        { 0x7C, ([typeof(BrokenCoveredChairDeed)], 1076257, 1076610, 0x3F26, 0x0, 18, 8) },
+        { 0x7D, ([typeof(BrokenBookcaseDeed)], 1076258, 1076610, 0x3F22, 0x0, 18, 8) },
+        { 0x7E, ([typeof(StandingBrokenChairDeed)], 1076259, 1076610, 0x3F24, 0x0, 18, 8) },
+        { 0x7F, ([typeof(BrokenVanityDeed)], 1076260, 1076610, 0x3F25, 0x0, 18, 8) },
+        { 0x80, ([typeof(BrokenChestOfDrawersDeed)], 1076261, 1076610, 0x3F23, 0x0, 18, 8) },
+        { 0x81, ([typeof(BrokenArmoireDeed)], 1076262, 1076610, 0x3F21, 0x0, 18, 8) },
+        { 0x82, ([typeof(BrokenBedDeed)], 1076263, 1076610, 0x3F0B, 0x0, 18, 8) },
+        { 0x83, ([typeof(BrokenFallenChairDeed)], 1076264, 1076610, 0xC19, 0x0, 13, 8) },
+
+        // other
+        { 0x84, ([typeof(SuitOfGoldArmorDeed)], 1076265, 1076611, 0x3DAA, 0x0, 20, -3) },
+        { 0x85, ([typeof(SuitOfSilverArmorDeed)], 1076266, 1076612, 0x151C, 0x0, -20, -3) },
+        { 0x86, ([typeof(BoilingCauldronDeed)], 1076267, 1076613, 0x3DB1, 0x0, 18, 8) },
+        { 0x87, ([typeof(GuillotineDeed)], 1024656, 1076614, 0x3F27, 0x0, 18, 8) },
+        { 0x88, ([typeof(CherryBlossomTreeDeed)], 1076268, 1076615, 0x3F0C, 0x0, 18, 8) },
+        { 0x89, ([typeof(AppleTreeDeed)], 1076269, 1076616, 0x3F07, 0x0, 18, 8) },
+        { 0x8A, ([typeof(PeachTreeDeed)], 1076270, 1076617, 0x3F16, 0x0, 18, 8) },
+        { 0x8B, ([typeof(HangingAxesDeed)], 1076271, 1076618, 0x3F12, 0x0, 18, 8) },
+        { 0x8C, ([typeof(HangingSwordsDeed)], 1076272, 1076619, 0x3F13, 0x0, 18, 8) },
+        { 0x8D, ([typeof(BlueFancyRugDeed)], 1076273, 1076620, 0x3F09, 0x0, 18, 8) },
+        { 0x8E, ([typeof(WoodenCoffinDeed)], 1076274, 1076621, 0x3F0E, 0x0, 18, 8) },
+        { 0x8F, ([typeof(VanityDeed)], 1074027, 1076623, 0x3F1F, 0x0, 18, 8) },
+        { 0x90, ([typeof(TableWithPurpleClothDeed)], 1076635, 1076624, 0x118B, 0x0, -4, -9) },
+        { 0x91, ([typeof(TableWithBlueClothDeed)], 1076636, 1076624, 0x118C, 0x0, -4, -9) },
+        { 0x92, ([typeof(TableWithRedClothDeed)], 1076637, 1076624, 0x118D, 0x0, -4, -9) },
+        { 0x93, ([typeof(TableWithOrangeClothDeed)], 1076638, 1076624, 0x118E, 0x0, -4, -9) },
+        { 0x94, ([typeof(UnmadeBedDeed)], 1076279, 1076625, 0x3F1E, 0x0, 18, 8) },
+        { 0x95, ([typeof(CurtainsDeed)], 1076280, 1076626, 0x3F0F, 0x0, 18, 8) },
+        { 0x96, ([typeof(ScarecrowDeed)], 1076281, 1076627, 0x1E34, 0x0, 18, -17) },
+        { 0x97, ([typeof(WallTorchDeed)], 1076282, 1076628, 0xA0C, 0x0, 18, 8) },
+        { 0x98, ([typeof(FountainDeed)], 1076283, 1076629, 0x3F10, 0x0, 18, 9) },
+        { 0x99, ([typeof(StoneStatueDeed)], 1076284, 1076630, 0x3F19, 0x0, 18, 8) },
+        { 0x9A, ([typeof(LargeFishingNetDeed)], 1076285, 1076631, 0x1EA5, 0x0, 5, -25) },
+        { 0x9B, ([typeof(SmallFishingNetDeed)], 1076286, 1076632, 0x1EA3, 0x0, 18, -27) },
+        { 0x9C, ([typeof(HouseLadderDeed)], 1076287, 1076633, 0x2FDF, 0x0, 18, -36) },
+        { 0x9D, ([typeof(IronMaidenDeed)], 1076288, 1076622, 0x3F15, 0x0, 18, 8) },
+        { 0x9E, ([typeof(BluePlainRugDeed)], 1076585, 1076620, 0x3F0A, 0x0, 18, 8) },
+        { 0x9F, ([typeof(GoldenDecorativeRugDeed)], 1076586, 1076620, 0x3F11, 0x0, 18, 8) },
+        { 0xA0, ([typeof(CinnamonFancyRugDeed)], 1076587, 1076620, 0x3F0D, 0x0, 18, 8) },
+        { 0xA1, ([typeof(RedPlainRugDeed)], 1076588, 1076620, 0x3F18, 0x0, 18, 8) },
+        { 0xA2, ([typeof(BlueDecorativeRugDeed)], 1076589, 1076620, 0x3F08, 0x0, 18, 8) },
+        { 0xA3, ([typeof(PinkFancyRugDeed)], 1076590, 1076620, 0x3F17, 0x0, 18, 8) },
+        { 0xA4, ([typeof(CherryBlossomTrunkDeed)], 1076784, 1076615, 0x312A, 0x0, 18, 8) },
+        { 0xA5, ([typeof(AppleTrunkDeed)], 1076785, 1076616, 0x3128, 0x0, 18, 8) },
+        { 0xA6, ([typeof(PeachTrunkDeed)], 1076786, 1076617, 0x3129, 0x0, 18, 8) }
+    };
+
+    private readonly HeritageToken _token;
+
+    public override bool Singleton => true;
+
+    private HeritageTokenGump(HeritageToken token) : base(60, 36) => _token = token;
+
+    public static void DisplayTo(Mobile from, HeritageToken token)
+    {
+        if (from?.NetState == null || token?.Deleted != false)
         {
-            // 7th anniversary
-            { 0x64, ([typeof(LeggingsOfEmbers)], 1078147) },
-            { 0x65, ([typeof(RoseOfTrinsic)], 1062913) },
-            { 0x66, ([typeof(ShaminoCrossbow)], 1062915) },
-            { 0x67, ([typeof(TapestryOfSosaria)], 1062917) },
-            { 0x68, ([typeof(HearthOfHomeFireDeed)], 1062919) },
-            { 0x69, ([typeof(HolySword)], 1062921) },
-            { 0x6A, ([typeof(SamuraiHelm)], 1062923) },
-
-            // 8th anniversary
-            { 0x6D, ([typeof(DupresShield)], 1075196) },
-            { 0x6E, ([typeof(FountainOfLifeDeed)], 1075197) },
-            { 0x6F, ([typeof(DawnsMusicBox)], 1075198) },
-            { 0x70, ([typeof(OssianGrimoire)], 1078148) },
-            { 0x71, ([typeof(FerretFormTalisman)], 1078142) },
-            { 0x72, ([typeof(SquirrelFormTalisman)], 1078143) },
-            { 0x73, ([typeof(CuSidheFormTalisman)], 1078144) },
-            { 0x74, ([typeof(ReptalonFormTalisman)], 1078145) },
-            { 0x75, ([typeof(QuiverOfInfinity)], 1075201) },
-
-            // evil home decor
-            { 0x76, ([typeof(BoneThroneDeed), typeof(BoneCouchDeed), typeof(BoneTableDeed)], 1074797) },
-            { 0x77, ([typeof(CreepyPortraitDeed), typeof(DisturbingPortraitDeed), typeof(UnsettlingPortraitDeed)], 1078146) },
-            {
-                0x78,
-                (
-                    [
-                        typeof(MountedPixieBlueDeed), typeof(MountedPixieGreenDeed), typeof(MountedPixieLimeDeed),
-                        typeof(MountedPixieOrangeDeed), typeof(MountedPixieWhiteDeed)
-                    ],
-                    1074799
-                )
-            },
-            { 0x79, ([typeof(HaunterMirrorDeed)], 1074800) },
-            { 0x7A, ([typeof(BedOfNailsDeed)], 1074801) },
-            { 0x7B, ([typeof(SacrificialAltarDeed)], 1074818) },
-
-            // broken furniture
-            { 0x7C, ([typeof(BrokenCoveredChairDeed)], 1076257) },
-            { 0x7D, ([typeof(BrokenBookcaseDeed)], 1076258) },
-            { 0x7E, ([typeof(StandingBrokenChairDeed)], 1076259) },
-            { 0x7F, ([typeof(BrokenVanityDeed)], 1076260) },
-            { 0x80, ([typeof(BrokenChestOfDrawersDeed)], 1076261) },
-            { 0x81, ([typeof(BrokenArmoireDeed)], 1076262) },
-            { 0x82, ([typeof(BrokenBedDeed)], 1076263) },
-            { 0x83, ([typeof(BrokenFallenChairDeed)], 1076264) },
-
-            // other
-            { 0x84, ([typeof(SuitOfGoldArmorDeed)], 1076265) },
-            { 0x85, ([typeof(SuitOfSilverArmorDeed)], 1076266) },
-            { 0x86, ([typeof(BoilingCauldronDeed)], 1076267) },
-            { 0x87, ([typeof(GuillotineDeed)], 1024656) },
-            { 0x88, ([typeof(CherryBlossomTreeDeed)], 1076268) },
-            { 0x89, ([typeof(AppleTreeDeed)], 1076269) },
-            { 0x8A, ([typeof(PeachTreeDeed)], 1076270) },
-            { 0x8B, ([typeof(HangingAxesDeed)], 1076271) },
-            { 0x8C, ([typeof(HangingSwordsDeed)], 1076272) },
-            { 0x8D, ([typeof(BlueFancyRugDeed)], 1076273) },
-            { 0x8E, ([typeof(WoodenCoffinDeed)], 1076274) },
-            { 0x8F, ([typeof(VanityDeed)], 1074027) },
-            { 0x90, ([typeof(TableWithPurpleClothDeed)], 1076635) },
-            { 0x91, ([typeof(TableWithBlueClothDeed)], 1076636) },
-            { 0x92, ([typeof(TableWithRedClothDeed)], 1076637) },
-            { 0x93, ([typeof(TableWithOrangeClothDeed)], 1076638) },
-            { 0x94, ([typeof(UnmadeBedDeed)], 1076279) },
-            { 0x95, ([typeof(CurtainsDeed)], 1076280) },
-            { 0x96, ([typeof(ScarecrowDeed)], 1076281) },
-            { 0x97, ([typeof(WallTorchDeed)], 1076282) },
-            { 0x98, ([typeof(FountainDeed)], 1076283) },
-            { 0x99, ([typeof(StoneStatueDeed)], 1076284) },
-            { 0x9A, ([typeof(LargeFishingNetDeed)], 1076285) },
-            { 0x9B, ([typeof(SmallFishingNetDeed)], 1076286) },
-            { 0x9C, ([typeof(HouseLadderDeed)], 1076287) },
-            { 0x9D, ([typeof(IronMaidenDeed)], 1076288) },
-            { 0x9E, ([typeof(BluePlainRugDeed)], 1076585) },
-            { 0x9F, ([typeof(GoldenDecorativeRugDeed)], 1076586) },
-            { 0xA0, ([typeof(CinnamonFancyRugDeed)], 1076587) },
-            { 0xA1, ([typeof(RedPlainRugDeed)], 1076588) },
-            { 0xA2, ([typeof(BlueDecorativeRugDeed)], 1076589) },
-            { 0xA3, ([typeof(PinkFancyRugDeed)], 1076590) },
-            { 0xA4, ([typeof(CherryBlossomTrunkDeed)], 1076784) },
-            { 0xA5, ([typeof(AppleTrunkDeed)], 1076785) },
-            { 0xA6, ([typeof(PeachTrunkDeed)], 1076786) }
-        };
-
-        private readonly HeritageToken _token;
-
-        public override bool Singleton => true;
-
-        private HeritageTokenGump(HeritageToken token) : base(60, 36) => _token = token;
-
-        public static void DisplayTo(Mobile from, HeritageToken token)
-        {
-            if (from?.NetState == null || token?.Deleted != false)
-            {
-                return;
-            }
-
-            from.SendGump(new HeritageTokenGump(token));
+            return;
         }
 
-        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        from.SendGump(new HeritageTokenGump(token));
+    }
+
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        // Standard static framing
+        builder.AddBackground(0, 0, 520, 404, 0x13BE);
+        builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+        builder.AddImageTiled(10, 40, 500, 324, 0xA40);
+        builder.AddImageTiled(10, 374, 500, 20, 0xA40);
+        builder.AddAlphaRegion(10, 10, 500, 384);
+        builder.AddButton(10, 374, 0xFB1, 0xFB2, 0);
+        builder.AddHtmlLocalized(45, 376, 450, 20, 1060051, 0x7FFF); // CANCEL
+        builder.AddHtmlLocalized(14, 12, 500, 20, 1075576, 0x7FFF);  // Choose your item from the following pages
+
+        const int itemsPerPage = 10;
+        int totalItems = ButtonLookup.Count;
+        int totalPages = (int)Math.Ceiling((double)totalItems / itemsPerPage);
+
+        int index = 0;
+        int page = 1;
+
+        foreach (var (buttonId, (_, cliloc, tooltip, itemId, hue, width, height)) in ButtonLookup)
         {
-            builder.AddPage();
+            // When index cleanly divides by 10, we are starting a new page
+            if (index % itemsPerPage == 0)
+            {
+                builder.AddPage(page);
 
-            builder.AddBackground(0, 0, 520, 404, 0x13BE);
-            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
-            builder.AddImageTiled(10, 40, 500, 324, 0xA40);
-            builder.AddImageTiled(10, 374, 500, 20, 0xA40);
-            builder.AddAlphaRegion(10, 10, 500, 384);
-            builder.AddButton(10, 374, 0xFB1, 0xFB2, 0);
-            builder.AddHtmlLocalized(45, 376, 450, 20, 1060051, 0x7FFF); // CANCEL
-            builder.AddHtmlLocalized(14, 12, 500, 20, 1075576, 0x7FFF);  // Choose your item from the following pages
+                // Add Next Button
+                if (page < totalPages)
+                {
+                    builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, page + 1);
+                    builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+                }
 
-            builder.AddPage(1);
+                // Add Back Button
+                if (page > 1)
+                {
+                    builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, page - 1);
+                    builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+                }
+            }
 
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x64, GumpButtonType.Reply, 0, 0x1411, 0x2C, 18, 8);
-            builder.AddTooltip(1062912);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1078147, 0x7FFF); // Royal Leggings of Embers
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x65, GumpButtonType.Reply, 0, 0x234D, 0x0, 18, 12);
-            builder.AddTooltip(1062914);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1062913, 0x7FFF); // Rose of Trinsic
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x66, GumpButtonType.Reply, 0, 0x26C3, 0x504, 18, 8);
-            builder.AddTooltip(1062916);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1062915, 0x7FFF); // Shamino’s Best Crossbow
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x67, GumpButtonType.Reply, 0, 0x3F1D, 0x0, 18, 8);
-            builder.AddTooltip(1062918);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1062917, 0x7FFF); // The Tapestry of Sosaria
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x68, GumpButtonType.Reply, 0, 0x3F14, 0x0, 18, 8);
-            builder.AddTooltip(1062920);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1062919, 0x7FFF); // Hearth of the Home Fire
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x69, GumpButtonType.Reply, 0, 0xF60, 0x482, -1, 10);
-            builder.AddTooltip(1062922);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1062921, 0x7FFF); // The Holy Sword
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x6A, GumpButtonType.Reply, 0, 0x236C, 0x0, 18, 6);
-            builder.AddTooltip(1062924);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1062923, 0x7FFF); // Ancient Samurai Helm
-            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x6B, GumpButtonType.Reply, 0, 0x2B10, 0x226, 18, 11);
-            builder.AddTooltip(1075223);
-            builder.AddHtmlLocalized(348, 236, 250, 60, 1075188, 0x7FFF); // Helm of Spirituality
-            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x6C, GumpButtonType.Reply, 0, 0x2B0C, 0x226, 18, 15);
-            builder.AddTooltip(1075224);
-            builder.AddHtmlLocalized(98, 300, 250, 60, 1075192, 0x7FFF); // Gauntlets of Valor
-            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x6D, GumpButtonType.Reply, 0, 0x2B01, 0x0, 18, 9);
-            builder.AddTooltip(1075225);
-            builder.AddHtmlLocalized(348, 300, 250, 60, 1075196, 0x7FFF); // Dupre’s Shield
-            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 2);
-            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            // Calculate dynamic grid placement (2 columns, 5 rows)
+            int posOnPage = index % itemsPerPage;
+            int col = posOnPage % 2; // 0 for left, 1 for right
+            int row = posOnPage / 2; // 0 through 4
 
-            builder.AddPage(2);
+            int xBase = col == 0 ? 14 : 264;
+            int yBase = 44 + (row * 64);
+            int textX = col == 0 ? 98 : 348;
 
-            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 1);
-            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x6E, GumpButtonType.Reply, 0, 0x2AC6, 0x0, 29, 0);
-            builder.AddTooltip(1075226);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1075197, 0x7FFF); // Fountain of Life
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x6F, GumpButtonType.Reply, 0, 0x2AF9, 0x0, -4, -5);
-            builder.AddTooltip(1075227);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1075198, 0x7FFF); // Dawn’s Music Box
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x70, GumpButtonType.Reply, 0, 0x2253, 0x0, 18, 12);
-            builder.AddTooltip(1075228);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1078148, 0x7FFF); // Ossian Grimoire
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x71, GumpButtonType.Reply, 0, 0x2D98, 0x0, 19, 13);
-            builder.AddTooltip(1078527);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1078142, 0x7FFF); // Talisman of the Fey:<br>Ferret
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x72, GumpButtonType.Reply, 0, 0x2D97, 0x0, 19, 13);
-            builder.AddTooltip(1078528);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1078143, 0x7FFF); // Talisman of the Fey:<br>Squirrel
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x73, GumpButtonType.Reply, 0, 0x2D96, 0x0, 19, 8);
-            builder.AddTooltip(1078529);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1078144, 0x7FFF); // Talisman of the Fey:<br>Cu Sidhe
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x74, GumpButtonType.Reply, 0, 0x2D95, 0x0, -4, 2);
-            builder.AddTooltip(1078530);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1078145, 0x7FFF); // Talisman of the Fey:<br>Reptalon
-            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x75, GumpButtonType.Reply, 0, 0x2B02, 0x0, -2, 9);
-            builder.AddTooltip(1078526);
-            builder.AddHtmlLocalized(348, 236, 250, 60, 1075201, 0x7FFF); // Quiver of Infinity
-            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x76, GumpButtonType.Reply, 0, 0x2A91, 0x0, 25, 5);
-            builder.AddTooltip(1075986);
-            builder.AddHtmlLocalized(98, 300, 250, 60, 1074797, 0x7FFF); // Bone Throne, Bone Couch<br>and Bone Table
-            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x77, GumpButtonType.Reply, 0, 0x2A99, 0x0, 18, 1);
-            builder.AddTooltip(1075987);
-            builder.AddHtmlLocalized(348, 300, 250, 60, 1078146, 0x7FFF); // Creepy Portraits
-            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 3);
-            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            // Render the UI entries
+            builder.AddImageTiledButton(
+                xBase,
+                yBase,
+                0x918,
+                0x919,
+                buttonId,
+                GumpButtonType.Reply,
+                0,
+                itemId,
+                hue,
+                width,
+                height
+            );
 
-            builder.AddPage(3);
+            if (tooltip > 0)
+            {
+                builder.AddTooltip(tooltip);
+            }
 
-            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 2);
-            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x78, GumpButtonType.Reply, 0, 0x2A71, 0x0, 13, 5);
-            builder.AddTooltip(1075988);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1074799, 0x7FFF); // Mounted Pixies (5)
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x79, GumpButtonType.Reply, 0, 0x2A98, 0x0, 26, 1);
-            builder.AddTooltip(1075990);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1074800, 0x7FFF); // Haunted Mirror
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x7A, GumpButtonType.Reply, 0, 0x2A92, 0x0, 18, 1);
-            builder.AddTooltip(1075989);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1074801, 0x7FFF); // Bed of Nails
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x7B, GumpButtonType.Reply, 0, 0x2AB8, 0x0, 18, 1);
-            builder.AddTooltip(1075991);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1074818, 0x7FFF); // Sacrificial Altar
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x7C, GumpButtonType.Reply, 0, 0x3F26, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1076257, 0x7FFF); // Broken Covered Chair
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x7D, GumpButtonType.Reply, 0, 0x3F22, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1076258, 0x7FFF); // Broken Bookcase
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x7E, GumpButtonType.Reply, 0, 0x3F24, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1076259, 0x7FFF); // Standing Broken Chair
-            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x7F, GumpButtonType.Reply, 0, 0x3F25, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(348, 236, 250, 60, 1076260, 0x7FFF); // Broken Vanity
-            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x80, GumpButtonType.Reply, 0, 0x3F23, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(98, 300, 250, 60, 1076261, 0x7FFF); // Broken Chest of Drawers
-            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x81, GumpButtonType.Reply, 0, 0x3F21, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(348, 300, 250, 60, 1076262, 0x7FFF); // Broken Armoire
-            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 4);
-            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddHtmlLocalized(textX, yBase, 250, 60, cliloc, 0x7FFF);
 
-            builder.AddPage(4);
+            index++;
 
-            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 3);
-            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x82, GumpButtonType.Reply, 0, 0x3F0B, 0x0, 18, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1076263, 0x7FFF); // Broken Bed
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x83, GumpButtonType.Reply, 0, 0xC19, 0x0, 13, 8);
-            builder.AddTooltip(1076610);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1076264, 0x7FFF); // Broken Fallen Chair
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x84, GumpButtonType.Reply, 0, 0x3DAA, 0x0, 20, -3);
-            builder.AddTooltip(1076611);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1076265, 0x7FFF); // Suit of Gold Armor
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x85, GumpButtonType.Reply, 0, 0x151C, 0x0, -20, -3);
-            builder.AddTooltip(1076612);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1076266, 0x7FFF); // Suit of Silver Armor
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x86, GumpButtonType.Reply, 0, 0x3DB1, 0x0, 18, 8);
-            builder.AddTooltip(1076613);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1076267, 0x7FFF); // Boiling Cauldron
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x87, GumpButtonType.Reply, 0, 0x3F27, 0x0, 18, 8);
-            builder.AddTooltip(1076614);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1024656, 0x7FFF); // Guillotine
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x88, GumpButtonType.Reply, 0, 0x3F0C, 0x0, 18, 8);
-            builder.AddTooltip(1076615);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1076268, 0x7FFF); // Cherry Blossom Tree
-            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x89, GumpButtonType.Reply, 0, 0x3F07, 0x0, 18, 8);
-            builder.AddTooltip(1076616);
-            builder.AddHtmlLocalized(348, 236, 250, 60, 1076269, 0x7FFF); // Apple Tree
-            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x8A, GumpButtonType.Reply, 0, 0x3F16, 0x0, 18, 8);
-            builder.AddTooltip(1076617);
-            builder.AddHtmlLocalized(98, 300, 250, 60, 1076270, 0x7FFF); // Peach Tree
-            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x8B, GumpButtonType.Reply, 0, 0x3F12, 0x0, 18, 8);
-            builder.AddTooltip(1076618);
-            builder.AddHtmlLocalized(348, 300, 250, 60, 1076271, 0x7FFF); // Hanging Axes
-            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 5);
-            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            // Bump to the next page when we fill the current one
+            if (index % itemsPerPage == 0)
+            {
+                page++;
+            }
+        }
+    }
 
-            builder.AddPage(5);
-
-            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 4);
-            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x8C, GumpButtonType.Reply, 0, 0x3F13, 0x0, 18, 8);
-            builder.AddTooltip(1076619);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1076272, 0x7FFF); // Hanging Swords
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x8D, GumpButtonType.Reply, 0, 0x3F09, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1076273, 0x7FFF); // Blue fancy rug
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x8E, GumpButtonType.Reply, 0, 0x3F0E, 0x0, 18, 8);
-            builder.AddTooltip(1076621);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1076274, 0x7FFF); // Coffin
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x8F, GumpButtonType.Reply, 0, 0x3F1F, 0x0, 18, 8);
-            builder.AddTooltip(1076623);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1074027, 0x7FFF); // Vanity
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x90, GumpButtonType.Reply, 0, 0x118B, 0x0, -4, -9);
-            builder.AddTooltip(1076624);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1076635, 0x7FFF); // Table With A Purple<br>Tablecloth
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x91, GumpButtonType.Reply, 0, 0x118C, 0x0, -4, -9);
-            builder.AddTooltip(1076624);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1076636, 0x7FFF); // Table With A Blue<br>Tablecloth
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x92, GumpButtonType.Reply, 0, 0x118D, 0x0, -4, -9);
-            builder.AddTooltip(1076624);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1076637, 0x7FFF); // Table With A Red<br>Tablecloth
-            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x93, GumpButtonType.Reply, 0, 0x118E, 0x0, -4, -9);
-            builder.AddTooltip(1076624);
-            builder.AddHtmlLocalized(348, 236, 250, 60, 1076638, 0x7FFF); // Table With An Orange<br>Tablecloth
-            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x94, GumpButtonType.Reply, 0, 0x3F1E, 0x0, 18, 8);
-            builder.AddTooltip(1076625);
-            builder.AddHtmlLocalized(98, 300, 250, 60, 1076279, 0x7FFF); // Unmade Bed
-            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x95, GumpButtonType.Reply, 0, 0x3F0F, 0x0, 18, 8);
-            builder.AddTooltip(1076626);
-            builder.AddHtmlLocalized(348, 300, 250, 60, 1076280, 0x7FFF); // Curtains
-            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 6);
-            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
-
-            builder.AddPage(6);
-
-            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 5);
-            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x96, GumpButtonType.Reply, 0, 0x1E34, 0x0, 18, -17);
-            builder.AddTooltip(1076627);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1076281, 0x7FFF); // Scarecrow
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x97, GumpButtonType.Reply, 0, 0xA0C, 0x0, 18, 8);
-            builder.AddTooltip(1076628);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1076282, 0x7FFF); // Wall Torch
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x98, GumpButtonType.Reply, 0, 0x3F10, 0x0, 18, 9);
-            builder.AddTooltip(1076629);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1076283, 0x7FFF); // Fountain
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x99, GumpButtonType.Reply, 0, 0x3F19, 0x0, 18, 8);
-            builder.AddTooltip(1076630);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1076284, 0x7FFF); // Statue
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x9A, GumpButtonType.Reply, 0, 0x1EA5, 0x0, 5, -25);
-            builder.AddTooltip(1076631);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1076285, 0x7FFF); // Large Fish Net
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x9B, GumpButtonType.Reply, 0, 0x1EA3, 0x0, 18, -27);
-            builder.AddTooltip(1076632);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1076286, 0x7FFF); // Small Fish Net
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x9C, GumpButtonType.Reply, 0, 0x2FDF, 0x0, 18, -36);
-            builder.AddTooltip(1076633);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1076287, 0x7FFF); // Ladder
-            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x9D, GumpButtonType.Reply, 0, 0x3F15, 0x0, 18, 8);
-            builder.AddTooltip(1076622);
-            builder.AddHtmlLocalized(348, 236, 250, 60, 1076288, 0x7FFF); // Iron Maiden
-            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x9E, GumpButtonType.Reply, 0, 0x3F0A, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(98, 300, 250, 60, 1076585, 0x7FFF); // Blue plain rug
-            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x9F, GumpButtonType.Reply, 0, 0x3F11, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(348, 300, 250, 60, 1076586, 0x7FFF); // Golden decorative rug
-            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 7);
-            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
-
-            builder.AddPage(7);
-
-            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 6);
-            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0xA0, GumpButtonType.Reply, 0, 0x3F0D, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(98, 44, 250, 60, 1076587, 0x7FFF); // Cinnamon fancy rug
-            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0xA1, GumpButtonType.Reply, 0, 0x3F18, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(348, 44, 250, 60, 1076588, 0x7FFF); // Red plain rug
-            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0xA2, GumpButtonType.Reply, 0, 0x3F08, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(98, 108, 250, 60, 1076589, 0x7FFF); // Blue decorative rug
-            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0xA3, GumpButtonType.Reply, 0, 0x3F17, 0x0, 18, 8);
-            builder.AddTooltip(1076620);
-            builder.AddHtmlLocalized(348, 108, 250, 60, 1076590, 0x7FFF); // Pink fancy rug
-            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0xA4, GumpButtonType.Reply, 0, 0x312A, 0x0, 18, 8);
-            builder.AddTooltip(1076615);
-            builder.AddHtmlLocalized(98, 172, 250, 60, 1076784, 0x7FFF); // Cherry Blossom Trunk
-            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0xA5, GumpButtonType.Reply, 0, 0x3128, 0x0, 18, 8);
-            builder.AddTooltip(1076616);
-            builder.AddHtmlLocalized(348, 172, 250, 60, 1076785, 0x7FFF); // Apple Trunk
-            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0xA6, GumpButtonType.Reply, 0, 0x3129, 0x0, 18, 8);
-            builder.AddTooltip(1076617);
-            builder.AddHtmlLocalized(98, 236, 250, 60, 1076786, 0x7FFF); // Peach Trunk
+    public override void OnResponse(NetState sender, in RelayInfo info)
+    {
+        if (_token?.Deleted != false || info.ButtonID == 0)
+        {
+            return;
         }
 
-        public override void OnResponse(NetState sender, in RelayInfo info)
+        if (!ButtonLookup.TryGetValue(info.ButtonID, out var buttonInfo))
         {
-            if (_token?.Deleted != false || info.ButtonID == 0)
-            {
-                return;
-            }
+            return;
+        }
 
-            if (!ButtonLookup.TryGetValue(info.ButtonID, out var buttonInfo))
-            {
-                return;
-            }
+        var (types, cliloc, _, _, _, _, _) = buttonInfo;
 
-            var (types, cliloc) = buttonInfo;
-
-            if (types?.Length > 0 && cliloc > 0)
-            {
-                ConfirmHeritageGump.DisplayTo(sender.Mobile, _token, types, cliloc);
-            }
-            else
-            {
-                // This option is currently disabled, while we evaluate it for game balance.
-                sender.Mobile.SendLocalizedMessage(501311);
-            }
+        if (types?.Length > 0 && cliloc > 0)
+        {
+            ConfirmHeritageGump.DisplayTo(sender.Mobile, _token, types, cliloc);
+        }
+        else
+        {
+            // This option is currently disabled, while we evaluate it for game balance.
+            sender.Mobile.SendLocalizedMessage(501311);
         }
     }
 }

--- a/Projects/UOContent/Gumps/HeritageTokenGump.cs
+++ b/Projects/UOContent/Gumps/HeritageTokenGump.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Server.Items;
 using Server.Network;
 
@@ -6,6 +7,93 @@ namespace Server.Gumps
 {
     public class HeritageTokenGump : StaticGump<HeritageTokenGump>
     {
+        private static readonly Dictionary<int, (Type[] Types, int CliLoc)> ButtonLookup = new()
+        {
+            // 7th anniversary
+            { 0x64, ([typeof(LeggingsOfEmbers)], 1078147) },
+            { 0x65, ([typeof(RoseOfTrinsic)], 1062913) },
+            { 0x66, ([typeof(ShaminoCrossbow)], 1062915) },
+            { 0x67, ([typeof(TapestryOfSosaria)], 1062917) },
+            { 0x68, ([typeof(HearthOfHomeFireDeed)], 1062919) },
+            { 0x69, ([typeof(HolySword)], 1062921) },
+            { 0x6A, ([typeof(SamuraiHelm)], 1062923) },
+
+            // 8th anniversary
+            { 0x6D, ([typeof(DupresShield)], 1075196) },
+            { 0x6E, ([typeof(FountainOfLifeDeed)], 1075197) },
+            { 0x6F, ([typeof(DawnsMusicBox)], 1075198) },
+            { 0x70, ([typeof(OssianGrimoire)], 1078148) },
+            { 0x71, ([typeof(FerretFormTalisman)], 1078142) },
+            { 0x72, ([typeof(SquirrelFormTalisman)], 1078143) },
+            { 0x73, ([typeof(CuSidheFormTalisman)], 1078144) },
+            { 0x74, ([typeof(ReptalonFormTalisman)], 1078145) },
+            { 0x75, ([typeof(QuiverOfInfinity)], 1075201) },
+
+            // evil home decor
+            { 0x76, ([typeof(BoneThroneDeed), typeof(BoneCouchDeed), typeof(BoneTableDeed)], 1074797) },
+            { 0x77, ([typeof(CreepyPortraitDeed), typeof(DisturbingPortraitDeed), typeof(UnsettlingPortraitDeed)], 1078146) },
+            {
+                0x78,
+                (
+                    [
+                        typeof(MountedPixieBlueDeed), typeof(MountedPixieGreenDeed), typeof(MountedPixieLimeDeed),
+                        typeof(MountedPixieOrangeDeed), typeof(MountedPixieWhiteDeed)
+                    ],
+                    1074799
+                )
+            },
+            { 0x79, ([typeof(HaunterMirrorDeed)], 1074800) },
+            { 0x7A, ([typeof(BedOfNailsDeed)], 1074801) },
+            { 0x7B, ([typeof(SacrificialAltarDeed)], 1074818) },
+
+            // broken furniture
+            { 0x7C, ([typeof(BrokenCoveredChairDeed)], 1076257) },
+            { 0x7D, ([typeof(BrokenBookcaseDeed)], 1076258) },
+            { 0x7E, ([typeof(StandingBrokenChairDeed)], 1076259) },
+            { 0x7F, ([typeof(BrokenVanityDeed)], 1076260) },
+            { 0x80, ([typeof(BrokenChestOfDrawersDeed)], 1076261) },
+            { 0x81, ([typeof(BrokenArmoireDeed)], 1076262) },
+            { 0x82, ([typeof(BrokenBedDeed)], 1076263) },
+            { 0x83, ([typeof(BrokenFallenChairDeed)], 1076264) },
+
+            // other
+            { 0x84, ([typeof(SuitOfGoldArmorDeed)], 1076265) },
+            { 0x85, ([typeof(SuitOfSilverArmorDeed)], 1076266) },
+            { 0x86, ([typeof(BoilingCauldronDeed)], 1076267) },
+            { 0x87, ([typeof(GuillotineDeed)], 1024656) },
+            { 0x88, ([typeof(CherryBlossomTreeDeed)], 1076268) },
+            { 0x89, ([typeof(AppleTreeDeed)], 1076269) },
+            { 0x8A, ([typeof(PeachTreeDeed)], 1076270) },
+            { 0x8B, ([typeof(HangingAxesDeed)], 1076271) },
+            { 0x8C, ([typeof(HangingSwordsDeed)], 1076272) },
+            { 0x8D, ([typeof(BlueFancyRugDeed)], 1076273) },
+            { 0x8E, ([typeof(WoodenCoffinDeed)], 1076274) },
+            { 0x8F, ([typeof(VanityDeed)], 1074027) },
+            { 0x90, ([typeof(TableWithPurpleClothDeed)], 1076635) },
+            { 0x91, ([typeof(TableWithBlueClothDeed)], 1076636) },
+            { 0x92, ([typeof(TableWithRedClothDeed)], 1076637) },
+            { 0x93, ([typeof(TableWithOrangeClothDeed)], 1076638) },
+            { 0x94, ([typeof(UnmadeBedDeed)], 1076279) },
+            { 0x95, ([typeof(CurtainsDeed)], 1076280) },
+            { 0x96, ([typeof(ScarecrowDeed)], 1076281) },
+            { 0x97, ([typeof(WallTorchDeed)], 1076282) },
+            { 0x98, ([typeof(FountainDeed)], 1076283) },
+            { 0x99, ([typeof(StoneStatueDeed)], 1076284) },
+            { 0x9A, ([typeof(LargeFishingNetDeed)], 1076285) },
+            { 0x9B, ([typeof(SmallFishingNetDeed)], 1076286) },
+            { 0x9C, ([typeof(HouseLadderDeed)], 1076287) },
+            { 0x9D, ([typeof(IronMaidenDeed)], 1076288) },
+            { 0x9E, ([typeof(BluePlainRugDeed)], 1076585) },
+            { 0x9F, ([typeof(GoldenDecorativeRugDeed)], 1076586) },
+            { 0xA0, ([typeof(CinnamonFancyRugDeed)], 1076587) },
+            { 0xA1, ([typeof(RedPlainRugDeed)], 1076588) },
+            { 0xA2, ([typeof(BlueDecorativeRugDeed)], 1076589) },
+            { 0xA3, ([typeof(PinkFancyRugDeed)], 1076590) },
+            { 0xA4, ([typeof(CherryBlossomTrunkDeed)], 1076784) },
+            { 0xA5, ([typeof(AppleTrunkDeed)], 1076785) },
+            { 0xA6, ([typeof(PeachTrunkDeed)], 1076786) }
+        };
+
         private readonly HeritageToken _token;
 
         public override bool Singleton => true;
@@ -19,7 +107,7 @@ namespace Server.Gumps
                 return;
             }
 
-            from.SendGump(new HeritageTokenGump(token), true);
+            from.SendGump(new HeritageTokenGump(token));
         }
 
         protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -289,431 +377,12 @@ namespace Server.Gumps
                 return;
             }
 
-            Type[] types;
-            int cliloc;
-
-            switch (info.ButtonID)
+            if (!ButtonLookup.TryGetValue(info.ButtonID, out var buttonInfo))
             {
-                default:
-                    {
-                        types = null;
-                        cliloc = 0;
-                        break;
-                    }
-                // 7th anniversary
-                case 0x64:
-                    {
-                        types = [typeof(LeggingsOfEmbers)];
-                        cliloc = 1078147;
-                        break;
-                    }
-                case 0x65:
-                    {
-                        types = [typeof(RoseOfTrinsic)];
-                        cliloc = 1062913;
-                        break;
-                    }
-                case 0x66:
-                    {
-                        types = [typeof(ShaminoCrossbow)];
-                        cliloc = 1062915;
-                        break;
-                    }
-                case 0x67:
-                    {
-                        types = [typeof(TapestryOfSosaria)];
-                        cliloc = 1062917;
-                        break;
-                    }
-                case 0x68:
-                    {
-                        types = [typeof(HearthOfHomeFireDeed)];
-                        cliloc = 1062919;
-                        break;
-                    }
-                case 0x69:
-                    {
-                        types = [typeof(HolySword)];
-                        cliloc = 1062921;
-                        break;
-                    }
-                case 0x6A:
-                    {
-                        types = [typeof(SamuraiHelm)];
-                        cliloc = 1062923;
-                        break;
-                    }
-
-                // 8th anniversary
-                /*case 0x6B: types = new [] {  typeof( SpiritualityHelm )  }; cliloc = 1075188; break;
-                case 0x6C: types = new [] {  typeof( ValorGauntlets )  }; cliloc = 1075192; break;*/
-                case 0x6D:
-                    {
-                        types = [typeof(DupresShield)];
-                        cliloc = 1075196;
-                        break;
-                    }
-                case 0x6E:
-                    {
-                        types = [typeof(FountainOfLifeDeed)];
-                        cliloc = 1075197;
-                        break;
-                    }
-                case 0x6F:
-                    {
-                        types = [typeof(DawnsMusicBox)];
-                        cliloc = 1075198;
-                        break;
-                    }
-                case 0x70:
-                    {
-                        types = [typeof(OssianGrimoire)];
-                        cliloc = 1078148;
-                        break;
-                    }
-                case 0x71:
-                    {
-                        types = [typeof(FerretFormTalisman)];
-                        cliloc = 1078142;
-                        break;
-                    }
-                case 0x72:
-                    {
-                        types = [typeof(SquirrelFormTalisman)];
-                        cliloc = 1078143;
-                        break;
-                    }
-                case 0x73:
-                    {
-                        types = [typeof(CuSidheFormTalisman)];
-                        cliloc = 1078144;
-                        break;
-                    }
-                case 0x74:
-                    {
-                        types = [typeof(ReptalonFormTalisman)];
-                        cliloc = 1078145;
-                        break;
-                    }
-                case 0x75:
-                    {
-                        types = [typeof(QuiverOfInfinity)];
-                        cliloc = 1075201;
-                        break;
-                    }
-
-                // evil home decor
-                case 0x76:
-                    {
-                        types = [typeof(BoneThroneDeed), typeof(BoneCouchDeed), typeof(BoneTableDeed)];
-                        cliloc = 1074797;
-                        break;
-                    }
-                case 0x77:
-                    {
-                        types =
-                        [
-                            typeof(CreepyPortraitDeed),
-                            typeof(DisturbingPortraitDeed),
-                            typeof(UnsettlingPortraitDeed)
-                        ];
-                        cliloc = 1078146;
-                        break;
-                    }
-                case 0x78:
-                    {
-                        types =
-                        [
-                            typeof(MountedPixieBlueDeed),
-                            typeof(MountedPixieGreenDeed),
-                            typeof(MountedPixieLimeDeed),
-                            typeof(MountedPixieOrangeDeed),
-                            typeof(MountedPixieWhiteDeed)
-                        ];
-                        cliloc = 1074799;
-                        break;
-                    }
-                case 0x79:
-                    {
-                        types = [typeof(HaunterMirrorDeed)];
-                        cliloc = 1074800;
-                        break;
-                    }
-                case 0x7A:
-                    {
-                        types = [typeof(BedOfNailsDeed)];
-                        cliloc = 1074801;
-                        break;
-                    }
-                case 0x7B:
-                    {
-                        types = [typeof(SacrificialAltarDeed)];
-                        cliloc = 1074818;
-                        break;
-                    }
-
-                // broken furniture
-                case 0x7C:
-                    {
-                        types = [typeof(BrokenCoveredChairDeed)];
-                        cliloc = 1076257;
-                        break;
-                    }
-                case 0x7D:
-                    {
-                        types = [typeof(BrokenBookcaseDeed)];
-                        cliloc = 1076258;
-                        break;
-                    }
-                case 0x7E:
-                    {
-                        types = [typeof(StandingBrokenChairDeed)];
-                        cliloc = 1076259;
-                        break;
-                    }
-                case 0x7F:
-                    {
-                        types = [typeof(BrokenVanityDeed)];
-                        cliloc = 1076260;
-                        break;
-                    }
-                case 0x80:
-                    {
-                        types = [typeof(BrokenChestOfDrawersDeed)];
-                        cliloc = 1076261;
-                        break;
-                    }
-                case 0x81:
-                    {
-                        types = [typeof(BrokenArmoireDeed)];
-                        cliloc = 1076262;
-                        break;
-                    }
-                case 0x82:
-                    {
-                        types = [typeof(BrokenBedDeed)];
-                        cliloc = 1076263;
-                        break;
-                    }
-                case 0x83:
-                    {
-                        types = [typeof(BrokenFallenChairDeed)];
-                        cliloc = 1076264;
-                        break;
-                    }
-
-                // other
-                case 0x84:
-                    {
-                        types = [typeof(SuitOfGoldArmorDeed)];
-                        cliloc = 1076265;
-                        break;
-                    }
-                case 0x85:
-                    {
-                        types = [typeof(SuitOfSilverArmorDeed)];
-                        cliloc = 1076266;
-                        break;
-                    }
-                case 0x86:
-                    {
-                        types = [typeof(BoilingCauldronDeed)];
-                        cliloc = 1076267;
-                        break;
-                    }
-                case 0x87:
-                    {
-                        types = [typeof(GuillotineDeed)];
-                        cliloc = 1024656;
-                        break;
-                    }
-                case 0x88:
-                    {
-                        types = [typeof(CherryBlossomTreeDeed)];
-                        cliloc = 1076268;
-                        break;
-                    }
-                case 0x89:
-                    {
-                        types = [typeof(AppleTreeDeed)];
-                        cliloc = 1076269;
-                        break;
-                    }
-                case 0x8A:
-                    {
-                        types = [typeof(PeachTreeDeed)];
-                        cliloc = 1076270;
-                        break;
-                    }
-                case 0x8B:
-                    {
-                        types = [typeof(HangingAxesDeed)];
-                        cliloc = 1076271;
-                        break;
-                    }
-                case 0x8C:
-                    {
-                        types = [typeof(HangingSwordsDeed)];
-                        cliloc = 1076272;
-                        break;
-                    }
-                case 0x8D:
-                    {
-                        types = [typeof(BlueFancyRugDeed)];
-                        cliloc = 1076273;
-                        break;
-                    }
-                case 0x8E:
-                    {
-                        types = [typeof(WoodenCoffinDeed)];
-                        cliloc = 1076274;
-                        break;
-                    }
-                case 0x8F:
-                    {
-                        types = [typeof(VanityDeed)];
-                        cliloc = 1074027;
-                        break;
-                    }
-                case 0x90:
-                    {
-                        types = [typeof(TableWithPurpleClothDeed)];
-                        cliloc = 1076635;
-                        break;
-                    }
-                case 0x91:
-                    {
-                        types = [typeof(TableWithBlueClothDeed)];
-                        cliloc = 1076636;
-                        break;
-                    }
-                case 0x92:
-                    {
-                        types = [typeof(TableWithRedClothDeed)];
-                        cliloc = 1076637;
-                        break;
-                    }
-                case 0x93:
-                    {
-                        types = [typeof(TableWithOrangeClothDeed)];
-                        cliloc = 1076638;
-                        break;
-                    }
-                case 0x94:
-                    {
-                        types = [typeof(UnmadeBedDeed)];
-                        cliloc = 1076279;
-                        break;
-                    }
-                case 0x95:
-                    {
-                        types = [typeof(CurtainsDeed)];
-                        cliloc = 1076280;
-                        break;
-                    }
-                case 0x96:
-                    {
-                        types = [typeof(ScarecrowDeed)];
-                        cliloc = 1076281;
-                        break;
-                    }
-                case 0x97:
-                    {
-                        types = [typeof(WallTorchDeed)];
-                        cliloc = 1076282;
-                        break;
-                    }
-                case 0x98:
-                    {
-                        types = [typeof(FountainDeed)];
-                        cliloc = 1076283;
-                        break;
-                    }
-                case 0x99:
-                    {
-                        types = [typeof(StoneStatueDeed)];
-                        cliloc = 1076284;
-                        break;
-                    }
-                case 0x9A:
-                    {
-                        types = [typeof(LargeFishingNetDeed)];
-                        cliloc = 1076285;
-                        break;
-                    }
-                case 0x9B:
-                    {
-                        types = [typeof(SmallFishingNetDeed)];
-                        cliloc = 1076286;
-                        break;
-                    }
-                case 0x9C:
-                    {
-                        types = [typeof(HouseLadderDeed)];
-                        cliloc = 1076287;
-                        break;
-                    }
-                case 0x9D:
-                    {
-                        types = [typeof(IronMaidenDeed)];
-                        cliloc = 1076288;
-                        break;
-                    }
-                case 0x9E:
-                    {
-                        types = [typeof(BluePlainRugDeed)];
-                        cliloc = 1076585;
-                        break;
-                    }
-                case 0x9F:
-                    {
-                        types = [typeof(GoldenDecorativeRugDeed)];
-                        cliloc = 1076586;
-                        break;
-                    }
-                case 0xA0:
-                    {
-                        types = [typeof(CinnamonFancyRugDeed)];
-                        cliloc = 1076587;
-                        break;
-                    }
-                case 0xA1:
-                    {
-                        types = [typeof(RedPlainRugDeed)];
-                        cliloc = 1076588;
-                        break;
-                    }
-                case 0xA2:
-                    {
-                        types = [typeof(BlueDecorativeRugDeed)];
-                        cliloc = 1076589;
-                        break;
-                    }
-                case 0xA3:
-                    {
-                        types = [typeof(PinkFancyRugDeed)];
-                        cliloc = 1076590;
-                        break;
-                    }
-                case 0xA4:
-                    {
-                        types = [typeof(CherryBlossomTrunkDeed)];
-                        cliloc = 1076784;
-                        break;
-                    }
-                case 0xA5:
-                    {
-                        types = [typeof(AppleTrunkDeed)];
-                        cliloc = 1076785;
-                        break;
-                    }
-                case 0xA6:
-                    {
-                        types = [typeof(PeachTrunkDeed)];
-                        cliloc = 1076786;
-                        break;
-                    }
+                return;
             }
+
+            var (types, cliloc) = buttonInfo;
 
             if (types?.Length > 0 && cliloc > 0)
             {

--- a/Projects/UOContent/Gumps/HeritageTokenGump.cs
+++ b/Projects/UOContent/Gumps/HeritageTokenGump.cs
@@ -4,275 +4,287 @@ using Server.Network;
 
 namespace Server.Gumps
 {
-    public class HeritageTokenGump : Gump
+    public class HeritageTokenGump : StaticGump<HeritageTokenGump>
     {
-        private readonly HeritageToken m_Token;
+        private readonly HeritageToken _token;
 
-        public HeritageTokenGump(HeritageToken token) : base(60, 36)
+        public override bool Singleton => true;
+
+        private HeritageTokenGump(HeritageToken token) : base(60, 36) => _token = token;
+
+        public static void DisplayTo(Mobile from, HeritageToken token)
         {
-            m_Token = token;
+            if (from?.NetState == null || token?.Deleted != false)
+            {
+                return;
+            }
 
-            AddPage(0);
+            from.SendGump(new HeritageTokenGump(token), true);
+        }
 
-            AddBackground(0, 0, 520, 404, 0x13BE);
-            AddImageTiled(10, 10, 500, 20, 0xA40);
-            AddImageTiled(10, 40, 500, 324, 0xA40);
-            AddImageTiled(10, 374, 500, 20, 0xA40);
-            AddAlphaRegion(10, 10, 500, 384);
-            AddButton(10, 374, 0xFB1, 0xFB2, 0);
-            AddHtmlLocalized(45, 376, 450, 20, 1060051, 0x7FFF); // CANCEL
-            AddHtmlLocalized(14, 12, 500, 20, 1075576, 0x7FFF);  // Choose your item from the following pages
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddPage(1);
+            builder.AddBackground(0, 0, 520, 404, 0x13BE);
+            builder.AddImageTiled(10, 10, 500, 20, 0xA40);
+            builder.AddImageTiled(10, 40, 500, 324, 0xA40);
+            builder.AddImageTiled(10, 374, 500, 20, 0xA40);
+            builder.AddAlphaRegion(10, 10, 500, 384);
+            builder.AddButton(10, 374, 0xFB1, 0xFB2, 0);
+            builder.AddHtmlLocalized(45, 376, 450, 20, 1060051, 0x7FFF); // CANCEL
+            builder.AddHtmlLocalized(14, 12, 500, 20, 1075576, 0x7FFF);  // Choose your item from the following pages
 
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0x64, GumpButtonType.Reply, 0, 0x1411, 0x2C, 18, 8);
-            AddTooltip(1062912);
-            AddHtmlLocalized(98, 44, 250, 60, 1078147, 0x7FFF); // Royal Leggings of Embers
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0x65, GumpButtonType.Reply, 0, 0x234D, 0x0, 18, 12);
-            AddTooltip(1062914);
-            AddHtmlLocalized(348, 44, 250, 60, 1062913, 0x7FFF); // Rose of Trinsic
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0x66, GumpButtonType.Reply, 0, 0x26C3, 0x504, 18, 8);
-            AddTooltip(1062916);
-            AddHtmlLocalized(98, 108, 250, 60, 1062915, 0x7FFF); // Shamino’s Best Crossbow
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0x67, GumpButtonType.Reply, 0, 0x3F1D, 0x0, 18, 8);
-            AddTooltip(1062918);
-            AddHtmlLocalized(348, 108, 250, 60, 1062917, 0x7FFF); // The Tapestry of Sosaria
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0x68, GumpButtonType.Reply, 0, 0x3F14, 0x0, 18, 8);
-            AddTooltip(1062920);
-            AddHtmlLocalized(98, 172, 250, 60, 1062919, 0x7FFF); // Hearth of the Home Fire
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0x69, GumpButtonType.Reply, 0, 0xF60, 0x482, -1, 10);
-            AddTooltip(1062922);
-            AddHtmlLocalized(348, 172, 250, 60, 1062921, 0x7FFF); // The Holy Sword
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0x6A, GumpButtonType.Reply, 0, 0x236C, 0x0, 18, 6);
-            AddTooltip(1062924);
-            AddHtmlLocalized(98, 236, 250, 60, 1062923, 0x7FFF); // Ancient Samurai Helm
-            AddImageTiledButton(264, 236, 0x918, 0x919, 0x6B, GumpButtonType.Reply, 0, 0x2B10, 0x226, 18, 11);
-            AddTooltip(1075223);
-            AddHtmlLocalized(348, 236, 250, 60, 1075188, 0x7FFF); // Helm of Spirituality
-            AddImageTiledButton(14, 300, 0x918, 0x919, 0x6C, GumpButtonType.Reply, 0, 0x2B0C, 0x226, 18, 15);
-            AddTooltip(1075224);
-            AddHtmlLocalized(98, 300, 250, 60, 1075192, 0x7FFF); // Gauntlets of Valor
-            AddImageTiledButton(264, 300, 0x918, 0x919, 0x6D, GumpButtonType.Reply, 0, 0x2B01, 0x0, 18, 9);
-            AddTooltip(1075225);
-            AddHtmlLocalized(348, 300, 250, 60, 1075196, 0x7FFF); // Dupre’s Shield
-            AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 2);
-            AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddPage(1);
 
-            AddPage(2);
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x64, GumpButtonType.Reply, 0, 0x1411, 0x2C, 18, 8);
+            builder.AddTooltip(1062912);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1078147, 0x7FFF); // Royal Leggings of Embers
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x65, GumpButtonType.Reply, 0, 0x234D, 0x0, 18, 12);
+            builder.AddTooltip(1062914);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1062913, 0x7FFF); // Rose of Trinsic
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x66, GumpButtonType.Reply, 0, 0x26C3, 0x504, 18, 8);
+            builder.AddTooltip(1062916);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1062915, 0x7FFF); // Shamino’s Best Crossbow
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x67, GumpButtonType.Reply, 0, 0x3F1D, 0x0, 18, 8);
+            builder.AddTooltip(1062918);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1062917, 0x7FFF); // The Tapestry of Sosaria
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x68, GumpButtonType.Reply, 0, 0x3F14, 0x0, 18, 8);
+            builder.AddTooltip(1062920);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1062919, 0x7FFF); // Hearth of the Home Fire
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x69, GumpButtonType.Reply, 0, 0xF60, 0x482, -1, 10);
+            builder.AddTooltip(1062922);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1062921, 0x7FFF); // The Holy Sword
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x6A, GumpButtonType.Reply, 0, 0x236C, 0x0, 18, 6);
+            builder.AddTooltip(1062924);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1062923, 0x7FFF); // Ancient Samurai Helm
+            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x6B, GumpButtonType.Reply, 0, 0x2B10, 0x226, 18, 11);
+            builder.AddTooltip(1075223);
+            builder.AddHtmlLocalized(348, 236, 250, 60, 1075188, 0x7FFF); // Helm of Spirituality
+            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x6C, GumpButtonType.Reply, 0, 0x2B0C, 0x226, 18, 15);
+            builder.AddTooltip(1075224);
+            builder.AddHtmlLocalized(98, 300, 250, 60, 1075192, 0x7FFF); // Gauntlets of Valor
+            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x6D, GumpButtonType.Reply, 0, 0x2B01, 0x0, 18, 9);
+            builder.AddTooltip(1075225);
+            builder.AddHtmlLocalized(348, 300, 250, 60, 1075196, 0x7FFF); // Dupre’s Shield
+            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 2);
+            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
 
-            AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 1);
-            AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0x6E, GumpButtonType.Reply, 0, 0x2AC6, 0x0, 29, 0);
-            AddTooltip(1075226);
-            AddHtmlLocalized(98, 44, 250, 60, 1075197, 0x7FFF); // Fountain of Life
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0x6F, GumpButtonType.Reply, 0, 0x2AF9, 0x0, -4, -5);
-            AddTooltip(1075227);
-            AddHtmlLocalized(348, 44, 250, 60, 1075198, 0x7FFF); // Dawn’s Music Box
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0x70, GumpButtonType.Reply, 0, 0x2253, 0x0, 18, 12);
-            AddTooltip(1075228);
-            AddHtmlLocalized(98, 108, 250, 60, 1078148, 0x7FFF); // Ossian Grimoire
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0x71, GumpButtonType.Reply, 0, 0x2D98, 0x0, 19, 13);
-            AddTooltip(1078527);
-            AddHtmlLocalized(348, 108, 250, 60, 1078142, 0x7FFF); // Talisman of the Fey:<br>Ferret
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0x72, GumpButtonType.Reply, 0, 0x2D97, 0x0, 19, 13);
-            AddTooltip(1078528);
-            AddHtmlLocalized(98, 172, 250, 60, 1078143, 0x7FFF); // Talisman of the Fey:<br>Squirrel
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0x73, GumpButtonType.Reply, 0, 0x2D96, 0x0, 19, 8);
-            AddTooltip(1078529);
-            AddHtmlLocalized(348, 172, 250, 60, 1078144, 0x7FFF); // Talisman of the Fey:<br>Cu Sidhe
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0x74, GumpButtonType.Reply, 0, 0x2D95, 0x0, -4, 2);
-            AddTooltip(1078530);
-            AddHtmlLocalized(98, 236, 250, 60, 1078145, 0x7FFF); // Talisman of the Fey:<br>Reptalon
-            AddImageTiledButton(264, 236, 0x918, 0x919, 0x75, GumpButtonType.Reply, 0, 0x2B02, 0x0, -2, 9);
-            AddTooltip(1078526);
-            AddHtmlLocalized(348, 236, 250, 60, 1075201, 0x7FFF); // Quiver of Infinity
-            AddImageTiledButton(14, 300, 0x918, 0x919, 0x76, GumpButtonType.Reply, 0, 0x2A91, 0x0, 25, 5);
-            AddTooltip(1075986);
-            AddHtmlLocalized(98, 300, 250, 60, 1074797, 0x7FFF); // Bone Throne, Bone Couch<br>and Bone Table
-            AddImageTiledButton(264, 300, 0x918, 0x919, 0x77, GumpButtonType.Reply, 0, 0x2A99, 0x0, 18, 1);
-            AddTooltip(1075987);
-            AddHtmlLocalized(348, 300, 250, 60, 1078146, 0x7FFF); // Creepy Portraits
-            AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 3);
-            AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddPage(2);
 
-            AddPage(3);
+            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 1);
+            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x6E, GumpButtonType.Reply, 0, 0x2AC6, 0x0, 29, 0);
+            builder.AddTooltip(1075226);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1075197, 0x7FFF); // Fountain of Life
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x6F, GumpButtonType.Reply, 0, 0x2AF9, 0x0, -4, -5);
+            builder.AddTooltip(1075227);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1075198, 0x7FFF); // Dawn’s Music Box
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x70, GumpButtonType.Reply, 0, 0x2253, 0x0, 18, 12);
+            builder.AddTooltip(1075228);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1078148, 0x7FFF); // Ossian Grimoire
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x71, GumpButtonType.Reply, 0, 0x2D98, 0x0, 19, 13);
+            builder.AddTooltip(1078527);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1078142, 0x7FFF); // Talisman of the Fey:<br>Ferret
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x72, GumpButtonType.Reply, 0, 0x2D97, 0x0, 19, 13);
+            builder.AddTooltip(1078528);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1078143, 0x7FFF); // Talisman of the Fey:<br>Squirrel
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x73, GumpButtonType.Reply, 0, 0x2D96, 0x0, 19, 8);
+            builder.AddTooltip(1078529);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1078144, 0x7FFF); // Talisman of the Fey:<br>Cu Sidhe
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x74, GumpButtonType.Reply, 0, 0x2D95, 0x0, -4, 2);
+            builder.AddTooltip(1078530);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1078145, 0x7FFF); // Talisman of the Fey:<br>Reptalon
+            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x75, GumpButtonType.Reply, 0, 0x2B02, 0x0, -2, 9);
+            builder.AddTooltip(1078526);
+            builder.AddHtmlLocalized(348, 236, 250, 60, 1075201, 0x7FFF); // Quiver of Infinity
+            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x76, GumpButtonType.Reply, 0, 0x2A91, 0x0, 25, 5);
+            builder.AddTooltip(1075986);
+            builder.AddHtmlLocalized(98, 300, 250, 60, 1074797, 0x7FFF); // Bone Throne, Bone Couch<br>and Bone Table
+            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x77, GumpButtonType.Reply, 0, 0x2A99, 0x0, 18, 1);
+            builder.AddTooltip(1075987);
+            builder.AddHtmlLocalized(348, 300, 250, 60, 1078146, 0x7FFF); // Creepy Portraits
+            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 3);
+            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
 
-            AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 2);
-            AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0x78, GumpButtonType.Reply, 0, 0x2A71, 0x0, 13, 5);
-            AddTooltip(1075988);
-            AddHtmlLocalized(98, 44, 250, 60, 1074799, 0x7FFF); // Mounted Pixies (5)
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0x79, GumpButtonType.Reply, 0, 0x2A98, 0x0, 26, 1);
-            AddTooltip(1075990);
-            AddHtmlLocalized(348, 44, 250, 60, 1074800, 0x7FFF); // Haunted Mirror
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0x7A, GumpButtonType.Reply, 0, 0x2A92, 0x0, 18, 1);
-            AddTooltip(1075989);
-            AddHtmlLocalized(98, 108, 250, 60, 1074801, 0x7FFF); // Bed of Nails
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0x7B, GumpButtonType.Reply, 0, 0x2AB8, 0x0, 18, 1);
-            AddTooltip(1075991);
-            AddHtmlLocalized(348, 108, 250, 60, 1074818, 0x7FFF); // Sacrificial Altar
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0x7C, GumpButtonType.Reply, 0, 0x3F26, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(98, 172, 250, 60, 1076257, 0x7FFF); // Broken Covered Chair
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0x7D, GumpButtonType.Reply, 0, 0x3F22, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(348, 172, 250, 60, 1076258, 0x7FFF); // Broken Bookcase
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0x7E, GumpButtonType.Reply, 0, 0x3F24, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(98, 236, 250, 60, 1076259, 0x7FFF); // Standing Broken Chair
-            AddImageTiledButton(264, 236, 0x918, 0x919, 0x7F, GumpButtonType.Reply, 0, 0x3F25, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(348, 236, 250, 60, 1076260, 0x7FFF); // Broken Vanity
-            AddImageTiledButton(14, 300, 0x918, 0x919, 0x80, GumpButtonType.Reply, 0, 0x3F23, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(98, 300, 250, 60, 1076261, 0x7FFF); // Broken Chest of Drawers
-            AddImageTiledButton(264, 300, 0x918, 0x919, 0x81, GumpButtonType.Reply, 0, 0x3F21, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(348, 300, 250, 60, 1076262, 0x7FFF); // Broken Armoire
-            AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 4);
-            AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddPage(3);
 
-            AddPage(4);
+            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 2);
+            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x78, GumpButtonType.Reply, 0, 0x2A71, 0x0, 13, 5);
+            builder.AddTooltip(1075988);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1074799, 0x7FFF); // Mounted Pixies (5)
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x79, GumpButtonType.Reply, 0, 0x2A98, 0x0, 26, 1);
+            builder.AddTooltip(1075990);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1074800, 0x7FFF); // Haunted Mirror
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x7A, GumpButtonType.Reply, 0, 0x2A92, 0x0, 18, 1);
+            builder.AddTooltip(1075989);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1074801, 0x7FFF); // Bed of Nails
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x7B, GumpButtonType.Reply, 0, 0x2AB8, 0x0, 18, 1);
+            builder.AddTooltip(1075991);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1074818, 0x7FFF); // Sacrificial Altar
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x7C, GumpButtonType.Reply, 0, 0x3F26, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1076257, 0x7FFF); // Broken Covered Chair
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x7D, GumpButtonType.Reply, 0, 0x3F22, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1076258, 0x7FFF); // Broken Bookcase
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x7E, GumpButtonType.Reply, 0, 0x3F24, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1076259, 0x7FFF); // Standing Broken Chair
+            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x7F, GumpButtonType.Reply, 0, 0x3F25, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(348, 236, 250, 60, 1076260, 0x7FFF); // Broken Vanity
+            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x80, GumpButtonType.Reply, 0, 0x3F23, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(98, 300, 250, 60, 1076261, 0x7FFF); // Broken Chest of Drawers
+            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x81, GumpButtonType.Reply, 0, 0x3F21, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(348, 300, 250, 60, 1076262, 0x7FFF); // Broken Armoire
+            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 4);
+            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
 
-            AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 3);
-            AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0x82, GumpButtonType.Reply, 0, 0x3F0B, 0x0, 18, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(98, 44, 250, 60, 1076263, 0x7FFF); // Broken Bed
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0x83, GumpButtonType.Reply, 0, 0xC19, 0x0, 13, 8);
-            AddTooltip(1076610);
-            AddHtmlLocalized(348, 44, 250, 60, 1076264, 0x7FFF); // Broken Fallen Chair
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0x84, GumpButtonType.Reply, 0, 0x3DAA, 0x0, 20, -3);
-            AddTooltip(1076611);
-            AddHtmlLocalized(98, 108, 250, 60, 1076265, 0x7FFF); // Suit of Gold Armor
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0x85, GumpButtonType.Reply, 0, 0x151C, 0x0, -20, -3);
-            AddTooltip(1076612);
-            AddHtmlLocalized(348, 108, 250, 60, 1076266, 0x7FFF); // Suit of Silver Armor
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0x86, GumpButtonType.Reply, 0, 0x3DB1, 0x0, 18, 8);
-            AddTooltip(1076613);
-            AddHtmlLocalized(98, 172, 250, 60, 1076267, 0x7FFF); // Boiling Cauldron
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0x87, GumpButtonType.Reply, 0, 0x3F27, 0x0, 18, 8);
-            AddTooltip(1076614);
-            AddHtmlLocalized(348, 172, 250, 60, 1024656, 0x7FFF); // Guillotine
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0x88, GumpButtonType.Reply, 0, 0x3F0C, 0x0, 18, 8);
-            AddTooltip(1076615);
-            AddHtmlLocalized(98, 236, 250, 60, 1076268, 0x7FFF); // Cherry Blossom Tree
-            AddImageTiledButton(264, 236, 0x918, 0x919, 0x89, GumpButtonType.Reply, 0, 0x3F07, 0x0, 18, 8);
-            AddTooltip(1076616);
-            AddHtmlLocalized(348, 236, 250, 60, 1076269, 0x7FFF); // Apple Tree
-            AddImageTiledButton(14, 300, 0x918, 0x919, 0x8A, GumpButtonType.Reply, 0, 0x3F16, 0x0, 18, 8);
-            AddTooltip(1076617);
-            AddHtmlLocalized(98, 300, 250, 60, 1076270, 0x7FFF); // Peach Tree
-            AddImageTiledButton(264, 300, 0x918, 0x919, 0x8B, GumpButtonType.Reply, 0, 0x3F12, 0x0, 18, 8);
-            AddTooltip(1076618);
-            AddHtmlLocalized(348, 300, 250, 60, 1076271, 0x7FFF); // Hanging Axes
-            AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 5);
-            AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddPage(4);
 
-            AddPage(5);
+            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 3);
+            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x82, GumpButtonType.Reply, 0, 0x3F0B, 0x0, 18, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1076263, 0x7FFF); // Broken Bed
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x83, GumpButtonType.Reply, 0, 0xC19, 0x0, 13, 8);
+            builder.AddTooltip(1076610);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1076264, 0x7FFF); // Broken Fallen Chair
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x84, GumpButtonType.Reply, 0, 0x3DAA, 0x0, 20, -3);
+            builder.AddTooltip(1076611);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1076265, 0x7FFF); // Suit of Gold Armor
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x85, GumpButtonType.Reply, 0, 0x151C, 0x0, -20, -3);
+            builder.AddTooltip(1076612);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1076266, 0x7FFF); // Suit of Silver Armor
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x86, GumpButtonType.Reply, 0, 0x3DB1, 0x0, 18, 8);
+            builder.AddTooltip(1076613);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1076267, 0x7FFF); // Boiling Cauldron
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x87, GumpButtonType.Reply, 0, 0x3F27, 0x0, 18, 8);
+            builder.AddTooltip(1076614);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1024656, 0x7FFF); // Guillotine
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x88, GumpButtonType.Reply, 0, 0x3F0C, 0x0, 18, 8);
+            builder.AddTooltip(1076615);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1076268, 0x7FFF); // Cherry Blossom Tree
+            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x89, GumpButtonType.Reply, 0, 0x3F07, 0x0, 18, 8);
+            builder.AddTooltip(1076616);
+            builder.AddHtmlLocalized(348, 236, 250, 60, 1076269, 0x7FFF); // Apple Tree
+            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x8A, GumpButtonType.Reply, 0, 0x3F16, 0x0, 18, 8);
+            builder.AddTooltip(1076617);
+            builder.AddHtmlLocalized(98, 300, 250, 60, 1076270, 0x7FFF); // Peach Tree
+            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x8B, GumpButtonType.Reply, 0, 0x3F12, 0x0, 18, 8);
+            builder.AddTooltip(1076618);
+            builder.AddHtmlLocalized(348, 300, 250, 60, 1076271, 0x7FFF); // Hanging Axes
+            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 5);
+            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
 
-            AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 4);
-            AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0x8C, GumpButtonType.Reply, 0, 0x3F13, 0x0, 18, 8);
-            AddTooltip(1076619);
-            AddHtmlLocalized(98, 44, 250, 60, 1076272, 0x7FFF); // Hanging Swords
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0x8D, GumpButtonType.Reply, 0, 0x3F09, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(348, 44, 250, 60, 1076273, 0x7FFF); // Blue fancy rug
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0x8E, GumpButtonType.Reply, 0, 0x3F0E, 0x0, 18, 8);
-            AddTooltip(1076621);
-            AddHtmlLocalized(98, 108, 250, 60, 1076274, 0x7FFF); // Coffin
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0x8F, GumpButtonType.Reply, 0, 0x3F1F, 0x0, 18, 8);
-            AddTooltip(1076623);
-            AddHtmlLocalized(348, 108, 250, 60, 1074027, 0x7FFF); // Vanity
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0x90, GumpButtonType.Reply, 0, 0x118B, 0x0, -4, -9);
-            AddTooltip(1076624);
-            AddHtmlLocalized(98, 172, 250, 60, 1076635, 0x7FFF); // Table With A Purple<br>Tablecloth
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0x91, GumpButtonType.Reply, 0, 0x118C, 0x0, -4, -9);
-            AddTooltip(1076624);
-            AddHtmlLocalized(348, 172, 250, 60, 1076636, 0x7FFF); // Table With A Blue<br>Tablecloth
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0x92, GumpButtonType.Reply, 0, 0x118D, 0x0, -4, -9);
-            AddTooltip(1076624);
-            AddHtmlLocalized(98, 236, 250, 60, 1076637, 0x7FFF); // Table With A Red<br>Tablecloth
-            AddImageTiledButton(264, 236, 0x918, 0x919, 0x93, GumpButtonType.Reply, 0, 0x118E, 0x0, -4, -9);
-            AddTooltip(1076624);
-            AddHtmlLocalized(348, 236, 250, 60, 1076638, 0x7FFF); // Table With An Orange<br>Tablecloth
-            AddImageTiledButton(14, 300, 0x918, 0x919, 0x94, GumpButtonType.Reply, 0, 0x3F1E, 0x0, 18, 8);
-            AddTooltip(1076625);
-            AddHtmlLocalized(98, 300, 250, 60, 1076279, 0x7FFF); // Unmade Bed
-            AddImageTiledButton(264, 300, 0x918, 0x919, 0x95, GumpButtonType.Reply, 0, 0x3F0F, 0x0, 18, 8);
-            AddTooltip(1076626);
-            AddHtmlLocalized(348, 300, 250, 60, 1076280, 0x7FFF); // Curtains
-            AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 6);
-            AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddPage(5);
 
-            AddPage(6);
+            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 4);
+            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x8C, GumpButtonType.Reply, 0, 0x3F13, 0x0, 18, 8);
+            builder.AddTooltip(1076619);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1076272, 0x7FFF); // Hanging Swords
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x8D, GumpButtonType.Reply, 0, 0x3F09, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1076273, 0x7FFF); // Blue fancy rug
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x8E, GumpButtonType.Reply, 0, 0x3F0E, 0x0, 18, 8);
+            builder.AddTooltip(1076621);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1076274, 0x7FFF); // Coffin
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x8F, GumpButtonType.Reply, 0, 0x3F1F, 0x0, 18, 8);
+            builder.AddTooltip(1076623);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1074027, 0x7FFF); // Vanity
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x90, GumpButtonType.Reply, 0, 0x118B, 0x0, -4, -9);
+            builder.AddTooltip(1076624);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1076635, 0x7FFF); // Table With A Purple<br>Tablecloth
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x91, GumpButtonType.Reply, 0, 0x118C, 0x0, -4, -9);
+            builder.AddTooltip(1076624);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1076636, 0x7FFF); // Table With A Blue<br>Tablecloth
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x92, GumpButtonType.Reply, 0, 0x118D, 0x0, -4, -9);
+            builder.AddTooltip(1076624);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1076637, 0x7FFF); // Table With A Red<br>Tablecloth
+            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x93, GumpButtonType.Reply, 0, 0x118E, 0x0, -4, -9);
+            builder.AddTooltip(1076624);
+            builder.AddHtmlLocalized(348, 236, 250, 60, 1076638, 0x7FFF); // Table With An Orange<br>Tablecloth
+            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x94, GumpButtonType.Reply, 0, 0x3F1E, 0x0, 18, 8);
+            builder.AddTooltip(1076625);
+            builder.AddHtmlLocalized(98, 300, 250, 60, 1076279, 0x7FFF); // Unmade Bed
+            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x95, GumpButtonType.Reply, 0, 0x3F0F, 0x0, 18, 8);
+            builder.AddTooltip(1076626);
+            builder.AddHtmlLocalized(348, 300, 250, 60, 1076280, 0x7FFF); // Curtains
+            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 6);
+            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
 
-            AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 5);
-            AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0x96, GumpButtonType.Reply, 0, 0x1E34, 0x0, 18, -17);
-            AddTooltip(1076627);
-            AddHtmlLocalized(98, 44, 250, 60, 1076281, 0x7FFF); // Scarecrow
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0x97, GumpButtonType.Reply, 0, 0xA0C, 0x0, 18, 8);
-            AddTooltip(1076628);
-            AddHtmlLocalized(348, 44, 250, 60, 1076282, 0x7FFF); // Wall Torch
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0x98, GumpButtonType.Reply, 0, 0x3F10, 0x0, 18, 9);
-            AddTooltip(1076629);
-            AddHtmlLocalized(98, 108, 250, 60, 1076283, 0x7FFF); // Fountain
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0x99, GumpButtonType.Reply, 0, 0x3F19, 0x0, 18, 8);
-            AddTooltip(1076630);
-            AddHtmlLocalized(348, 108, 250, 60, 1076284, 0x7FFF); // Statue
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0x9A, GumpButtonType.Reply, 0, 0x1EA5, 0x0, 5, -25);
-            AddTooltip(1076631);
-            AddHtmlLocalized(98, 172, 250, 60, 1076285, 0x7FFF); // Large Fish Net
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0x9B, GumpButtonType.Reply, 0, 0x1EA3, 0x0, 18, -27);
-            AddTooltip(1076632);
-            AddHtmlLocalized(348, 172, 250, 60, 1076286, 0x7FFF); // Small Fish Net
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0x9C, GumpButtonType.Reply, 0, 0x2FDF, 0x0, 18, -36);
-            AddTooltip(1076633);
-            AddHtmlLocalized(98, 236, 250, 60, 1076287, 0x7FFF); // Ladder
-            AddImageTiledButton(264, 236, 0x918, 0x919, 0x9D, GumpButtonType.Reply, 0, 0x3F15, 0x0, 18, 8);
-            AddTooltip(1076622);
-            AddHtmlLocalized(348, 236, 250, 60, 1076288, 0x7FFF); // Iron Maiden
-            AddImageTiledButton(14, 300, 0x918, 0x919, 0x9E, GumpButtonType.Reply, 0, 0x3F0A, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(98, 300, 250, 60, 1076585, 0x7FFF); // Blue plain rug
-            AddImageTiledButton(264, 300, 0x918, 0x919, 0x9F, GumpButtonType.Reply, 0, 0x3F11, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(348, 300, 250, 60, 1076586, 0x7FFF); // Golden decorative rug
-            AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 7);
-            AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
+            builder.AddPage(6);
 
-            AddPage(7);
+            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 5);
+            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0x96, GumpButtonType.Reply, 0, 0x1E34, 0x0, 18, -17);
+            builder.AddTooltip(1076627);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1076281, 0x7FFF); // Scarecrow
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0x97, GumpButtonType.Reply, 0, 0xA0C, 0x0, 18, 8);
+            builder.AddTooltip(1076628);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1076282, 0x7FFF); // Wall Torch
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0x98, GumpButtonType.Reply, 0, 0x3F10, 0x0, 18, 9);
+            builder.AddTooltip(1076629);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1076283, 0x7FFF); // Fountain
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0x99, GumpButtonType.Reply, 0, 0x3F19, 0x0, 18, 8);
+            builder.AddTooltip(1076630);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1076284, 0x7FFF); // Statue
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0x9A, GumpButtonType.Reply, 0, 0x1EA5, 0x0, 5, -25);
+            builder.AddTooltip(1076631);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1076285, 0x7FFF); // Large Fish Net
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0x9B, GumpButtonType.Reply, 0, 0x1EA3, 0x0, 18, -27);
+            builder.AddTooltip(1076632);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1076286, 0x7FFF); // Small Fish Net
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0x9C, GumpButtonType.Reply, 0, 0x2FDF, 0x0, 18, -36);
+            builder.AddTooltip(1076633);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1076287, 0x7FFF); // Ladder
+            builder.AddImageTiledButton(264, 236, 0x918, 0x919, 0x9D, GumpButtonType.Reply, 0, 0x3F15, 0x0, 18, 8);
+            builder.AddTooltip(1076622);
+            builder.AddHtmlLocalized(348, 236, 250, 60, 1076288, 0x7FFF); // Iron Maiden
+            builder.AddImageTiledButton(14, 300, 0x918, 0x919, 0x9E, GumpButtonType.Reply, 0, 0x3F0A, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(98, 300, 250, 60, 1076585, 0x7FFF); // Blue plain rug
+            builder.AddImageTiledButton(264, 300, 0x918, 0x919, 0x9F, GumpButtonType.Reply, 0, 0x3F11, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(348, 300, 250, 60, 1076586, 0x7FFF); // Golden decorative rug
+            builder.AddButton(400, 374, 0xFA5, 0xFA7, 0, GumpButtonType.Page, 7);
+            builder.AddHtmlLocalized(440, 376, 60, 20, 1043353, 0x7FFF); // Next
 
-            AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 6);
-            AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
-            AddImageTiledButton(14, 44, 0x918, 0x919, 0xA0, GumpButtonType.Reply, 0, 0x3F0D, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(98, 44, 250, 60, 1076587, 0x7FFF); // Cinnamon fancy rug
-            AddImageTiledButton(264, 44, 0x918, 0x919, 0xA1, GumpButtonType.Reply, 0, 0x3F18, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(348, 44, 250, 60, 1076588, 0x7FFF); // Red plain rug
-            AddImageTiledButton(14, 108, 0x918, 0x919, 0xA2, GumpButtonType.Reply, 0, 0x3F08, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(98, 108, 250, 60, 1076589, 0x7FFF); // Blue decorative rug
-            AddImageTiledButton(264, 108, 0x918, 0x919, 0xA3, GumpButtonType.Reply, 0, 0x3F17, 0x0, 18, 8);
-            AddTooltip(1076620);
-            AddHtmlLocalized(348, 108, 250, 60, 1076590, 0x7FFF); // Pink fancy rug
-            AddImageTiledButton(14, 172, 0x918, 0x919, 0xA4, GumpButtonType.Reply, 0, 0x312A, 0x0, 18, 8);
-            AddTooltip(1076615);
-            AddHtmlLocalized(98, 172, 250, 60, 1076784, 0x7FFF); // Cherry Blossom Trunk
-            AddImageTiledButton(264, 172, 0x918, 0x919, 0xA5, GumpButtonType.Reply, 0, 0x3128, 0x0, 18, 8);
-            AddTooltip(1076616);
-            AddHtmlLocalized(348, 172, 250, 60, 1076785, 0x7FFF); // Apple Trunk
-            AddImageTiledButton(14, 236, 0x918, 0x919, 0xA6, GumpButtonType.Reply, 0, 0x3129, 0x0, 18, 8);
-            AddTooltip(1076617);
-            AddHtmlLocalized(98, 236, 250, 60, 1076786, 0x7FFF); // Peach Trunk
+            builder.AddPage(7);
+
+            builder.AddButton(300, 374, 0xFAE, 0xFB0, 0, GumpButtonType.Page, 6);
+            builder.AddHtmlLocalized(340, 376, 60, 20, 1011393, 0x7FFF); // Back
+            builder.AddImageTiledButton(14, 44, 0x918, 0x919, 0xA0, GumpButtonType.Reply, 0, 0x3F0D, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(98, 44, 250, 60, 1076587, 0x7FFF); // Cinnamon fancy rug
+            builder.AddImageTiledButton(264, 44, 0x918, 0x919, 0xA1, GumpButtonType.Reply, 0, 0x3F18, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(348, 44, 250, 60, 1076588, 0x7FFF); // Red plain rug
+            builder.AddImageTiledButton(14, 108, 0x918, 0x919, 0xA2, GumpButtonType.Reply, 0, 0x3F08, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(98, 108, 250, 60, 1076589, 0x7FFF); // Blue decorative rug
+            builder.AddImageTiledButton(264, 108, 0x918, 0x919, 0xA3, GumpButtonType.Reply, 0, 0x3F17, 0x0, 18, 8);
+            builder.AddTooltip(1076620);
+            builder.AddHtmlLocalized(348, 108, 250, 60, 1076590, 0x7FFF); // Pink fancy rug
+            builder.AddImageTiledButton(14, 172, 0x918, 0x919, 0xA4, GumpButtonType.Reply, 0, 0x312A, 0x0, 18, 8);
+            builder.AddTooltip(1076615);
+            builder.AddHtmlLocalized(98, 172, 250, 60, 1076784, 0x7FFF); // Cherry Blossom Trunk
+            builder.AddImageTiledButton(264, 172, 0x918, 0x919, 0xA5, GumpButtonType.Reply, 0, 0x3128, 0x0, 18, 8);
+            builder.AddTooltip(1076616);
+            builder.AddHtmlLocalized(348, 172, 250, 60, 1076785, 0x7FFF); // Apple Trunk
+            builder.AddImageTiledButton(14, 236, 0x918, 0x919, 0xA6, GumpButtonType.Reply, 0, 0x3129, 0x0, 18, 8);
+            builder.AddTooltip(1076617);
+            builder.AddHtmlLocalized(98, 236, 250, 60, 1076786, 0x7FFF); // Peach Trunk
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_Token?.Deleted != false || info.ButtonID == 0)
+            if (_token?.Deleted != false || info.ButtonID == 0)
             {
                 return;
             }
@@ -705,7 +717,7 @@ namespace Server.Gumps
 
             if (types?.Length > 0 && cliloc > 0)
             {
-                sender.Mobile.SendGump(new ConfirmHeritageGump(m_Token, types, cliloc));
+                ConfirmHeritageGump.DisplayTo(sender.Mobile, _token, types, cliloc);
             }
             else
             {

--- a/Projects/UOContent/Items/Armor/Sets/SpiritualityHelm.cs
+++ b/Projects/UOContent/Items/Armor/Sets/SpiritualityHelm.cs
@@ -1,0 +1,31 @@
+using ModernUO.Serialization;
+
+namespace Server.Items;
+
+[Flippable(0x2B10, 0x2B11)]
+[SerializationGenerator(0)]
+public partial class SpiritualityHelm : BaseArmor
+{
+    [Constructible]
+    public SpiritualityHelm() : base(0x2B10)
+    {
+        LootType = LootType.Blessed;
+        Weight = 6.0;
+        Hue = 0x226;
+
+        ArmorAttributes.SelfRepair = 5;
+    }
+
+    public override int LabelNumber => 1075237; // Helm of Spirituality (Virtue Armor Set)
+    public override int BasePhysicalResistance => 13;
+    public override int BaseFireResistance => 13;
+    public override int BaseColdResistance => 12;
+    public override int BasePoisonResistance => 14;
+    public override int BaseEnergyResistance => 13;
+
+    public override int InitMinHits => 255;
+    public override int InitMaxHits => 255;
+    public override int AosStrReq => 25;
+
+    public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
+}

--- a/Projects/UOContent/Items/Armor/Sets/ValorGauntlets.cs
+++ b/Projects/UOContent/Items/Armor/Sets/ValorGauntlets.cs
@@ -1,0 +1,36 @@
+using ModernUO.Serialization;
+
+namespace Server.Items;
+
+[Flippable(0x2B0C, 0x2B0D)]
+[SerializationGenerator(0)]
+public partial class ValorGauntlets : BaseArmor
+{
+    [Constructible]
+    public ValorGauntlets() : base(0x2B0C)
+    {
+        LootType = LootType.Blessed;
+        Weight = 4.0;
+        Hue = 0x226;
+
+        ArmorAttributes.SelfRepair = 5;
+    }
+
+    public override int LabelNumber => 1075238; // Gauntlets of Valor (Virtue Armor Set)
+
+    public override int BasePhysicalResistance => 11;
+
+    public override int BaseFireResistance => 11;
+
+    public override int BaseColdResistance => 13;
+
+    public override int BasePoisonResistance => 14;
+
+    public override int BaseEnergyResistance => 10;
+
+    public override int InitMinHits => 255;
+    public override int InitMaxHits => 255;
+    public override int AosStrReq => 50;
+
+    public override ArmorMaterialType MaterialType => ArmorMaterialType.Plate;
+}

--- a/Projects/UOContent/Items/Deeds/HairRestylingDeed.cs
+++ b/Projects/UOContent/Items/Deeds/HairRestylingDeed.cs
@@ -33,54 +33,54 @@ public partial class HairRestylingDeed : Item
     private class HairRestylingDeedGump : DynamicGump
     {
         private static readonly int[][] ElvenArray =
-        {
-            new[] { 0 },
-            new[] { 1011064, 1011064, 0, 0, 0, 0 },                     // bald
-            new[] { 1074386, 1074386, 0x2fc0, 0x2fc0, 0xedf5, 0xc6e5 }, // long feather
-            new[] { 1074387, 1074387, 0x2fc1, 0x2fc1, 0xedf6, 0xc6e6 }, // short
-            new[] { 1074388, 1074388, 0x2fc2, 0x2fc2, 0xedf7, 0xc6e7 }, // mullet
-            new[] { 1074391, 1074391, 0x2fce, 0x2fce, 0xeddc, 0xc6cc }, // knob
-            new[] { 1074392, 1074392, 0x2fcf, 0x2fcf, 0xeddd, 0xc6cd }, // braided
-            new[] { 1074394, 1074394, 0x2fd1, 0x2fd1, 0xeddf, 0xc6cf }, // spiked
-            new[] { 1074389, 1074385, 0x2fcc, 0x2fbf, 0xedda, 0xc6e4 }, // flower, mid-long
-            new[] { 1074393, 1074390, 0x2fd0, 0x2fcd, 0xedde, 0xc6cb }  // buns, long
-        };
+        [
+            [0],
+            [1011064, 1011064, 0, 0, 0, 0],                     // bald
+            [1074386, 1074386, 0x2fc0, 0x2fc0, 0xedf5, 0xc6e5], // long feather
+            [1074387, 1074387, 0x2fc1, 0x2fc1, 0xedf6, 0xc6e6], // short
+            [1074388, 1074388, 0x2fc2, 0x2fc2, 0xedf7, 0xc6e7], // mullet
+            [1074391, 1074391, 0x2fce, 0x2fce, 0xeddc, 0xc6cc], // knob
+            [1074392, 1074392, 0x2fcf, 0x2fcf, 0xeddd, 0xc6cd], // braided
+            [1074394, 1074394, 0x2fd1, 0x2fd1, 0xeddf, 0xc6cf], // spiked
+            [1074389, 1074385, 0x2fcc, 0x2fbf, 0xedda, 0xc6e4], // flower, mid-long
+            [1074393, 1074390, 0x2fd0, 0x2fcd, 0xedde, 0xc6cb]  // buns, long
+        ];
 
         /*
             racial arrays are: cliloc_F, cliloc_M, ItemID_F, ItemID_M, gump_img_F, gump_img_M
         */
         private static readonly int[][] HumanArray = /* why on earth cant these utilities be consistent with hex/dec */
-        {
-            new[] { 0 },
-            new[] { 1011064, 1011064, 0, 0, 0, 0 },                     // bald
-            new[] { 1011052, 1011052, 0x203B, 0x203B, 0xed1c, 0xC60C }, // Short
-            new[] { 1011053, 1011053, 0x203C, 0x203C, 0xed1d, 0xc60d }, // Long
-            new[] { 1011054, 1011054, 0x203D, 0x203D, 0xed1e, 0xc60e }, // Ponytail
-            new[] { 1011055, 1011055, 0x2044, 0x2044, 0xed27, 0xC60F }, // Mohawk
-            new[] { 1011047, 1011047, 0x2045, 0x2045, 0xED26, 0xED26 }, // Pageboy
-            new[] { 1074393, 1011048, 0x2046, 0x2048, 0xed28, 0xEDE5 }, // Buns, Receding
-            new[] { 1011049, 1011049, 0x2049, 0x2049, 0xede6, 0xede6 }, // 2-tails
-            new[] { 1011050, 1011050, 0x204A, 0x204A, 0xED29, 0xED29 }, // Topknot
-            new[] { 1011396, 1011396, 0x2047, 0x2047, 0xed25, 0xc618 }  // Curly
-        };
+        [
+            [0],
+            [1011064, 1011064, 0, 0, 0, 0],                     // bald
+            [1011052, 1011052, 0x203B, 0x203B, 0xed1c, 0xC60C], // Short
+            [1011053, 1011053, 0x203C, 0x203C, 0xed1d, 0xc60d], // Long
+            [1011054, 1011054, 0x203D, 0x203D, 0xed1e, 0xc60e], // Ponytail
+            [1011055, 1011055, 0x2044, 0x2044, 0xed27, 0xC60F], // Mohawk
+            [1011047, 1011047, 0x2045, 0x2045, 0xED26, 0xED26], // Pageboy
+            [1074393, 1011048, 0x2046, 0x2048, 0xed28, 0xEDE5], // Buns, Receding
+            [1011049, 1011049, 0x2049, 0x2049, 0xede6, 0xede6], // 2-tails
+            [1011050, 1011050, 0x204A, 0x204A, 0xED29, 0xED29], // Topknot
+            [1011396, 1011396, 0x2047, 0x2047, 0xed25, 0xc618]  // Curly
+        ];
 
         /*
             gump data: bgX, bgY, htmlX, htmlY, imgX, imgY, butX, butY
         */
         private static readonly int[][] LayoutArray =
-        {
-            new[] { 0 }, /* padding: its more efficient than code to ++ the index/buttonid */
-            new[] { 425, 280, 342, 295, 000, 000, 310, 292 },
-            new[] { 235, 060, 150, 075, 168, 020, 118, 073 },
-            new[] { 235, 115, 150, 130, 168, 070, 118, 128 },
-            new[] { 235, 170, 150, 185, 168, 130, 118, 183 },
-            new[] { 235, 225, 150, 240, 168, 185, 118, 238 },
-            new[] { 425, 060, 342, 075, 358, 018, 310, 073 },
-            new[] { 425, 115, 342, 130, 358, 075, 310, 128 },
-            new[] { 425, 170, 342, 185, 358, 125, 310, 183 },
-            new[] { 425, 225, 342, 240, 358, 185, 310, 238 },
-            new[] { 235, 280, 150, 295, 168, 245, 118, 292 } // slot 10, Curly - N/A for elfs.
-        };
+        [
+            [0], /* padding: its more efficient than code to ++ the index/buttonid */
+            [425, 280, 342, 295, 000, 000, 310, 292],
+            [235, 060, 150, 075, 168, 020, 118, 073],
+            [235, 115, 150, 130, 168, 070, 118, 128],
+            [235, 170, 150, 185, 168, 130, 118, 183],
+            [235, 225, 150, 240, 168, 185, 118, 238],
+            [425, 060, 342, 075, 358, 018, 310, 073],
+            [425, 115, 342, 130, 358, 075, 310, 128],
+            [425, 170, 342, 185, 358, 125, 310, 183],
+            [425, 225, 342, 240, 358, 185, 310, 238],
+            [235, 280, 150, 295, 168, 245, 118, 292] // slot 10, Curly - N/A for elfs.
+        ];
 
         private readonly HairRestylingDeed _deed;
         private readonly Mobile _from;

--- a/Projects/UOContent/Items/Deeds/HairRestylingDeed.cs
+++ b/Projects/UOContent/Items/Deeds/HairRestylingDeed.cs
@@ -26,11 +26,11 @@ public partial class HairRestylingDeed : Item
         }
         else
         {
-            from.SendGump(new InternalGump(from, this));
+            HairRestylingDeedGump.DisplayTo(from, this);
         }
     }
 
-    private class InternalGump : Gump
+    private class HairRestylingDeedGump : DynamicGump
     {
         private static readonly int[][] ElvenArray =
         {
@@ -82,52 +82,65 @@ public partial class HairRestylingDeed : Item
             new[] { 235, 280, 150, 295, 168, 245, 118, 292 } // slot 10, Curly - N/A for elfs.
         };
 
-        private readonly HairRestylingDeed m_Deed;
-        private readonly Mobile m_From;
+        private readonly HairRestylingDeed _deed;
+        private readonly Mobile _from;
 
         public override bool Singleton => true;
 
-        public InternalGump(Mobile from, HairRestylingDeed deed) : base(50, 50)
+        private HairRestylingDeedGump(Mobile from, HairRestylingDeed deed) : base(50, 50)
         {
-            m_From = from;
-            m_Deed = deed;
+            _from = from;
+            _deed = deed;
+        }
 
-            AddBackground(100, 10, 400, 385, 0xA28);
-
-            AddHtmlLocalized(100, 25, 400, 35, 1013008);
-            AddButton(175, 340, 0xFA5, 0xFA7, 0x0); // CANCEL
-
-            AddHtmlLocalized(210, 342, 90, 35, 1011012); // <CENTER>HAIRSTYLE SELECTION MENU</center>
-
-            var RacialData = from.Race == Race.Human ? HumanArray : ElvenArray;
-
-            for (var i = 1; i < RacialData.Length; i++)
+        public static void DisplayTo(Mobile from, HairRestylingDeed deed)
+        {
+            if (from?.NetState == null || deed?.Deleted != false)
             {
-                AddHtmlLocalized(
+                return;
+            }
+
+            from.SendGump(new HairRestylingDeedGump(from, deed));
+        }
+
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddBackground(100, 10, 400, 385, 0xA28);
+
+            builder.AddHtmlLocalized(100, 25, 400, 35, 1013008);
+            builder.AddButton(175, 340, 0xFA5, 0xFA7, 0x0); // CANCEL
+
+            builder.AddHtmlLocalized(210, 342, 90, 35, 1011012); // <CENTER>HAIRSTYLE SELECTION MENU</center>
+
+            var racialData = _from.Race == Race.Human ? HumanArray : ElvenArray;
+
+            for (var i = 1; i < racialData.Length; i++)
+            {
+                builder.AddHtmlLocalized(
                     LayoutArray[i][2],
                     LayoutArray[i][3],
                     i == 1 ? 125 : 80,
                     i == 1 ? 70 : 35,
-                    m_From.Female ? RacialData[i][0] : RacialData[i][1]
+                    _from.Female ? racialData[i][0] : racialData[i][1]
                 );
                 if (LayoutArray[i][4] != 0)
                 {
-                    AddBackground(LayoutArray[i][0], LayoutArray[i][1], 50, 50, 0xA3C);
-                    AddImage(LayoutArray[i][4], LayoutArray[i][5], m_From.Female ? RacialData[i][4] : RacialData[i][5]);
+                    builder.AddBackground(LayoutArray[i][0], LayoutArray[i][1], 50, 50, 0xA3C);
+                    builder.AddImage(LayoutArray[i][4], LayoutArray[i][5], _from.Female ? racialData[i][4] : racialData[i][5]);
                 }
 
-                AddButton(LayoutArray[i][6], LayoutArray[i][7], 0xFA5, 0xFA7, i);
+                builder.AddButton(LayoutArray[i][6], LayoutArray[i][7], 0xFA5, 0xFA7, i);
             }
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_From?.Alive != true)
+            if (_from?.Alive != true)
             {
                 return;
             }
 
-            if (m_Deed.Deleted)
+            if (_deed.Deleted)
             {
                 return;
             }
@@ -137,13 +150,13 @@ public partial class HairRestylingDeed : Item
                 return;
             }
 
-            var RacialData = m_From.Race == Race.Human ? HumanArray : ElvenArray;
+            var racialData = _from.Race == Race.Human ? HumanArray : ElvenArray;
 
-            if (m_From is PlayerMobile pm)
+            if (_from is PlayerMobile pm)
             {
                 pm.SetHairMods(-1, -1); // clear any hairmods (disguise kit, incognito)
-                pm.HairItemID = pm.Female ? RacialData[info.ButtonID][2] : RacialData[info.ButtonID][3];
-                m_Deed.Delete();
+                pm.HairItemID = pm.Female ? racialData[info.ButtonID][2] : racialData[info.ButtonID][3];
+                _deed.Delete();
             }
         }
     }

--- a/Projects/UOContent/Items/Deeds/HolidayTreeDeed.cs
+++ b/Projects/UOContent/Items/Deeds/HolidayTreeDeed.cs
@@ -111,15 +111,10 @@ public partial class HolidayTreeDeed : Item
 public class HolidayTreeChoiceGump : StaticGump<HolidayTreeChoiceGump>
 {
     private readonly HolidayTreeDeed _deed;
-    private readonly Mobile _from;
 
     public override bool Singleton => true;
 
-    private HolidayTreeChoiceGump(Mobile from, HolidayTreeDeed deed) : base(200, 200)
-    {
-        _from = from;
-        _deed = deed;
-    }
+    private HolidayTreeChoiceGump(HolidayTreeDeed deed) : base(200, 200) => _deed = deed;
 
     public static void DisplayTo(Mobile from, HolidayTreeDeed deed)
     {
@@ -128,7 +123,7 @@ public class HolidayTreeChoiceGump : StaticGump<HolidayTreeChoiceGump>
             return;
         }
 
-        from.SendGump(new HolidayTreeChoiceGump(from, deed));
+        from.SendGump(new HolidayTreeChoiceGump(deed));
     }
 
     protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -152,16 +147,18 @@ public class HolidayTreeChoiceGump : StaticGump<HolidayTreeChoiceGump>
             return;
         }
 
+        var from = sender.Mobile;
+
         switch (info.ButtonID)
         {
             case 1:
                 {
-                    _deed.BeginPlace(_from, HolidayTreeType.Classic);
+                    _deed.BeginPlace(from, HolidayTreeType.Classic);
                     break;
                 }
             case 2:
                 {
-                    _deed.BeginPlace(_from, HolidayTreeType.Modern);
+                    _deed.BeginPlace(from, HolidayTreeType.Modern);
                     break;
                 }
         }

--- a/Projects/UOContent/Items/Deeds/HolidayTreeDeed.cs
+++ b/Projects/UOContent/Items/Deeds/HolidayTreeDeed.cs
@@ -104,37 +104,50 @@ public partial class HolidayTreeDeed : Item
 
     public override void OnDoubleClick(Mobile from)
     {
-        from.SendGump(new HolidayTreeChoiceGump(from, this));
+        HolidayTreeChoiceGump.DisplayTo(from, this);
     }
 }
 
-public class HolidayTreeChoiceGump : Gump
+public class HolidayTreeChoiceGump : StaticGump<HolidayTreeChoiceGump>
 {
-    private readonly HolidayTreeDeed m_Deed;
-    private readonly Mobile m_From;
+    private readonly HolidayTreeDeed _deed;
+    private readonly Mobile _from;
 
     public override bool Singleton => true;
 
-    public HolidayTreeChoiceGump(Mobile from, HolidayTreeDeed deed) : base(200, 200)
+    private HolidayTreeChoiceGump(Mobile from, HolidayTreeDeed deed) : base(200, 200)
     {
-        m_From = from;
-        m_Deed = deed;
+        _from = from;
+        _deed = deed;
+    }
 
-        AddPage(0);
+    public static void DisplayTo(Mobile from, HolidayTreeDeed deed)
+    {
+        if (from?.NetState == null || deed?.Deleted != false)
+        {
+            return;
+        }
 
-        AddBackground(0, 0, 220, 120, 5054);
-        AddBackground(10, 10, 200, 100, 3000);
+        from.SendGump(new HolidayTreeChoiceGump(from, deed));
+    }
 
-        AddButton(20, 35, 4005, 4007, 1);
-        AddHtmlLocalized(55, 35, 145, 25, 1018322); // Classic
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage();
 
-        AddButton(20, 65, 4005, 4007, 2);
-        AddHtmlLocalized(55, 65, 145, 25, 1018321); // Modern
+        builder.AddBackground(0, 0, 220, 120, 5054);
+        builder.AddBackground(10, 10, 200, 100, 3000);
+
+        builder.AddButton(20, 35, 4005, 4007, 1);
+        builder.AddHtmlLocalized(55, 35, 145, 25, 1018322); // Classic
+
+        builder.AddButton(20, 65, 4005, 4007, 2);
+        builder.AddHtmlLocalized(55, 65, 145, 25, 1018321); // Modern
     }
 
     public override void OnResponse(NetState sender, in RelayInfo info)
     {
-        if (m_Deed.Deleted)
+        if (_deed.Deleted)
         {
             return;
         }
@@ -143,12 +156,12 @@ public class HolidayTreeChoiceGump : Gump
         {
             case 1:
                 {
-                    m_Deed.BeginPlace(m_From, HolidayTreeType.Classic);
+                    _deed.BeginPlace(_from, HolidayTreeType.Classic);
                     break;
                 }
             case 2:
                 {
-                    m_Deed.BeginPlace(m_From, HolidayTreeType.Modern);
+                    _deed.BeginPlace(_from, HolidayTreeType.Modern);
                     break;
                 }
         }

--- a/Projects/UOContent/Items/Deeds/NameChangeDeed.cs
+++ b/Projects/UOContent/Items/Deeds/NameChangeDeed.cs
@@ -18,7 +18,7 @@ public partial class NameChangeDeed : Item
     {
         if (RootParent == from)
         {
-            from.SendGump(new NameChangeDeedGump(this));
+            NameChangeDeedGump.DisplayTo(from, this);
         }
         else
         {
@@ -27,53 +27,59 @@ public partial class NameChangeDeed : Item
     }
 }
 
-public class NameChangeDeedGump : Gump
+public class NameChangeDeedGump : StaticGump<NameChangeDeedGump>
 {
-    private readonly Item m_Sender;
+    private readonly Item _sender;
 
     public override bool Singleton => true;
 
-    public NameChangeDeedGump(Item sender) : base(50, 50)
+    private NameChangeDeedGump(Item sender) : base(50, 50) => _sender = sender;
+
+    public static void DisplayTo(Mobile from, Item sender)
     {
-        m_Sender = sender;
+        if (from?.NetState == null || sender?.Deleted != false)
+        {
+            return;
+        }
 
-        Closable = true;
-        Draggable = true;
-        Resizable = false;
-
-        AddPage(0);
-
-        AddBlackAlpha(10, 120, 250, 85);
-        AddHtml(10, 125, 250, 20, "Name Change Deed".Center(0xFFFFFF));
-
-        AddLabel(73, 15, 1152, "");
-        AddLabel(20, 150, 0x480, "New Name:");
-        AddTextField(100, 150, 150, 20, 0);
-
-        AddButtonLabeled(75, 180, 1, "Submit");
+        from.SendGump(new NameChangeDeedGump(sender));
     }
 
-    public void AddBlackAlpha(int x, int y, int width, int height)
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
     {
-        AddImageTiled(x, y, width, height, 2624);
-        AddAlphaRegion(x, y, width, height);
+        builder.AddPage();
+
+        AddBlackAlpha(ref builder, 10, 120, 250, 85);
+        builder.AddHtml(10, 125, 250, 20, "Name Change Deed".Center(0xFFFFFF));
+
+        builder.AddLabel(73, 15, 1152, "");
+        builder.AddLabel(20, 150, 0x480, "New Name:");
+        AddTextField(ref builder, 100, 150, 150, 20, 0);
+
+        AddButtonLabeled(ref builder, 75, 180, 1, "Submit");
     }
 
-    public void AddTextField(int x, int y, int width, int height, int index)
+    private static void AddBlackAlpha(ref StaticGumpBuilder builder, int x, int y, int width, int height)
     {
-        AddBackground(x - 2, y - 2, width + 4, height + 4, 0x2486);
-        AddTextEntry(x + 2, y + 2, width - 4, height - 4, 0, index, "");
+        builder.AddImageTiled(x, y, width, height, 2624);
+        builder.AddAlphaRegion(x, y, width, height);
     }
 
-    public void AddButtonLabeled(int x, int y, int buttonID, string text)
+    private static void AddTextField(ref StaticGumpBuilder builder, int x, int y, int width, int height, int index)
     {
-        AddButton(x, y - 1, 4005, 4007, buttonID);
-        AddHtml(x + 35, y, 240, 20, text.Color(0xFFFFFF));
+        builder.AddBackground(x - 2, y - 2, width + 4, height + 4, 0x2486);
+        builder.AddTextEntry(x + 2, y + 2, width - 4, height - 4, 0, index, "");
+    }
+
+    private static void AddButtonLabeled(ref StaticGumpBuilder builder, int x, int y, int buttonID, string text)
+    {
+        builder.AddButton(x, y - 1, 4005, 4007, buttonID);
+        builder.AddHtml(x + 35, y, 240, 20, text.Color(0xFFFFFF));
     }
 
     public override void OnResponse(NetState sender, in RelayInfo info)
     {
-        if (m_Sender?.Deleted != false || info.ButtonID != 1 || m_Sender.RootParent != sender.Mobile)
+        if (_sender?.Deleted != false || info.ButtonID != 1 || _sender.RootParent != sender.Mobile)
         {
             return;
         }
@@ -91,6 +97,6 @@ public class NameChangeDeedGump : Gump
         m.RawName = newName.ToString();
         m.SendMessage("Your name has been changed!");
         m.SendMessage($"You are now known as {newName}");
-        m_Sender.Delete();
+        _sender.Delete();
     }
 }

--- a/Projects/UOContent/Items/Deeds/NewPlayerTicket.cs
+++ b/Projects/UOContent/Items/Deeds/NewPlayerTicket.cs
@@ -88,16 +88,11 @@ public partial class NewPlayerTicket : Item
 
     private class NewPlayerTicketGump : StaticGump<NewPlayerTicketGump>
     {
-        private readonly Mobile _from;
         private readonly NewPlayerTicket _ticket;
 
         public override bool Singleton => true;
 
-        private NewPlayerTicketGump(Mobile from, NewPlayerTicket ticket) : base(50, 50)
-        {
-            _from = from;
-            _ticket = ticket;
-        }
+        private NewPlayerTicketGump(NewPlayerTicket ticket) : base(50, 50) => _ticket = ticket;
 
         public static void DisplayTo(Mobile from, NewPlayerTicket ticket)
         {
@@ -106,7 +101,7 @@ public partial class NewPlayerTicket : Item
                 return;
             }
 
-            from.SendGump(new NewPlayerTicketGump(from, ticket));
+            from.SendGump(new NewPlayerTicketGump(ticket));
         }
 
         protected override void BuildLayout(ref StaticGumpBuilder builder)
@@ -193,14 +188,15 @@ public partial class NewPlayerTicket : Item
 
             if (item != null)
             {
+                var from = sender.Mobile;
                 _ticket.Delete();
 
-                _from.SendLocalizedMessage(number);
-                _from.AddToBackpack(item);
+                from.SendLocalizedMessage(number);
+                from.AddToBackpack(item);
 
                 if (item2 != null)
                 {
-                    _from.AddToBackpack(item2);
+                    from.AddToBackpack(item2);
                 }
             }
         }

--- a/Projects/UOContent/Items/Deeds/NewPlayerTicket.cs
+++ b/Projects/UOContent/Items/Deeds/NewPlayerTicket.cs
@@ -71,8 +71,8 @@ public partial class NewPlayerTicket : Item
                 }
                 else
                 {
-                    from.SendGump(new InternalGump(from, m_Ticket));
-                    them.SendGump(new InternalGump(them, theirTicket));
+                    NewPlayerTicketGump.DisplayTo(from, m_Ticket);
+                    NewPlayerTicketGump.DisplayTo(them, theirTicket);
                 }
             }
             else if ((targeted as Item)?.ItemID == 0x14F0)
@@ -86,46 +86,61 @@ public partial class NewPlayerTicket : Item
         }
     }
 
-    private class InternalGump : Gump
+    private class NewPlayerTicketGump : StaticGump<NewPlayerTicketGump>
     {
-        private readonly Mobile m_From;
-        private readonly NewPlayerTicket m_Ticket;
+        private readonly Mobile _from;
+        private readonly NewPlayerTicket _ticket;
 
-        public InternalGump(Mobile from, NewPlayerTicket ticket) : base(50, 50)
+        public override bool Singleton => true;
+
+        private NewPlayerTicketGump(Mobile from, NewPlayerTicket ticket) : base(50, 50)
         {
-            m_From = from;
-            m_Ticket = ticket;
+            _from = from;
+            _ticket = ticket;
+        }
 
-            AddBackground(0, 0, 400, 385, 0xA28);
+        public static void DisplayTo(Mobile from, NewPlayerTicket ticket)
+        {
+            if (from?.NetState == null || ticket?.Deleted != false)
+            {
+                return;
+            }
+
+            from.SendGump(new NewPlayerTicketGump(from, ticket));
+        }
+
+        protected override void BuildLayout(ref StaticGumpBuilder builder)
+        {
+            builder.AddBackground(0, 0, 400, 385, 0xA28);
 
             // Choose the gift you prefer. WARNING: if you cancel, and your partner does not, you will need to find another matching ticket!
-            AddHtmlLocalized(30, 45, 340, 70, 1013011, true, true);
+            builder.AddHtmlLocalized(30, 45, 340, 70, 1013011, true, true);
 
-            AddButton(46, 128, 0xFA5, 0xFA7, 1);
-            AddHtmlLocalized(80, 130, 320, 35, 1013012); // A sextant
+            builder.AddButton(46, 128, 0xFA5, 0xFA7, 1);
+            builder.AddHtmlLocalized(80, 130, 320, 35, 1013012); // A sextant
 
-            AddButton(46, 163, 0xFA5, 0xFA7, 2);
-            AddHtmlLocalized(80, 165, 320, 35, 1013013); // A coupon for a single hair restyling
+            builder.AddButton(46, 163, 0xFA5, 0xFA7, 2);
+            builder.AddHtmlLocalized(80, 165, 320, 35, 1013013); // A coupon for a single hair restyling
 
-            AddButton(46, 198, 0xFA5, 0xFA7, 3);
-            AddHtmlLocalized(80, 200, 320, 35, 1013014); // A spellbook with all 1st - 4th spells.
+            builder.AddButton(46, 198, 0xFA5, 0xFA7, 3);
+            builder.AddHtmlLocalized(80, 200, 320, 35, 1013014); // A spellbook with all 1st - 4th spells.
 
-            AddButton(46, 233, 0xFA5, 0xFA7, 4);
-            AddHtmlLocalized(80, 235, 320, 35, 1013015); // A wand of fireworks
+            builder.AddButton(46, 233, 0xFA5, 0xFA7, 4);
+            builder.AddHtmlLocalized(80, 235, 320, 35, 1013015); // A wand of fireworks
 
-            AddButton(46, 268, 0xFA5, 0xFA7, 5);
-            AddHtmlLocalized(80, 270, 320, 35, 1013016); // A spyglass
+            builder.AddButton(46, 268, 0xFA5, 0xFA7, 5);
+            builder.AddHtmlLocalized(80, 270, 320, 35, 1013016); // A spyglass
 
-            AddButton(46, 303, 0xFA5, 0xFA7, 6);
-            AddHtmlLocalized(80, 305, 320, 35, 1013017); // Dyes and a dye tub
+            builder.AddButton(46, 303, 0xFA5, 0xFA7, 6);
+            builder.AddHtmlLocalized(80, 305, 320, 35, 1013017); // Dyes and a dye tub
 
-            AddButton(120, 340, 0xFA5, 0xFA7, 0);
-            AddHtmlLocalized(154, 342, 100, 35, 1011012); // CANCEL
+            builder.AddButton(120, 340, 0xFA5, 0xFA7, 0);
+            builder.AddHtmlLocalized(154, 342, 100, 35, 1011012); // CANCEL
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_Ticket.Deleted)
+            if (_ticket.Deleted)
             {
                 return;
             }
@@ -178,14 +193,14 @@ public partial class NewPlayerTicket : Item
 
             if (item != null)
             {
-                m_Ticket.Delete();
+                _ticket.Delete();
 
-                m_From.SendLocalizedMessage(number);
-                m_From.AddToBackpack(item);
+                _from.SendLocalizedMessage(number);
+                _from.AddToBackpack(item);
 
                 if (item2 != null)
                 {
-                    m_From.AddToBackpack(item2);
+                    _from.AddToBackpack(item2);
                 }
             }
         }

--- a/Projects/UOContent/Items/Misc/InteriorDecorator.cs
+++ b/Projects/UOContent/Items/Misc/InteriorDecorator.cs
@@ -57,9 +57,9 @@ public partial class InteriorDecorator : Item
             return;
         }
 
-        if (!from.HasGump<InternalGump>())
+        if (!from.HasGump<InteriorDecoratorGump>())
         {
-            from.SendGump(new InternalGump(this));
+            InteriorDecoratorGump.DisplayTo(from, this);
         }
 
         if (m_Command != DecorateCommand.None)
@@ -79,24 +79,36 @@ public partial class InteriorDecorator : Item
         return false;
     }
 
-    private class InternalGump : Gump
+    private class InteriorDecoratorGump : DynamicGump
     {
-        private readonly InteriorDecorator m_Decorator;
+        private readonly InteriorDecorator _decorator;
 
-        public InternalGump(InteriorDecorator decorator) : base(150, 50)
+        public override bool Singleton => true;
+
+        private InteriorDecoratorGump(InteriorDecorator decorator) : base(150, 50) => _decorator = decorator;
+
+        public static void DisplayTo(Mobile from, InteriorDecorator decorator)
         {
-            m_Decorator = decorator;
+            if (from?.NetState == null || decorator?.Deleted != false)
+            {
+                return;
+            }
 
-            AddBackground(0, 0, 200, 200, 2600);
+            from.SendGump(new InteriorDecoratorGump(decorator));
+        }
 
-            AddButton(50, 45, decorator.Command == DecorateCommand.Turn ? 2154 : 2152, 2154, 1);
-            AddHtmlLocalized(90, 50, 70, 40, 1018323); // Turn
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddBackground(0, 0, 200, 200, 2600);
 
-            AddButton(50, 95, decorator.Command == DecorateCommand.Up ? 2154 : 2152, 2154, 2);
-            AddHtmlLocalized(90, 100, 70, 40, 1018324); // Up
+            builder.AddButton(50, 45, _decorator.Command == DecorateCommand.Turn ? 2154 : 2152, 2154, 1);
+            builder.AddHtmlLocalized(90, 50, 70, 40, 1018323); // Turn
 
-            AddButton(50, 145, decorator.Command == DecorateCommand.Down ? 2154 : 2152, 2154, 3);
-            AddHtmlLocalized(90, 150, 70, 40, 1018325); // Down
+            builder.AddButton(50, 95, _decorator.Command == DecorateCommand.Up ? 2154 : 2152, 2154, 2);
+            builder.AddHtmlLocalized(90, 100, 70, 40, 1018324); // Up
+
+            builder.AddButton(50, 145, _decorator.Command == DecorateCommand.Down ? 2154 : 2152, 2154, 3);
+            builder.AddHtmlLocalized(90, 150, 70, 40, 1018325); // Down
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -111,9 +123,9 @@ public partial class InteriorDecorator : Item
 
             if (command != DecorateCommand.None)
             {
-                m_Decorator.Command = command;
-                sender.Mobile.SendGump(new InternalGump(m_Decorator));
-                sender.Mobile.Target = new InternalTarget(m_Decorator);
+                _decorator.Command = command;
+                DisplayTo(sender.Mobile, _decorator);
+                sender.Mobile.Target = new InternalTarget(_decorator);
             }
             else
             {
@@ -245,7 +257,7 @@ public partial class InteriorDecorator : Item
         {
             if (cancelType == TargetCancelType.Canceled)
             {
-                from.CloseGump<InternalGump>();
+                from.CloseGump<InteriorDecoratorGump>();
             }
         }
 

--- a/Projects/UOContent/Items/Misc/PowerGenerator.cs
+++ b/Projects/UOContent/Items/Misc/PowerGenerator.cs
@@ -153,7 +153,7 @@ public partial class ControlPanel : AddonComponent
 
         if (m_User != null)
         {
-            m_User.CloseGump<GameGump>();
+            m_User.CloseGump<PowerGeneratorGump>();
             m_User = null;
         }
     }
@@ -176,7 +176,7 @@ public partial class ControlPanel : AddonComponent
             if (m_User.Deleted || m_User.Map != Map || !m_User.InRange(this, 3)
                 || m_User.NetState == null || Core.Now - m_LastUse >= m_UseTimeout)
             {
-                m_User.CloseGump<GameGump>();
+                m_User.CloseGump<PowerGeneratorGump>();
             }
             else
             {
@@ -188,7 +188,7 @@ public partial class ControlPanel : AddonComponent
         m_User = from;
         m_LastUse = Core.Now;
 
-        from.SendGump(new GameGump(this, from, 0, false));
+        PowerGeneratorGump.DisplayTo(from, this, 0, false);
     }
 
     public void DoDamage(Mobile to)
@@ -277,57 +277,74 @@ public partial class ControlPanel : AddonComponent
         Down
     }
 
-    private class GameGump : Gump
+    private class PowerGeneratorGump : DynamicGump
     {
-        private readonly Mobile m_From;
+        private readonly Mobile _from;
 
-        private readonly ControlPanel m_Panel;
-        private readonly int m_Step;
+        private readonly ControlPanel _panel;
+        private readonly int _step;
+        private readonly bool _hint;
 
-        public GameGump(ControlPanel panel, Mobile from, int step, bool hint) : base(5, 30)
+        public override bool Singleton => true;
+
+        private PowerGeneratorGump(ControlPanel panel, Mobile from, int step, bool hint) : base(5, 30)
         {
-            m_Panel = panel;
-            m_From = from;
-            m_Step = step;
+            _panel = panel;
+            _from = from;
+            _step = step;
+            _hint = hint;
+        }
 
-            var sideLength = panel.SideLength;
+        public static void DisplayTo(Mobile from, ControlPanel panel, int step, bool hint)
+        {
+            if (from?.NetState == null || panel?.Deleted != false)
+            {
+                return;
+            }
 
-            AddBackground(50, 0, 530, 410, 0xA28);
+            from.SendGump(new PowerGeneratorGump(panel, from, step, hint));
+        }
 
-            AddImage(0, 0, 0x28C8);
-            AddImage(547, 0, 0x28C9);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            var sideLength = _panel.SideLength;
 
-            AddBackground(95, 20, 442, 90, 0xA28);
+            builder.AddBackground(50, 0, 530, 410, 0xA28);
 
-            AddHtml(229, 35, 300, 45, "GENERATOR CONTROL PANEL");
+            builder.AddImage(0, 0, 0x28C8);
+            builder.AddImage(547, 0, 0x28C9);
 
-            AddHtml(223, 60, 300, 70, "Use the Directional Controls to");
-            AddHtml(253, 75, 300, 85, "Close the Grid Circuit");
+            builder.AddBackground(95, 20, 442, 90, 0xA28);
 
-            AddImage(140, 40, 0x28D3);
-            AddImage(420, 40, 0x28D3);
+            builder.AddHtml(229, 35, 300, 45, "GENERATOR CONTROL PANEL");
 
-            AddBackground(365, 120, 178, 210, 0x1400);
+            builder.AddHtml(223, 60, 300, 70, "Use the Directional Controls to");
+            builder.AddHtml(253, 75, 300, 85, "Close the Grid Circuit");
 
-            AddImage(365, 115, 0x28D4);
-            AddImage(365, 288, 0x28D4);
+            builder.AddImage(140, 40, 0x28D3);
+            builder.AddImage(420, 40, 0x28D3);
 
-            AddImage(414, 189, 0x589);
-            AddImage(435, 210, 0xA52);
+            builder.AddBackground(365, 120, 178, 210, 0x1400);
 
-            AddButton(408, 222, 0x29EA, 0x29EC, 1); // Left
-            AddButton(448, 185, 0x29CC, 0x29CE, 2); // Up
-            AddButton(473, 222, 0x29D6, 0x29D8, 3); // Right
-            AddButton(448, 243, 0x29E0, 0x29E2, 4); // Down
+            builder.AddImage(365, 115, 0x28D4);
+            builder.AddImage(365, 288, 0x28D4);
 
-            AddBackground(90, 115, 30 + 40 * sideLength, 30 + 40 * sideLength, 0xA28);
-            AddBackground(100, 125, 10 + 40 * sideLength, 10 + 40 * sideLength, 0x1400);
+            builder.AddImage(414, 189, 0x589);
+            builder.AddImage(435, 210, 0xA52);
+
+            builder.AddButton(408, 222, 0x29EA, 0x29EC, 1); // Left
+            builder.AddButton(448, 185, 0x29CC, 0x29CE, 2); // Up
+            builder.AddButton(473, 222, 0x29D6, 0x29D8, 3); // Right
+            builder.AddButton(448, 243, 0x29E0, 0x29E2, 4); // Down
+
+            builder.AddBackground(90, 115, 30 + 40 * sideLength, 30 + 40 * sideLength, 0xA28);
+            builder.AddBackground(100, 125, 10 + 40 * sideLength, 10 + 40 * sideLength, 0x1400);
 
             for (var i = 0; i < sideLength; i++)
             {
                 for (var j = 0; j < sideLength - 1; j++)
                 {
-                    AddImage(120 + 40 * i, 162 + 40 * j, 0x13F9);
+                    builder.AddImage(120 + 40 * i, 162 + 40 * j, 0x13F9);
                 }
             }
 
@@ -335,15 +352,15 @@ public partial class ControlPanel : AddonComponent
             {
                 for (var j = 0; j < sideLength; j++)
                 {
-                    AddImage(138 + 40 * i, 147 + 40 * j, 0x13FD);
+                    builder.AddImage(138 + 40 * i, 147 + 40 * j, 0x13FD);
                 }
             }
 
-            var path = panel.Path;
+            var path = _panel.Path;
 
             var hues = new NodeHue[sideLength, sideLength];
 
-            for (var i = 0; i <= step; i++)
+            for (var i = 0; i <= _step; i++)
             {
                 var n = path[i];
                 hues[n.X, n.Y] = NodeHue.Blue;
@@ -356,27 +373,27 @@ public partial class ControlPanel : AddonComponent
             {
                 for (var j = 0; j < sideLength; j++)
                 {
-                    AddNode(110 + 40 * i, 135 + 40 * j, hues[i, j]);
+                    AddNode(ref builder, 110 + 40 * i, 135 + 40 * j, hues[i, j]);
                 }
             }
 
-            var curNode = path[step];
-            AddImage(118 + 40 * curNode.X, 143 + 40 * curNode.Y, 0x13A8);
+            var curNode = path[_step];
+            builder.AddImage(118 + 40 * curNode.X, 143 + 40 * curNode.Y, 0x13A8);
 
-            if (hint)
+            if (_hint)
             {
-                var nextNode = path[step + 1];
-                AddImage(119 + 40 * nextNode.X, 143 + 40 * nextNode.Y, 0x939);
+                var nextNode = path[_step + 1];
+                builder.AddImage(119 + 40 * nextNode.X, 143 + 40 * nextNode.Y, 0x939);
             }
 
-            if (from.Skills.Lockpicking.Value >= 65.0)
+            if (_from.Skills.Lockpicking.Value >= 65.0)
             {
-                AddButton(365, 350, 0xFA6, 0xFA7, 5);
-                AddHtml(405, 345, 140, 40, "Attempt to Decipher the Circuit Path");
+                builder.AddButton(365, 350, 0xFA6, 0xFA7, 5);
+                builder.AddHtml(405, 345, 140, 40, "Attempt to Decipher the Circuit Path");
             }
         }
 
-        private void AddNode(int x, int y, NodeHue hue)
+        private static void AddNode(ref DynamicGumpBuilder builder, int x, int y, NodeHue hue)
         {
             var id = hue switch
             {
@@ -385,51 +402,51 @@ public partial class ControlPanel : AddonComponent
                 _            => 0x9A8
             };
 
-            AddImage(x, y, id);
+            builder.AddImage(x, y, id);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (m_Panel.Deleted || info.ButtonID == 0 || !m_From.CheckAlive())
+            if (_panel.Deleted || info.ButtonID == 0 || !_from.CheckAlive())
             {
-                m_Panel.m_User = null;
+                _panel.m_User = null;
                 return;
             }
 
-            if (m_From.Map != m_Panel.Map || !m_From.InRange(m_Panel, 3))
+            if (_from.Map != _panel.Map || !_from.InRange(_panel, 3))
             {
-                m_From.SendLocalizedMessage(500446); // That is too far away.
-                m_Panel.m_User = null;
+                _from.SendLocalizedMessage(500446); // That is too far away.
+                _panel.m_User = null;
                 return;
             }
 
-            var nextNode = m_Panel.Path[m_Step + 1];
+            var nextNode = _panel.Path[_step + 1];
 
             if (info.ButtonID == 5) // Attempt to Decipher
             {
-                var lockpicking = m_From.Skills.Lockpicking.Value;
+                var lockpicking = _from.Skills.Lockpicking.Value;
 
                 if (lockpicking < 65.0)
                 {
                     return;
                 }
 
-                m_From.PlaySound(0x241);
+                _from.PlaySound(0x241);
 
                 if (40.0 + Utility.RandomDouble() * 80.0 < lockpicking)
                 {
-                    m_From.SendGump(new GameGump(m_Panel, m_From, m_Step, true));
-                    m_Panel.m_LastUse = Core.Now;
+                    DisplayTo(_from, _panel, _step, true);
+                    _panel.m_LastUse = Core.Now;
                 }
                 else
                 {
-                    m_Panel.DoDamage(m_From);
-                    m_Panel.m_User = null;
+                    _panel.DoDamage(_from);
+                    _panel.m_User = null;
                 }
             }
             else
             {
-                var curNode = m_Panel.Path[m_Step];
+                var curNode = _panel.Path[_step];
 
                 int newX, newY;
                 switch (info.ButtonID)
@@ -467,22 +484,22 @@ public partial class ControlPanel : AddonComponent
 
                 if (nextNode.X == newX && nextNode.Y == newY)
                 {
-                    if (m_Step + 1 == m_Panel.Path.Length - 1)
+                    if (_step + 1 == _panel.Path.Length - 1)
                     {
-                        m_Panel.Solve(m_From);
-                        m_Panel.m_User = null;
+                        _panel.Solve(_from);
+                        _panel.m_User = null;
                     }
                     else
                     {
-                        m_From.PlaySound(0x1F4);
-                        m_From.SendGump(new GameGump(m_Panel, m_From, m_Step + 1, false));
-                        m_Panel.m_LastUse = Core.Now;
+                        _from.PlaySound(0x1F4);
+                        DisplayTo(_from, _panel, _step + 1, false);
+                        _panel.m_LastUse = Core.Now;
                     }
                 }
                 else
                 {
-                    m_Panel.DoDamage(m_From);
-                    m_Panel.m_User = null;
+                    _panel.DoDamage(_from);
+                    _panel.m_User = null;
                 }
             }
         }

--- a/Projects/UOContent/Items/Misc/PromotionalToken.cs
+++ b/Projects/UOContent/Items/Misc/PromotionalToken.cs
@@ -47,7 +47,7 @@ public abstract partial class PromotionalToken : Item
         }
         else
         {
-            from.SendGump(new PromotionalTokenGump(this));
+            PromotionalTokenGump.DisplayTo(from, this);
         }
     }
 
@@ -67,25 +67,35 @@ public abstract partial class PromotionalToken : Item
         m?.CloseGump<PromotionalTokenGump>();
     }
 
-    private class PromotionalTokenGump : Gump
+    private class PromotionalTokenGump : DynamicGump
     {
-        private readonly PromotionalToken m_Token;
+        private readonly PromotionalToken _token;
 
         public override bool Singleton => true;
 
-        public PromotionalTokenGump(PromotionalToken token) : base(10, 10)
+        private PromotionalTokenGump(PromotionalToken token) : base(10, 10) => _token = token;
+
+        public static void DisplayTo(Mobile from, PromotionalToken token)
         {
-            m_Token = token;
+            if (from?.NetState == null || token?.Deleted != false)
+            {
+                return;
+            }
 
-            AddPage(0);
+            from.SendGump(new PromotionalTokenGump(token));
+        }
 
-            AddBackground(0, 0, 240, 135, 0x2422);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
+
+            builder.AddBackground(0, 0, 240, 135, 0x2422);
             // Click "OKAY" to redeem the following promotional item:
-            AddHtmlLocalized(15, 15, 210, 75, 1070972, 0x0, true);
-            m_Token.ItemGumpName.AddHtmlText(this, 15, 60, 210, 75);
+            builder.AddHtmlLocalized(15, 15, 210, 75, 1070972, 0x0, true);
+            _token.ItemGumpName.AddHtmlText(ref builder, 15, 60, 210, 75);
 
-            AddButton(160, 95, 0xF7, 0xF8, 1); // Okay
-            AddButton(90, 95, 0xF2, 0xF1, 0);  // Cancel
+            builder.AddButton(160, 95, 0xF7, 0xF8, 1); // Okay
+            builder.AddButton(90, 95, 0xF2, 0xF1, 0);  // Cancel
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -97,19 +107,19 @@ public abstract partial class PromotionalToken : Item
 
             var from = sender.Mobile;
 
-            if (!m_Token.IsChildOf(from.Backpack))
+            if (!_token.IsChildOf(from.Backpack))
             {
                 from.SendLocalizedMessage(1062334); // This item must be in your backpack to be used.
             }
             else
             {
-                var i = m_Token.CreateItemFor(from);
+                var i = _token.CreateItemFor(from);
 
                 if (i != null)
                 {
                     from.BankBox.AddItem(i);
-                    m_Token.ItemReceiveMessage.SendMessageTo(from);
-                    m_Token.Delete();
+                    _token.ItemReceiveMessage.SendMessageTo(from);
+                    _token.Delete();
                 }
             }
         }

--- a/Projects/UOContent/Items/Misc/SpecialHairDye.cs
+++ b/Projects/UOContent/Items/Misc/SpecialHairDye.cs
@@ -19,7 +19,7 @@ public partial class SpecialHairDye : Item
     {
         if (from.InRange(GetWorldLocation(), 1))
         {
-            from.SendGump(new SpecialHairDyeGump(this));
+            SpecialHairDyeGump.DisplayTo(from, this);
         }
         else
         {
@@ -28,7 +28,7 @@ public partial class SpecialHairDye : Item
     }
 }
 
-public class SpecialHairDyeGump : Gump
+public class SpecialHairDyeGump : StaticGump<SpecialHairDyeGump>
 {
     private static readonly SpecialHairDyeEntry[] _entries =
     {
@@ -42,37 +42,47 @@ public class SpecialHairDyeGump : Gump
         new("*****", 1153, 2)
     };
 
-    private SpecialHairDye _specialHairDye;
+    private readonly SpecialHairDye _specialHairDye;
 
     public override bool Singleton => true;
 
-    public SpecialHairDyeGump(SpecialHairDye dye) : base(0, 0)
-    {
-        _specialHairDye = dye;
+    private SpecialHairDyeGump(SpecialHairDye dye) : base(0, 0) => _specialHairDye = dye;
 
-        AddPage(0);
-        AddBackground(150, 60, 350, 358, 2600);
-        AddBackground(170, 104, 110, 270, 5100);
-        AddHtmlLocalized(230, 75, 200, 20, 1011013);  // Hair Color Selection Menu
-        AddHtmlLocalized(235, 380, 300, 20, 1011014); // Dye my hair this color!
-        AddButton(200, 380, 0xFA5, 0xFA7, 1);         // DYE HAIR
+    public static void DisplayTo(Mobile from, SpecialHairDye dye)
+    {
+        if (from?.NetState == null || dye?.Deleted != false)
+        {
+            return;
+        }
+
+        from.SendGump(new SpecialHairDyeGump(dye));
+    }
+
+    protected override void BuildLayout(ref StaticGumpBuilder builder)
+    {
+        builder.AddPage();
+        builder.AddBackground(150, 60, 350, 358, 2600);
+        builder.AddBackground(170, 104, 110, 270, 5100);
+        builder.AddHtmlLocalized(230, 75, 200, 20, 1011013);  // Hair Color Selection Menu
+        builder.AddHtmlLocalized(235, 380, 300, 20, 1011014); // Dye my hair this color!
+        builder.AddButton(200, 380, 0xFA5, 0xFA7, 1);         // DYE HAIR
 
         for (var i = 0; i < _entries.Length; ++i)
         {
-            AddLabel(180, 109 + i * 22, _entries[i].HueStart - 1, _entries[i].Name);
-            AddButton(257, 110 + i * 22, 5224, 5224, 0, GumpButtonType.Page, i + 1);
+            builder.AddLabel(180, 109 + i * 22, _entries[i].HueStart - 1, _entries[i].Name);
+            builder.AddButton(257, 110 + i * 22, 5224, 5224, 0, GumpButtonType.Page, i + 1);
         }
 
         for (var i = 0; i < _entries.Length; ++i)
         {
             var e = _entries[i];
 
-            AddPage(i + 1);
+            builder.AddPage(i + 1);
 
             for (var j = 0; j < e.HueCount; ++j)
             {
-                AddLabel(328 + j / 16 * 80, 102 + j % 16 * 17, e.HueStart + j - 1, "*****");
-                AddRadio(310 + j / 16 * 80, 102 + j % 16 * 17, 210, 211, false, i * 100 + j);
+                builder.AddLabel(328 + j / 16 * 80, 102 + j % 16 * 17, e.HueStart + j - 1, "*****");
+                builder.AddRadio(310 + j / 16 * 80, 102 + j % 16 * 17, 210, 211, false, i * 100 + j);
             }
         }
     }

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBox.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBox.cs
@@ -212,7 +212,7 @@ public partial class DawnsMusicBox : Item, ISecurable
         }
         else
         {
-            from.SendGump(new DawnsMusicBoxGump(this));
+            DawnsMusicBoxGump.DisplayTo(from, this);
         }
     }
 

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBoxGump.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBoxGump.cs
@@ -3,44 +3,54 @@ using Server.Network;
 
 namespace Server.Gumps;
 
-public class DawnsMusicBoxGump : Gump
+public class DawnsMusicBoxGump : DynamicGump
 {
-    private readonly DawnsMusicBox m_Box;
+    private readonly DawnsMusicBox _box;
 
     public override bool Singleton => true;
 
-    public DawnsMusicBoxGump(DawnsMusicBox box) : base(60, 36)
+    private DawnsMusicBoxGump(DawnsMusicBox box) : base(60, 36) => _box = box;
+
+    public static void DisplayTo(Mobile from, DawnsMusicBox box)
     {
-        m_Box = box;
+        if (from?.NetState == null || box?.Deleted != false)
+        {
+            return;
+        }
 
-        AddPage(0);
+        from.SendGump(new DawnsMusicBoxGump(box));
+    }
 
-        AddBackground(0, 0, 273, 324, 0x13BE);
-        AddImageTiled(10, 10, 253, 20, 0xA40);
-        AddImageTiled(10, 40, 253, 244, 0xA40);
-        AddImageTiled(10, 294, 253, 20, 0xA40);
-        AddAlphaRegion(10, 10, 253, 304);
-        AddButton(10, 294, 0xFB1, 0xFB2, 0);
-        AddHtmlLocalized(45, 296, 450, 20, 1060051, 0x7FFF); // CANCEL
-        AddHtmlLocalized(14, 12, 273, 20, 1075130, 0x7FFF);  // Choose a track to play
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
+
+        builder.AddBackground(0, 0, 273, 324, 0x13BE);
+        builder.AddImageTiled(10, 10, 253, 20, 0xA40);
+        builder.AddImageTiled(10, 40, 253, 244, 0xA40);
+        builder.AddImageTiled(10, 294, 253, 20, 0xA40);
+        builder.AddAlphaRegion(10, 10, 253, 304);
+        builder.AddButton(10, 294, 0xFB1, 0xFB2, 0);
+        builder.AddHtmlLocalized(45, 296, 450, 20, 1060051, 0x7FFF); // CANCEL
+        builder.AddHtmlLocalized(14, 12, 273, 20, 1075130, 0x7FFF);  // Choose a track to play
 
         var page = 1;
         int i, y = 49;
 
-        AddPage(page);
+        builder.AddPage(page);
 
-        for (i = 0; i < m_Box.Tracks.Count; i++, y += 24)
+        for (i = 0; i < _box.Tracks.Count; i++, y += 24)
         {
-            var info = DawnsMusicBox.GetInfo(m_Box.Tracks[i]);
+            var info = DawnsMusicBox.GetInfo(_box.Tracks[i]);
 
             if (i > 0 && i % 10 == 0)
             {
-                AddButton(228, 294, 0xFA5, 0xFA6, 0, GumpButtonType.Page, page + 1);
+                builder.AddButton(228, 294, 0xFA5, 0xFA6, 0, GumpButtonType.Page, page + 1);
 
-                AddPage(page + 1);
+                builder.AddPage(page + 1);
                 y = 49;
 
-                AddButton(193, 294, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page);
+                builder.AddButton(193, 294, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page);
 
                 page++;
             }
@@ -50,49 +60,49 @@ public class DawnsMusicBoxGump : Gump
                 continue;
             }
 
-            AddButton(19, y, 0x845, 0x846, 100 + i);
-            AddHtmlLocalized(44, y - 2, 213, 20, info.Name, 0x7FFF);
+            builder.AddButton(19, y, 0x845, 0x846, 100 + i);
+            builder.AddHtmlLocalized(44, y - 2, 213, 20, info.Name, 0x7FFF);
         }
 
         if (i % 10 == 0)
         {
-            AddButton(228, 294, 0xFA5, 0xFA6, 0, GumpButtonType.Page, page + 1);
+            builder.AddButton(228, 294, 0xFA5, 0xFA6, 0, GumpButtonType.Page, page + 1);
 
-            AddPage(page + 1);
+            builder.AddPage(page + 1);
             y = 49;
 
-            AddButton(193, 294, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page);
+            builder.AddButton(193, 294, 0xFAE, 0xFAF, 0, GumpButtonType.Page, page);
         }
 
-        AddButton(19, y, 0x845, 0x846, 1);
-        AddHtmlLocalized(44, y - 2, 213, 20, 1075207, 0x7FFF); // Stop Song
+        builder.AddButton(19, y, 0x845, 0x846, 1);
+        builder.AddHtmlLocalized(44, y - 2, 213, 20, 1075207, 0x7FFF); // Stop Song
     }
 
     public override void OnResponse(NetState sender, in RelayInfo info)
     {
-        if (m_Box?.Deleted != false)
+        if (_box?.Deleted != false)
         {
             return;
         }
 
         var m = sender.Mobile;
 
-        if (!m_Box.IsChildOf(m.Backpack) && !m_Box.IsLockedDown)
+        if (!_box.IsChildOf(m.Backpack) && !_box.IsLockedDown)
         {
             // You must have the item in your backpack or locked down in order to use it.
             m.SendLocalizedMessage(1061856);
         }
-        else if (m_Box.IsLockedDown && !m_Box.HasAccess(m))
+        else if (_box.IsLockedDown && !_box.HasAccess(m))
         {
             m.SendLocalizedMessage(502691); // You must be the owner to use this.
         }
         else if (info.ButtonID == 1)
         {
-            m_Box.EndMusic(m);
+            _box.EndMusic(m);
         }
-        else if (info.ButtonID >= 100 && info.ButtonID - 100 < m_Box.Tracks.Count)
+        else if (info.ButtonID >= 100 && info.ButtonID - 100 < _box.Tracks.Count)
         {
-            m_Box.PlayMusic(m, m_Box.Tracks[info.ButtonID - 100]);
+            _box.PlayMusic(m, _box.Tracks[info.ButtonID - 100]);
         }
     }
 }

--- a/Projects/UOContent/Items/Special/HeritageToken.cs
+++ b/Projects/UOContent/Items/Special/HeritageToken.cs
@@ -16,7 +16,7 @@ public partial class HeritageToken : Item
     {
         if (IsChildOf(from.Backpack))
         {
-            from.SendGump(new HeritageTokenGump(this), true);
+            HeritageTokenGump.DisplayTo(from, this);
         }
         else
         {

--- a/Projects/UOContent/Migrations/Server.Items.SpiritualityHelm.v0.json
+++ b/Projects/UOContent/Migrations/Server.Items.SpiritualityHelm.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Items.SpiritualityHelm"
+}

--- a/Projects/UOContent/Migrations/Server.Items.ValorGauntlets.v0.json
+++ b/Projects/UOContent/Migrations/Server.Items.ValorGauntlets.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Items.ValorGauntlets"
+}


### PR DESCRIPTION
## Summary

Migrates 11 player-facing Item Interaction gumps from legacy `Gump` to `StaticGump<T>` or `DynamicGump`.

| File | Gump | Base | Reason |
|---|---|---|---|
| `Items/Deeds/NameChangeDeed.cs` | `NameChangeDeedGump` | `StaticGump<T>` | Fully fixed layout |
| `Items/Deeds/HairRestylingDeed.cs` | `HairRestylingDeedGump` (renamed from `InternalGump`) | `DynamicGump` | Per-race/per-gender cliloc IDs and gump images vary every instance |
| `Items/Deeds/HolidayTreeDeed.cs` | `HolidayTreeChoiceGump` | `StaticGump<T>` | Fully fixed (Classic/Modern radio) |
| `Items/Deeds/NewPlayerTicket.cs` | `NewPlayerTicketGump` (renamed from `InternalGump`) | `StaticGump<T>` | Fully fixed gift menu |
| `Items/Misc/PromotionalToken.cs` | `PromotionalTokenGump` | `DynamicGump` | `TextDefinition` (`ItemGumpName`) varies per token subclass — cliloc/string differs |
| `Items/Misc/SpecialHairDye.cs` | `SpecialHairDyeGump` | `StaticGump<T>` | Static entry array drives a fixed layout |
| `Items/Misc/InteriorDecorator.cs` | `InteriorDecoratorGump` (renamed from `InternalGump`) | `DynamicGump` | Button art flips per `decorator.Command` (Turn/Up/Down) |
| `Items/Special/8th Anniversary Items/Dawn's Music Box/DawnsMusicBoxGump.cs` | `DawnsMusicBoxGump` | `DynamicGump` | Page count derived from variable `Tracks.Count` |
| `Items/Misc/PowerGenerator.cs` | `PowerGeneratorGump` (renamed from `GameGump`) | `DynamicGump` | Variable side length 3-6 and per-step node hues |
| `Gumps/HeritageTokenGump.cs` | `HeritageTokenGump` | `StaticGump<T>` | All 7 pages fully baked — only static cliloc IDs |
| `Gumps/ConfirmHeritageGump.cs` | `ConfirmHeritageGump` | `DynamicGump` | Confirmation cliloc chosen at runtime per item selected |

All gumps use `Singleton => true`, private constructors, and a static `DisplayTo` entry point that validates prerequisites before constructing.

External callers updated (`HeritageToken`, `DawnsMusicBox`) to the new `DisplayTo` entry points. `Console.WriteLine` in `ConfirmHeritageGump` exception handler replaced with `LogFactory`-backed logger.

## Test plan

- [x] `dotnet build Projects/UOContent/UOContent.csproj` — 0 warnings, 0 errors
- [ ] In-game smoke: Name Change Deed double-click → submit a new name → name changes, deed deletes
- [ ] In-game smoke: Hair Restyling Deed → race/gender variants render → pick a style
- [ ] In-game smoke: Holiday Tree Deed → Classic / Modern → places correct tree
- [ ] In-game smoke: New Player Ticket pair → both gumps show, both pick and receive prize
- [ ] In-game smoke: Promotional Token (e.g. Soulstone Fragment) → OKAY redeems, item lands in bank
- [ ] In-game smoke: Special Hair Dye → page through entries, dye hue applies
- [ ] In-game smoke: Interior Decorator → Turn/Up/Down buttons reflect active command, target sequence works
- [ ] In-game smoke: Dawn's Music Box → tracks span pages, Stop Song works
- [ ] In-game smoke: Power Generator → side length 3-6, directional buttons advance/damage, Lockpicking >=65 hint button visible
- [ ] In-game smoke: Heritage Token → all pages render, choice opens confirmation with correct cliloc, OKAY redeems / CANCEL returns to choice gump
