### PR TITLE
Fix HouseRaffleStone timer cleanup

### DIFF
--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -207,13 +207,8 @@ public partial class HouseRaffleStone : Item
 
     public override bool DisplayWeight => false;
 
-    public static void CheckEnd_OnTick()
+    private static void CheckEnd_OnTick()
     {
-        if (_allStones == null)
-        {
-            return;
-        }
-
         foreach (var stone in _allStones)
         {
             stone.CheckEnd();
@@ -222,25 +217,21 @@ public partial class HouseRaffleStone : Item
 
     private static void AddRaffleStone(HouseRaffleStone stone)
     {
-        _allStones ??= new HashSet<HouseRaffleStone>();
+        _allStones ??= [];
 
-        /* BEGIN HOUSE RAFFLE TIMER REGISTRATION: keep the shared end-check timer paired with active raffle stones. */
         if (_allStones.Add(stone) && _allStones.Count == 1)
         {
             _allStonesTimer ??= Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(1.0), CheckEnd_OnTick);
         }
-        /* END HOUSE RAFFLE TIMER REGISTRATION */
     }
 
     private static void RemoveRaffleStone(HouseRaffleStone stone)
     {
-        /* BEGIN HOUSE RAFFLE TIMER CLEANUP: stop the shared end-check timer when the final raffle stone is removed. */
         if (_allStones?.Remove(stone) == true && _allStones.Count == 0)
         {
             _allStonesTimer?.Stop();
             _allStonesTimer = null;
         }
-        /* END HOUSE RAFFLE TIMER CLEANUP */
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -221,7 +221,7 @@ public partial class HouseRaffleStone : Item
 
         if (_allStones.Add(stone) && _allStones.Count == 1)
         {
-            _allStonesTimer ??= Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(1.0), CheckEnd_OnTick);
+            _allStonesTimer = Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(1.0), CheckEnd_OnTick);
         }
     }
 
@@ -229,7 +229,7 @@ public partial class HouseRaffleStone : Item
     {
         if (_allStones?.Remove(stone) == true && _allStones.Count == 0)
         {
-            _allStonesTimer?.Stop();
+            _allStonesTimer.Stop();
             _allStonesTimer = null;
         }
     }

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -209,6 +209,11 @@ public partial class HouseRaffleStone : Item
 
     public static void CheckEnd_OnTick()
     {
+        if (_allStones == null)
+        {
+            return;
+        }
+
         foreach (var stone in _allStones)
         {
             stone.CheckEnd();
@@ -218,21 +223,24 @@ public partial class HouseRaffleStone : Item
     private static void AddRaffleStone(HouseRaffleStone stone)
     {
         _allStones ??= new HashSet<HouseRaffleStone>();
-        _allStones.Add(stone);
 
-        if (_allStones.Count == 1)
+        /* BEGIN HOUSE RAFFLE TIMER REGISTRATION: keep the shared end-check timer paired with active raffle stones. */
+        if (_allStones.Add(stone) && _allStones.Count == 1)
         {
-            Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(1.0), CheckEnd_OnTick);
+            _allStonesTimer ??= Timer.DelayCall(TimeSpan.FromMinutes(1.0), TimeSpan.FromMinutes(1.0), CheckEnd_OnTick);
         }
+        /* END HOUSE RAFFLE TIMER REGISTRATION */
     }
 
     private static void RemoveRaffleStone(HouseRaffleStone stone)
     {
+        /* BEGIN HOUSE RAFFLE TIMER CLEANUP: stop the shared end-check timer when the final raffle stone is removed. */
         if (_allStones?.Remove(stone) == true && _allStones.Count == 0)
         {
-            _allStonesTimer.Stop();
+            _allStonesTimer?.Stop();
             _allStonesTimer = null;
         }
+        /* END HOUSE RAFFLE TIMER CLEANUP */
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Summary

Fixes a `NullReferenceException` when deleting/removing the last active `HouseRaffleStone`.

`AddRaffleStone()` started the shared repeating raffle timer but did not assign it to `_allStonesTimer`. When the final tracked raffle stone was removed, `RemoveRaffleStone()` attempted to call `_allStonesTimer.Stop()`, causing a null reference.

## Changes

- Store the shared raffle timer when it is created.
- Avoid duplicate timer registration for the same stone.
- Stop the shared timer null-safely when the final tracked stone is removed.
- Guard the timer tick against a null stone set.

## Testing

- Tested removing stone in game during active raffles / etc to ensure no further DCs