### PR TITLE
feat: Add youngPlayerSystem.enabled toggle to disable Young player system

### DIFF
--- a/Projects/UOContent/Accounting/Account.cs
+++ b/Projects/UOContent/Accounting/Account.cs
@@ -10,6 +10,7 @@ using Server.Misc;
 using Server.Mobiles;
 using Server.Multis;
 using Server.Network;
+using Server.Systems.FeatureFlags;
 
 namespace Server.Accounting;
 
@@ -250,7 +251,7 @@ public partial class Account : IAccount, IComparable<Account>
     /// </summary>
     public bool Young
     {
-        get => !GetFlag(1);
+        get => ContentFeatureFlags.YoungPlayerSystem && !GetFlag(1);
         set
         {
             SetFlag(1, !value);

--- a/Projects/UOContent/Engines/FeatureFlags/ContentFeatureFlags.cs
+++ b/Projects/UOContent/Engines/FeatureFlags/ContentFeatureFlags.cs
@@ -13,4 +13,5 @@ public static class ContentFeatureFlags
     public static bool BoatPlacement { get; set; } = true;
     public static bool BulkOrders { get; set; } = true;
     public static bool PassiveDetectHidden { get; set; } = true;
+    public static bool YoungPlayerSystem { get; set; } = true;
 }

--- a/Projects/UOContent/Engines/FeatureFlags/FeatureFlagManager.cs
+++ b/Projects/UOContent/Engines/FeatureFlags/FeatureFlagManager.cs
@@ -975,6 +975,7 @@ public static class FeatureFlagManager
             "boat_placement"         => ContentFeatureFlags.BoatPlacement = enabled,
             "bulk_orders"            => ContentFeatureFlags.BulkOrders = enabled,
             "passive_detect_hidden"  => ContentFeatureFlags.PassiveDetectHidden = enabled,
+            "young_player_system"    => ContentFeatureFlags.YoungPlayerSystem = enabled,
         };
     }
 

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -684,7 +684,7 @@ namespace Server.Mobiles
         [CommandProperty(AccessLevel.GameMaster)]
         public bool Young
         {
-            get => GetFlag(PlayerFlag.Young);
+            get => ContentFeatureFlags.YoungPlayerSystem && GetFlag(PlayerFlag.Young);
             set
             {
                 SetFlag(PlayerFlag.Young, value);


### PR DESCRIPTION
Adds an opt-in 'youngPlayerSystem.enabled' server setting (default true) that, when set to false, disables the Young player system server-wide:

- Account.Young and PlayerMobile.Young getters short-circuit to false.

- New characters no longer receive Young status or a NewPlayerTicket.

- All downstream Young checks (notoriety beneficial-action restriction, CheckYoungProtection, stealing penalties, YoungDeathTeleport, death-item movement, poison immunity, '(Young)' name suffix, CanLogout, renounce-young keyword/gump, BaseCreature.OnDeath fame penalty, OnLogin time-remaining message) become inert.

Setters are intentionally left untouched so serialized account/player flags round-trip cleanly when the setting is later re-enabled.