### PR TITLE
perf: Migrate HouseRaffleManagementGump to DynamicGump

### DIFF
--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleManagementGump.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleManagementGump.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Server.Accounting;
 using Server.Items;
@@ -18,8 +19,27 @@ public class HouseRaffleManagementGump : DynamicGump
     public const int LabelColor = 0xFFFFFF;
     public const int HighlightColor = 0x11EE11;
 
+    private enum Buttons
+    {
+        Close,
+        PrevPage,
+        NextPage,
+        SortByName,
+        SortByAccount,
+        SortByAddress,
+        Refresh,
+        Delete // per-row delete buttons start here: (int)Buttons.Delete + row index
+    }
+
+    private const int RowsPerPage = 10;
+
     private readonly HouseRaffleStone _stone;
-    private readonly List<RaffleEntry> _list;
+    // Cached, sorted snapshot of _stone.Entries. Page navigation, sort, and delete operate on
+    // this snapshot so paginated indices stay stable even while other staff or players add or
+    // remove entries on the live stone. Staff hits the Refresh button (or reopens the gump) to
+    // resync. _count is the logical length; _entries backing array is reused across responses.
+    private RaffleEntry[] _entries;
+    private int _count;
     private SortMethod _sort;
     private int _page;
 
@@ -32,44 +52,57 @@ public class HouseRaffleManagementGump : DynamicGump
         _page = page;
         _sort = sort;
 
-        _list = new List<RaffleEntry>(_stone.Entries);
-
-        SortList();
+        _entries = _stone.Entries.ToArray();
+        _count = _entries.Length;
+        SortSnapshot();
     }
 
     public static void DisplayTo(Mobile from, HouseRaffleStone stone, SortMethod sort = SortMethod.Default, int page = 0)
     {
-        if (from?.NetState == null || stone == null || stone.Deleted)
+        if (from?.NetState != null && stone != null && !stone.Deleted)
+        {
+            from.SendGump(new HouseRaffleManagementGump(stone, sort, page));
+        }
+    }
+
+    private void SortSnapshot()
+    {
+        if (_sort == SortMethod.Default || _count <= 1)
         {
             return;
         }
 
-        from.SendGump(new HouseRaffleManagementGump(stone, sort, page));
+        var sortMethod = _sort switch
+        {
+            SortMethod.Name    => NameComparer.Instance,
+            SortMethod.Account => AccountComparer.Instance,
+            SortMethod.Address => AddressComparer.Instance
+        };
+
+        Array.Sort(_entries, 0, _count, sortMethod);
     }
 
-    private void SortList()
+    private void RefreshSnapshot()
     {
-        switch (_sort)
+        var live = _stone.Entries;
+        var liveCount = live.Count;
+
+        if (_entries.Length < liveCount)
         {
-            case SortMethod.Name:
-                {
-                    _list.Sort(NameComparer.Instance);
-
-                    break;
-                }
-            case SortMethod.Account:
-                {
-                    _list.Sort(AccountComparer.Instance);
-
-                    break;
-                }
-            case SortMethod.Address:
-                {
-                    _list.Sort(AddressComparer.Instance);
-
-                    break;
-                }
+            // Grow with doubling so subsequent inserts can fit without re-allocating each time.
+            Array.Resize(ref _entries, Math.Max(_entries.Length * 2, liveCount));
         }
+
+        live.CopyTo(_entries, 0);
+
+        // Clear any references in trailing slots so we don't pin deleted entries.
+        if (_count > liveCount)
+        {
+            Array.Clear(_entries, liveCount, _count - liveCount);
+        }
+
+        _count = liveCount;
+        SortSnapshot();
     }
 
     protected override void BuildLayout(ref DynamicGumpBuilder builder)
@@ -90,13 +123,13 @@ public class HouseRaffleManagementGump : DynamicGump
         builder.AddHtml(45, 75, 100, 20, "Total Entries:".Color(LabelColor));
         builder.AddHtml(145, 75, 250, 20, Html.Color($"{_stone.Entries.Count}", LabelColor));
 
-        builder.AddButton(440, 33, 0xFA5, 0xFA7, 3);
+        builder.AddButton(440, 33, 0xFA5, 0xFA7, (int)Buttons.SortByName);
         builder.AddHtml(474, 35, 120, 20, "Sort by name".Color(LabelColor));
 
-        builder.AddButton(440, 53, 0xFA5, 0xFA7, 4);
+        builder.AddButton(440, 53, 0xFA5, 0xFA7, (int)Buttons.SortByAccount);
         builder.AddHtml(474, 55, 120, 20, "Sort by account".Color(LabelColor));
 
-        builder.AddButton(440, 73, 0xFA5, 0xFA7, 5);
+        builder.AddButton(440, 73, 0xFA5, 0xFA7, (int)Buttons.SortByAddress);
         builder.AddHtml(474, 75, 120, 20, "Sort by address".Color(LabelColor));
 
         builder.AddImageTiled(13, 99, 592, 242, 9264);
@@ -105,18 +138,20 @@ public class HouseRaffleManagementGump : DynamicGump
 
         builder.AddHtml(14, 100, 590, 20, "Entries".Center(LabelColor));
 
+        builder.AddButton(545, 104, 0x845, 0x846, (int)Buttons.Refresh);
+
         if (_page > 0)
         {
-            builder.AddButton(567, 104, 0x15E3, 0x15E7, 1);
+            builder.AddButton(567, 104, 0x15E3, 0x15E7, (int)Buttons.PrevPage);
         }
         else
         {
             builder.AddImage(567, 104, 0x25EA);
         }
 
-        if ((_page + 1) * 10 < _list.Count)
+        if ((_page + 1) * RowsPerPage < _count)
         {
-            builder.AddButton(584, 104, 0x15E1, 0x15E5, 2);
+            builder.AddButton(584, 104, 0x15E1, 0x15E5, (int)Buttons.NextPage);
         }
         else
         {
@@ -131,17 +166,19 @@ public class HouseRaffleManagementGump : DynamicGump
 
         var idx = 0;
         var winner = _stone.Winner;
+        var pageStart = _page * RowsPerPage;
+        var pageEnd = Math.Min(pageStart + RowsPerPage, _count);
 
-        for (var i = _page * 10; i >= 0 && i < _list.Count && i < (_page + 1) * 10; ++i, ++idx)
+        for (var i = pageStart; i < pageEnd; ++i, ++idx)
         {
-            var entry = _list[i];
+            var entry = _entries[i];
 
             if (entry == null)
             {
                 continue;
             }
 
-            builder.AddButton(13, 138 + idx * 20, 4002, 4004, 6 + i);
+            builder.AddButton(13, 138 + idx * 20, 4002, 4004, (int)Buttons.Delete + i);
 
             var x = 45;
             var color = winner != null && entry.From == winner ? HighlightColor : LabelColor;
@@ -176,70 +213,105 @@ public class HouseRaffleManagementGump : DynamicGump
 
     public override void OnResponse(NetState sender, in RelayInfo info)
     {
-        var from = sender.Mobile;
-        var buttonId = info.ButtonID;
-
-        switch (buttonId)
+        if (_stone.Deleted)
         {
-            case 1: // Previous
+            return;
+        }
+
+        switch ((Buttons)info.ButtonID)
+        {
+            case Buttons.Close:
+                {
+                    return;
+                }
+            case Buttons.PrevPage:
                 {
                     if (_page > 0)
                     {
                         _page--;
                     }
 
-                    DisplayTo(from, _stone, _sort, _page);
-
                     break;
                 }
-            case 2: // Next
+            case Buttons.NextPage:
                 {
-                    if ((_page + 1) * 10 < _stone.Entries.Count)
+                    if ((_page + 1) * RowsPerPage < _count)
                     {
                         _page++;
                     }
 
-                    DisplayTo(from, _stone, _sort, _page);
+                    break;
+                }
+            case Buttons.SortByName:
+                {
+                    _sort = SortMethod.Name;
+                    _page = 0;
+                    SortSnapshot();
 
                     break;
                 }
-            case 3: // Sort by name
+            case Buttons.SortByAccount:
                 {
-                    DisplayTo(from, _stone, SortMethod.Name);
+                    _sort = SortMethod.Account;
+                    _page = 0;
+                    SortSnapshot();
 
                     break;
                 }
-            case 4: // Sort by account
+            case Buttons.SortByAddress:
                 {
-                    DisplayTo(from, _stone, SortMethod.Account);
+                    _sort = SortMethod.Address;
+                    _page = 0;
+                    SortSnapshot();
 
                     break;
                 }
-            case 5: // Sort by address
+            case Buttons.Refresh:
                 {
-                    DisplayTo(from, _stone, SortMethod.Address);
+                    RefreshSnapshot();
 
-                    break;
-                }
-            default: // Delete
-                {
-                    buttonId -= 6;
-
-                    if (buttonId >= 0 && buttonId < _list.Count)
+                    var maxPage = _count == 0 ? 0 : (_count - 1) / RowsPerPage;
+                    if (_page > maxPage)
                     {
-                        _stone.Entries.Remove(_list[buttonId]);
+                        _page = maxPage;
+                    }
 
-                        if (_page > 0 && _page * 10 >= _list.Count - 1)
-                        {
-                            _page--;
-                        }
+                    break;
+                }
+            default: // Per-row delete
+                {
+                    var deleteIndex = info.ButtonID - (int)Buttons.Delete;
 
-                        DisplayTo(from, _stone, _sort, _page);
+                    if (deleteIndex < 0 || deleteIndex >= _count)
+                    {
+                        return;
+                    }
+
+                    var target = _entries[deleteIndex];
+
+                    if (target != null)
+                    {
+                        _stone.Entries.Remove(target);
+                    }
+
+                    // Compact the snapshot in place — array stays sorted, no reallocation.
+                    var tail = _count - deleteIndex - 1;
+                    if (tail > 0)
+                    {
+                        Array.Copy(_entries, deleteIndex + 1, _entries, deleteIndex, tail);
+                    }
+                    _entries[--_count] = null;
+
+                    if (_page > 0 && _page * RowsPerPage >= _count)
+                    {
+                        _page--;
                     }
 
                     break;
                 }
         }
+
+        sender.Mobile.SendGump(this);
     }
 
     private class NameComparer : IComparer<RaffleEntry>
@@ -266,7 +338,7 @@ public class HouseRaffleManagementGump : DynamicGump
                 return 1;
             }
 
-            var result = x.From.Name.InsensitiveCompare(y.From.Name);
+            var result = x.From.RawName.InsensitiveCompare(y.From.RawName);
 
             return result == 0 ? x.Date.CompareTo(y.Date) : result;
         }

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleManagementGump.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleManagementGump.cs
@@ -5,7 +5,7 @@ using Server.Network;
 
 namespace Server.Gumps;
 
-public class HouseRaffleManagementGump : Gump
+public class HouseRaffleManagementGump : DynamicGump
 {
     public enum SortMethod
     {
@@ -17,21 +17,38 @@ public class HouseRaffleManagementGump : Gump
 
     public const int LabelColor = 0xFFFFFF;
     public const int HighlightColor = 0x11EE11;
-    private readonly List<RaffleEntry> _list;
-    private readonly SortMethod _sort;
 
     private readonly HouseRaffleStone _stone;
+    private readonly List<RaffleEntry> _list;
+    private SortMethod _sort;
     private int _page;
 
-    public HouseRaffleManagementGump(HouseRaffleStone stone, SortMethod sort = SortMethod.Default, int page = 0)
+    public override bool Singleton => true;
+
+    private HouseRaffleManagementGump(HouseRaffleStone stone, SortMethod sort = SortMethod.Default, int page = 0)
         : base(40, 40)
     {
         _stone = stone;
         _page = page;
-
-        _list = new List<RaffleEntry>(_stone.Entries);
         _sort = sort;
 
+        _list = new List<RaffleEntry>(_stone.Entries);
+
+        SortList();
+    }
+
+    public static void DisplayTo(Mobile from, HouseRaffleStone stone, SortMethod sort = SortMethod.Default, int page = 0)
+    {
+        if (from?.NetState == null || stone == null || stone.Deleted)
+        {
+            return;
+        }
+
+        from.SendGump(new HouseRaffleManagementGump(stone, sort, page));
+    }
+
+    private void SortList()
+    {
         switch (_sort)
         {
             case SortMethod.Name:
@@ -53,66 +70,69 @@ public class HouseRaffleManagementGump : Gump
                     break;
                 }
         }
+    }
 
-        AddPage(0);
+    protected override void BuildLayout(ref DynamicGumpBuilder builder)
+    {
+        builder.AddPage();
 
-        AddBackground(0, 0, 618, 354, 9270);
-        AddAlphaRegion(10, 10, 598, 334);
+        builder.AddBackground(0, 0, 618, 354, 9270);
+        builder.AddAlphaRegion(10, 10, 598, 334);
 
-        AddHtml(10, 10, 598, 20, "Raffle Management".Center(LabelColor));
+        builder.AddHtml(10, 10, 598, 20, "Raffle Management".Center(LabelColor));
 
-        AddHtml(45, 35, 100, 20, "Location:".Color(LabelColor));
-        AddHtml(145, 35, 250, 20, HouseRaffleStone.FormatLocation(stone.PlotBounds, stone.GetPlotCenter(), stone.PlotFacet).Color(LabelColor));
+        builder.AddHtml(45, 35, 100, 20, "Location:".Color(LabelColor));
+        builder.AddHtml(145, 35, 250, 20, HouseRaffleStone.FormatLocation(_stone.PlotBounds, _stone.GetPlotCenter(), _stone.PlotFacet).Color(LabelColor));
 
-        AddHtml(45, 55, 100, 20, "Ticket Price:".Color(LabelColor));
-        AddHtml(145, 55, 250, 20, HouseRaffleStone.FormatPrice(stone.TicketPrice).Color(LabelColor));
+        builder.AddHtml(45, 55, 100, 20, "Ticket Price:".Color(LabelColor));
+        builder.AddHtml(145, 55, 250, 20, HouseRaffleStone.FormatPrice(_stone.TicketPrice).Color(LabelColor));
 
-        AddHtml(45, 75, 100, 20, "Total Entries:".Color(LabelColor));
-        AddHtml(145, 75, 250, 20, Html.Color($"{_stone.Entries.Count}", LabelColor));
+        builder.AddHtml(45, 75, 100, 20, "Total Entries:".Color(LabelColor));
+        builder.AddHtml(145, 75, 250, 20, Html.Color($"{_stone.Entries.Count}", LabelColor));
 
-        AddButton(440, 33, 0xFA5, 0xFA7, 3);
-        AddHtml(474, 35, 120, 20, "Sort by name".Color(LabelColor));
+        builder.AddButton(440, 33, 0xFA5, 0xFA7, 3);
+        builder.AddHtml(474, 35, 120, 20, "Sort by name".Color(LabelColor));
 
-        AddButton(440, 53, 0xFA5, 0xFA7, 4);
-        AddHtml(474, 55, 120, 20, "Sort by account".Color(LabelColor));
+        builder.AddButton(440, 53, 0xFA5, 0xFA7, 4);
+        builder.AddHtml(474, 55, 120, 20, "Sort by account".Color(LabelColor));
 
-        AddButton(440, 73, 0xFA5, 0xFA7, 5);
-        AddHtml(474, 75, 120, 20, "Sort by address".Color(LabelColor));
+        builder.AddButton(440, 73, 0xFA5, 0xFA7, 5);
+        builder.AddHtml(474, 75, 120, 20, "Sort by address".Color(LabelColor));
 
-        AddImageTiled(13, 99, 592, 242, 9264);
-        AddImageTiled(14, 100, 590, 240, 9274);
-        AddAlphaRegion(14, 100, 590, 240);
+        builder.AddImageTiled(13, 99, 592, 242, 9264);
+        builder.AddImageTiled(14, 100, 590, 240, 9274);
+        builder.AddAlphaRegion(14, 100, 590, 240);
 
-        AddHtml(14, 100, 590, 20, "Entries".Center(LabelColor));
+        builder.AddHtml(14, 100, 590, 20, "Entries".Center(LabelColor));
 
-        if (page > 0)
+        if (_page > 0)
         {
-            AddButton(567, 104, 0x15E3, 0x15E7, 1);
+            builder.AddButton(567, 104, 0x15E3, 0x15E7, 1);
         }
         else
         {
-            AddImage(567, 104, 0x25EA);
+            builder.AddImage(567, 104, 0x25EA);
         }
 
-        if ((page + 1) * 10 < _list.Count)
+        if ((_page + 1) * 10 < _list.Count)
         {
-            AddButton(584, 104, 0x15E1, 0x15E5, 2);
+            builder.AddButton(584, 104, 0x15E1, 0x15E5, 2);
         }
         else
         {
-            AddImage(584, 104, 0x25E6);
+            builder.AddImage(584, 104, 0x25E6);
         }
 
-        AddHtml(14, 120, 30, 20, "DEL".Center(LabelColor));
-        AddHtml(47, 120, 250, 20, "Name".Color(LabelColor));
-        AddHtml(295, 120, 100, 20, "Address".Center(LabelColor));
-        AddHtml(395, 120, 150, 20, "Date".Center(LabelColor));
-        AddHtml(545, 120, 60, 20, "Num".Center(LabelColor));
+        builder.AddHtml(14, 120, 30, 20, "DEL".Center(LabelColor));
+        builder.AddHtml(47, 120, 250, 20, "Name".Color(LabelColor));
+        builder.AddHtml(295, 120, 100, 20, "Address".Center(LabelColor));
+        builder.AddHtml(395, 120, 150, 20, "Date".Center(LabelColor));
+        builder.AddHtml(545, 120, 60, 20, "Num".Center(LabelColor));
 
         var idx = 0;
         var winner = _stone.Winner;
 
-        for (var i = page * 10; i >= 0 && i < _list.Count && i < (page + 1) * 10; ++i, ++idx)
+        for (var i = _page * 10; i >= 0 && i < _list.Count && i < (_page + 1) * 10; ++i, ++idx)
         {
             var entry = _list[i];
 
@@ -121,7 +141,7 @@ public class HouseRaffleManagementGump : Gump
                 continue;
             }
 
-            AddButton(13, 138 + idx * 20, 4002, 4004, 6 + i);
+            builder.AddButton(13, 138 + idx * 20, 4002, 4004, 6 + i);
 
             var x = 45;
             var color = winner != null && entry.From == winner ? HighlightColor : LabelColor;
@@ -130,11 +150,11 @@ public class HouseRaffleManagementGump : Gump
             {
                 if (entry.From.Account is Account acc)
                 {
-                    AddHtml(x + 2, 140 + idx * 20, 250, 20, Html.Color($"{entry.From.RawName} ({acc})", color));
+                    builder.AddHtml(x + 2, 140 + idx * 20, 250, 20, Html.Color($"{entry.From.RawName} ({acc})", color));
                 }
                 else
                 {
-                    AddHtml(x + 2, 140 + idx * 20, 250, 20, entry.From.RawName.Color(color));
+                    builder.AddHtml(x + 2, 140 + idx * 20, 250, 20, entry.From.RawName.Color(color));
                 }
             }
 
@@ -142,15 +162,15 @@ public class HouseRaffleManagementGump : Gump
 
             if (entry.Address != null)
             {
-                AddHtml(x, 140 + idx * 20, 100, 20, entry.Address.ToString().Center(color));
+                builder.AddHtml(x, 140 + idx * 20, 100, 20, Html.Center($"{entry.Address}", color));
             }
 
             x += 100;
 
-            AddHtml(x, 140 + idx * 20, 150, 20, entry.Date.ToString().Center(color));
+            builder.AddHtml(x, 140 + idx * 20, 150, 20, Html.Center($"{entry.Date}", color));
             x += 150;
 
-            AddHtml(x, 140 + idx * 20, 60, 20, "1".Center(color));
+            builder.AddHtml(x, 140 + idx * 20, 60, 20, "1".Center(color));
         }
     }
 
@@ -168,7 +188,7 @@ public class HouseRaffleManagementGump : Gump
                         _page--;
                     }
 
-                    from.SendGump(new HouseRaffleManagementGump(_stone, _sort, _page));
+                    DisplayTo(from, _stone, _sort, _page);
 
                     break;
                 }
@@ -179,25 +199,25 @@ public class HouseRaffleManagementGump : Gump
                         _page++;
                     }
 
-                    from.SendGump(new HouseRaffleManagementGump(_stone, _sort, _page));
+                    DisplayTo(from, _stone, _sort, _page);
 
                     break;
                 }
             case 3: // Sort by name
                 {
-                    from.SendGump(new HouseRaffleManagementGump(_stone, SortMethod.Name));
+                    DisplayTo(from, _stone, SortMethod.Name);
 
                     break;
                 }
             case 4: // Sort by account
                 {
-                    from.SendGump(new HouseRaffleManagementGump(_stone, SortMethod.Account));
+                    DisplayTo(from, _stone, SortMethod.Account);
 
                     break;
                 }
             case 5: // Sort by address
                 {
-                    from.SendGump(new HouseRaffleManagementGump(_stone, SortMethod.Address));
+                    DisplayTo(from, _stone, SortMethod.Address);
 
                     break;
                 }
@@ -214,7 +234,7 @@ public class HouseRaffleManagementGump : Gump
                             _page--;
                         }
 
-                        from.SendGump(new HouseRaffleManagementGump(_stone, _sort, _page));
+                        DisplayTo(from, _stone, _sort, _page);
                     }
 
                     break;

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -638,7 +638,7 @@ public partial class HouseRaffleStone : Item
         {
             if (from.AccessLevel >= AccessLevel.Seer && target is HouseRaffleStone { Deleted: false } stone)
             {
-                from.SendGump(new HouseRaffleManagementGump(stone));
+                HouseRaffleManagementGump.DisplayTo(from, stone);
             }
         }
     }


### PR DESCRIPTION
## Summary
Converts `HouseRaffleManagementGump` from legacy `Gump` to `DynamicGump` with the static `DisplayTo` entry-point pattern.

The gump has paginated entries (up to 10 rows per page), conditional prev/next navigation buttons (vs. inactive image when at page boundary), and per-entry conditional layout (account-bearing vs. raw name). DynamicGump is the right choice.

Constructor is private; `DisplayTo` validates `from` / `NetState` / `stone.Deleted` before constructing. The list+sort runs eagerly in `DisplayTo` so paging math stays consistent across rebuilds.

Builder labels use `$"{value}"` interpolated-string-handler form for zero-allocation text.

Updates the caller in `HouseRaffleStone.ManagementEntry.OnClick`.

## Test plan
- [ ] As a GM, double-click a HouseRaffleStone to open the management gump.
- [ ] Verify entries paginate correctly (10 per page), with prev/next buttons disabled at boundaries.
- [ ] Try each sort order (Name, Address, Date, etc.) and verify entries reorder.
- [ ] Pick a winner via the gump and verify the deed flow still works.
- [ ] Reject an entry and verify it's removed from the list.