### PR TITLE
fix(opl): only apply the ':#' cliloc marker to integer values

### DIFF
--- a/Projects/Server.Tests/Tests/PropertyList/ObjectPropertyListSpanAddTests.cs
+++ b/Projects/Server.Tests/Tests/PropertyList/ObjectPropertyListSpanAddTests.cs
@@ -63,6 +63,21 @@ public class ObjectPropertyListSpanAddTests
     }
 
     [Fact]
+    public void HashFormat_OnlyMarksIntegers()
+    {
+        // Integer {value:#} emits the cliloc marker "#<value>".
+        var intList = new ObjectPropertyList(null);
+        intList.Add(1062028, $"{1043009:#}");
+        Assert.Equal((1062028, "#1043009"), Decode(intList)[0]);
+
+        // Float {value:#} is the standard '#' custom-numeric (digit-placeholder) format, not a cliloc
+        // marker -- so no leading '#'.
+        var dblList = new ObjectPropertyList(null);
+        dblList.Add(1062028, $"{42.0:#}");
+        Assert.Equal((1062028, 42.0.ToString("#")), Decode(dblList)[0]); // "42"
+    }
+
+    [Fact]
     public void Add_TruncatesArgumentOverMaxLength()
     {
         var oversized = new string('x', ObjectPropertyList.MaxArgumentLength + 50);

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -384,9 +384,9 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted<T>(T value, string? format)
     {
-        // We support localization '#' cliloc formatter for custom property lists
-        // This allows someone to build an IPropertyList that creates HTML using the same syntax as LocalizationInterpolationHandler
-        if (format == "#")
+        // '#' marks an integer argument as a cliloc ("#<value>"). Integers only -- a float/double/decimal
+        // '#' is the standard numeric format, not a cliloc marker.
+        if (format == "#" && value is int or uint or long or ulong or short or ushort or byte or sbyte)
         {
             AppendLiteral("#");
             format = null;


### PR DESCRIPTION
`ObjectPropertyList.AppendFormatted<T>(value, format)` treated **any** `{value:#}` as the cliloc marker (emitting `#<value>`). But cliloc numbers are integers — a `float`/`double`/`decimal` formatted with `#` is the standard custom-numeric (`#` = digit placeholder) format, not a cliloc reference, so those were being mis-marked.

Gate the marker on an integer value type:
```csharp
if (format == "#" && value is int or uint or long or ulong or short or ushort or byte or sbyte)
```

Now `{someFloat:#}` formats normally (passes `#` through to `TryFormat`); the marker/standard-format ambiguity narrows to the harmless `{0:#}` **integer** case (`#0`). Existing `AddLocalized(int)` / `{value:#}` (all `int`) are unaffected.

Adds `ObjectPropertyListSpanAddTests.HashFormat_OnlyMarksIntegers`: `int {value:#}` → `#<value>`; `double {value:#}` → `42.0.ToString("#")` (`"42"`, no `#`).