### PR TITLE
fix: Bumps dependencies. Adds epoll and Server 2012/2016 support.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,7 +68,7 @@
         <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
-            <Version>3.9.50</Version>
+            <Version>3.10.85</Version>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <AdditionalFiles Include="..\..\Rules.ruleset" />

--- a/Projects/BuildTool/BuildTool.csproj
+++ b/Projects/BuildTool/BuildTool.csproj
@@ -16,6 +16,6 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Spectre.Console" Version="0.56.0" />
+        <PackageReference Include="Spectre.Console" Version="0.57.2" />
     </ItemGroup>
 </Project>

--- a/Projects/Server.Tests/Server.Tests.csproj
+++ b/Projects/Server.Tests/Server.Tests.csproj
@@ -5,7 +5,7 @@
         <RootNamespace>Server.Tests</RootNamespace>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.SkippableFact" Version="1.5.61" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,10 +34,10 @@
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Logger\Logger.csproj" />
-        <PackageReference Include="IORingGroup" Version="1.0.6" />
+        <PackageReference Include="IORingGroup" Version="1.0.7" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.3" />
-        <PackageReference Include="System.IO.Hashing" Version="10.0.8" />
+        <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
 
         <PackageReference Include="ModernUO.Serialization.Annotations" Version="2.14.2" />
         <PackageReference Include="ModernUO.Serialization.Generator" Version="2.14.3" />

--- a/Projects/UOContent.Tests/UOContent.Tests.csproj
+++ b/Projects/UOContent.Tests/UOContent.Tests.csproj
@@ -4,7 +4,7 @@
         <Configurations>Debug;Release;Analyze</Configurations>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -41,9 +41,9 @@
             <IncludeInPackage>false</IncludeInPackage>
         </ProjectReference>
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.3" />
-        <PackageReference Include="System.IO.Hashing" Version="10.0.8" />
+        <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
         <PackageReference Include="MailKit" Version="4.17.0" />
-        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.9" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="Argon2.Bindings" Version="1.17.0" />
         <PackageReference Include="ModernUO.CodeGeneratedEvents.Annotations" Version="1.0.0" />


### PR DESCRIPTION
### Summary

* Bumps dependencies
* Bumps IORingGroup to add epoll support and backward compatibility for Server 2012/2016.

Closes #2508 