### PR TITLE
refactor(server): unify first-boot prompts into the ConfigurePrompts phase

### DIFF
--- a/Projects/Server/Configuration/ServerConfiguration.cs
+++ b/Projects/Server/Configuration/ServerConfiguration.cs
@@ -218,11 +218,13 @@ public static class ServerConfiguration
         Save();
     }
 
-    // If mock is enabled we skip the console readline.
+    // Reads (or creates) the configuration file. The interactive first-boot prompts live in
+    // ConfigurePrompts (run later via AssemblyHandler.Invoke("ConfigurePrompts")) so all
+    // first-boot prompting — engine and content — shares one phase/wiring. mocked skips prompts
+    // entirely (ConfigurePrompts is gated on m_Mocked and isn't invoked by the test fixtures).
     public static void Load(bool mocked = false)
     {
         m_Mocked = mocked;
-        var updated = false;
 
         if (File.Exists(m_FilePath))
         {
@@ -239,14 +241,26 @@ public static class ServerConfiguration
         }
         else
         {
-            updated = true;
             _settings = new ServerSettings();
         }
+    }
 
-        if (mocked)
+    // First-boot interactive configuration, discovered + run by AssemblyHandler.Invoke(
+    // "ConfigurePrompts") after assemblies load but before Serilog's first log line, so the
+    // console prompts are not interleaved with the async console sink (see
+    // dev-docs/server-lifecycle.md). CallPriority(0) so the engine's own prompts (data dirs,
+    // listeners, server name, expansion + map selection) run before any content ConfigurePrompts
+    // that build on them (e.g. map selection before a pathfinding pre-bake prompt). Also resolves
+    // Core.Expansion on every non-mocked boot.
+    [CallPriority(0)]
+    public static void ConfigurePrompts()
+    {
+        if (m_Mocked)
         {
             return;
         }
+
+        var updated = false;
 
         if (_settings.DataDirectories.Count == 0)
         {

--- a/dev-docs/server-lifecycle.md
+++ b/dev-docs/server-lifecycle.md
@@ -105,19 +105,23 @@ Tests do **not** go through `Main`. The test fixtures (`Server.Tests`/`UOContent
 to the **startup ordering in `Main.cs`** (including the prompt phases) are **not** covered by the
 test suite and need first-boot runtime verification.
 
-## Planned: unify the engine's first-boot prompts into `ConfigurePrompts`
+## Unified: the engine's first-boot prompts run through `ConfigurePrompts`
 
-Today the engine's own first-boot prompts (data dirs, listeners, server name, expansion + maps)
-are inline in `ServerConfiguration.Load`, separate from the `ConfigurePrompts` mechanism. They
-can be unified into the same phase so there's one prompt sequence/wiring:
+The engine's own first-boot prompts (data directories, listeners, server name, expansion + map
+selection) live in **`ServerConfiguration.ConfigurePrompts()`** (`[CallPriority(0)]`) and are
+discovered by the same `Invoke("ConfigurePrompts")` phase as content prompts — one sequence and
+one wiring for all first-boot prompting. `ServerConfiguration.Load` now only reads/creates the
+config file. What made this safe:
 
-- **Feasible because** assembly loading uses `AssemblyDirectories` (default `./Assemblies`), not
-  `DataDirectories` — so assemblies can load *before* the data-dir prompt, letting all prompts
-  move into the post-assembly `ConfigurePrompts` phase.
-- **`UOClient.Load()`** (client-file discovery via `Core.FindDataFile`) needs `DataDirectories`,
-  so it must move *with* the data-dir prompt into the unified phase.
-- **`Core.Expansion`** is currently assigned during `Load`; under unification it'd be set during
-  `ConfigurePrompts` — verify nothing between assembly-load and that point depends on it.
+- Assembly loading uses `AssemblyDirectories` (default `./Assemblies`), **not** `DataDirectories`,
+  so assemblies load fine before the (now-later) data-dir prompt.
+- `UOClient.Load()` (client-file discovery via `Core.FindDataFile`) needs `DataDirectories`, so it
+  moved *with* the data-dir prompt into `ConfigurePrompts`.
+- `Core.Expansion` is now assigned in `ConfigurePrompts` (every non-mocked boot). Nothing between
+  assembly-load and that phase reads it — type initializers run lazily on first use, not during
+  `LoadAssemblies`.
+- `[CallPriority(0)]` keeps the engine prompts (including map selection) ahead of content prompts
+  such as the pathfinding pre-bake (default priority 50), preserving "after map selection".
 
-This is an engine-startup restructure the test suite can't cover (see Testing note), so it needs
-first-boot runtime verification before merging.
+Since `Main.cs` startup ordering isn't covered by the fixture-based suite (see Testing note), this
+path is validated by a first-boot runtime check rather than tests.


### PR DESCRIPTION
Stacked on #2475 (the `ConfigurePrompts` phase). Base will switch to `main` once #2475 merges.

## What

Move the engine's own first-boot prompts — data directories, listeners, server name, expansion + map selection — out of `ServerConfiguration.Load` and into **`ServerConfiguration.ConfigurePrompts()`** (`[CallPriority(0)]`), so **all** first-boot prompting (engine and content) runs through the single `AssemblyHandler.Invoke("ConfigurePrompts")` phase. `Load` now only reads/creates the config file.

## Why it's safe

- **Assembly loading uses `AssemblyDirectories` (default `./Assemblies`), not `DataDirectories`** — so assemblies load fine before the now-later data-dir prompt. This is the linchpin that makes the move possible.
- **`UOClient.Load()`** (client-file discovery via `Core.FindDataFile`) needs `DataDirectories`, so it moved *with* the data-dir prompt into `ConfigurePrompts`.
- **`Core.Expansion`** is now assigned in `ConfigurePrompts` (every non-mocked boot). Nothing between `LoadAssemblies` and that phase reads it — type initializers run lazily on first use, not during `LoadAssemblies`.
- **`[CallPriority(0)]`** keeps the engine prompts (including map selection) ahead of content prompts such as the pathfinding pre-bake (priority 50), preserving "after map selection".
- `Main.cs` already invokes the phase — **no startup-ordering edit** here.

## Tests

`Server.Tests` **708/708**, `UOContent.Tests` **418/418**, build clean. Fixtures are unaffected: they call `Load(true)` (now just reads config) and set expansion/data dirs directly; `ConfigurePrompts` is gated on `m_Mocked`.

## ⚠️ Needs first-boot runtime verification

`Main.cs` startup ordering is **not** covered by the fixture-based suite (the fixtures bypass `Main`). Please boot once with a fresh `modernuo.json` to confirm the first-boot prompt sequence (data dirs → … → expansion/maps → pathfinding pre-bake) and that `Core.Expansion` resolves correctly. Docs updated in `dev-docs/server-lifecycle.md`.