### PR TITLE
ci: cap job runtime, dump on test hangs, expand the Linux matrix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,6 +23,8 @@ on:
 jobs:
   build-macos:
     runs-on: ${{ matrix.os }}
+    # A hung run otherwise bills the full 360-minute default before GitHub kills it.
+    timeout-minutes: 30
     name: Build (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -52,15 +54,26 @@ jobs:
     - name: Migration Changes
       run: git diff --exit-code ./**/Migrations/*.v*.json
     - name: Test
+      # blame-hang kills a stuck test host after 10 minutes and reports the in-flight
+      # tests plus a process dump instead of hanging until the job timeout.
       run: |
-        dotnet test --logger trx --results-directory ./TestResults
+        dotnet test --logger trx --results-directory ./TestResults --blame-hang --blame-hang-timeout 10m --blame-hang-dump-type full
         if [ -z "$(find ./TestResults -name '*.trx' 2>/dev/null)" ]; then
           echo "::error::No test result files were produced - no test projects ran. Failing to avoid masking failures."
           exit 1
         fi
+    - name: Upload test results on failure
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: TestResults-${{ matrix.name }}
+        path: ./TestResults
+        if-no-files-found: ignore
 
   build-linux:
     runs-on: ubuntu-latest
+    # A hung run otherwise bills the full 360-minute default before GitHub kills it.
+    timeout-minutes: 30
     container:
       image: ${{ matrix.container }}
       options: --security-opt seccomp=unconfined
@@ -69,6 +82,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - container: ubuntu:26.04
+            name: Ubuntu 26
+            packageManager: apt
           - container: ubuntu:noble
             name: Ubuntu 24
             packageManager: apt
@@ -81,20 +97,33 @@ jobs:
           - container: debian:bookworm
             name: Debian 12
             packageManager: apt
-          - container: fedora:42
-            name: Fedora 42
+          - container: fedora:44
+            name: Fedora 44
             packageManager: dnf
           - container: quay.io/centos/centos:stream9
             name: CentOS 9 Stream
             packageManager: dnf
+            epel: true
+          - container: quay.io/centos/centos:stream10
+            name: CentOS 10 Stream
+            packageManager: dnf
+            epel: true
+          - container: almalinux:10
+            name: AlmaLinux 10
+            packageManager: dnf
+            epel: true
 
     steps:
-      - name: Enable EPEL and CRB for CentOS
+      # Enable CRB before EPEL, per the EPEL quickstart. epel-next is not installed:
+      # none of the prerequisites need it, EPEL 10 does not have it, and it is one more
+      # mirrorlist to fetch.
+      - name: Enable EPEL and CRB
         run: |
           dnf upgrade --refresh -y
-          dnf install -y epel-release epel-next-release
+          dnf install -y dnf-plugins-core
           dnf config-manager --set-enabled crb
-        if: ${{ startsWith(matrix.name, 'CentOS') }}
+          dnf install -y epel-release
+        if: ${{ matrix.epel }}
       - name: Install Prerequisites using dnf
         run: dnf makecache --refresh && dnf install -y findutils libicu libdeflate-devel zstd libargon2-devel liburing-devel
         if: ${{ matrix.packageManager == 'dnf' }}
@@ -111,9 +140,18 @@ jobs:
       - name: Build
         run: dotnet run --project Projects/BuildTool -- --config Release --skip-prereqs
       - name: Test
+        # blame-hang kills a stuck test host after 10 minutes and reports the in-flight
+        # tests plus a process dump instead of hanging until the job timeout.
         run: |
-          dotnet test --logger trx --results-directory ./TestResults
+          dotnet test --logger trx --results-directory ./TestResults --blame-hang --blame-hang-timeout 10m --blame-hang-dump-type full
           if [ -z "$(find ./TestResults -name '*.trx' 2>/dev/null)" ]; then
             echo "::error::No test result files were produced - no test projects ran. Failing to avoid masking failures."
             exit 1
           fi
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TestResults-${{ matrix.name }}
+          path: ./TestResults
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ ModernUO [![Discord](https://img.shields.io/discord/751317910504603701?logo=disc
 [![Windows 10/11/2012/2016/2019/2022/2025](https://img.shields.io/badge/-server%202025-3c78d5?labelColor=222222&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHJvbGU9ImltZyIgdmlld0JveD0iMCAwIDI0IDI0Ij48dGl0bGU+V2luZG93czwvdGl0bGU+PHBhdGggZD0iTTAsMEgxMS4zNzdWMTEuMzcySDBaTTEyLjYyMywwSDI0VjExLjM3MkgxMi42MjNaTTAsMTIuNjIzSDExLjM3N1YyNEgwWm0xMi42MjMsMEgyNFYyNEgxMi42MjMiIGZpbGw9IiMzYzc4ZDUiLz48L3N2Zz4=)](https://www.microsoft.com/en-US/evalcenter/evaluate-windows-server-2022)
 ![MacOS 14+](https://img.shields.io/badge/-sonoma-222222?logo=apple&logoColor=white&labelColor=222222)
 [![Debian 12+](https://img.shields.io/badge/-trixie-A81D33?logo=debian&logoColor=A81D33&labelColor=222222)](https://www.debian.org/distrib/)
-[![Ubuntu 22+ LTS](https://img.shields.io/badge/-24LTS-E95420?logo=ubuntu&logoColor=E95420&labelColor=222222)](https://ubuntu.com/download/server)
+[![Ubuntu 22+ LTS](https://img.shields.io/badge/-26LTS-E95420?logo=ubuntu&logoColor=E95420&labelColor=222222)](https://ubuntu.com/download/server)
 <br/>
 [![Alpine 3.22+](https://img.shields.io/badge/-3.22-0D597F?logo=alpinelinux&logoColor=0D597F&labelColor=222222)](https://alpinelinux.org/downloads/)
-[![Fedora 42+](https://img.shields.io/badge/-42-51a2da?logo=fedora&logoColor=51a2da&labelColor=222222)](https://getfedora.org/en/server/download/)
-[![RedHat 9+](https://img.shields.io/badge/-9-BE0000?logo=redhat&logoColor=BE0000&labelColor=222222)](https://access.redhat.com/downloads)
-[![CentOS Stream 9+](https://img.shields.io/badge/-stream_9-262577?logo=centos&logoColor=white&labelColor=222222)](https://www.centos.org/download/)
+[![Fedora 42+](https://img.shields.io/badge/-44-51a2da?logo=fedora&logoColor=51a2da&labelColor=222222)](https://getfedora.org/en/server/download/)
+[![RedHat 9+](https://img.shields.io/badge/-10-BE0000?logo=redhat&logoColor=BE0000&labelColor=222222)](https://access.redhat.com/downloads)
+[![CentOS Stream 9+](https://img.shields.io/badge/-stream_10-262577?logo=centos&logoColor=white&labelColor=222222)](https://www.centos.org/download/)
+[![AlmaLinux 10](https://img.shields.io/badge/-10-0F4266?logo=almalinux&logoColor=white&labelColor=222222)](https://almalinux.org/get-almalinux/)
 [![openSUSE 15.6+](https://img.shields.io/badge/-15.6-73BA25?logo=openSUSE&logoColor=73BA25&labelColor=222222)](https://get.opensuse.org/)
 [![SUSE Enterprise 15 SP6](https://img.shields.io/badge/-15%20SP6-0C322C?logo=suse&logoColor=30BA78&labelColor=222222)](https://www.suse.com/download/sles/)
 [![Linux Mint 21+](https://img.shields.io/badge/-21-87CF3E?logo=linux%20mint&logoColor=87CF3E&labelColor=222222)](https://linuxmint.com/download.php)
@@ -77,11 +78,15 @@ Run `./publish.cmd` (Windows) or `./publish.sh` (Linux/macOS) with no arguments 
   - `arm64` - ARM 64-bit
 
 ## Linux Prerequisites
-### Fedora, CentOS, RHEL, etc
+### Fedora, CentOS, RHEL, AlmaLinux, Rocky, etc
 ```shell
 dnf upgrade --refresh -y
-# CentOS does not come with EPEL enabled
-dnf install -y epel-release epel-next-release
+# RHEL-family distributions (CentOS Stream, AlmaLinux, Rocky, RHEL) need CRB and EPEL enabled.
+# Fedora skips this block.
+dnf install -y dnf-plugins-core
+dnf config-manager --set-enabled crb
+dnf install -y epel-release
+# Prerequisites
 dnf install -y findutils libicu libdeflate-devel zstd libargon2-devel liburing-devel
 ```
 


### PR DESCRIPTION
Two stalls hit CI in one night with nothing bounding them but GitHub's 360-minute default:

1. A silently deadlocked test host (2h41m before manual cancel) — the code fix is on #2525; this PR adds the guardrails that make any recurrence cheap and self-diagnosing.
2. A dnf step stalled mid-download for 12+ then 30 minutes. Probing the EPEL mirror pool directly: the **first** mirror in the current US mirrorlist returns consistent HTTP 500, and sibling mirrors serve mismatched metadata generations, while Fedora's status page reads all-green (it only tracks central services, not the volunteer pool).

## Changes

- **`timeout-minutes: 30` on both jobs.** Verified live: the cap killed a stalled job at exactly 30:02 instead of 6 hours.
- **`dotnet test --blame-hang-timeout 10m --blame-hang-dump-type full`** — a stuck test host is killed after 10 minutes and vstest names the in-flight tests with a full process dump; `TestResults` (including dumps) upload as artifacts on failure. A future hang produces a stack trace instead of a bill.
- **EPEL setup follows the quickstart ordering**: `dnf-plugins-core` → enable CRB → `epel-release`. `epel-next` is no longer installed — none of the prerequisites need it (validated green on Stream 9), EPEL 10 doesn't have it, and it's one more mirrorlist to fetch.
- **Matrix**: adds **Ubuntu 26.04 LTS**, **CentOS Stream 10**, and **AlmaLinux 10** (real-EL10 coverage); bumps **Fedora 42 → 44** (42 went EOL in May). README badges and the Linux prerequisites section updated to match.

Kept deliberately simple per review: no retry wrappers around dnf — mirror hiccups are rare and the job cap bounds the damage.