### PR TITLE
feat(throwing): add remaining SA throwing artifacts (add-only)

### DIFF
--- a/Projects/UOContent/Items/Weapons/Throwing/AbyssReaver.cs
+++ b/Projects/UOContent/Items/Weapons/Throwing/AbyssReaver.cs
@@ -1,0 +1,17 @@
+using ModernUO.Serialization;
+
+namespace Server.Items;
+
+[SerializationGenerator(0)]
+public partial class AbyssReaver : Cyclone
+{
+    [Constructible]
+    public AbyssReaver()
+    {
+        SkillBonuses.SetValues(0, SkillName.Throwing, Utility.RandomMinMax(5, 10));
+        Attributes.WeaponDamage = Utility.RandomMinMax(25, 35);
+        Slayer = SlayerName.Exorcism;
+    }
+
+    public override int LabelNumber => 1112694; // Abyss Reaver
+}

--- a/Projects/UOContent/Items/Weapons/Throwing/BansheesCall.cs
+++ b/Projects/UOContent/Items/Weapons/Throwing/BansheesCall.cs
@@ -1,0 +1,25 @@
+using ModernUO.Serialization;
+
+namespace Server.Items;
+
+[SerializationGenerator(0)]
+public partial class BansheesCall : Cyclone
+{
+    [Constructible]
+    public BansheesCall()
+    {
+        Hue = 1266;
+        WeaponAttributes.HitHarm = 40;
+        WeaponAttributes.HitLeechHits = 45;
+        Attributes.BonusStr = 5;
+        Attributes.WeaponSpeed = 30;
+        Attributes.WeaponDamage = 50;
+        Velocity = 35;
+        AosElementDamages.Cold = 100;
+    }
+
+    public override int LabelNumber => 1113529; // Banshee's Call
+
+    public override int InitMinHits => 255;
+    public override int InitMaxHits => 255;
+}

--- a/Projects/UOContent/Items/Weapons/Throwing/StormCaller.cs
+++ b/Projects/UOContent/Items/Weapons/Throwing/StormCaller.cs
@@ -1,0 +1,30 @@
+using ModernUO.Serialization;
+
+namespace Server.Items;
+
+[SerializationGenerator(0)]
+public partial class StormCaller : Boomerang
+{
+    [Constructible]
+    public StormCaller()
+    {
+        Hue = 456;
+        //TODO Implement BattleLust
+        //WeaponAttributes.BattleLust = 1;
+        WeaponAttributes.HitLightning = 40;
+        WeaponAttributes.HitLowerDefend = 30;
+        Attributes.BonusStr = 5;
+        Attributes.WeaponSpeed = 30;
+        Attributes.WeaponDamage = 40;
+        AosElementDamages.Physical = 20;
+        AosElementDamages.Fire = 20;
+        AosElementDamages.Cold = 20;
+        AosElementDamages.Poison = 20;
+        AosElementDamages.Energy = 20;
+    }
+
+    public override int LabelNumber => 1113530; // Storm Caller
+
+    public override int InitMinHits => 255;
+    public override int InitMaxHits => 255;
+}

--- a/Projects/UOContent/Items/Weapons/Throwing/WindOfCorruption.cs
+++ b/Projects/UOContent/Items/Weapons/Throwing/WindOfCorruption.cs
@@ -1,0 +1,24 @@
+using ModernUO.Serialization;
+
+namespace Server.Items;
+
+[SerializationGenerator(0)]
+public partial class WindOfCorruption : Cyclone
+{
+    [Constructible]
+    public WindOfCorruption()
+    {
+        Hue = 1171;
+        WeaponAttributes.HitLeechStam = 40;
+        WeaponAttributes.HitLowerDefend = 40;
+        Attributes.WeaponSpeed = 30;
+        Attributes.WeaponDamage = 50;
+        Slayer = SlayerName.Fey;
+        AosElementDamages.Chaos = 100;
+    }
+
+    public override int LabelNumber => 1150358; // Wind of Corruption
+
+    public override int InitMinHits => 255;
+    public override int InitMaxHits => 255;
+}

--- a/Projects/UOContent/Migrations/Server.Items.AbyssReaver.v0.json
+++ b/Projects/UOContent/Migrations/Server.Items.AbyssReaver.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Items.AbyssReaver"
+}

--- a/Projects/UOContent/Migrations/Server.Items.BansheesCall.v0.json
+++ b/Projects/UOContent/Migrations/Server.Items.BansheesCall.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Items.BansheesCall"
+}

--- a/Projects/UOContent/Migrations/Server.Items.StormCaller.v0.json
+++ b/Projects/UOContent/Migrations/Server.Items.StormCaller.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Items.StormCaller"
+}

--- a/Projects/UOContent/Migrations/Server.Items.WindOfCorruption.v0.json
+++ b/Projects/UOContent/Migrations/Server.Items.WindOfCorruption.v0.json
@@ -1,0 +1,4 @@
+{
+  "version": 0,
+  "type": "Server.Items.WindOfCorruption"
+}


### PR DESCRIPTION
Adds the four remaining named Stygian Abyss throwing artifacts as item definitions, completing the throwing artifact set (7/7 now defined in ModernUO).

## Added (stat-for-stat from ServUO)
- **Abyss Reaver** (Cyclone) — random Throwing +5..10 skill bonus, +25..35 damage, Exorcism slayer
- **Storm Caller** (Boomerang) — Hit Lightning / Hit Lower Defense, 20/20/20/20/20 elemental split
- **Banshee's Call** (Cyclone) — Hit Harm / Hit Life Leech, 100% cold, Velocity 35
- **Wind of Corruption** (Cyclone) — Hit Stamina Leech / Hit Lower Defense, 100% chaos, Fey slayer

## Acquisition — deferred (documented)
These are **`[add`-only for now**. Their OSI sources aren't in ModernUO yet:
- Abyss Reaver → the Into the Void quest (Agralem), deferred with the Abyss void-creature content.
- Storm Caller / Banshee's Call / Wind of Corruption → renowned/boss creatures (`WyvernRenowned`, `PrimevalLich`, etc.) that need a `BaseRenowned` framework port.

Per direction, the items are worth defining now; wiring their drops follows later.

## Notes
- Storm Caller's ServUO `WeaponAttributes.BattleLust = 1` is left as a `//TODO Implement BattleLust` — the attribute doesn't exist in ModernUO's `AosWeaponAttribute` set yet.
- The human Bow variant `WindOfCorruptionHuman` is archery, not throwing — intentionally out of scope.

Server builds clean.