### PR TITLE
fix(opl): don't tear down a property list that is mid-interpolation

### DIFF
--- a/Projects/Server.Tests/Tests/PropertyList/ObjectPropertyListReentrancyTests.cs
+++ b/Projects/Server.Tests/Tests/PropertyList/ObjectPropertyListReentrancyTests.cs
@@ -1,0 +1,66 @@
+using System;
+using Xunit;
+
+namespace Server.Tests;
+
+/// <summary>
+/// The interpolation scratch buffer is rented by the compiler-generated handler ctor
+/// (InitializeInterpolation) and returned by the closing Add. Reset()/Dispose() also return it, so
+/// if either runs while a hole is still being evaluated the buffer is nulled underneath the
+/// in-flight handler and the next Append* spans a null array:
+///
+///   System.ArgumentNullException: Value cannot be null. (Parameter 'array')
+///     at Server.ObjectPropertyList.AppendStringDirect(String value)
+///
+/// This is reachable in practice. Mobile.InvalidateProperties rebuilds in place:
+///
+///   m_PropertyList.Reset();
+///   InitializePropertyList(m_PropertyList);   // <- GetProperties runs with m_PropertyList set
+///
+/// so any property getter with an InvalidateProperties side effect that is read from inside
+/// GetProperties re-enters, calls Reset() on the list being written, and kills the whole tooltip
+/// build. Factions PlayerState.Rank is exactly such a getter: its getter calls Invalidate(), and
+/// m_InvalidateRank defaults to true, so the first tooltip build for a faction member on the
+/// faction facet after a load trips it.
+/// </summary>
+public class ObjectPropertyListReentrancyTests
+{
+    // Stands in for a property getter that invalidates the entity while its tooltip is being built.
+    private static string ResettingHole(ObjectPropertyList list, string value)
+    {
+        list.Reset();
+        return value;
+    }
+
+    private static string DisposingHole(ObjectPropertyList list, string value)
+    {
+        list.Dispose();
+        return value;
+    }
+
+    [Fact]
+    public void InterpolatedAdd_ResetMidHole_DoesNotThrow()
+    {
+        var opl = new ObjectPropertyList(null);
+
+        // Mirrors PlayerMobile.GetProperties:
+        //   list.Add(1060776, $"{pl.Rank.Title}\t{faction.Definition.PropName}");
+        var ex = Record.Exception(
+            () => opl.Add(1060776, $"{ResettingHole(opl, "Knight")}\t{"Council of Mages"}")
+        );
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void InterpolatedAdd_DisposeMidHole_DoesNotThrow()
+    {
+        var opl = new ObjectPropertyList(null);
+
+        var ex = Record.Exception(
+            () => opl.Add(1060776, $"{DisposingHole(opl, "Knight")}\t{"Council of Mages"}")
+        );
+
+        Assert.Null(ex);
+    }
+}

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2427,11 +2427,34 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
         }
     }
 
+    // See Mobile._buildingPropertyList: a property getter reached from GetProperties /
+    // AppendChildProperties can call InvalidateProperties, which Reset()s the list being built and
+    // returns its interpolation scratch buffer under an in-flight `$"..."` handler.
+    private bool _buildingPropertyList;
+    private bool _propertyListInvalidatedDuringBuild;
+
     private ObjectPropertyList InitializePropertyList(ObjectPropertyList list)
     {
-        GetProperties(list);
-        AppendChildProperties(list);
-        list.Terminate();
+        _buildingPropertyList = true;
+        _propertyListInvalidatedDuringBuild = false;
+
+        try
+        {
+            GetProperties(list);
+            AppendChildProperties(list);
+            list.Terminate();
+        }
+        finally
+        {
+            _buildingPropertyList = false;
+        }
+
+        if (_propertyListInvalidatedDuringBuild)
+        {
+            _propertyListInvalidatedDuringBuild = false;
+            Delta(ItemDelta.Properties);
+        }
+
         return list;
     }
 
@@ -2445,6 +2468,13 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
     {
         if (!ObjectPropertyList.Enabled)
         {
+            return;
+        }
+
+        // Re-entered from a side-effecting getter inside GetProperties. See _buildingPropertyList.
+        if (_buildingPropertyList)
+        {
+            _propertyListInvalidatedDuringBuild = true;
             return;
         }
 

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -7223,10 +7223,37 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         return delta != 0 ? body : 0;
     }
 
+    // A property getter reached from GetProperties can itself call InvalidateProperties -- Factions
+    // PlayerState.Rank does exactly that. InvalidateProperties rebuilds in place via
+    // list.Reset() + InitializePropertyList(list), and Reset() returns the interpolation scratch
+    // buffer to the pool. Re-entering it mid-build therefore pulls that buffer out from under an
+    // in-flight `$"..."` handler and the next Append* spans a null array (ArgumentNullException,
+    // parameter "array"), aborting the whole tooltip build. The list being built already observes
+    // the new state, so a nested invalidate only has to push the update once the build finishes.
+    private bool _buildingPropertyList;
+    private bool _propertyListInvalidatedDuringBuild;
+
     private ObjectPropertyList InitializePropertyList(ObjectPropertyList list)
     {
-        GetProperties(list);
-        list.Terminate();
+        _buildingPropertyList = true;
+        _propertyListInvalidatedDuringBuild = false;
+
+        try
+        {
+            GetProperties(list);
+            list.Terminate();
+        }
+        finally
+        {
+            _buildingPropertyList = false;
+        }
+
+        if (_propertyListInvalidatedDuringBuild)
+        {
+            _propertyListInvalidatedDuringBuild = false;
+            Delta(MobileDelta.Properties);
+        }
+
         return list;
     }
 
@@ -7240,6 +7267,13 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     {
         if (!ObjectPropertyList.Enabled)
         {
+            return;
+        }
+
+        // Re-entered from a side-effecting getter inside GetProperties. See _buildingPropertyList.
+        if (_buildingPropertyList)
+        {
+            _propertyListInvalidatedDuringBuild = true;
             return;
         }
 

--- a/Projects/Server/PropertyList/ObjectPropertyList.cs
+++ b/Projects/Server/PropertyList/ObjectPropertyList.cs
@@ -319,8 +319,27 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
     private static int GetDefaultLength(int literalLength, int formattedCount) =>
         Math.Max(256, literalLength + formattedCount * 11);
 
+    // Last line of defense for interpolation re-entrancy. Reset()/Dispose() return the scratch
+    // buffer to the pool; if either runs while a `$"..."` handler is still appending -- a property
+    // getter with an InvalidateProperties side effect called from inside GetProperties, see
+    // Mobile._buildingPropertyList -- every subsequent Append* would span a null array and throw
+    // ArgumentNullException("array"), aborting the entire GetProperties call. Re-rent instead so
+    // the property is still emitted. Mobile/Item hold the primary guard; this keeps a stray Reset()
+    // from any other caller off the crash path.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void EnsureInterpolationBuffer()
+    {
+        if (_arrayToReturnToPool == null)
+        {
+            _arrayToReturnToPool = STArrayPool<char>.Shared.Rent(256);
+            _pos = 0;
+        }
+    }
+
     public void AppendLiteral(string value)
     {
+        EnsureInterpolationBuffer();
+
         if (value.Length == 1)
         {
             var chars = _arrayToReturnToPool.AsSpan();
@@ -354,6 +373,8 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted<T>(T value)
     {
+        EnsureInterpolationBuffer();
+
         string? s;
         if (value is IFormattable)
         {
@@ -384,6 +405,8 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted<T>(T value, string? format)
     {
+        EnsureInterpolationBuffer();
+
         // '#' marks an integer argument as a cliloc ("#<value>"). Integers only -- a float/double/decimal
         // '#' is the standard numeric format, not a cliloc marker.
         if (format == "#" && value is int or uint or long or ulong or short or ushort or byte or sbyte)
@@ -442,6 +465,8 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted(ReadOnlySpan<char> value)
     {
+        EnsureInterpolationBuffer();
+
         if (value.TryCopyTo(_arrayToReturnToPool.AsSpan(_pos..)))
         {
             _pos += value.Length;
@@ -454,6 +479,8 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null)
     {
+        EnsureInterpolationBuffer();
+
         var leftAlign = false;
         if (alignment < 0)
         {
@@ -488,6 +515,8 @@ public sealed class ObjectPropertyList : IPropertyList, IDisposable
 
     public void AppendFormatted(string? value)
     {
+        EnsureInterpolationBuffer();
+
         if (value?.TryCopyTo(_arrayToReturnToPool.AsSpan(_pos..)) == true)
         {
             _pos += value.Length;

--- a/Projects/UOContent/Engines/Factions/Core/PlayerState.cs
+++ b/Projects/UOContent/Engines/Factions/Core/PlayerState.cs
@@ -194,10 +194,20 @@ public class PlayerState : IComparable<PlayerState>
             {
                 m_RankIndex = value;
                 m_InvalidateRank = true;
+
+                // Refresh the tooltip here, where the rank actually changes, rather than from the
+                // Rank getter -- which is read from inside GetProperties. See the note on Rank.
+                Invalidate();
             }
         }
     }
 
+    // NOTE: this getter must stay side-effect free. It is read from PlayerMobile.GetProperties
+    // while the object property list is being built; the Invalidate() that used to live here
+    // re-entered Mobile.InvalidateProperties, which Reset()s the very list being written and
+    // returns its pooled interpolation buffer under the in-flight `$"..."` handler, throwing
+    // ArgumentNullException("array") out of GetProperties. Invalidation now happens where the rank
+    // is actually dirtied (the RankIndex and KillPoints setters).
     public RankDefinition Rank
     {
         get
@@ -211,7 +221,7 @@ public class PlayerState : IComparable<PlayerState>
                 {
                     percent = 1000;
                 }
-                else if (m_RankIndex == -1)
+                else if (m_RankIndex == -1 || Faction.ZeroRankOffset <= 0)
                 {
                     percent = 0;
                 }
@@ -220,6 +230,12 @@ public class PlayerState : IComparable<PlayerState>
                     percent = (Faction.ZeroRankOffset - m_RankIndex) * 1000 / Faction.ZeroRankOffset;
                 }
 
+                // Ranks are ordered by Required descending and the last entry requires 0, so this
+                // matches for any percent >= 0. A negative percent (RankIndex out of sync with
+                // ZeroRankOffset) would otherwise leave the rank null AND permanently dirty, which
+                // NREs on Rank.Title and re-invalidates on every tooltip build.
+                m_Rank = ranks.Length > 0 ? ranks[^1] : null;
+
                 for (var i = 0; i < ranks.Length; i++)
                 {
                     var check = ranks[i];
@@ -227,12 +243,11 @@ public class PlayerState : IComparable<PlayerState>
                     if (percent >= check.Required)
                     {
                         m_Rank = check;
-                        m_InvalidateRank = false;
                         break;
                     }
                 }
 
-                Invalidate();
+                m_InvalidateRank = false;
             }
 
             return m_Rank;


### PR DESCRIPTION
## The bug

Any property getter reached from `GetProperties` that calls `InvalidateProperties` aborts the whole tooltip build:

```
System.ArgumentNullException: Value cannot be null. (Parameter 'array')
   at Server.ObjectPropertyList.AppendFormatted(String value)
   at Server.Mobiles.PlayerMobile.GetProperties(IPropertyList list)
```

`InvalidateProperties` rebuilds in place:

```csharp
m_PropertyList.Reset();
InitializePropertyList(m_PropertyList);   // GetProperties runs with m_PropertyList set
```

`Reset()` calls `Dispose()`, which returns the interpolation scratch buffer to `STArrayPool` and nulls `_arrayToReturnToPool`. Re-entering that while a `$"..."` handler is still appending pulls the buffer out from under the in-flight handler, so the next `Append*` does `_arrayToReturnToPool.AsSpan(_pos..)` on a null array — `ArgumentNullException`, parameter `"array"`.

The first-build path happens to survive (`PropertyList` uses `??=`, so `m_PropertyList` is still null and the nested call recurses into a throwaway list instead), which is why this only shows up on rebuilds.

## The trigger in content

Factions `PlayerState.Rank` is exactly such a getter — it called `Invalidate()` from inside its own getter. `m_InvalidateRank` defaults to `true`, so the first tooltip rebuild for any faction member on the faction facet after a load threw out of `PlayerMobile.GetProperties`:

```csharp
list.Add(1060776, $"{pl.Rank.Title}\t{faction.Definition.PropName}"); // ~1_val~, ~2_val~
```

## The fix

Three layers, root cause first:

1. **`PlayerState.Rank` is side-effect free.** Invalidation moves to the `RankIndex` setter, where the rank is actually dirtied. The getter also now always resolves a rank: ranks are ordered by `Required` descending with a final `Required = 0`, so a *negative* percent (`RankIndex` out of sync with `ZeroRankOffset`) matched nothing and left `m_Rank` null **and** `m_InvalidateRank` true — which NREs on `Rank.Title` and re-invalidates on every subsequent build. It also no longer divides by a zero `ZeroRankOffset`.
2. **`Mobile` and `Item` defer a nested `InvalidateProperties`** raised during a build and push the delta once the build completes. The list under construction already observes the new state, so nothing is lost — and no other side-effecting getter anywhere in content can reach the crash.
3. **`ObjectPropertyList` re-rents its scratch buffer** instead of spanning a null array, so a stray `Reset()` from any caller degrades gracefully rather than aborting `GetProperties`.

## Tests

Adds `ObjectPropertyListReentrancyTests` covering `Reset()` and `Dispose()` re-entered mid-hole. Both are red before the change with the exact production exception.

790/790 `Server.Tests` and 603/603 `UOContent.Tests` pass.

## Note, not addressed here

`~ObjectPropertyList()` returns the rented array to `STArrayPool<char>.Shared` from the **finalizer thread**, and that pool is single-threaded by design. Left alone as a separate concern.