### PR TITLE
perf: Migrate New Guild System gumps to DynamicGump

### DIFF
--- a/Projects/UOContent/Gumps/Guilds/New Guild System/AdvancedSearch.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/AdvancedSearch.cs
@@ -8,55 +8,53 @@ namespace Server.Guilds
 
     public class GuildAdvancedSearchGump : BaseGuildGump
     {
-        private readonly SearchSelectionCallback m_Callback;
-        private readonly GuildDisplayType m_Display;
+        private readonly SearchSelectionCallback _callback;
+        private readonly GuildDisplayType _display;
 
         public GuildAdvancedSearchGump(PlayerMobile pm, Guild g, GuildDisplayType display, SearchSelectionCallback callback)
             : base(pm, g)
         {
-            m_Callback = callback;
-            m_Display = display;
-            PopulateGump();
+            _callback = callback;
+            _display = display;
         }
 
-        public override void PopulateGump()
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
         {
-            base.PopulateGump();
+            builder.AddHtmlLocalized(431, 43, 110, 26, 1062978, 0xF); // Diplomacy
 
-            AddHtmlLocalized(431, 43, 110, 26, 1062978, 0xF); // Diplomacy
+            builder.AddHtmlLocalized(65, 80, 480, 26, 1063124, 0xF, true); // <i>Advanced Search Options</i>
 
-            AddHtmlLocalized(65, 80, 480, 26, 1063124, 0xF, true); // <i>Advanced Search Options</i>
-
-            AddHtmlLocalized(
+            // Showing All Guilds/w/Relation/Waiting Relation
+            builder.AddHtmlLocalized(
                 65,
                 110,
                 480,
                 26,
-                1063136 + (int)m_Display,
+                1063136 + (int)_display,
                 0xF
-            ); // Showing All Guilds/w/Relation/Waiting Relation
+            );
 
-            AddGroup(1);
-            AddRadio(75, 140, 0xD2, 0xD3, false, 2);
-            AddHtmlLocalized(105, 140, 200, 26, 1063006, 0x0); // Show Guilds with Relationship
-            AddRadio(75, 170, 0xD2, 0xD3, false, 1);
-            AddHtmlLocalized(105, 170, 200, 26, 1063005, 0x0); // Show Guilds Awaiting Action
-            AddRadio(75, 200, 0xD2, 0xD3, false, 0);
-            AddHtmlLocalized(105, 200, 200, 26, 1063007, 0x0); // Show All Guilds
+            builder.AddGroup(1);
+            builder.AddRadio(75, 140, 0xD2, 0xD3, false, 2);
+            builder.AddHtmlLocalized(105, 140, 200, 26, 1063006, 0x0); // Show Guilds with Relationship
+            builder.AddRadio(75, 170, 0xD2, 0xD3, false, 1);
+            builder.AddHtmlLocalized(105, 170, 200, 26, 1063005, 0x0); // Show Guilds Awaiting Action
+            builder.AddRadio(75, 200, 0xD2, 0xD3, false, 0);
+            builder.AddHtmlLocalized(105, 200, 200, 26, 1063007, 0x0); // Show All Guilds
 
-            AddBackground(450, 370, 100, 26, 0x2486);
-            AddButton(455, 375, 0x845, 0x846, 5);
-            AddHtmlLocalized(480, 373, 60, 26, 1006044, 0x0); // OK
-            AddBackground(340, 370, 100, 26, 0x2486);
-            AddButton(345, 375, 0x845, 0x846, 0);
-            AddHtmlLocalized(370, 373, 60, 26, 1006045, 0x0); // Cancel
+            builder.AddBackground(450, 370, 100, 26, 0x2486);
+            builder.AddButton(455, 375, 0x845, 0x846, 5);
+            builder.AddHtmlLocalized(480, 373, 60, 26, 1006044, 0x0); // OK
+            builder.AddBackground(340, 370, 100, 26, 0x2486);
+            builder.AddButton(345, 375, 0x845, 0x846, 0);
+            builder.AddHtmlLocalized(370, 373, 60, 26, 1006045, 0x0); // Cancel
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             base.OnResponse(sender, info);
 
-            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, guild))
+            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, Guild))
             {
                 return;
             }
@@ -68,7 +66,7 @@ namespace Server.Guilds
                     if (info.IsSwitched(i))
                     {
                         var display = (GuildDisplayType)i;
-                        m_Callback(display);
+                        _callback(display);
                         break;
                     }
                 }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/BaseGuildGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/BaseGuildGump.cs
@@ -6,38 +6,48 @@ using Server.Network;
 
 namespace Server.Guilds
 {
-    public abstract class BaseGuildGump : Gump
+    public abstract class BaseGuildGump : DynamicGump
     {
         public override bool Singleton => true;
 
-        public BaseGuildGump(PlayerMobile pm, Guild g, int x = 10, int y = 10) : base(x, y)
+        protected BaseGuildGump(PlayerMobile pm, Guild g, int x = 10, int y = 10) : base(x, y)
         {
-            guild = g;
-            player = pm;
+            Guild = g;
+            Player = pm;
         }
 
-        protected Guild guild { get; }
+        protected Guild Guild { get; }
 
-        protected PlayerMobile player { get; }
+        protected PlayerMobile Player { get; }
 
-        // There's prolly a way to have all the vars set of inherited classes before something is called in the Ctor... but... I can't think of it right now, and I can't use Timer.DelayCall here :<
+        // Subclasses that draw their own background/layout (e.g. OtherGuildInfo,
+        // WarDeclarationGump, GuildMemberInfoGump) can opt out of the standard
+        // 600x440 frame and three-button tab strip drawn at the top of the gump.
+        protected virtual bool ShowTabStrip => true;
 
-        public virtual void PopulateGump()
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
         {
-            AddPage(0);
+            builder.AddPage();
 
-            AddBackground(0, 0, 600, 440, 0x24AE);
-            AddBackground(66, 40, 150, 26, 0x2486);
-            AddButton(71, 45, 0x845, 0x846, 1);
-            AddHtmlLocalized(96, 43, 110, 26, 1063014, 0x0); // My Guild
-            AddBackground(236, 40, 150, 26, 0x2486);
-            AddButton(241, 45, 0x845, 0x846, 2);
-            AddHtmlLocalized(266, 43, 110, 26, 1062974, 0x0); // Guild Roster
-            AddBackground(401, 40, 150, 26, 0x2486);
-            AddButton(406, 45, 0x845, 0x846, 3);
-            AddHtmlLocalized(431, 43, 110, 26, 1062978, 0x0); // Diplomacy
-            AddPage(1);
+            if (ShowTabStrip)
+            {
+                builder.AddBackground(0, 0, 600, 440, 0x24AE);
+                builder.AddBackground(66, 40, 150, 26, 0x2486);
+                builder.AddButton(71, 45, 0x845, 0x846, 1);
+                builder.AddHtmlLocalized(96, 43, 110, 26, 1063014, 0x0); // My Guild
+                builder.AddBackground(236, 40, 150, 26, 0x2486);
+                builder.AddButton(241, 45, 0x845, 0x846, 2);
+                builder.AddHtmlLocalized(266, 43, 110, 26, 1062974, 0x0); // Guild Roster
+                builder.AddBackground(401, 40, 150, 26, 0x2486);
+                builder.AddButton(406, 45, 0x845, 0x846, 3);
+                builder.AddHtmlLocalized(431, 43, 110, 26, 1062978, 0x0); // Diplomacy
+                builder.AddPage(1);
+            }
+
+            BuildContent(ref builder);
         }
+
+        protected abstract void BuildContent(ref DynamicGumpBuilder builder);
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
@@ -46,7 +56,7 @@ namespace Server.Guilds
                 return;
             }
 
-            if (!IsMember(pm, guild))
+            if (!IsMember(pm, Guild))
             {
                 return;
             }
@@ -55,29 +65,27 @@ namespace Server.Guilds
             {
                 case 1:
                     {
-                        pm.SendGump(new GuildInfoGump(pm, guild));
+                        pm.SendGump(new GuildInfoGump(pm, Guild));
                         break;
                     }
                 case 2:
                     {
-                        pm.SendGump(new GuildRosterGump(pm, guild));
+                        pm.SendGump(new GuildRosterGump(pm, Guild));
                         break;
                     }
                 case 3:
                     {
-                        pm.SendGump(new GuildDiplomacyGump(pm, guild));
+                        pm.SendGump(new GuildDiplomacyGump(pm, Guild));
                         break;
                     }
             }
         }
 
         public static bool IsLeader(Mobile m, Guild g) =>
-            !(m.Deleted || g.Disbanded || m is not PlayerMobile ||
-              m.AccessLevel < AccessLevel.GameMaster && g.Leader != m);
+            !(m.Deleted || g.Disbanded || m is not PlayerMobile || m.AccessLevel < AccessLevel.GameMaster && g.Leader != m);
 
         public static bool IsMember(Mobile m, Guild g) =>
-            !(m.Deleted || g.Disbanded || m is not PlayerMobile ||
-              m.AccessLevel < AccessLevel.GameMaster && !g.IsMember(m));
+            !(m.Deleted || g.Disbanded || m is not PlayerMobile || m.AccessLevel < AccessLevel.GameMaster && !g.IsMember(m));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool CheckProfanity(string s, int maxLength = 50) =>
@@ -94,15 +102,24 @@ namespace Server.Guilds
                 ProfanityProtection.DisallowedSearchValues
             );
 
-        public void AddHtmlText(int x, int y, int width, int height, TextDefinition text, bool back, bool scroll)
+        protected static void AddHtmlText(
+            ref DynamicGumpBuilder builder,
+            int x,
+            int y,
+            int width,
+            int height,
+            TextDefinition text,
+            bool back,
+            bool scroll
+        )
         {
             if (text?.Number > 0)
             {
-                AddHtmlLocalized(x, y, width, height, text.Number, back, scroll);
+                builder.AddHtmlLocalized(x, y, width, height, text.Number, back, scroll);
             }
             else if (text?.String != null)
             {
-                AddHtml(x, y, width, height, text.String, back, scroll);
+                builder.AddHtml(x, y, width, height, text.String, background: back, scrollbar: scroll);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/BaseGuildListGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/BaseGuildListGump.cs
@@ -9,137 +9,146 @@ namespace Server.Guilds
     public abstract class BaseGuildListGump<T> : BaseGuildGump
     {
         private const int itemsPerPage = 8;
-        private readonly IComparer<T> m_Comparer;
-        private readonly InfoField<T>[] m_Fields;
-        private readonly string m_Filter;
-        private bool m_Ascending;
-        private List<T> m_List;
-        private int m_StartNumber;
 
-        public BaseGuildListGump(
+        private readonly InfoField<T>[] _fields;
+        private readonly List<T> _originalList;
+        private List<T> _displayList;
+        private IComparer<T> _comparer;
+        private bool _ascending;
+        private string _filter;
+        private int _startNumber;
+
+        protected BaseGuildListGump(
             PlayerMobile pm, Guild g, List<T> list, IComparer<T> currentComparer, bool ascending,
             string filter, int startNumber, InfoField<T>[] fields
-        )
-            : base(pm, g)
+        ) : base(pm, g)
         {
-            m_Filter = filter.Trim();
-
-            m_Comparer = currentComparer;
-            m_Fields = fields;
-            m_Ascending = ascending;
-            m_StartNumber = startNumber;
-            m_List = list;
+            _filter = filter.Trim();
+            _comparer = currentComparer;
+            _fields = fields;
+            _ascending = ascending;
+            _startNumber = startNumber;
+            _originalList = list;
         }
 
-        public virtual bool WillFilter => m_Filter.Length > 0;
+        public virtual bool WillFilter => _filter.Length > 0;
 
-        public override void PopulateGump()
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
         {
-            base.PopulateGump();
-
-            var list = m_List;
+            // Build the filtered/sorted display list per-render so refreshes pick up
+            // the latest filter/sort/pagination state.
             if (WillFilter)
             {
-                m_List = [];
-                for (var i = 0; i < list.Count; i++)
+                var filtered = new List<T>(_originalList.Count);
+                for (var i = 0; i < _originalList.Count; i++)
                 {
-                    if (!IsFiltered(list[i], m_Filter))
+                    if (!IsFiltered(_originalList[i], _filter))
                     {
-                        m_List.Add(list[i]);
+                        filtered.Add(_originalList[i]);
                     }
                 }
+
+                _displayList = filtered;
             }
             else
             {
-                m_List = new List<T>(list);
+                _displayList = new List<T>(_originalList);
             }
 
-            m_List.Sort(m_Comparer);
-            m_StartNumber = Math.Max(Math.Min(m_StartNumber, m_List.Count - 1), 0);
+            _displayList.Sort(_comparer);
+            _startNumber = Math.Max(Math.Min(_startNumber, _displayList.Count - 1), 0);
 
-            AddBackground(130, 75, 385, 30, 0xBB8);
-            AddTextEntry(135, 80, 375, 30, 0x481, 1, m_Filter);
-            AddButton(520, 75, 0x867, 0x868, 5); // Filter Button
+            builder.AddBackground(130, 75, 385, 30, 0xBB8);
+            builder.AddTextEntry(135, 80, 375, 30, 0x481, 1, _filter);
+            builder.AddButton(520, 75, 0x867, 0x868, 5); // Filter Button
 
             var width = 0;
-            for (var i = 0; i < m_Fields.Length; i++)
+            for (var i = 0; i < _fields.Length; i++)
             {
-                var f = m_Fields[i];
+                var f = _fields[i];
 
-                AddImageTiled(65 + width, 110, f.Width + 10, 26, 0xA40);
-                AddImageTiled(67 + width, 112, f.Width + 6, 22, 0xBBC);
-                AddHtmlText(70 + width, 113, f.Width, 20, f.Name, false, false);
+                builder.AddImageTiled(65 + width, 110, f.Width + 10, 26, 0xA40);
+                builder.AddImageTiled(67 + width, 112, f.Width + 6, 22, 0xBBC);
+                AddHtmlText(ref builder, 70 + width, 113, f.Width, 20, f.Name, false, false);
 
-                var isComparer = m_Fields[i].Comparer.GetType() == m_Comparer.GetType();
+                var isComparer = _fields[i].Comparer.GetType() == _comparer.GetType();
 
-                var ButtonID = isComparer ? m_Ascending ? 0x983 : 0x985 : 0x2716;
+                var buttonId = isComparer ? _ascending ? 0x983 : 0x985 : 0x2716;
 
-                AddButton(59 + width + f.Width, 117, ButtonID, ButtonID + (isComparer ? 1 : 0), 100 + i);
+                builder.AddButton(59 + width + f.Width, 117, buttonId, buttonId + (isComparer ? 1 : 0), 100 + i);
 
                 width += f.Width + 12;
             }
 
-            if (m_StartNumber <= 0)
+            if (_startNumber <= 0)
             {
-                AddButton(65, 80, 0x15E3, 0x15E7, 0, GumpButtonType.Page);
+                builder.AddButton(65, 80, 0x15E3, 0x15E7, 0, GumpButtonType.Page);
             }
             else
             {
-                AddButton(65, 80, 0x15E3, 0x15E7, 6); // Back
+                builder.AddButton(65, 80, 0x15E3, 0x15E7, 6); // Back
             }
 
-            if (m_StartNumber + itemsPerPage > m_List.Count)
+            if (_startNumber + itemsPerPage > _displayList.Count)
             {
-                AddButton(95, 80, 0x15E1, 0x15E5, 0, GumpButtonType.Page);
+                builder.AddButton(95, 80, 0x15E1, 0x15E5, 0, GumpButtonType.Page);
             }
             else
             {
-                AddButton(95, 80, 0x15E1, 0x15E5, 7); // Forward
+                builder.AddButton(95, 80, 0x15E1, 0x15E5, 7); // Forward
             }
 
             var itemNumber = 0;
 
-            if (m_Ascending)
+            if (_ascending)
             {
-                for (var i = m_StartNumber; i < m_StartNumber + itemsPerPage && i < m_List.Count; i++)
+                for (var i = _startNumber; i < _startNumber + itemsPerPage && i < _displayList.Count; i++)
                 {
-                    DrawEntry(m_List[i], i, itemNumber++);
+                    DrawEntry(ref builder, _displayList[i], i, itemNumber++);
                 }
             }
             else // descending, go from bottom of list to the top
             {
-                for (var i = m_List.Count - 1 - m_StartNumber;
-                     i >= 0 && i >= m_List.Count - itemsPerPage - m_StartNumber;
+                for (var i = _displayList.Count - 1 - _startNumber;
+                     i >= 0 && i >= _displayList.Count - itemsPerPage - _startNumber;
                      i--)
                 {
-                    DrawEntry(m_List[i], i, itemNumber++);
+                    DrawEntry(ref builder, _displayList[i], i, itemNumber++);
                 }
             }
 
-            DrawEndingEntry(itemNumber);
+            DrawEndingEntry(ref builder, itemNumber);
+
+            BuildListExtras(ref builder);
         }
 
-        public virtual void DrawEndingEntry(int itemNumber)
+        protected virtual void BuildListExtras(ref DynamicGumpBuilder builder)
+        {
+        }
+
+        protected virtual void DrawEndingEntry(ref DynamicGumpBuilder builder, int itemNumber)
         {
         }
 
         public virtual bool HasRelationship(T o) => false;
 
-        public virtual void DrawEntry(T o, int index, int itemNumber)
+        protected virtual void DrawEntry(ref DynamicGumpBuilder builder, T o, int index, int itemNumber)
         {
             var width = 0;
-            for (var j = 0; j < m_Fields.Length; j++)
+            var values = GetValuesFor(o, _fields.Length);
+            for (var j = 0; j < _fields.Length; j++)
             {
-                var f = m_Fields[j];
+                var f = _fields[j];
 
-                AddImageTiled(65 + width, 138 + itemNumber * 28, f.Width + 10, 26, 0xA40);
-                AddImageTiled(67 + width, 140 + itemNumber * 28, f.Width + 6, 22, 0xBBC);
+                builder.AddImageTiled(65 + width, 138 + itemNumber * 28, f.Width + 10, 26, 0xA40);
+                builder.AddImageTiled(67 + width, 140 + itemNumber * 28, f.Width + 6, 22, 0xBBC);
                 AddHtmlText(
+                    ref builder,
                     70 + width,
                     141 + itemNumber * 28,
                     f.Width,
                     20,
-                    GetValuesFor(o, m_Fields.Length)[j],
+                    values[j],
                     false,
                     false
                 );
@@ -149,22 +158,23 @@ namespace Server.Guilds
 
             if (HasRelationship(o))
             {
-                AddButton(40, 143 + itemNumber * 28, 0x8AF, 0x8AF, 200 + index); // Info Button
+                builder.AddButton(40, 143 + itemNumber * 28, 0x8AF, 0x8AF, 200 + index); // Info Button
             }
             else
             {
-                AddButton(40, 143 + itemNumber * 28, 0x4B9, 0x4BA, 200 + index); // Info Button
+                builder.AddButton(40, 143 + itemNumber * 28, 0x4B9, 0x4BA, 200 + index); // Info Button
             }
         }
 
         protected abstract TextDefinition[] GetValuesFor(T o, int aryLength);
+
         protected abstract bool IsFiltered(T o, string filter);
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             base.OnResponse(sender, info);
 
-            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, guild))
+            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, Guild))
             {
                 return;
             }
@@ -176,52 +186,59 @@ namespace Server.Guilds
                 case 5: // Filter
                     {
                         var t = info.GetTextEntry(1);
-                        pm.SendGump(GetResentGump(player, guild, m_Comparer, m_Ascending, t ?? "", 0));
-                        break;
+                        _filter = (t ?? "").Trim();
+                        _startNumber = 0;
+                        pm.SendGump(this);
+                        return;
                     }
                 case 6: // Back
                     {
-                        pm.SendGump(
-                            GetResentGump(player, guild, m_Comparer, m_Ascending, m_Filter, m_StartNumber - itemsPerPage)
-                        );
-                        break;
+                        _startNumber -= itemsPerPage;
+                        pm.SendGump(this);
+                        return;
                     }
                 case 7: // Forward
                     {
-                        pm.SendGump(
-                            GetResentGump(player, guild, m_Comparer, m_Ascending, m_Filter, m_StartNumber + itemsPerPage)
-                        );
-                        break;
+                        _startNumber += itemsPerPage;
+                        pm.SendGump(this);
+                        return;
                     }
             }
 
-            if (id >= 100 && id < 100 + m_Fields.Length)
+            if (id >= 100 && id < 100 + _fields.Length)
             {
-                var comparer = m_Fields[id - 100].Comparer;
+                var comparer = _fields[id - 100].Comparer;
 
-                if (m_Comparer.GetType() == comparer.GetType())
+                if (_comparer.GetType() == comparer.GetType())
                 {
-                    m_Ascending = !m_Ascending;
+                    _ascending = !_ascending;
+                }
+                else
+                {
+                    _comparer = comparer;
                 }
 
-                pm.SendGump(GetResentGump(player, guild, comparer, m_Ascending, m_Filter, 0));
+                _startNumber = 0;
+                pm.SendGump(this);
             }
-            else if (id >= 200 && id < 200 + m_List.Count)
+            else if (id >= 200)
             {
-                pm.SendGump(GetObjectInfoGump(player, guild, m_List[id - 200]));
+                // The display list is rebuilt every render, so we use the most recent
+                // build to resolve the clicked entry.
+                var list = _displayList ?? _originalList;
+                var idx = id - 200;
+                if (idx < list.Count)
+                {
+                    pm.SendGump(GetObjectInfoGump(Player, Guild, list[idx]));
+                }
             }
         }
 
-        public abstract Gump GetResentGump(
-            PlayerMobile pm, Guild g, IComparer<T> comparer, bool ascending, string filter,
-            int startNumber
-        );
-
-        public abstract Gump GetObjectInfoGump(PlayerMobile pm, Guild g, T o);
+        public abstract BaseGump GetObjectInfoGump(PlayerMobile pm, Guild g, T o);
 
         public void ResendGump()
         {
-            player.SendGump(GetResentGump(player, guild, m_Comparer, m_Ascending, m_Filter, m_StartNumber));
+            Player.SendGump(this);
         }
     }
 

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/CreateGuildGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/CreateGuildGump.cs
@@ -4,43 +4,55 @@ using Server.Network;
 
 namespace Server.Guilds
 {
-    public class CreateGuildGump : Gump
+    public class CreateGuildGump : DynamicGump
     {
+        private readonly PlayerMobile _player;
+        private readonly string _guildName;
+        private readonly string _guildAbbrev;
+
         public override bool Singleton => true;
 
         public CreateGuildGump(PlayerMobile pm, string guildName = "Guild Name", string guildAbbrev = "") : base(10, 10)
         {
+            _player = pm;
+            _guildName = guildName;
+            _guildAbbrev = guildAbbrev;
+
             pm.CloseGump<BaseGuildGump>();
+        }
 
-            AddPage(0);
+        protected override void BuildLayout(ref DynamicGumpBuilder builder)
+        {
+            builder.AddPage();
 
-            AddBackground(0, 0, 500, 300, 0x2422);
-            AddHtmlLocalized(25, 20, 450, 25, 1062939, 0x0, true); // <center>GUILD MENU</center>
+            builder.AddBackground(0, 0, 500, 300, 0x2422);
+            builder.AddHtmlLocalized(25, 20, 450, 25, 1062939, 0x0, true); // <center>GUILD MENU</center>
 
-            // As you are not a member of any guild, you can create your own by providing a unique guild name and paying the standard guild registration fee.
-            AddHtmlLocalized(25, 60, 450, 60, 1062940, 0x0);
+            // As you are not a member of any guild, you can create your own by providing a unique guild name and
+            // paying the standard guild registration fee.
+            builder.AddHtmlLocalized(25, 60, 450, 60, 1062940, 0x0);
 
-            AddHtmlLocalized(25, 135, 120, 25, 1062941, 0x0); // Registration Fee:
-            AddLabel(155, 135, 0x481, Guild.RegistrationFee.ToString());
-            AddHtmlLocalized(25, 165, 120, 25, 1011140, 0x0); // Enter Guild Name:
-            AddBackground(155, 160, 320, 26, 0xBB8);
-            AddTextEntry(160, 163, 315, 21, 0x481, 5, guildName);
-            AddHtmlLocalized(25, 191, 120, 26, 1063035, 0x0); // Abbreviation:
-            AddBackground(155, 186, 320, 26, 0xBB8);
-            AddTextEntry(160, 189, 315, 21, 0x481, 6, guildAbbrev);
-            AddButton(415, 217, 0xF7, 0xF8, 1);
-            AddButton(345, 217, 0xF2, 0xF1, 0);
+            builder.AddHtmlLocalized(25, 135, 120, 25, 1062941, 0x0); // Registration Fee:
+            builder.AddLabel(155, 135, 0x481, $"{Guild.RegistrationFee}");
+            builder.AddHtmlLocalized(25, 165, 120, 25, 1011140, 0x0); // Enter Guild Name:
+            builder.AddBackground(155, 160, 320, 26, 0xBB8);
+            builder.AddTextEntry(160, 163, 315, 21, 0x481, 5, _guildName);
+            builder.AddHtmlLocalized(25, 191, 120, 26, 1063035, 0x0); // Abbreviation:
+            builder.AddBackground(155, 186, 320, 26, 0xBB8);
+            builder.AddTextEntry(160, 189, 315, 21, 0x481, 6, _guildAbbrev);
+            builder.AddButton(415, 217, 0xF7, 0xF8, 1);
+            builder.AddButton(345, 217, 0xF2, 0xF1, 0);
 
-            if (pm.AcceptGuildInvites)
+            if (_player.AcceptGuildInvites)
             {
-                AddButton(20, 260, 0xD2, 0xD3, 2);
+                builder.AddButton(20, 260, 0xD2, 0xD3, 2);
             }
             else
             {
-                AddButton(20, 260, 0xD3, 0xD2, 2);
+                builder.AddButton(20, 260, 0xD3, 0xD2, 2);
             }
 
-            AddHtmlLocalized(45, 260, 200, 30, 1062943, 0x0); // <i>Ignore Guild Invites</i>
+            builder.AddHtmlLocalized(45, 260, 200, 30, 1062943, 0x0); // <i>Ignore Guild Invites</i>
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/DiplomacyGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/DiplomacyGump.cs
@@ -14,8 +14,8 @@ namespace Server.Guilds
 
     public class GuildDiplomacyGump : BaseGuildListGump<Guild>
     {
-        private readonly TextDefinition m_LowerText;
-        private GuildDisplayType m_Display;
+        private readonly TextDefinition _lowerText;
+        private GuildDisplayType _display;
 
         public GuildDiplomacyGump(PlayerMobile pm, Guild g)
             : this(
@@ -85,9 +85,8 @@ namespace Server.Guilds
                 ]
             )
         {
-            m_Display = display;
-            m_LowerText = lowerText;
-            PopulateGump();
+            _display = display;
+            _lowerText = lowerText;
         }
 
         protected virtual bool AllowAdvancedSearch => true;
@@ -96,7 +95,7 @@ namespace Server.Guilds
         {
             get
             {
-                if (m_Display == GuildDisplayType.All)
+                if (_display == GuildDisplayType.All)
                 {
                     return base.WillFilter;
                 }
@@ -105,25 +104,23 @@ namespace Server.Guilds
             }
         }
 
-        public override void PopulateGump()
+        protected override void BuildListExtras(ref DynamicGumpBuilder builder)
         {
-            base.PopulateGump();
-
-            AddHtmlLocalized(431, 43, 110, 26, 1062978, 0xF); // Diplomacy
+            builder.AddHtmlLocalized(431, 43, 110, 26, 1062978, 0xF); // Diplomacy
         }
 
         protected override TextDefinition[] GetValuesFor(Guild g, int aryLength)
         {
             var defs = new TextDefinition[aryLength];
 
-            defs[0] = g == guild ? g.Name.Color(0x006600) : g.Name;
+            defs[0] = g == Guild ? g.Name.Color(0x006600) : g.Name;
             defs[1] = g.Abbreviation;
 
             defs[2] = 3000085; // Peace
 
-            if (guild.IsAlly(g))
+            if (Guild.IsAlly(g))
             {
-                if (guild.Alliance.Leader == g)
+                if (Guild.Alliance.Leader == g)
                 {
                     defs[2] = 1063237; // Alliance Leader
                 }
@@ -132,7 +129,7 @@ namespace Server.Guilds
                     defs[2] = 1062964; // Ally
                 }
             }
-            else if (guild.IsWar(g))
+            else if (Guild.IsWar(g))
             {
                 defs[2] = 3000086; // War
             }
@@ -142,17 +139,17 @@ namespace Server.Guilds
 
         public override bool HasRelationship(Guild g)
         {
-            if (g == guild)
+            if (g == Guild)
             {
                 return false;
             }
 
-            if (guild.FindPendingWar(g) != null)
+            if (Guild.FindPendingWar(g) != null)
             {
                 return true;
             }
 
-            var alliance = guild.Alliance;
+            var alliance = Guild.Alliance;
 
             if (alliance != null)
             {
@@ -160,7 +157,7 @@ namespace Server.Guilds
 
                 if (leader != null)
                 {
-                    if (guild == leader && alliance.IsPendingMember(g) || g == leader && alliance.IsPendingMember(guild))
+                    if (Guild == leader && alliance.IsPendingMember(g) || g == leader && alliance.IsPendingMember(Guild))
                     {
                         return true;
                     }
@@ -174,25 +171,22 @@ namespace Server.Guilds
             return false;
         }
 
-        public override void DrawEndingEntry(int itemNumber)
+        protected override void DrawEndingEntry(ref DynamicGumpBuilder builder, int itemNumber)
         {
-            // AddHtmlLocalized( 66, 153 + itemNumber * 28, 280, 26, 1063136 + (int)m_Display, 0xF, false, false ); // Showing All Guilds/Awaiting Action/ w/Relation Ship
-            // AddHtmlText( 66, 153 + itemNumber * 28, 280, 26, m_LowerText, false, false );
-
-            if (m_LowerText?.Number > 0)
+            if (_lowerText?.Number > 0)
             {
-                AddHtmlLocalized(66, 153 + itemNumber * 28, 280, 26, m_LowerText.Number, 0xF);
+                builder.AddHtmlLocalized(66, 153 + itemNumber * 28, 280, 26, _lowerText.Number, 0xF);
             }
-            else if (m_LowerText?.String != null)
+            else if (_lowerText?.String != null)
             {
-                AddHtml(66, 153 + itemNumber * 28, 280, 26, m_LowerText.String.Color(0x99));
+                builder.AddHtml(66, 153 + itemNumber * 28, 280, 26, _lowerText.String.Color(0x99));
             }
 
             if (AllowAdvancedSearch)
             {
-                AddBackground(350, 148 + itemNumber * 28, 200, 26, 0x2486);
-                AddButton(355, 153 + itemNumber * 28, 0x845, 0x846, 8);
-                AddHtmlLocalized(380, 151 + itemNumber * 28, 160, 26, 1063083, 0x0); // Advanced Search
+                builder.AddBackground(350, 148 + itemNumber * 28, 200, 26, 0x2486);
+                builder.AddButton(355, 153 + itemNumber * 28, 0x845, 0x846, 8);
+                builder.AddHtmlLocalized(380, 151 + itemNumber * 28, 160, 26, 1063083, 0x0); // Advanced Search
             }
         }
 
@@ -203,12 +197,12 @@ namespace Server.Guilds
                 return true;
             }
 
-            switch (m_Display)
+            switch (_display)
             {
                 case GuildDisplayType.Relations:
                     {
                         // As per OSI, only the guild leader wars show up under the sorting by relation
-                        return !(guild.FindActiveWar(g) != null || guild.IsAlly(g));
+                        return !(Guild.FindActiveWar(g) != null || Guild.IsAlly(g));
                     }
                 case GuildDisplayType.AwaitingAction:
                     {
@@ -219,15 +213,9 @@ namespace Server.Guilds
             return !(g.Name.InsensitiveContains(filter) || g.Abbreviation.InsensitiveContains(filter));
         }
 
-        public override Gump GetResentGump(
-            PlayerMobile pm, Guild g, IComparer<Guild> comparer, bool ascending,
-            string filter, int startNumber
-        ) =>
-            new GuildDiplomacyGump(pm, g, comparer, ascending, filter, startNumber, m_Display);
-
-        public override Gump GetObjectInfoGump(PlayerMobile pm, Guild g, Guild o)
+        public override BaseGump GetObjectInfoGump(PlayerMobile pm, Guild g, Guild o)
         {
-            if (guild == o)
+            if (Guild == o)
             {
                 return new GuildInfoGump(pm, g);
             }
@@ -239,20 +227,20 @@ namespace Server.Guilds
         {
             base.OnResponse(sender, info);
 
-            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, guild))
+            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, Guild))
             {
                 return;
             }
 
             if (AllowAdvancedSearch && info.ButtonID == 8)
             {
-                pm.SendGump(new GuildAdvancedSearchGump(pm, guild, m_Display, AdvancedSearch_Callback));
+                pm.SendGump(new GuildAdvancedSearchGump(pm, Guild, _display, AdvancedSearch_Callback));
             }
         }
 
         public void AdvancedSearch_Callback(GuildDisplayType display)
         {
-            m_Display = display;
+            _display = display;
             ResendGump();
         }
 
@@ -283,9 +271,9 @@ namespace Server.Guilds
 
         private class StatusComparer : IComparer<Guild>
         {
-            private readonly Guild m_Guild;
+            private readonly Guild _guild;
 
-            public StatusComparer(Guild g) => m_Guild = g;
+            public StatusComparer(Guild g) => _guild = g;
 
             public int Compare(Guild x, Guild y)
             {
@@ -307,20 +295,20 @@ namespace Server.Guilds
                 var aStatus = GuildCompareStatus.Peace;
                 var bStatus = GuildCompareStatus.Peace;
 
-                if (m_Guild.IsAlly(x))
+                if (_guild.IsAlly(x))
                 {
                     aStatus = GuildCompareStatus.Ally;
                 }
-                else if (m_Guild.IsWar(x))
+                else if (_guild.IsWar(x))
                 {
                     aStatus = GuildCompareStatus.War;
                 }
 
-                if (m_Guild.IsAlly(y))
+                if (_guild.IsAlly(y))
                 {
                     bStatus = GuildCompareStatus.Ally;
                 }
-                else if (m_Guild.IsWar(y))
+                else if (_guild.IsWar(y))
                 {
                     bStatus = GuildCompareStatus.War;
                 }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/GuildInfoGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/GuildInfoGump.cs
@@ -8,81 +8,76 @@ namespace Server.Guilds
 {
     public class GuildInfoGump : BaseGuildGump
     {
-        private readonly bool m_IsResigning;
+        private readonly bool _isResigning;
 
-        public GuildInfoGump(PlayerMobile pm, Guild g, bool isResigning = false) : base(pm, g)
+        public GuildInfoGump(PlayerMobile pm, Guild g, bool isResigning = false) : base(pm, g) => _isResigning = isResigning;
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
         {
-            m_IsResigning = isResigning;
-            PopulateGump();
-        }
+            var isLeader = IsLeader(Player, Guild);
 
-        public override void PopulateGump()
-        {
-            var isLeader = IsLeader(player, guild);
-            base.PopulateGump();
+            builder.AddHtmlLocalized(96, 43, 110, 26, 1063014, 0xF); // My Guild
 
-            AddHtmlLocalized(96, 43, 110, 26, 1063014, 0xF); // My Guild
+            builder.AddImageTiled(65, 80, 160, 26, 0xA40);
+            builder.AddImageTiled(67, 82, 156, 22, 0xBBC);
+            builder.AddHtmlLocalized(70, 83, 150, 20, 1062954, 0x0); // <i>Guild Name</i>
+            builder.AddHtml(233, 84, 320, 26, Guild.Name);
 
-            AddImageTiled(65, 80, 160, 26, 0xA40);
-            AddImageTiled(67, 82, 156, 22, 0xBBC);
-            AddHtmlLocalized(70, 83, 150, 20, 1062954, 0x0); // <i>Guild Name</i>
-            AddHtml(233, 84, 320, 26, guild.Name);
+            builder.AddImageTiled(65, 114, 160, 26, 0xA40);
+            builder.AddImageTiled(67, 116, 156, 22, 0xBBC);
+            builder.AddHtmlLocalized(70, 117, 150, 20, 1063025, 0x0); // <i>Alliance</i>
 
-            AddImageTiled(65, 114, 160, 26, 0xA40);
-            AddImageTiled(67, 116, 156, 22, 0xBBC);
-            AddHtmlLocalized(70, 117, 150, 20, 1063025, 0x0); // <i>Alliance</i>
-
-            if (guild.Alliance?.IsMember(guild) == true)
+            if (Guild.Alliance?.IsMember(Guild) == true)
             {
-                AddHtml(233, 118, 320, 26, guild.Alliance.Name);
-                AddButton(40, 120, 0x4B9, 0x4BA, 6); // Alliance Roster
+                builder.AddHtml(233, 118, 320, 26, Guild.Alliance.Name);
+                builder.AddButton(40, 120, 0x4B9, 0x4BA, 6); // Alliance Roster
             }
 
             if (Guild.OrderChaos && isLeader)
             {
-                AddButton(40, 154, 0x4B9, 0x4BA, 100); // Guild Faction
+                builder.AddButton(40, 154, 0x4B9, 0x4BA, 100); // Guild Faction
             }
 
-            AddImageTiled(65, 148, 160, 26, 0xA40);
-            AddImageTiled(67, 150, 156, 22, 0xBBC);
-            AddHtmlLocalized(70, 151, 150, 20, 1063084, 0x0); // <i>Guild Faction</i>
+            builder.AddImageTiled(65, 148, 160, 26, 0xA40);
+            builder.AddImageTiled(67, 150, 156, 22, 0xBBC);
+            builder.AddHtmlLocalized(70, 151, 150, 20, 1063084, 0x0); // <i>Guild Faction</i>
 
             GuildType gt;
             Faction f;
 
-            if ((gt = guild.Type) != GuildType.Regular)
+            if ((gt = Guild.Type) != GuildType.Regular)
             {
-                AddHtml(233, 152, 320, 26, gt.ToString());
+                builder.AddHtml(233, 152, 320, 26, $"{gt}");
             }
-            else if ((f = Faction.Find(guild.Leader)) != null)
+            else if ((f = Faction.Find(Guild.Leader)) != null)
             {
-                AddHtml(233, 152, 320, 26, f.ToString());
+                builder.AddHtml(233, 152, 320, 26, $"{f}");
             }
 
-            AddImageTiled(65, 196, 480, 4, 0x238D);
+            builder.AddImageTiled(65, 196, 480, 4, 0x238D);
 
-            var s = guild.Charter.DefaultIfNullOrEmpty("The guild leader has not yet set the guild charter.");
+            var s = Guild.Charter.DefaultIfNullOrEmpty("The guild leader has not yet set the guild charter.");
 
-            AddHtml(65, 216, 480, 80, s, true, true);
+            builder.AddHtml(65, 216, 480, 80, s, background: true, scrollbar: true);
             if (isLeader)
             {
-                AddButton(40, 251, 0x4B9, 0x4BA, 4); // Charter Edit button
+                builder.AddButton(40, 251, 0x4B9, 0x4BA, 4); // Charter Edit button
             }
 
-            s = guild.Website.DefaultIfNullOrEmpty("Guild website not yet set.");
+            s = Guild.Website.DefaultIfNullOrEmpty("Guild website not yet set.");
 
-            AddHtml(65, 306, 480, 30, s, true);
+            builder.AddHtml(65, 306, 480, 30, s, background: true);
             if (isLeader)
             {
-                AddButton(40, 313, 0x4B9, 0x4BA, 5); // Website Edit button
+                builder.AddButton(40, 313, 0x4B9, 0x4BA, 5); // Website Edit button
             }
 
-            AddCheck(65, 370, 0xD2, 0xD3, player.DisplayGuildTitle, 0);
-            AddHtmlLocalized(95, 370, 150, 26, 1063085, 0x0); // Show Guild Title
-            AddBackground(450, 370, 100, 26, 0x2486);
+            builder.AddCheckbox(65, 370, 0xD2, 0xD3, Player.DisplayGuildTitle, 0);
+            builder.AddHtmlLocalized(95, 370, 150, 26, 1063085, 0x0); // Show Guild Title
+            builder.AddBackground(450, 370, 100, 26, 0x2486);
 
-            AddButton(455, 375, 0x845, 0x846, 7);
-            AddHtmlLocalized(480, 373, 60, 26, 3006115, m_IsResigning ? 0x5000 : 0); // Resign
+            builder.AddButton(455, 375, 0x845, 0x846, 7);
+            builder.AddHtmlLocalized(480, 373, 60, 26, 3006115, _isResigning ? 0x5000 : 0); // Resign
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
@@ -91,7 +86,7 @@ namespace Server.Guilds
 
             var pm = (PlayerMobile)sender.Mobile;
 
-            if (!IsMember(pm, guild))
+            if (!IsMember(pm, Guild))
             {
                 return;
             }
@@ -103,27 +98,23 @@ namespace Server.Guilds
                 // 1-3 handled by base.OnResponse
                 case 4:
                     {
-                        if (IsLeader(pm, guild))
+                        if (IsLeader(pm, Guild))
                         {
                             pm.SendLocalizedMessage(1013071); // Enter the new guild charter (50 characters max):
 
-                            pm.BeginPrompt(
-                                SetCharter_Callback,
-                                true
-                            ); // Have the same callback handle both canceling and deletion cause the 2nd callback would just get a text of ""
+                            // Have the same callback handle both canceling and deletion cause the 2nd callback would
+                            // just get a text of ""
+                            pm.BeginPrompt(SetCharter_Callback, true);
                         }
 
                         break;
                     }
                 case 5:
                     {
-                        if (IsLeader(pm, guild))
+                        if (IsLeader(pm, Guild))
                         {
                             pm.SendLocalizedMessage(1013072); // Enter the new website for the guild (50 characters max):
-                            pm.BeginPrompt(
-                                SetWebsite_Callback,
-                                true
-                            ); // Have the same callback handle both canceling and deletion cause the 2nd callback would just get a text of ""
+                            pm.BeginPrompt(SetWebsite_Callback, true);
                         }
 
                         break;
@@ -131,9 +122,9 @@ namespace Server.Guilds
                 case 6:
                     {
                         // Alliance Roster
-                        if (guild.Alliance?.IsMember(guild) == true)
+                        if (Guild.Alliance?.IsMember(Guild) == true)
                         {
-                            pm.SendGump(new AllianceInfo.AllianceRosterGump(pm, guild, guild.Alliance));
+                            pm.SendGump(new AllianceInfo.AllianceRosterGump(pm, Guild, Guild.Alliance));
                         }
 
                         break;
@@ -141,14 +132,14 @@ namespace Server.Guilds
                 case 7:
                     {
                         // Resign
-                        if (!m_IsResigning)
+                        if (!_isResigning)
                         {
                             pm.SendLocalizedMessage(1063332); // Are you sure you wish to resign from your guild?
-                            pm.SendGump(new GuildInfoGump(pm, guild, true));
+                            pm.SendGump(new GuildInfoGump(pm, Guild, true));
                         }
                         else
                         {
-                            guild.RemoveMember(pm, 1063411); // You resign from your guild.
+                            Guild.RemoveMember(pm, 1063411); // You resign from your guild.
                         }
 
                         break;
@@ -156,9 +147,9 @@ namespace Server.Guilds
                 case 100: // Custom code to support Order/Chaos in the new guild system
                     {
                         // Guild Faction
-                        if (Guild.OrderChaos && IsLeader(pm, guild))
+                        if (Guild.OrderChaos && IsLeader(pm, Guild))
                         {
-                            GuildChangeTypeGump.DisplayTo(pm, guild);
+                            GuildChangeTypeGump.DisplayTo(pm, Guild);
                         }
 
                         break;
@@ -168,7 +159,7 @@ namespace Server.Guilds
 
         public void SetCharter_Callback(Mobile from, string text)
         {
-            if (!IsLeader(from, guild))
+            if (!IsLeader(from, Guild))
             {
                 return;
             }
@@ -181,14 +172,14 @@ namespace Server.Guilds
             }
             else
             {
-                guild.Charter = charter;
+                Guild.Charter = charter;
                 from.SendLocalizedMessage(1070775); // You submit a new guild charter.
             }
         }
 
         public void SetWebsite_Callback(Mobile from, string text)
         {
-            if (!IsLeader(from, guild))
+            if (!IsLeader(from, Guild))
             {
                 return;
             }
@@ -201,7 +192,7 @@ namespace Server.Guilds
             }
             else
             {
-                guild.Website = site;
+                Guild.Website = site;
                 from.SendLocalizedMessage(1070778); // You submit a new guild website.
             }
         }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/GuildInvitationRequest.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/GuildInvitationRequest.cs
@@ -6,39 +6,30 @@ namespace Server.Guilds
 {
     public class GuildInvitationRequest : BaseGuildGump
     {
-        private readonly PlayerMobile m_Inviter;
+        private readonly PlayerMobile _inviter;
 
         public GuildInvitationRequest(PlayerMobile pm, Guild g, PlayerMobile inviter) : base(pm, g)
         {
-            m_Inviter = inviter;
-
-            PopulateGump();
+            _inviter = inviter;
         }
 
-        public override void PopulateGump()
-        {
-            AddPage(0);
+        protected override bool ShowTabStrip => false;
 
-            AddBackground(0, 0, 350, 170, 0x2422);
-            AddHtmlLocalized(
-                25,
-                20,
-                300,
-                45,
-                1062946,
-                0x0,
-                true
-            ); // <center>You have been invited to join a guild! (Warning: Accepting will make you attackable!)</center>
-            AddHtml(25, 75, 300, 25, $"<center>{guild.Name}</center>", true);
-            AddButton(265, 130, 0xF7, 0xF8, 1);
-            AddButton(195, 130, 0xF2, 0xF1, 0);
-            AddButton(20, 130, 0xD2, 0xD3, 2);
-            AddHtmlLocalized(45, 130, 150, 30, 1062943, 0x0); // <i>Ignore Guild Invites</i>
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
+        {
+            builder.AddBackground(0, 0, 350, 170, 0x2422);
+            // <center>You have been invited to join a guild! (Warning: Accepting will make you attackable!)</center>
+            builder.AddHtmlLocalized(25, 20, 300, 45, 1062946, 0x0, true);
+            builder.AddHtml(25, 75, 300, 25, $"<center>{Guild.Name}</center>", background: true);
+            builder.AddButton(265, 130, 0xF7, 0xF8, 1);
+            builder.AddButton(195, 130, 0xF2, 0xF1, 0);
+            builder.AddButton(20, 130, 0xD2, 0xD3, 2);
+            builder.AddHtmlLocalized(45, 130, 150, 30, 1062943, 0x0); // <i>Ignore Guild Invites</i>
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (guild.Disbanded || player.Guild != null)
+            if (Guild.Disbanded || Player.Guild != null)
             {
                 return;
             }
@@ -47,27 +38,23 @@ namespace Server.Guilds
             {
                 case 0:
                     {
-                        m_Inviter.SendLocalizedMessage(
-                            1063250,
-                            $"{player.Name}\t{guild.Name}"
-                        ); // ~1_val~ has declined your invitation to join ~2_val~.
+                        // ~1_val~ has declined your invitation to join ~2_val~.
+                        _inviter.SendLocalizedMessage(1063250, $"{Player.Name}\t{Guild.Name}");
                         break;
                     }
                 case 1:
                     {
-                        guild.AddMember(player);
-                        player.SendLocalizedMessage(1063056, guild.Name); // You have joined ~1_val~.
-                        m_Inviter.SendLocalizedMessage(
-                            1063249,
-                            $"{player.Name}\t{guild.Name}"
-                        ); // ~1_val~ has accepted your invitation to join ~2_val~.
+                        Guild.AddMember(Player);
+                        Player.SendLocalizedMessage(1063056, Guild.Name); // You have joined ~1_val~.
+                        // ~1_val~ has accepted your invitation to join ~2_val~.
+                        _inviter.SendLocalizedMessage(1063249, $"{Player.Name}\t{Guild.Name}");
 
                         break;
                     }
                 case 2:
                     {
-                        player.AcceptGuildInvites = false;
-                        player.SendLocalizedMessage(1070698); // You are now ignoring guild invitations.
+                        Player.AcceptGuildInvites = false;
+                        Player.SendLocalizedMessage(1070698); // You are now ignoring guild invitations.
 
                         break;
                     }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/GuildMemberInfoGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/GuildMemberInfoGump.cs
@@ -7,75 +7,74 @@ namespace Server.Guilds
 {
     public class GuildMemberInfoGump : BaseGuildGump
     {
-        private readonly PlayerMobile m_Member;
-        private readonly bool m_toKick;
-        private readonly bool m_ToLeader;
+        private readonly PlayerMobile _member;
+        private readonly bool _toKick;
+        private readonly bool _toLeader;
 
         public GuildMemberInfoGump(
             PlayerMobile pm, Guild g, PlayerMobile member, bool toKick, bool toPromoteToLeader
         ) : base(pm, g, 10, 40)
         {
-            m_ToLeader = toPromoteToLeader;
-            m_toKick = toKick;
-            m_Member = member;
-            PopulateGump();
+            _toLeader = toPromoteToLeader;
+            _toKick = toKick;
+            _member = member;
         }
 
-        public override void PopulateGump()
+        protected override bool ShowTabStrip => false;
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
         {
-            AddPage(0);
+            builder.AddBackground(0, 0, 350, 255, 0x242C);
+            builder.AddHtmlLocalized(20, 15, 310, 26, 1063018, 0x0); // <div align=center><i>Guild Member Information</i></div>
+            builder.AddImageTiled(20, 40, 310, 2, 0x2711);
 
-            AddBackground(0, 0, 350, 255, 0x242C);
-            AddHtmlLocalized(20, 15, 310, 26, 1063018, 0x0); // <div align=center><i>Guild Member Information</i></div>
-            AddImageTiled(20, 40, 310, 2, 0x2711);
+            builder.AddHtmlLocalized(20, 50, 150, 26, 1062955, 0x0, true); // <i>Name</i>
+            builder.AddHtml(180, 53, 150, 26, _member.Name);
 
-            AddHtmlLocalized(20, 50, 150, 26, 1062955, 0x0, true); // <i>Name</i>
-            AddHtml(180, 53, 150, 26, m_Member.Name);
+            builder.AddHtmlLocalized(20, 80, 150, 26, 1062956, 0x0, true); // <i>Rank</i>
+            builder.AddHtmlLocalized(180, 83, 150, 26, _member.GuildRank.Name, 0x0);
 
-            AddHtmlLocalized(20, 80, 150, 26, 1062956, 0x0, true); // <i>Rank</i>
-            AddHtmlLocalized(180, 83, 150, 26, m_Member.GuildRank.Name, 0x0);
+            builder.AddHtmlLocalized(20, 110, 150, 26, 1062953, 0x0, true); // <i>Guild Title</i>
+            builder.AddHtml(180, 113, 150, 26, _member.GuildTitle);
+            builder.AddImageTiled(20, 142, 310, 2, 0x2711);
 
-            AddHtmlLocalized(20, 110, 150, 26, 1062953, 0x0, true); // <i>Guild Title</i>
-            AddHtml(180, 113, 150, 26, m_Member.GuildTitle);
-            AddImageTiled(20, 142, 310, 2, 0x2711);
-
-            AddBackground(20, 150, 310, 26, 0x2486);
-            AddButton(25, 155, 0x845, 0x846, 4);
-            AddHtmlLocalized(
+            builder.AddBackground(20, 150, 310, 26, 0x2486);
+            builder.AddButton(25, 155, 0x845, 0x846, 4);
+            builder.AddHtmlLocalized(
                 50,
                 153,
                 270,
                 26,
-                m_Member == player.GuildFealty && guild.Leader != m_Member ? 1063082 : 1062996,
+                _member == Player.GuildFealty && Guild.Leader != _member ? 1063082 : 1062996,
                 0x0
             ); // Clear/Cast Vote For This Member
 
-            AddBackground(20, 180, 150, 26, 0x2486);
-            AddButton(25, 185, 0x845, 0x846, 1);
-            AddHtmlLocalized(50, 183, 110, 26, 1062993, m_ToLeader ? 0x990000 : 0); // Promote
+            builder.AddBackground(20, 180, 150, 26, 0x2486);
+            builder.AddButton(25, 185, 0x845, 0x846, 1);
+            builder.AddHtmlLocalized(50, 183, 110, 26, 1062993, _toLeader ? 0x990000 : 0); // Promote
 
-            AddBackground(180, 180, 150, 26, 0x2486);
-            AddButton(185, 185, 0x845, 0x846, 3);
-            AddHtmlLocalized(210, 183, 110, 26, 1062995, 0x0); // Set Guild Title
+            builder.AddBackground(180, 180, 150, 26, 0x2486);
+            builder.AddButton(185, 185, 0x845, 0x846, 3);
+            builder.AddHtmlLocalized(210, 183, 110, 26, 1062995, 0x0); // Set Guild Title
 
-            AddBackground(20, 210, 150, 26, 0x2486);
-            AddButton(25, 215, 0x845, 0x846, 2);
-            AddHtmlLocalized(50, 213, 110, 26, 1062994, 0x0); // Demote
+            builder.AddBackground(20, 210, 150, 26, 0x2486);
+            builder.AddButton(25, 215, 0x845, 0x846, 2);
+            builder.AddHtmlLocalized(50, 213, 110, 26, 1062994, 0x0); // Demote
 
-            AddBackground(180, 210, 150, 26, 0x2486);
-            AddButton(185, 215, 0x845, 0x846, 5);
-            AddHtmlLocalized(210, 213, 110, 26, 1062997, m_toKick ? 0x5000 : 0); // Kick
+            builder.AddBackground(180, 210, 150, 26, 0x2486);
+            builder.AddButton(185, 215, 0x845, 0x846, 5);
+            builder.AddHtmlLocalized(210, 213, 110, 26, 1062997, _toKick ? 0x5000 : 0); // Kick
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, guild) || !IsMember(m_Member, guild))
+            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, Guild) || !IsMember(_member, Guild))
             {
                 return;
             }
 
             var playerRank = pm.GuildRank;
-            var targetRank = m_Member.GuildRank;
+            var targetRank = _member.GuildRank;
 
             switch (info.ButtonID)
             {
@@ -89,34 +88,26 @@ namespace Server.Guilds
 
                             if (targetRank == RankDefinition.Leader)
                             {
-                                if (m_ToLeader)
+                                if (_toLeader)
                                 {
-                                    m_Member.GuildRank = targetRank;
-                                    pm.SendLocalizedMessage(
-                                        1063156,
-                                        m_Member.Name
-                                    ); // The guild information for ~1_val~ has been updated.
-                                    pm.SendLocalizedMessage(
-                                        1063156,
-                                        pm.Name
-                                    ); // The guild information for ~1_val~ has been updated.
-                                    guild.Leader = m_Member;
+                                    _member.GuildRank = targetRank;
+                                    // The guild information for ~1_val~ has been updated.
+                                    pm.SendLocalizedMessage(1063156, _member.Name);
+                                    pm.SendLocalizedMessage(1063156, pm.Name);
+                                    Guild.Leader = _member;
                                 }
                                 else
                                 {
-                                    pm.SendLocalizedMessage(
-                                        1063144
-                                    ); // Are you sure you wish to make this member the new guild leader?
-                                    pm.SendGump(new GuildMemberInfoGump(player, guild, m_Member, false, true));
+                                    // Are you sure you wish to make this member the new guild leader?
+                                    pm.SendLocalizedMessage(1063144);
+                                    pm.SendGump(new GuildMemberInfoGump(Player, Guild, _member, false, true));
                                 }
                             }
                             else
                             {
-                                m_Member.GuildRank = targetRank;
-                                pm.SendLocalizedMessage(
-                                    1063156,
-                                    m_Member.Name
-                                ); // The guild information for ~1_val~ has been updated.
+                                _member.GuildRank = targetRank;
+                                // The guild information for ~1_val~ has been updated.
+                                pm.SendLocalizedMessage(1063156, _member.Name);
                             }
                         }
                         else
@@ -143,11 +134,9 @@ namespace Server.Guilds
                             }
                             else
                             {
-                                m_Member.GuildRank = RankDefinition.Ranks[targetRank.Rank - 1];
-                                pm.SendLocalizedMessage(
-                                    1063156,
-                                    m_Member.Name
-                                ); // The guild information for ~1_val~ has been updated.
+                                _member.GuildRank = RankDefinition.Ranks[targetRank.Rank - 1];
+                                // The guild information for ~1_val~ has been updated.
+                                pm.SendLocalizedMessage(1063156, _member.Name);
                             }
                         }
                         else
@@ -160,52 +149,47 @@ namespace Server.Guilds
                 case 3: // Set Guild title
                     {
                         if (playerRank.GetFlag(RankFlags.CanSetGuildTitle) &&
-                            (playerRank.Rank > targetRank.Rank || m_Member == player))
+                            (playerRank.Rank > targetRank.Rank || _member == Player))
                         {
-                            pm.SendLocalizedMessage(
-                                1011128
-                            ); // Enter the new title for this guild member or 'none' to remove a title:
+                            // Enter the new title for this guild member or 'none' to remove a title:
+                            pm.SendLocalizedMessage(1011128);
 
                             pm.BeginPrompt(SetTitle_Callback);
                         }
-                        else if (m_Member.GuildTitle == null || m_Member.GuildTitle.Length <= 0)
+                        else if (_member.GuildTitle == null || _member.GuildTitle.Length <= 0)
                         {
-                            pm.SendLocalizedMessage(
-                                1070746
-                            ); // You don't have the permission to set that member's guild title.
+                            // You don't have the permission to set that member's guild title.
+                            pm.SendLocalizedMessage(1070746);
                         }
                         else
                         {
-                            pm.SendLocalizedMessage(
-                                1063148
-                            ); // You don't have permission to change this member's guild title.
+                            // You don't have permission to change this member's guild title.
+                            pm.SendLocalizedMessage(1063148);
                         }
 
                         break;
                     }
                 case 4: // Vote
                     {
-                        if (m_Member == pm.GuildFealty && guild.Leader != m_Member)
+                        if (_member == pm.GuildFealty && Guild.Leader != _member)
                         {
                             pm.SendLocalizedMessage(1063158); // You have cleared your vote for guild leader.
                         }
-                        else if (guild.CanVote(m_Member))
+                        else if (Guild.CanVote(_member))
                         {
-                            if (m_Member == guild.Leader)
+                            if (_member == Guild.Leader)
                             {
                                 pm.SendLocalizedMessage(1063424); // You can't vote for the current guild leader.
                             }
-                            else if (!guild.CanBeVotedFor(m_Member))
+                            else if (!Guild.CanBeVotedFor(_member))
                             {
                                 pm.SendLocalizedMessage(1063425); // You can't vote for an inactive guild member.
                             }
                             else
                             {
-                                pm.GuildFealty = m_Member;
-                                pm.SendLocalizedMessage(
-                                    1063159,
-                                    m_Member.Name
-                                ); // You cast your vote for ~1_val~ for guild leader.
+                                pm.GuildFealty = _member;
+                                // You cast your vote for ~1_val~ for guild leader.
+                                pm.SendLocalizedMessage(1063159, _member.Name);
                             }
                         }
                         else
@@ -220,17 +204,16 @@ namespace Server.Guilds
                         if (playerRank.GetFlag(RankFlags.RemovePlayers) && playerRank.Rank > targetRank.Rank ||
                             playerRank.GetFlag(RankFlags.RemoveLowestRank) && targetRank == RankDefinition.Lowest)
                         {
-                            if (m_toKick)
+                            if (_toKick)
                             {
-                                guild.RemoveMember(m_Member);
+                                Guild.RemoveMember(_member);
                                 pm.SendLocalizedMessage(1063157); // The member has been removed from your guild.
                             }
                             else
                             {
-                                pm.SendLocalizedMessage(
-                                    1063152
-                                ); // Are you sure you wish to kick this member from the guild?
-                                pm.SendGump(new GuildMemberInfoGump(player, guild, m_Member, true, false));
+                                // Are you sure you wish to kick this member from the guild?
+                                pm.SendLocalizedMessage(1063152);
+                                pm.SendGump(new GuildMemberInfoGump(Player, Guild, _member, true, false));
                             }
                         }
                         else
@@ -245,22 +228,24 @@ namespace Server.Guilds
 
         public void SetTitle_Callback(Mobile from, string text)
         {
-            if (from is not PlayerMobile pm || m_Member == null)
+            if (from is not PlayerMobile pm || _member == null)
             {
                 return;
             }
 
-            if (m_Member.Guild is not Guild g || !IsMember(pm, g) ||
+            if (_member.Guild is not Guild g || !IsMember(pm, g) ||
                 !(pm.GuildRank.GetFlag(RankFlags.CanSetGuildTitle) &&
-                  (pm.GuildRank.Rank > m_Member.GuildRank.Rank || pm == m_Member)))
+                  (pm.GuildRank.Rank > _member.GuildRank.Rank || pm == _member)))
             {
-                if (m_Member.GuildTitle == null || m_Member.GuildTitle.Length <= 0)
+                if (_member.GuildTitle == null || _member.GuildTitle.Length <= 0)
                 {
-                    pm.SendLocalizedMessage(1070746); // You don't have the permission to set that member's guild title.
+                    // You don't have the permission to set that member's guild title.
+                    pm.SendLocalizedMessage(1070746);
                 }
                 else
                 {
-                    pm.SendLocalizedMessage(1063148); // You don't have permission to change this member's guild title.
+                    // You don't have permission to change this member's guild title.
+                    pm.SendLocalizedMessage(1063148);
                 }
 
                 return;
@@ -278,16 +263,10 @@ namespace Server.Guilds
             }
             else
             {
-                if (title.InsensitiveEquals("none"))
-                {
-                    m_Member.GuildTitle = null;
-                }
-                else
-                {
-                    m_Member.GuildTitle = title;
-                }
+                _member.GuildTitle = title.InsensitiveEquals("none") ? null : title;
 
-                pm.SendLocalizedMessage(1063156, m_Member.Name); // The guild information for ~1_val~ has been updated.
+                // The guild information for ~1_val~ has been updated.
+                pm.SendLocalizedMessage(1063156, _member.Name);
             }
         }
     }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/GuildRosterGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/GuildRosterGump.cs
@@ -9,7 +9,7 @@ namespace Server.Guilds
 {
     public class GuildRosterGump : BaseGuildListGump<PlayerMobile>
     {
-        private static readonly InfoField<PlayerMobile>[] m_Fields =
+        private static readonly InfoField<PlayerMobile>[] _fields =
         [
             new(1062955, 130, NameComparer.Instance),  // Name
             new(1062956, 80, RankComparer.Instance),   // Rank
@@ -33,33 +33,30 @@ namespace Server.Guilds
                 ascending,
                 filter,
                 startNumber,
-                m_Fields
+                _fields
             )
         {
-            PopulateGump();
         }
 
-        public override void PopulateGump()
+        protected override void BuildListExtras(ref DynamicGumpBuilder builder)
         {
-            base.PopulateGump();
-
-            AddHtmlLocalized(266, 43, 110, 26, 1062974, 0xF); // Guild Roster
+            builder.AddHtmlLocalized(266, 43, 110, 26, 1062974, 0xF); // Guild Roster
         }
 
-        public override void DrawEndingEntry(int itemNumber)
+        protected override void DrawEndingEntry(ref DynamicGumpBuilder builder, int itemNumber)
         {
-            AddBackground(225, 148 + itemNumber * 28, 150, 26, 0x2486);
-            AddButton(230, 153 + itemNumber * 28, 0x845, 0x846, 8);
-            AddHtmlLocalized(255, 151 + itemNumber * 28, 110, 26, 1062992, 0x0); // Invite Player
+            builder.AddBackground(225, 148 + itemNumber * 28, 150, 26, 0x2486);
+            builder.AddButton(230, 153 + itemNumber * 28, 0x845, 0x846, 8);
+            builder.AddHtmlLocalized(255, 151 + itemNumber * 28, 110, 26, 1062992, 0x0); // Invite Player
         }
 
         protected override TextDefinition[] GetValuesFor(PlayerMobile pm, int aryLength)
         {
             var defs = new TextDefinition[aryLength];
 
-            var name = $"{pm.Name}{(player.GuildFealty == pm && player.GuildFealty != guild.Leader ? " *" : "")}";
+            var name = $"{pm.Name}{(Player.GuildFealty == pm && Player.GuildFealty != Guild.Leader ? " *" : "")}";
 
-            if (pm == player)
+            if (pm == Player)
             {
                 name = name.Color(0x006600);
             }
@@ -86,20 +83,14 @@ namespace Server.Guilds
             return !pm.Name.InsensitiveContains(filter);
         }
 
-        public override Gump GetResentGump(
-            PlayerMobile pm, Guild g, IComparer<PlayerMobile> comparer, bool ascending,
-            string filter, int startNumber
-        ) =>
-            new GuildRosterGump(pm, g, comparer, ascending, filter, startNumber);
-
-        public override Gump GetObjectInfoGump(PlayerMobile pm, Guild g, PlayerMobile o) =>
+        public override BaseGump GetObjectInfoGump(PlayerMobile pm, Guild g, PlayerMobile o) =>
             new GuildMemberInfoGump(pm, g, o, false, false);
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             base.OnResponse(sender, info);
 
-            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, guild))
+            if (sender.Mobile is not PlayerMobile pm || !IsMember(pm, Guild))
             {
                 return;
             }
@@ -109,7 +100,7 @@ namespace Server.Guilds
                 if (pm.GuildRank.GetFlag(RankFlags.CanInvitePlayer))
                 {
                     pm.SendLocalizedMessage(1063048); // Whom do you wish to invite into your guild?
-                    pm.BeginTarget(-1, false, TargetFlags.None, InvitePlayer_Callback, guild);
+                    pm.BeginTarget(-1, false, TargetFlags.None, InvitePlayer_Callback, Guild);
                 }
                 else
                 {
@@ -129,7 +120,7 @@ namespace Server.Guilds
             var guildFaction = guildState?.Faction;
             var targetFaction = targetState?.Faction;
 
-            if (pm == null || !IsMember(pm, guild) || !pm.GuildRank.GetFlag(RankFlags.CanInvitePlayer))
+            if (pm == null || !IsMember(pm, Guild) || !pm.GuildRank.GetFlag(RankFlags.CanInvitePlayer))
             {
                 from.SendLocalizedMessage(503301); // You don't have permission to do that.
             }
@@ -181,7 +172,7 @@ namespace Server.Guilds
             else
             {
                 pm.SendLocalizedMessage(1063053, targ.Name); // You invite ~1_val~ to join your guild.
-                targ.SendGump(new GuildInvitationRequest(targ, guild, pm));
+                targ.SendGump(new GuildInvitationRequest(targ, Guild, pm));
             }
         }
 

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/OtherGuildInfo.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/OtherGuildInfo.cs
@@ -8,55 +8,55 @@ namespace Server.Guilds
 {
     public class OtherGuildInfo : BaseGuildGump
     {
-        private readonly Guild m_Other;
+        private readonly Guild _other;
 
         public OtherGuildInfo(PlayerMobile pm, Guild g, Guild otherGuild) : base(pm, g, 10, 40)
         {
-            m_Other = otherGuild;
+            _other = otherGuild;
 
             g.CheckExpiredWars();
-
-            PopulateGump();
         }
 
-        public void AddButtonAndBackground(int x, int y, int buttonID, int locNum)
+        protected override bool ShowTabStrip => false;
+
+        private static void AddButtonAndBackground(ref DynamicGumpBuilder builder, int x, int y, int buttonID, int locNum)
         {
-            AddBackground(x, y, 225, 26, 0x2486);
-            AddButton(x + 5, y + 5, 0x845, 0x846, buttonID);
-            AddHtmlLocalized(x + 30, y + 3, 185, 26, locNum, 0x0);
+            builder.AddBackground(x, y, 225, 26, 0x2486);
+            builder.AddButton(x + 5, y + 5, 0x845, 0x846, buttonID);
+            builder.AddHtmlLocalized(x + 30, y + 3, 185, 26, locNum, 0x0);
         }
 
-        public override void PopulateGump()
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
         {
-            var g = Guild.GetAllianceLeader(guild);
-            var other = Guild.GetAllianceLeader(m_Other);
+            builder.AddBackground(0, 0, 520, 335, 0x242C);
+
+            var g = Guild.GetAllianceLeader(Guild);
+            var other = Guild.GetAllianceLeader(_other);
 
             var war = g.FindPendingWar(other);
             var activeWar = g.FindActiveWar(other);
 
-            var alliance = guild.Alliance;
-            var otherAlliance = m_Other.Alliance;
+            var alliance = Guild.Alliance;
+            var otherAlliance = _other.Alliance;
             // NOTE TO SELF: Only only alliance leader can see pending guild alliance statuses
 
-            var PendingWar = war != null;
-            var ActiveWar = activeWar != null;
-            AddPage(0);
+            var pendingWar = war != null;
+            var activeWarFlag = activeWar != null;
 
-            AddBackground(0, 0, 520, 335, 0x242C);
-            AddHtmlLocalized(20, 15, 480, 26, 1062975, 0x0); // <div align=center><i>Guild Relationship</i></div>
-            AddImageTiled(20, 40, 480, 2, 0x2711);
-            AddHtmlLocalized(20, 50, 120, 26, 1062954, 0x0, true); // <i>Guild Name</i>
-            AddHtml(150, 53, 360, 26, m_Other.Name);
+            builder.AddHtmlLocalized(20, 15, 480, 26, 1062975, 0x0); // <div align=center><i>Guild Relationship</i></div>
+            builder.AddImageTiled(20, 40, 480, 2, 0x2711);
+            builder.AddHtmlLocalized(20, 50, 120, 26, 1062954, 0x0, true); // <i>Guild Name</i>
+            builder.AddHtml(150, 53, 360, 26, _other.Name);
 
-            AddHtmlLocalized(20, 80, 120, 26, 1063025, 0x0, true); // <i>Alliance</i>
+            builder.AddHtmlLocalized(20, 80, 120, 26, 1063025, 0x0, true); // <i>Alliance</i>
 
-            if (otherAlliance?.IsMember(m_Other) == true)
+            if (otherAlliance?.IsMember(_other) == true)
             {
-                AddHtml(150, 83, 360, 26, otherAlliance.Name);
+                builder.AddHtml(150, 83, 360, 26, otherAlliance.Name);
             }
 
-            AddHtmlLocalized(20, 110, 120, 26, 1063139, 0x0, true); // <i>Abbreviation</i>
-            AddHtml(150, 113, 120, 26, m_Other.Abbreviation);
+            builder.AddHtmlLocalized(20, 110, 120, 26, 1063139, 0x0, true); // <i>Abbreviation</i>
+            builder.AddHtml(150, 113, 120, 26, _other.Abbreviation);
 
             var kills = "0/0";
             var time = "00:00";
@@ -64,7 +64,7 @@ namespace Server.Guilds
 
             WarDeclaration otherWar;
 
-            if (ActiveWar)
+            if (activeWarFlag)
             {
                 kills = $"{activeWar.Kills}/{activeWar.MaxKills}";
 
@@ -77,38 +77,38 @@ namespace Server.Guilds
 
                 time = $"{timeRemaining.Hours:D2}:{DateTime.MinValue + timeRemaining:mm}";
 
-                otherWar = m_Other.FindActiveWar(guild);
+                otherWar = _other.FindActiveWar(Guild);
                 if (otherWar != null)
                 {
                     otherKills = $"{otherWar.Kills}/{otherWar.MaxKills}";
                 }
             }
-            else if (PendingWar)
+            else if (pendingWar)
             {
                 kills = Html.Color($"{war.Kills}/{war.MaxKills}", 0x990000);
                 time = Html.Color($"{war.WarLength.Hours:D2}:{DateTime.MinValue + war.WarLength:mm}", 0x990000);
 
-                otherWar = m_Other.FindPendingWar(guild);
+                otherWar = _other.FindPendingWar(Guild);
                 if (otherWar != null)
                 {
                     otherKills = Html.Color($"{otherWar.Kills}/{otherWar.MaxKills}", 0x990000);
                 }
             }
 
-            AddHtmlLocalized(280, 110, 120, 26, 1062966, 0x0, true); // <i>Your Kills</i>
-            AddHtml(410, 113, 120, 26, kills);
+            builder.AddHtmlLocalized(280, 110, 120, 26, 1062966, 0x0, true); // <i>Your Kills</i>
+            builder.AddHtml(410, 113, 120, 26, kills);
 
-            AddHtmlLocalized(20, 140, 120, 26, 1062968, 0x0, true); // <i>Time Remaining</i>
-            AddHtml(150, 143, 120, 26, time);
+            builder.AddHtmlLocalized(20, 140, 120, 26, 1062968, 0x0, true); // <i>Time Remaining</i>
+            builder.AddHtml(150, 143, 120, 26, time);
 
-            AddHtmlLocalized(280, 140, 120, 26, 1062967, 0x0, true); // <i>Their Kills</i>
-            AddHtml(410, 143, 120, 26, otherKills);
+            builder.AddHtmlLocalized(280, 140, 120, 26, 1062967, 0x0, true); // <i>Their Kills</i>
+            builder.AddHtml(410, 143, 120, 26, otherKills);
 
-            AddImageTiled(20, 172, 480, 2, 0x2711);
+            builder.AddImageTiled(20, 172, 480, 2, 0x2711);
 
             var number = 1062973; // <div align=center>You are at peace with this guild.</div>
 
-            if (PendingWar)
+            if (pendingWar)
             {
                 if (war.WarRequester)
                 {
@@ -118,92 +118,92 @@ namespace Server.Guilds
                 {
                     number = 1062969; // <div align=center>This guild has challenged you to war!</div>
 
-                    AddButtonAndBackground(20, 260, 5, 1062981);  // Accept Challenge
-                    AddButtonAndBackground(275, 260, 6, 1062983); // Modify Terms
+                    AddButtonAndBackground(ref builder, 20, 260, 5, 1062981);  // Accept Challenge
+                    AddButtonAndBackground(ref builder, 275, 260, 6, 1062983); // Modify Terms
                 }
 
-                AddButtonAndBackground(20, 290, 7, 1062982); // Dismiss Challenge
+                AddButtonAndBackground(ref builder, 20, 290, 7, 1062982); // Dismiss Challenge
             }
-            else if (ActiveWar)
+            else if (activeWarFlag)
             {
                 number = 1062965; // <div align=center>You are at war with this guild!</div>
-                AddButtonAndBackground(20, 290, 8, 1062980); // Surrender
+                AddButtonAndBackground(ref builder, 20, 290, 8, 1062980); // Surrender
             }
             else if (alliance != null && alliance == otherAlliance) // alliance, Same Alliance
             {
-                if (alliance.IsMember(guild) && alliance.IsMember(m_Other)) // Both in Same alliance, full members
+                if (alliance.IsMember(Guild) && alliance.IsMember(_other)) // Both in Same alliance, full members
                 {
                     number = 1062970; // <div align=center>You are allied with this guild.</div>
 
-                    if (alliance.Leader == guild)
+                    if (alliance.Leader == Guild)
                     {
-                        AddButtonAndBackground(20, 260, 12, 1062984); // Remove Guild from Alliance
+                        AddButtonAndBackground(ref builder, 20, 260, 12, 1062984); // Remove Guild from Alliance
 
-                        //Note: No 'confirmation' like the other leader guild promotion things
+                        // Note: No 'confirmation' like the other leader guild promotion things
                         // Promote to Alliance Leader
-                        AddButtonAndBackground(275, 260, 13, 1063433);
+                        AddButtonAndBackground(ref builder, 275, 260, 13, 1063433);
                         // Remove guild from alliance	//Promote to Alliance Leader
                     }
 
                     // Show roster, Centered, up
-                    AddButtonAndBackground(148, 215, 10, 1063164); // Show Alliance Roster
+                    AddButtonAndBackground(ref builder, 148, 215, 10, 1063164); // Show Alliance Roster
                     // Leave Alliance
-                    AddButtonAndBackground(20, 290, 11, 1062985); // Leave Alliance
+                    AddButtonAndBackground(ref builder, 20, 290, 11, 1062985); // Leave Alliance
                 }
-                else if (alliance.Leader == guild && alliance.IsPendingMember(m_Other))
+                else if (alliance.Leader == Guild && alliance.IsPendingMember(_other))
                 {
                     number = 1062971; // <div align=center>You have requested an alliance with this guild.</div>
 
                     // Show Alliance Roster, Centered, down.
-                    AddButtonAndBackground(148, 245, 10, 1063164); // Show Alliance Roster
+                    AddButtonAndBackground(ref builder, 148, 245, 10, 1063164); // Show Alliance Roster
                     // Withdraw Request
-                    AddButtonAndBackground(20, 290, 14, 1062986); // Withdraw Request
+                    AddButtonAndBackground(ref builder, 20, 290, 14, 1062986); // Withdraw Request
 
-                    AddHtml(150, 83, 360, 26, alliance.Name.Color(0x99));
+                    builder.AddHtml(150, 83, 360, 26, alliance.Name.Color(0x99));
                 }
-                else if (alliance.Leader == m_Other && alliance.IsPendingMember(guild))
+                else if (alliance.Leader == _other && alliance.IsPendingMember(Guild))
                 {
                     number = 1062972; // <div align=center>This guild has requested an alliance.</div>
 
                     // Show alliance Roster, top
-                    AddButtonAndBackground(148, 215, 10, 1063164); // Show Alliance Roster
+                    AddButtonAndBackground(ref builder, 148, 215, 10, 1063164); // Show Alliance Roster
                     // Deny Request
                     // Accept Request
-                    AddButtonAndBackground(20, 260, 15, 1062988); // Deny Request
-                    AddButtonAndBackground(20, 290, 16, 1062987); // Accept Request
+                    AddButtonAndBackground(ref builder, 20, 260, 15, 1062988); // Deny Request
+                    AddButtonAndBackground(ref builder, 20, 290, 16, 1062987); // Accept Request
 
-                    AddHtml(150, 83, 360, 26, alliance.Name.Color(0x99));
+                    builder.AddHtml(150, 83, 360, 26, alliance.Name.Color(0x99));
                 }
             }
             else
             {
-                AddButtonAndBackground(20, 260, 2, 1062990); // Request Alliance
-                AddButtonAndBackground(20, 290, 1, 1062989); // Declare War!
+                AddButtonAndBackground(ref builder, 20, 260, 2, 1062990); // Request Alliance
+                AddButtonAndBackground(ref builder, 20, 290, 1, 1062989); // Declare War!
             }
 
-            AddButtonAndBackground(275, 290, 0, 3000091); // Cancel
+            AddButtonAndBackground(ref builder, 275, 290, 0, 3000091); // Cancel
 
-            AddHtmlLocalized(20, 180, 480, 30, number, 0x0, true);
-            AddImageTiled(20, 245, 480, 2, 0x2711);
+            builder.AddHtmlLocalized(20, 180, 480, 30, number, 0x0, true);
+            builder.AddImageTiled(20, 245, 480, 2, 0x2711);
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
-            if (!(sender.Mobile is PlayerMobile pm && IsMember(pm, guild)))
+            if (!(sender.Mobile is PlayerMobile pm && IsMember(pm, Guild)))
             {
                 return;
             }
 
             var playerRank = pm.GuildRank;
 
-            var guildLeader = Guild.GetAllianceLeader(guild);
-            var otherGuild = Guild.GetAllianceLeader(m_Other);
+            var guildLeader = Guild.GetAllianceLeader(Guild);
+            var otherGuild = Guild.GetAllianceLeader(_other);
 
             var war = guildLeader.FindPendingWar(otherGuild);
             var activeWar = guildLeader.FindActiveWar(otherGuild);
             var otherWar = otherGuild.FindPendingWar(guildLeader);
 
-            var alliance = guild.Alliance;
+            var alliance = Guild.Alliance;
             var otherAlliance = otherGuild.Alliance;
 
             switch (info.ButtonID)
@@ -216,10 +216,10 @@ namespace Server.Guilds
                             {
                                 pm.SendLocalizedMessage(1063440); // You don't have permission to negotiate wars.
                             }
-                            else if (alliance != null && alliance.Leader != guild)
+                            else if (alliance != null && alliance.Leader != Guild)
                             {
                                 // ~1_val~ is not the leader of the ~2_val~ alliance.
-                                pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                                pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
 
                                 // You need to negotiate via ~1_val~ instead.
                                 pm.SendLocalizedMessage(1070707, alliance.Leader.Name);
@@ -227,11 +227,11 @@ namespace Server.Guilds
                             else
                             {
                                 // Accept the war
-                                guild.PendingWars.Remove(war);
+                                Guild.PendingWars.Remove(war);
                                 war.WarBeginning = Core.Now;
-                                guild.AcceptedWars.Add(war);
+                                Guild.AcceptedWars.Add(war);
 
-                                if (alliance?.IsMember(guild) == true)
+                                if (alliance?.IsMember(Guild) == true)
                                 {
                                     // Guild Message: Your guild is now at war with ~1_GUILDNAME~
                                     alliance.AllianceMessage(1070769, otherAlliance?.Name ?? otherGuild.Name);
@@ -240,8 +240,8 @@ namespace Server.Guilds
                                 else
                                 {
                                     // Guild Message: Your guild is now at war with ~1_GUILDNAME~
-                                    guild.GuildMessage(1070769, otherAlliance?.Name ?? otherGuild.Name);
-                                    guild.InvalidateMemberProperties();
+                                    Guild.GuildMessage(1070769, otherAlliance?.Name ?? otherGuild.Name);
+                                    Guild.InvalidateMemberProperties();
                                 }
                                 // Technically  SHOULD say Your guild is now at war w/out any info, intentional diff.
 
@@ -249,16 +249,16 @@ namespace Server.Guilds
                                 otherWar.WarBeginning = Core.Now;
                                 otherGuild.AcceptedWars.Add(otherWar);
 
-                                if (otherAlliance != null && m_Other.Alliance.IsMember(m_Other))
+                                if (otherAlliance != null && _other.Alliance.IsMember(_other))
                                 {
                                     // Guild Message: Your guild is now at war with ~1_GUILDNAME~
-                                    otherAlliance.AllianceMessage(1070769, alliance?.Name ?? guild.Name);
+                                    otherAlliance.AllianceMessage(1070769, alliance?.Name ?? Guild.Name);
                                     otherAlliance.InvalidateMemberProperties();
                                 }
                                 else
                                 {
                                     // Guild Message: Your guild is now at war with ~1_GUILDNAME~
-                                    otherGuild.GuildMessage(1070769, alliance?.Name ?? guild.Name);
+                                    otherGuild.GuildMessage(1070769, alliance?.Name ?? Guild.Name);
                                     otherGuild.InvalidateMemberProperties();
                                 }
                             }
@@ -274,17 +274,17 @@ namespace Server.Guilds
                             {
                                 pm.SendLocalizedMessage(1063440); // You don't have permission to negotiate wars.
                             }
-                            else if (alliance != null && alliance.Leader != guild)
+                            else if (alliance != null && alliance.Leader != Guild)
                             {
                                 // ~1_val~ is not the leader of the ~2_val~ alliance.
-                                pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                                pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
 
                                 // You need to negotiate via ~1_val~ instead.
                                 pm.SendLocalizedMessage(1070707, alliance.Leader.Name);
                             }
                             else
                             {
-                                pm.SendGump(new WarDeclarationGump(pm, guild, otherGuild));
+                                pm.SendGump(new WarDeclarationGump(pm, Guild, otherGuild));
                             }
                         }
 
@@ -298,10 +298,10 @@ namespace Server.Guilds
                             {
                                 pm.SendLocalizedMessage(1063440); // You don't have permission to negotiate wars.
                             }
-                            else if (alliance != null && alliance.Leader != guild)
+                            else if (alliance != null && alliance.Leader != Guild)
                             {
                                 // ~1_val~ is not the leader of the ~2_val~ alliance.
-                                pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                                pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
 
                                 // You need to negotiate via ~1_val~ instead.
                                 pm.SendLocalizedMessage(1070707, alliance.Leader.Name);
@@ -309,7 +309,7 @@ namespace Server.Guilds
                             else
                             {
                                 // Dismiss the war
-                                guild.PendingWars.Remove(war);
+                                Guild.PendingWars.Remove(war);
                                 otherGuild.PendingWars.Remove(otherWar);
                                 pm.SendLocalizedMessage(1070752); // The proposal has been updated.
                                 // Messages to opposing guild? (Testing on OSI says no)
@@ -324,10 +324,10 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063440); // You don't have permission to negotiate wars.
                         }
-                        else if (alliance != null && alliance.Leader != guild)
+                        else if (alliance != null && alliance.Leader != Guild)
                         {
                             // ~1_val~ is not the leader of the ~2_val~ alliance.
-                            pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                            pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
 
                             // You need to negotiate via ~1_val~ instead.
                             pm.SendLocalizedMessage(1070707, alliance.Leader.Name);
@@ -336,7 +336,7 @@ namespace Server.Guilds
                         {
                             if (activeWar != null)
                             {
-                                if (alliance?.IsMember(guild) == true)
+                                if (alliance?.IsMember(Guild) == true)
                                 {
                                     // You have lost the war with ~1_val~.
                                     alliance.AllianceMessage(1070740, otherAlliance?.Name ?? otherGuild.Name);
@@ -345,26 +345,26 @@ namespace Server.Guilds
                                 else
                                 {
                                     // You have lost the war with ~1_val~.
-                                    guild.GuildMessage(1070740, otherAlliance?.Name ?? otherGuild.Name);
-                                    guild.InvalidateMemberProperties();
+                                    Guild.GuildMessage(1070740, otherAlliance?.Name ?? otherGuild.Name);
+                                    Guild.InvalidateMemberProperties();
                                 }
 
-                                guild.AcceptedWars.Remove(activeWar);
+                                Guild.AcceptedWars.Remove(activeWar);
 
                                 if (otherAlliance?.IsMember(otherGuild) == true)
                                 {
                                     // You have won the war against ~1_val~!
-                                    otherAlliance.AllianceMessage(1070739, guild.Alliance?.Name ?? guild.Name);
+                                    otherAlliance.AllianceMessage(1070739, Guild.Alliance?.Name ?? Guild.Name);
                                     otherAlliance.InvalidateMemberProperties();
                                 }
                                 else
                                 {
                                     // You have won the war against ~1_val~!
-                                    otherGuild.GuildMessage(1070739, guild.Alliance?.Name ?? guild.Name);
+                                    otherGuild.GuildMessage(1070739, Guild.Alliance?.Name ?? Guild.Name);
                                     otherGuild.InvalidateMemberProperties();
                                 }
 
-                                otherGuild.AcceptedWars.Remove(otherGuild.FindActiveWar(guild));
+                                otherGuild.AcceptedWars.Remove(otherGuild.FindActiveWar(Guild));
                             }
                         }
 
@@ -378,25 +378,25 @@ namespace Server.Guilds
                             {
                                 pm.SendLocalizedMessage(1063440); // You don't have permission to negotiate wars.
                             }
-                            else if (alliance != null && alliance.Leader != guild)
+                            else if (alliance != null && alliance.Leader != Guild)
                             {
                                 // ~1_val~ is not the leader of the ~2_val~ alliance.
-                                pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                                pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
 
                                 // You need to negotiate via ~1_val~ instead.
                                 pm.SendLocalizedMessage(1070707, alliance.Leader.Name);
                             }
-                            else if (otherAlliance != null && otherAlliance.Leader != m_Other)
+                            else if (otherAlliance != null && otherAlliance.Leader != _other)
                             {
                                 // ~1_val~ is not the leader of the ~2_val~ alliance.
-                                pm.SendLocalizedMessage(1063239, $"{m_Other.Name}\t{otherAlliance.Name}");
+                                pm.SendLocalizedMessage(1063239, $"{_other.Name}\t{otherAlliance.Name}");
 
                                 // You need to negotiate via ~1_val~ instead.
                                 pm.SendLocalizedMessage(1070707, otherAlliance.Leader.Name);
                             }
                             else
                             {
-                                pm.SendGump(new WarDeclarationGump(pm, guild, m_Other));
+                                pm.SendGump(new WarDeclarationGump(pm, Guild, _other));
                             }
                         }
 
@@ -411,33 +411,33 @@ namespace Server.Guilds
                             {
                                 pm.SendLocalizedMessage(1070747); // You don't have permission to create an alliance.
                             }
-                            else if (Faction.Find(guild.Leader) != Faction.Find(m_Other.Leader))
+                            else if (Faction.Find(Guild.Leader) != Faction.Find(_other.Leader))
                             {
                                 // You cannot propose an alliance to a guild with a different faction allegiance.
                                 pm.SendLocalizedMessage(1070758);
                             }
                             else if (otherAlliance != null)
                             {
-                                if (otherAlliance.IsPendingMember(m_Other))
+                                if (otherAlliance.IsPendingMember(_other))
                                 {
                                     // ~1_val~ is currently considering another alliance proposal.
-                                    pm.SendLocalizedMessage(1063416, m_Other.Name);
+                                    pm.SendLocalizedMessage(1063416, _other.Name);
                                 }
                                 else
                                 {
                                     // ~1_val~ already belongs to an alliance.
-                                    pm.SendLocalizedMessage(1063426, m_Other.Name);
+                                    pm.SendLocalizedMessage(1063426, _other.Name);
                                 }
                             }
-                            else if (m_Other.AcceptedWars.Count > 0 || m_Other.PendingWars.Count > 0)
+                            else if (_other.AcceptedWars.Count > 0 || _other.PendingWars.Count > 0)
                             {
                                 // ~1_val~ is currently involved in a guild war.
-                                pm.SendLocalizedMessage(1063427, m_Other.Name);
+                                pm.SendLocalizedMessage(1063427, _other.Name);
                             }
-                            else if (guild.AcceptedWars.Count > 0 || guild.PendingWars.Count > 0)
+                            else if (Guild.AcceptedWars.Count > 0 || Guild.PendingWars.Count > 0)
                             {
                                 // ~1_val~ is currently involved in a guild war.
-                                pm.SendLocalizedMessage(1063427, guild.Name);
+                                pm.SendLocalizedMessage(1063427, Guild.Name);
                             }
                             else
                             {
@@ -451,40 +451,40 @@ namespace Server.Guilds
                             {
                                 pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                             }
-                            else if (alliance.Leader != guild)
+                            else if (alliance.Leader != Guild)
                             {
                                 // ~1_val~ is not the leader of the ~2_val~ alliance.
-                                pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                                pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
                             }
                             else if (otherAlliance != null)
                             {
-                                if (otherAlliance.IsPendingMember(m_Other))
+                                if (otherAlliance.IsPendingMember(_other))
                                 {
                                     // ~1_val~ is currently considering another alliance proposal.
-                                    pm.SendLocalizedMessage(1063416, m_Other.Name);
+                                    pm.SendLocalizedMessage(1063416, _other.Name);
                                 }
                                 else
                                 {
                                     // ~1_val~ already belongs to an alliance.
-                                    pm.SendLocalizedMessage(1063426, m_Other.Name);
+                                    pm.SendLocalizedMessage(1063426, _other.Name);
                                 }
                             }
-                            else if (alliance.IsPendingMember(guild))
+                            else if (alliance.IsPendingMember(Guild))
                             {
                                 // ~1_val~ is currently considering another alliance proposal.
-                                pm.SendLocalizedMessage(1063416, guild.Name);
+                                pm.SendLocalizedMessage(1063416, Guild.Name);
                             }
-                            else if (m_Other.AcceptedWars.Count > 0 || m_Other.PendingWars.Count > 0)
+                            else if (_other.AcceptedWars.Count > 0 || _other.PendingWars.Count > 0)
                             {
                                 // ~1_val~ is currently involved in a guild war.
-                                pm.SendLocalizedMessage(1063427, m_Other.Name);
+                                pm.SendLocalizedMessage(1063427, _other.Name);
                             }
-                            else if (guild.AcceptedWars.Count > 0 || guild.PendingWars.Count > 0)
+                            else if (Guild.AcceptedWars.Count > 0 || Guild.PendingWars.Count > 0)
                             {
                                 // ~1_val~ is currently involved in a guild war.
-                                pm.SendLocalizedMessage(1063427, guild.Name);
+                                pm.SendLocalizedMessage(1063427, Guild.Name);
                             }
-                            else if (Faction.Find(guild.Leader) != Faction.Find(m_Other.Leader))
+                            else if (Faction.Find(Guild.Leader) != Faction.Find(_other.Leader))
                             {
                                 // You cannot propose an alliance to a guild with a different faction allegiance.
                                 pm.SendLocalizedMessage(1070758);
@@ -492,12 +492,11 @@ namespace Server.Guilds
                             else
                             {
                                 // An invitation to join your alliance has been sent to ~1_val~.
-                                pm.SendLocalizedMessage(1070750, m_Other.Name);
+                                pm.SendLocalizedMessage(1070750, _other.Name);
 
-                                m_Other.GuildMessage(1070780, guild.Name); // ~1_val~ has proposed an alliance.
+                                _other.GuildMessage(1070780, Guild.Name); // ~1_val~ has proposed an alliance.
 
-                                m_Other.Alliance = alliance; // Calls addPendingGuild
-                                // alliance.AddPendingGuild( m_Other );
+                                _other.Alliance = alliance; // Calls addPendingGuild
                             }
                         }
 
@@ -507,7 +506,7 @@ namespace Server.Guilds
                     {
                         if (alliance != null && alliance == otherAlliance)
                         {
-                            pm.SendGump(new AllianceInfo.AllianceRosterGump(pm, guild, alliance));
+                            pm.SendGump(new AllianceInfo.AllianceRosterGump(pm, Guild, alliance));
                         }
 
                         break;
@@ -518,14 +517,13 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                         }
-                        else if (alliance?.IsMember(guild) == true)
+                        else if (alliance?.IsMember(Guild) == true)
                         {
-                            guild.Alliance = null; // Calls alliance.RemoveGuild
-                            // alliance.RemoveGuild( guild );
+                            Guild.Alliance = null; // Calls alliance.RemoveGuild
 
-                            m_Other.InvalidateWarNotoriety();
+                            _other.InvalidateWarNotoriety();
 
-                            guild.InvalidateMemberNotoriety();
+                            Guild.InvalidateMemberNotoriety();
                         }
 
                         break;
@@ -536,18 +534,18 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                         }
-                        else if (alliance != null && alliance.Leader != guild)
+                        else if (alliance != null && alliance.Leader != Guild)
                         {
                             // ~1_val~ is not the leader of the ~2_val~ alliance.
-                            pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                            pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
                         }
-                        else if (alliance?.IsMember(guild) == true && alliance.IsMember(m_Other))
+                        else if (alliance?.IsMember(Guild) == true && alliance.IsMember(_other))
                         {
-                            m_Other.Alliance = null;
+                            _other.Alliance = null;
 
-                            m_Other.InvalidateMemberNotoriety();
+                            _other.InvalidateMemberNotoriety();
 
-                            guild.InvalidateWarNotoriety();
+                            Guild.InvalidateWarNotoriety();
                         }
 
                         break;
@@ -558,17 +556,17 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                         }
-                        else if (alliance != null && alliance.Leader != guild)
+                        else if (alliance != null && alliance.Leader != Guild)
                         {
                             // ~1_val~ is not the leader of the ~2_val~ alliance.
-                            pm.SendLocalizedMessage(1063239, $"{guild.Name}\t{alliance.Name}");
+                            pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
                         }
-                        else if (alliance?.IsMember(guild) == true && alliance.IsMember(m_Other))
+                        else if (alliance?.IsMember(Guild) == true && alliance.IsMember(_other))
                         {
                             // ~1_val~ is now the leader of ~2_val~.
-                            pm.SendLocalizedMessage(1063434, $"{m_Other.Name}\t{alliance.Name}");
+                            pm.SendLocalizedMessage(1063434, $"{_other.Name}\t{alliance.Name}");
 
-                            alliance.Leader = m_Other;
+                            alliance.Leader = _other;
                         }
 
                         break;
@@ -579,9 +577,9 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                         }
-                        else if (alliance != null && alliance.Leader == guild && alliance.IsPendingMember(m_Other))
+                        else if (alliance != null && alliance.Leader == Guild && alliance.IsPendingMember(_other))
                         {
-                            m_Other.Alliance = null;
+                            _other.Alliance = null;
                             pm.SendLocalizedMessage(1070752); // The proposal has been updated.
                         }
 
@@ -593,15 +591,15 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                         }
-                        else if (alliance != null && otherAlliance != null && alliance.Leader == m_Other &&
-                                 otherAlliance.IsPendingMember(guild))
+                        else if (alliance != null && otherAlliance != null && alliance.Leader == _other &&
+                                 otherAlliance.IsPendingMember(Guild))
                         {
                             // The proposal has been updated.
-                            // m_Other.GuildMessage( 1070782 );
+                            // _other.GuildMessage( 1070782 );
                             // // ~1_val~ has responded to your proposal.
-                            // //Per OSI commented out.
+                            // // Per OSI commented out.
                             pm.SendLocalizedMessage(1070752);
-                            guild.Alliance = null;
+                            Guild.Alliance = null;
                         }
 
                         break;
@@ -612,15 +610,15 @@ namespace Server.Guilds
                         {
                             pm.SendLocalizedMessage(1063436); // You don't have permission to negotiate an alliance.
                         }
-                        else if (otherAlliance != null && otherAlliance.Leader == m_Other &&
-                                 otherAlliance.IsPendingMember(guild))
+                        else if (otherAlliance != null && otherAlliance.Leader == _other &&
+                                 otherAlliance.IsPendingMember(Guild))
                         {
                             pm.SendLocalizedMessage(1070752); // The proposal has been updated.
 
                             // No need to verify it's in the guild or already a member, the function does this
-                            otherAlliance.TurnToMember(m_Other);
+                            otherAlliance.TurnToMember(_other);
 
-                            otherAlliance.TurnToMember(guild);
+                            otherAlliance.TurnToMember(Guild);
                         }
 
                         break;
@@ -635,10 +633,10 @@ namespace Server.Guilds
                 return;
             }
 
-            var alliance = guild.Alliance;
-            var otherAlliance = m_Other.Alliance;
+            var alliance = Guild.Alliance;
+            var otherAlliance = _other.Alliance;
 
-            if (!IsMember(from, guild) || alliance != null)
+            if (!IsMember(from, Guild) || alliance != null)
             {
                 return;
             }
@@ -649,7 +647,7 @@ namespace Server.Guilds
             {
                 pm.SendLocalizedMessage(1070747); // You don't have permission to create an alliance.
             }
-            else if (Faction.Find(guild.Leader) != Faction.Find(m_Other.Leader))
+            else if (Faction.Find(Guild.Leader) != Faction.Find(_other.Leader))
             {
                 // Notes about this: OSI only cares/checks when proposing, you can change your faction all you want later.
                 // You cannot propose an alliance to a guild with a different faction allegiance.
@@ -657,23 +655,23 @@ namespace Server.Guilds
             }
             else if (otherAlliance != null)
             {
-                if (otherAlliance.IsPendingMember(m_Other))
+                if (otherAlliance.IsPendingMember(_other))
                 {
                     // ~1_val~ is currently considering another alliance proposal.
-                    pm.SendLocalizedMessage(1063416, m_Other.Name);
+                    pm.SendLocalizedMessage(1063416, _other.Name);
                 }
                 else
                 {
-                    pm.SendLocalizedMessage(1063426, m_Other.Name); // ~1_val~ already belongs to an alliance.
+                    pm.SendLocalizedMessage(1063426, _other.Name); // ~1_val~ already belongs to an alliance.
                 }
             }
-            else if (m_Other.AcceptedWars.Count > 0 || m_Other.PendingWars.Count > 0)
+            else if (_other.AcceptedWars.Count > 0 || _other.PendingWars.Count > 0)
             {
-                pm.SendLocalizedMessage(1063427, m_Other.Name); // ~1_val~ is currently involved in a guild war.
+                pm.SendLocalizedMessage(1063427, _other.Name); // ~1_val~ is currently involved in a guild war.
             }
-            else if (guild.AcceptedWars.Count > 0 || guild.PendingWars.Count > 0)
+            else if (Guild.AcceptedWars.Count > 0 || Guild.PendingWars.Count > 0)
             {
-                pm.SendLocalizedMessage(1063427, guild.Name); // ~1_val~ is currently involved in a guild war.
+                pm.SendLocalizedMessage(1063427, Guild.Name); // ~1_val~ is currently involved in a guild war.
             }
             else
             {
@@ -695,11 +693,11 @@ namespace Server.Guilds
                 else
                 {
                     // An invitation to join your alliance has been sent to ~1_val~.
-                    pm.SendLocalizedMessage(1070750, m_Other.Name);
+                    pm.SendLocalizedMessage(1070750, _other.Name);
 
-                    m_Other.GuildMessage(1070780, guild.Name); // ~1_val~ has proposed an alliance.
+                    _other.GuildMessage(1070780, Guild.Name); // ~1_val~ has proposed an alliance.
 
-                    new AllianceInfo(guild, name, m_Other);
+                    new AllianceInfo(Guild, name, _other);
                 }
             }
         }

--- a/Projects/UOContent/Gumps/Guilds/New Guild System/WarDeclarationGump.cs
+++ b/Projects/UOContent/Gumps/Guilds/New Guild System/WarDeclarationGump.cs
@@ -7,40 +7,42 @@ namespace Server.Guilds
 {
     public class WarDeclarationGump : BaseGuildGump
     {
-        private readonly Guild m_Other;
+        private readonly Guild _other;
 
-        public WarDeclarationGump(PlayerMobile pm, Guild g, Guild otherGuild) : base(pm, g)
+        public WarDeclarationGump(PlayerMobile pm, Guild g, Guild otherGuild) : base(pm, g) => _other = otherGuild;
+
+        protected override bool ShowTabStrip => false;
+
+        protected override void BuildContent(ref DynamicGumpBuilder builder)
         {
-            m_Other = otherGuild;
-            var war = g.FindPendingWar(otherGuild);
+            var war = Guild.FindPendingWar(_other);
 
-            AddPage(0);
-
-            AddBackground(0, 0, 500, 340, 0x24AE);
-            AddBackground(65, 50, 370, 30, 0x2486);
-            AddHtmlLocalized(75, 55, 370, 26, 1062979, 0x3C00); // <div align=center><i>Declaration of War</i></div>
-            AddImage(410, 45, 0x232C);
-            AddHtmlLocalized(65, 95, 200, 20, 1063009, 0x14AF); // <i>Duration of War</i>
-            AddHtmlLocalized(65, 120, 400, 20, 1063010, 0x0);   // Enter the number of hours the war will last.
-            AddBackground(65, 150, 40, 30, 0x2486);
-            AddTextEntry(70, 154, 50, 30, 0x481, 10, war?.WarLength.Hours.ToString() ?? "0");
-            AddHtmlLocalized(65, 195, 200, 20, 1063011, 0x14AF); // <i>Victory Condition</i>
-            AddHtmlLocalized(65, 220, 400, 20, 1063012, 0x0);    // Enter the winning number of kills.
-            AddBackground(65, 250, 40, 30, 0x2486);
-            AddTextEntry(70, 254, 50, 30, 0x481, 11, war?.MaxKills.ToString() ?? "0");
-            AddBackground(190, 270, 130, 26, 0x2486);
-            AddButton(195, 275, 0x845, 0x846, 0);
-            AddHtmlLocalized(220, 273, 90, 26, 1006045, 0x0); // Cancel
-            AddBackground(330, 270, 130, 26, 0x2486);
-            AddButton(335, 275, 0x845, 0x846, 1);
-            AddHtmlLocalized(360, 273, 90, 26, 1062989, 0x5000); // Declare War!
+            builder.AddBackground(0, 0, 500, 340, 0x24AE);
+            builder.AddBackground(65, 50, 370, 30, 0x2486);
+            // <div align=center><i>Declaration of War</i></div>
+            builder.AddHtmlLocalized(75, 55, 370, 26, 1062979, 0x3C00);
+            builder.AddImage(410, 45, 0x232C);
+            builder.AddHtmlLocalized(65, 95, 200, 20, 1063009, 0x14AF); // <i>Duration of War</i>
+            builder.AddHtmlLocalized(65, 120, 400, 20, 1063010, 0x0);   // Enter the number of hours the war will last.
+            builder.AddBackground(65, 150, 40, 30, 0x2486);
+            builder.AddTextEntry(70, 154, 50, 30, 0x481, 10, $"{war?.WarLength.Hours ?? 0}");
+            builder.AddHtmlLocalized(65, 195, 200, 20, 1063011, 0x14AF); // <i>Victory Condition</i>
+            builder.AddHtmlLocalized(65, 220, 400, 20, 1063012, 0x0);    // Enter the winning number of kills.
+            builder.AddBackground(65, 250, 40, 30, 0x2486);
+            builder.AddTextEntry(70, 254, 50, 30, 0x481, 11, $"{war?.MaxKills ?? 0}");
+            builder.AddBackground(190, 270, 130, 26, 0x2486);
+            builder.AddButton(195, 275, 0x845, 0x846, 0);
+            builder.AddHtmlLocalized(220, 273, 90, 26, 1006045, 0x0); // Cancel
+            builder.AddBackground(330, 270, 130, 26, 0x2486);
+            builder.AddButton(335, 275, 0x845, 0x846, 1);
+            builder.AddHtmlLocalized(360, 273, 90, 26, 1062989, 0x5000); // Declare War!
         }
 
         public override void OnResponse(NetState sender, in RelayInfo info)
         {
             var pm = sender.Mobile as PlayerMobile;
 
-            if (!IsMember(pm, guild))
+            if (!IsMember(pm, Guild))
             {
                 return;
             }
@@ -51,45 +53,38 @@ namespace Server.Guilds
             {
                 case 1:
                     {
-                        var alliance = guild.Alliance;
-                        var otherAlliance = m_Other.Alliance;
+                        var alliance = Guild.Alliance;
+                        var otherAlliance = _other.Alliance;
 
                         if (!playerRank.GetFlag(RankFlags.ControlWarStatus))
                         {
                             pm.SendLocalizedMessage(1063440); // You don't have permission to negotiate wars.
                         }
-                        else if (alliance != null && alliance.Leader != guild)
+                        else if (alliance != null && alliance.Leader != Guild)
                         {
-                            pm.SendLocalizedMessage(
-                                1063239,
-                                $"{guild.Name}\t{alliance.Name}"
-                            ); // ~1_val~ is not the leader of the ~2_val~ alliance.
-                            pm.SendLocalizedMessage(
-                                1070707,
-                                alliance.Leader.Name
-                            ); // You need to negotiate via ~1_val~ instead.
+                            // ~1_val~ is not the leader of the ~2_val~ alliance.
+                            pm.SendLocalizedMessage(1063239, $"{Guild.Name}\t{alliance.Name}");
+                            // You need to negotiate via ~1_val~ instead.
+                            pm.SendLocalizedMessage(1070707, alliance.Leader.Name);
                         }
-                        else if (otherAlliance != null && otherAlliance.Leader != m_Other)
+                        else if (otherAlliance != null && otherAlliance.Leader != _other)
                         {
-                            pm.SendLocalizedMessage(
-                                1063239,
-                                $"{m_Other.Name}\t{otherAlliance.Name}"
-                            ); // ~1_val~ is not the leader of the ~2_val~ alliance.
-                            pm.SendLocalizedMessage(
-                                1070707,
-                                otherAlliance.Leader.Name
-                            ); // You need to negotiate via ~1_val~ instead.
+                            // ~1_val~ is not the leader of the ~2_val~ alliance.
+                            pm.SendLocalizedMessage(1063239, $"{_other.Name}\t{otherAlliance.Name}");
+                            // You need to negotiate via ~1_val~ instead.
+                            pm.SendLocalizedMessage(1070707, otherAlliance.Leader.Name);
                         }
                         else
                         {
-                            var activeWar = guild.FindActiveWar(m_Other);
+                            var activeWar = Guild.FindActiveWar(_other);
 
                             if (activeWar == null)
                             {
-                                var war = guild.FindPendingWar(m_Other);
-                                var otherWar = m_Other.FindPendingWar(guild);
+                                var war = Guild.FindPendingWar(_other);
+                                var otherWar = _other.FindPendingWar(Guild);
 
-                                // Note: OSI differs from what it says on website.  unlimited war = 0 kills/ 0 hrs.  Not > 999.  (sidenote: they both cap at 65535, 7.5 years, but, still.)
+                                // Note: OSI differs from what it says on website. unlimited war = 0 kills/0 hrs.
+                                // Not > 999. (sidenote: they both cap at 65535, 7.5 years, but, still.)
                                 var tKills = info.GetTextEntry(11);
                                 var tWarLength = info.GetTextEntry(10);
 
@@ -110,7 +105,7 @@ namespace Server.Guilds
                                 }
                                 else
                                 {
-                                    guild.PendingWars.Add(new WarDeclaration(guild, m_Other, maxKills, warLength, true));
+                                    Guild.PendingWars.Add(new WarDeclaration(Guild, _other, maxKills, warLength, true));
                                 }
 
                                 if (otherWar != null)
@@ -121,7 +116,7 @@ namespace Server.Guilds
                                 }
                                 else
                                 {
-                                    m_Other.PendingWars.Add(new WarDeclaration(m_Other, guild, maxKills, warLength, false));
+                                    _other.PendingWars.Add(new WarDeclaration(_other, Guild, maxKills, warLength, false));
                                 }
 
                                 if (war != null)
@@ -130,20 +125,22 @@ namespace Server.Guilds
                                 }
                                 else
                                 {
-                                    m_Other.GuildMessage(
+                                    // ~1_val~ has proposed a war.
+                                    _other.GuildMessage(
                                         1070781,
-                                        guild.Alliance != null
-                                            ? guild.Alliance.Name
-                                            : guild.Name
-                                    ); // ~1_val~ has proposed a war.
+                                        Guild.Alliance != null
+                                            ? Guild.Alliance.Name
+                                            : Guild.Name
+                                    );
                                 }
 
+                                // War proposal has been sent to ~1_val~.
                                 pm.SendLocalizedMessage(
                                     1070751,
-                                    m_Other.Alliance != null
-                                        ? m_Other.Alliance.Name
-                                        : m_Other.Name
-                                ); // War proposal has been sent to ~1_val~.
+                                    _other.Alliance != null
+                                        ? _other.Alliance.Name
+                                        : _other.Name
+                                );
                             }
                         }
 
@@ -151,7 +148,7 @@ namespace Server.Guilds
                     }
                 default:
                     {
-                        pm.SendGump(new OtherGuildInfo(pm, guild, m_Other));
+                        pm.SendGump(new OtherGuildInfo(pm, Guild, _other));
                         break;
                     }
             }

--- a/Projects/UOContent/Misc/Guild.cs
+++ b/Projects/UOContent/Misc/Guild.cs
@@ -351,8 +351,6 @@ namespace Server.Guilds
 
         public class AllianceRosterGump : GuildDiplomacyGump
         {
-            private readonly AllianceInfo m_Alliance;
-
             public AllianceRosterGump(PlayerMobile pm, Guild g, AllianceInfo alliance) : base(
                 pm,
                 g,
@@ -361,31 +359,11 @@ namespace Server.Guilds
                 0,
                 alliance.m_Members,
                 alliance.Name
-            ) =>
-                m_Alliance = alliance;
-
-            public AllianceRosterGump(
-                PlayerMobile pm, Guild g, AllianceInfo alliance, IComparer<Guild> currentComparer,
-                bool ascending, string filter, int startNumber
-            ) : base(
-                pm,
-                g,
-                currentComparer,
-                ascending,
-                filter,
-                startNumber,
-                alliance.m_Members,
-                alliance.Name
-            ) =>
-                m_Alliance = alliance;
+            )
+            {
+            }
 
             protected override bool AllowAdvancedSearch => false;
-
-            public override Gump GetResentGump(
-                PlayerMobile pm, Guild g, IComparer<Guild> comparer, bool ascending,
-                string filter, int startNumber
-            ) =>
-                new AllianceRosterGump(pm, g, m_Alliance, comparer, ascending, filter, startNumber);
 
             public override void OnResponse(NetState sender, in RelayInfo info)
             {


### PR DESCRIPTION
## Summary

Migrates the eight concrete New Guild System gumps (CreateGuild, GuildInfo,
GuildMemberInfo, GuildRoster, GuildDiplomacy, WarDeclaration,
GuildAdvancedSearch, GuildInvitationRequest) and three abstract bases
(BaseGuildGump, BaseGuildListGump, OtherGuildInfo) from the legacy `Gump`
class to `DynamicGump`. Layout work moves from constructor-side `AddX(...)`
calls into `BuildLayout(ref DynamicGumpBuilder builder)` — the abstract
`BaseGuildGump` now provides a `BuildContent` callout for shared
tab-strip chrome, and `BaseGuildListGump<T>` adds another
`BuildListExtras` hook so subclasses can paint highlighted titles after
the filter/sort/pagination chrome.

The headline win is the **self-refresh pattern** on the list gumps and
diplomacy advanced search. Previously each filter/sort/back/forward
click allocated a brand new gump via `GetResentGump`. After migration,
those handlers mutate `_filter`, `_startNumber`, `_comparer`, `_ascending`,
or `_display` on the existing gump and call `from.SendGump(this)`,
letting the singleton path in `NetStateGumps.Send` swap in the same
instance with the new layout. The original list is preserved separately
from the per-render filtered/sorted `_displayList`, so refreshes pick up
the latest state without losing the source list.

All guild gumps deal with per-instance dynamic strings (guild names,
member names, war declarations, alliance names), which would defeat
`StaticGump<T>` caching per the cliloc rule, so every concrete subclass
migrates to `DynamicGump`. `AllianceRosterGump` (in `Misc/Guild.cs`)
is a `GuildDiplomacyGump` subclass and inherits the new behavior; its
unused override and stored alliance reference were dropped along with
the now-obsolete `GetResentGump` abstract.

## Test plan

- [x] `dotnet build Projects/UOContent/UOContent.csproj` clean (0 warnings, 0 errors)
- [x] `dotnet build` of the full solution clean
- [ ] In-game smoke: form a guild via `CreateGuildGump`, invite a player, accept the invitation
- [ ] Open `GuildRosterGump`, verify name/rank/last-on/title sort toggles refresh in place
- [ ] Open `GuildRosterGump`, type a filter and click the filter button, verify list updates without reopening
- [ ] Page through roster with back/forward, verify pagination state advances and clamps correctly
- [ ] Open `GuildDiplomacyGump`, swap among All/Awaiting Action/Relations tabs via Advanced Search, verify content refresh
- [ ] Declare war via `WarDeclarationGump`, accept/dismiss/modify via `OtherGuildInfo`
- [ ] Vote for, promote, demote, and kick members via `GuildMemberInfoGump`