### PR TITLE
chore(docs): Drop the liburing prerequisite, which was never used

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -125,10 +125,10 @@ jobs:
           dnf install -y epel-release
         if: ${{ matrix.epel }}
       - name: Install Prerequisites using dnf
-        run: dnf makecache --refresh && dnf install -y findutils libicu libdeflate-devel zstd libargon2-devel liburing-devel
+        run: dnf makecache --refresh && dnf install -y findutils libicu libdeflate-devel zstd libargon2-devel
         if: ${{ matrix.packageManager == 'dnf' }}
       - name: Install Prerequisites using apt
-        run: apt-get update -y && apt-get install -y curl libicu-dev libdeflate-dev zstd libargon2-dev tzdata liburing-dev
+        run: apt-get update -y && apt-get install -y curl libicu-dev libdeflate-dev zstd libargon2-dev tzdata
         if: ${{ matrix.packageManager == 'apt' }}
       - uses: actions/checkout@v7
         with:

--- a/Projects/BuildTool/Prerequisites/NativeLibraryChecker.cs
+++ b/Projects/BuildTool/Prerequisites/NativeLibraryChecker.cs
@@ -31,8 +31,8 @@ public static class NativeLibraryChecker
                 "Linux",
                 [
                     ".NET 10 Runtime — https://dotnet.microsoft.com/download/dotnet/10.0",
-                    "Debian/Ubuntu:  sudo apt-get install -y libicu-dev libdeflate-dev zstd libargon2-dev liburing-dev",
-                    "Fedora/RHEL:    sudo dnf install -y libicu libdeflate-devel zstd libargon2-devel liburing-devel",
+                    "Debian/Ubuntu:  sudo apt-get install -y libicu-dev libdeflate-dev zstd libargon2-dev",
+                    "Fedora/RHEL:    sudo dnf install -y libicu libdeflate-devel zstd libargon2-devel",
                     "CentOS:         Also requires epel-release and CRB enabled"
                 ]
             ),
@@ -189,7 +189,7 @@ public static class NativeLibraryChecker
     private static List<PrerequisiteResult> CheckLinuxApt()
     {
         var results = new List<PrerequisiteResult>();
-        var packages = new[] { "libicu-dev", "libdeflate-dev", "zstd", "libargon2-dev", "liburing-dev" };
+        var packages = new[] { "libicu-dev", "libdeflate-dev", "zstd", "libargon2-dev" };
         var missing = new List<string>();
 
         foreach (var package in packages)
@@ -228,7 +228,7 @@ public static class NativeLibraryChecker
     private static List<PrerequisiteResult> CheckLinuxDnf(PlatformInfo platform)
     {
         var results = new List<PrerequisiteResult>();
-        var packages = new[] { "libicu", "libdeflate-devel", "zstd", "libargon2-devel", "liburing-devel" };
+        var packages = new[] { "libicu", "libdeflate-devel", "zstd", "libargon2-devel" };
         var missing = new List<string>();
 
         foreach (var package in packages)
@@ -291,8 +291,7 @@ public static class NativeLibraryChecker
             ["libicu"] = "libicuuc",
             ["libdeflate"] = "libdeflate",
             ["zstd"] = "libzstd",
-            ["libargon2"] = "libargon2",
-            ["liburing"] = "liburing"
+            ["libargon2"] = "libargon2"
         };
 
         foreach (var (name, soName) in libraries)

--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ dnf install -y dnf-plugins-core
 dnf config-manager --set-enabled crb
 dnf install -y epel-release
 # Prerequisites
-dnf install -y findutils libicu libdeflate-devel zstd libargon2-devel liburing-devel
+dnf install -y findutils libicu libdeflate-devel zstd libargon2-devel
 ```
 
 ### Ubuntu, Debian, etc
 ```shell
 apt-get update -y
-apt-get install -y libicu-dev libdeflate-dev zstd libargon2-dev liburing-dev
+apt-get install -y libicu-dev libdeflate-dev zstd libargon2-dev
 ```
 
 ## OSX Requirements


### PR DESCRIPTION
## Why

`IORingGroup` issues io_uring syscalls directly rather than linking `liburing`, so the package has
never been needed — but we ask operators to install it in the README, install it in CI, and check
for it in `build-tool`.

Verified against the **shipped** `IORingGroup` 1.0.9 assembly, not just the source:

| Symbol | Occurrences in `IORingGroup.dll` |
|---|---|
| `libc`, `libSystem.dylib`, `kernel32.dll`, `kernelbase.dll`, `ws2_32.dll` | present |
| `liburing` | **0** |
| `io_uring_queue_init` — liburing's entry point | **0** |
| `io_uring_setup` — the raw syscall | 1 |

If it linked liburing it would call `io_uring_queue_init` / `io_uring_submit`. It calls neither.

## What changes

Nine lines across three files, removing `liburing-dev` / `liburing-devel` from:

- `README.md` — both the dnf and apt prerequisite blocks
- `.github/workflows/build-test.yml` — both install steps
- `Projects/BuildTool/Prerequisites/NativeLibraryChecker.cs` — the cross-compile target text, the
  apt and dnf package lists, and the `ldconfig` fallback map

Nothing else is touched. `zstd` and the `-dev` packages are a separate discussion and a separate PR.

## Risk

None to the build. `liburing` was only ever installed, never linked or loaded — removing it cannot
change resolution behaviour. `build-tool` builds clean.

This was found while investigating why Linux requires `-dev` packages at all; that fix lives in the
binding packages (modernuo/LibDeflate.Bindings#4, modernuo/Argon2.Bindings#13) and lands separately
once those publish. This piece is independent and unblocked, hence its own PR.