### PR TITLE
perf(messages): restructure format-string call sites

### DIFF
--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -7908,14 +7908,26 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
                     type = "";
                 }
 
-                var text = string.Format(
-                    title.Length <= 0 ? "[{1}]{2}" : "[{0}, {1}]{2}",
-                    title,
-                    guild.Abbreviation,
-                    type
-                );
-
-                PrivateOverheadMessage(MessageType.Regular, SpeechHue, true, text, from.NetState);
+                if (title.Length <= 0)
+                {
+                    PrivateOverheadMessage(
+                        MessageType.Regular,
+                        SpeechHue,
+                        true,
+                        $"[{guild.Abbreviation}]{type}",
+                        from.NetState
+                    );
+                }
+                else
+                {
+                    PrivateOverheadMessage(
+                        MessageType.Regular,
+                        SpeechHue,
+                        true,
+                        $"[{title}, {guild.Abbreviation}]{type}",
+                        from.NetState
+                    );
+                }
             }
         }
 

--- a/Projects/UOContent/Engines/ConPVP/DuelContext.cs
+++ b/Projects/UOContent/Engines/ConPVP/DuelContext.cs
@@ -1334,16 +1334,26 @@ public partial class DuelContext
                 return; // sanity
             }
 
-            var text =
-                $"{{0}} are ranked {LadderGump.Rank(entry.Index + 1)} at level {Ladder.GetLevel(entry.Experience)}.";
-
-            pm.PrivateOverheadMessage(
-                MessageType.Regular,
-                pm.SpeechHue,
-                true,
-                string.Format(text, from == pm ? "You" : "They"),
-                from.NetState
-            );
+            if (from == pm)
+            {
+                pm.PrivateOverheadMessage(
+                    MessageType.Regular,
+                    pm.SpeechHue,
+                    true,
+                    $"You are ranked {LadderGump.Rank(entry.Index + 1)} at level {Ladder.GetLevel(entry.Experience)}.",
+                    from.NetState
+                );
+            }
+            else
+            {
+                pm.PrivateOverheadMessage(
+                    MessageType.Regular,
+                    pm.SpeechHue,
+                    true,
+                    $"They are ranked {LadderGump.Rank(entry.Index + 1)} at level {Ladder.GetLevel(entry.Experience)}.",
+                    from.NetState
+                );
+            }
         }
         else if (obj is Mobile mob)
         {
@@ -1460,15 +1470,17 @@ public partial class DuelContext
                         return; // sanity
                     }
 
-                    var text =
-                        $"{{0}} {{1}} ranked {LadderGump.Rank(entry.Index + 1)} at level {Ladder.GetLevel(entry.Experience)}.";
-
-                    pm.LocalOverheadMessage(MessageType.Regular, pm.SpeechHue, true, string.Format(text, "You", "are"));
+                    pm.LocalOverheadMessage(
+                        MessageType.Regular,
+                        pm.SpeechHue,
+                        true,
+                        $"You are ranked {LadderGump.Rank(entry.Index + 1)} at level {Ladder.GetLevel(entry.Experience)}."
+                    );
                     pm.NonlocalOverheadMessage(
                         MessageType.Regular,
                         pm.SpeechHue,
                         true,
-                        string.Format(text, pm.Name, "is")
+                        $"{pm.Name} is ranked {LadderGump.Rank(entry.Index + 1)} at level {Ladder.GetLevel(entry.Experience)}."
                     );
 
                     // pm.PublicOverheadMessage( MessageType.Regular, pm.SpeechHue, true, String.Format( "Level {0} with {1} win{2} and {3} loss{4}.", Ladder.GetLevel( entry.Experience ), entry.Wins, entry.Wins==1?"":"s", entry.Losses, entry.Losses==1?"":"es" ) );

--- a/Projects/UOContent/Engines/ConPVP/Gumps/ConfirmSignupGump.cs
+++ b/Projects/UOContent/Engines/ConPVP/Gumps/ConfirmSignupGump.cs
@@ -499,13 +499,6 @@ public class ConfirmSignupGump : DynamicGump
 
                     if (_registrar != null)
                     {
-                        string fmt = _tournament.PlayersPerParticipant switch
-                        {
-                            1 => "As you say m'{0}. I've written your name to the bracket. The tournament will begin {1}.",
-                            2 => "As you wish m'{0}. The tournament will begin {1}, but first you must name your partner.",
-                            _ => "As you wish m'{0}. The tournament will begin {1}, but first you must name your team."
-                        };
-
                         var minutesUntil = (int)Math.Round(
                             (_tournament.SignupStart + _tournament.SignupPeriod - Core.Now)
                             .TotalMinutes
@@ -515,13 +508,44 @@ public class ConfirmSignupGump : DynamicGump
                             ? "momentarily"
                             : $"in {minutesUntil} minute{(minutesUntil == 1 ? "" : "s")}";
 
-                        _registrar.PrivateOverheadMessage(
-                            MessageType.Regular,
-                            0x35,
-                            false,
-                            string.Format(fmt, from.Female ? "Lady" : "Lord", timeUntil),
-                            from.NetState
-                        );
+                        var title = from.Female ? "Lady" : "Lord";
+
+                        switch (_tournament.PlayersPerParticipant)
+                        {
+                            case 1:
+                                {
+                                    _registrar.PrivateOverheadMessage(
+                                        MessageType.Regular,
+                                        0x35,
+                                        false,
+                                        $"As you say m'{title}. I've written your name to the bracket. The tournament will begin {timeUntil}.",
+                                        from.NetState
+                                    );
+                                    break;
+                                }
+                            case 2:
+                                {
+                                    _registrar.PrivateOverheadMessage(
+                                        MessageType.Regular,
+                                        0x35,
+                                        false,
+                                        $"As you wish m'{title}. The tournament will begin {timeUntil}, but first you must name your partner.",
+                                        from.NetState
+                                    );
+                                    break;
+                                }
+                            default:
+                                {
+                                    _registrar.PrivateOverheadMessage(
+                                        MessageType.Regular,
+                                        0x35,
+                                        false,
+                                        $"As you wish m'{title}. The tournament will begin {timeUntil}, but first you must name your team.",
+                                        from.NetState
+                                    );
+                                    break;
+                                }
+                        }
                     }
 
                     var part = new TourneyParticipant(from);

--- a/Projects/UOContent/Engines/ConPVP/Participant.cs
+++ b/Projects/UOContent/Engines/ConPVP/Participant.cs
@@ -135,6 +135,7 @@ namespace Server.Engines.ConPVP
 
                     if (nonLocalOverhead != null)
                     {
+                        // Phase 3 audit: Format string passed by caller; restructuring requires changing all callers — out of scope for this PR.
                         Players[i]
                             .Mobile.NonlocalOverheadMessage(
                                 MessageType.Regular,

--- a/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaLord.cs
+++ b/Projects/UOContent/Mobiles/Monsters/LBR/Jukas/JukaLord.cs
@@ -74,15 +74,29 @@ namespace Server.Mobiles
         {
             if (!willKill && amount > 5 && from?.Player == true && Utility.Random(100) < 5)
             {
-                string[] toSay =
+                switch (Utility.Random(4))
                 {
-                    "{0}!!  You will have to do better than that!",
-                    "{0}!!  Prepare to meet your doom!",
-                    "{0}!!  My armies will crush you!",
-                    "{0}!!  You will pay for that!"
-                };
-
-                Say(true, string.Format(toSay.RandomElement(), from.Name));
+                    case 0:
+                        {
+                            Say(true, $"{from.Name}!!  You will have to do better than that!");
+                            break;
+                        }
+                    case 1:
+                        {
+                            Say(true, $"{from.Name}!!  Prepare to meet your doom!");
+                            break;
+                        }
+                    case 2:
+                        {
+                            Say(true, $"{from.Name}!!  My armies will crush you!");
+                            break;
+                        }
+                    default:
+                        {
+                            Say(true, $"{from.Name}!!  You will pay for that!");
+                            break;
+                        }
+                }
             }
 
             base.OnDamage(amount, from, willKill);


### PR DESCRIPTION
## Summary

Phase 3 PR B of the message-interpolation cleanup. Handles the multi-line restructure sites flagged in `dev-docs/string-handling-message-interp-audit.md` (Phase 2). Phase 3.1 (PR #2436) handled trivial sweeps; this PR handles sites that needed an `if/else` hoist or switch restructure to eliminate `string.Format` while preserving exact message text.

Each site previously allocated an intermediate `string.Format(...)` result before passing to the message handler, despite Phase 1 making the handler accept interpolated string handlers natively.

## Sites fixed

- **`Projects/Server/Mobiles/Mobile.cs:7911`** - Title/guild header was using `string.Format` with a conditional template (`"[{1}]{2}"` vs `"[{0}, {1}]{2}"`). Split into `if (title.Length <= 0)` / `else` with direct `$"..."` interpolation.
- **`Projects/UOContent/Engines/ConPVP/DuelContext.cs:1337`** - View-ladder rank text used `string.Format(text, from == pm ? "You" : "They")`. Split into `if (from == pm)` / `else` with direct `$"..."` interpolation in each branch.
- **`Projects/UOContent/Engines/ConPVP/DuelContext.cs:1463`** - Showladder text reused a single format string for both `LocalOverheadMessage` ("You ... are ...") and `NonlocalOverheadMessage` ("`{pm.Name}` ... is ..."). Each call now uses an inline `$"..."` directly; no shared template.
- **`Projects/UOContent/Engines/ConPVP/Gumps/ConfirmSignupGump.cs:518`** - The signup confirmation message used a `switch` expression assigning a literal format string to `fmt`, then `string.Format(fmt, from.Female ? "Lady" : "Lord", timeUntil)`. Converted to a `switch` statement where each case calls `_registrar.PrivateOverheadMessage(...)` directly with an inline `$"..."`. Lady/Lord branching is hoisted to a `title` local.

## Exempted

- **`Projects/UOContent/Engines/ConPVP/Participant.cs:138`** - The `nonLocalOverhead` format string is a parameter passed in by callers of `Participant.Broadcast`. Investigation found 5 call sites in `DuelContext.cs` (lines 782, 802, 1187, 1196, and three at 1535/1564/1608) that pass distinct literal format strings. Refactoring would require changing all 5 callers and the method signature - out of scope for this PR. Marked with a `// Phase 3 audit:` comment per the audit's exemption convention.

## Test plan

- [x] `dotnet build ModernUO.slnx --nologo` - clean build, 0 warnings, 0 errors
- [x] `dotnet test ModernUO.slnx --nologo` - all 996 tests pass (Server.Tests: 695, UOContent.Tests: 301)
- [x] Each fix preserves exact message text wording (no copy-editing)
- [x] Follows CLAUDE.md rule #15 (braces required on all control flow)

Independent of Phase 1, 2, 3.1 branches - branched directly from main.