### PR TITLE
fix: Consolidate PlayerConstructed onto Item, stamped by the craft system

### DIFF
--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -749,6 +749,12 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
 
     public static bool ScissorCopyLootType { get; set; }
 
+    /// <summary>
+    ///     True when the item was produced by the crafting system rather than bought or looted.
+    /// </summary>
+    [CommandProperty(AccessLevel.GameMaster)]
+    public bool PlayerConstructed { get; set; }
+
     [CommandProperty(AccessLevel.GameMaster)]
     public bool QuestItem
     {
@@ -977,6 +983,11 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
         if (implFlags != (ImplFlag.Visible | ImplFlag.Movable))
         {
             flags |= SaveFlag.ImplFlags;
+        }
+
+        if (PlayerConstructed)
+        {
+            flags |= SaveFlag.PlayerConstructed;
         }
 
         writer.Write((int)flags);
@@ -2854,6 +2865,8 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
                         AcquireCompactInfo().m_SavedFlags = reader.ReadEncodedInt();
                     }
 
+                    PlayerConstructed = GetSaveFlag(flags, SaveFlag.PlayerConstructed);
+
                     if (m_Map != null && m_Parent == null)
                     {
                         m_Map.OnEnter(this);
@@ -4380,6 +4393,7 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
         HeldBy = 0x00800000,
         IntWeight = 0x01000000,
         SavedFlags = 0x02000000,
-        NullWeight = 0x04000000
+        NullWeight = 0x04000000,
+        PlayerConstructed = 0x08000000
     }
 }

--- a/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
@@ -136,10 +136,8 @@ public abstract partial class SmallBOD : BaseBOD
         else
         {
             var material = GetMaterial(armor?.Resource ?? clothing?.Resource ?? CraftResource.None);
-            var playerConstructed = armor?.PlayerConstructed ?? clothing?.PlayerConstructed ??
-                weapon?.PlayerConstructed ?? false;
 
-            if (!playerConstructed)
+            if (!item.PlayerConstructed)
             {
                 from.SendLocalizedMessage(1045169); // The item is not in the request.
             }

--- a/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
+++ b/Projects/UOContent/Engines/Craft/Core/CraftItem.cs
@@ -1451,6 +1451,9 @@ namespace Server.Engines.Craft
 
                 if (item != null)
                 {
+                    // Stamped here, not in OnCraft: most craftables do not implement ICraftable.
+                    item.PlayerConstructed = true;
+
                     if (item is ICraftable craftable)
                     {
                         endquality = craftable.OnCraft(quality, makersMark, from, craftSystem, typeRes, tool, this, resHue);
@@ -1742,6 +1745,9 @@ namespace Server.Engines.Craft
 
                 if (item != null)
                 {
+                    // Stamped here, not in OnCraft: most craftables do not implement ICraftable.
+                    item.PlayerConstructed = true;
+
                     if (item is ICraftable craftable)
                     {
                         endquality = craftable.OnCraft(quality, makersMark, from, craftSystem, typeRes, tool, this, resHue);

--- a/Projects/UOContent/Items/Armor/BaseArmor.Migrations.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.Migrations.cs
@@ -4,6 +4,36 @@ namespace Server.Items;
 
 public partial class BaseArmor
 {
+    // PlayerConstructed moved onto Item
+    private void MigrateFrom(V9Content content)
+    {
+        _attributes = content.Attributes ?? AttributesDefaultValue();
+        _armorAttributes = content.ArmorAttributes ?? ArmorAttributesDefaultValue();
+        _physicalBonus = content.PhysicalBonus ?? 0;
+        _fireBonus = content.FireBonus ?? 0;
+        _coldBonus = content.ColdBonus ?? 0;
+        _poisonBonus = content.PoisonBonus ?? 0;
+        _energyBonus = content.EnergyBonus ?? 0;
+        _identified = content.Identified;
+        _maxHitPoints = content.MaxHitPoints ?? 0;
+        _hitPoints = content.HitPoints ?? 0;
+        _crafter = content.Crafter;
+        _quality = content.Quality ?? ArmorQuality.Regular;
+        _durability = content.Durability ?? ArmorDurabilityLevel.Regular;
+        _protectionLevel = content.ProtectionLevel ?? ArmorProtectionLevel.Regular;
+        _resource = content.Resource ?? DefaultResource;
+        _armorBase = content.BaseArmorRating ?? -1;
+        _strBonus = content.StrBonus ?? -1;
+        _dexBonus = content.DexBonus ?? -1;
+        _intBonus = content.IntBonus ?? -1;
+        _strReq = content.StrRequirement ?? -1;
+        _dexReq = content.DexRequirement ?? -1;
+        _intReq = content.IntRequirement ?? -1;
+        _meditate = content.MeditationAllowance ?? (AMA)(-1);
+        _skillBonuses = content.SkillBonuses ?? SkillBonusesDefaultValue();
+        PlayerConstructed = content.PlayerConstructed;
+    }
+
     private void MigrateFrom(V8Content content)
     {
         _attributes = content.Attributes ?? AttributesDefaultValue();
@@ -29,7 +59,7 @@ public partial class BaseArmor
         _intReq = content.IntRequirement ?? -1;
         _meditate = content.MeditationAllowance ?? (AMA)(-1);
         _skillBonuses = content.SkillBonuses ?? SkillBonusesDefaultValue();
-        _playerConstructed = content.PlayerConstructed;
+        PlayerConstructed = content.PlayerConstructed;
     }
 
     // Version 7 (pre-codegen)

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -12,7 +12,7 @@ using AMT = Server.Items.ArmorMaterialType;
 
 namespace Server.Items
 {
-    [SerializationGenerator(9, false)]
+    [SerializationGenerator(10, false)]
     public abstract partial class BaseArmor
         : Item, IScissorable, IFactionItem, ICraftable, IWearableDurability, IAosItem, IIdentifiable
     {
@@ -143,13 +143,6 @@ namespace Server.Items
 
         [SerializableFieldDefault(23)]
         private AosSkillBonuses SkillBonusesDefaultValue() => new(this);
-
-        [SerializableField(24)]
-        [SerializedCommandProperty(AccessLevel.GameMaster)]
-        public bool _playerConstructed;
-
-        [SerializableFieldSaveFlag(24)]
-        private bool ShouldSerializePlayerConstructed() => _playerConstructed;
 
         private FactionItem m_FactionState;
 
@@ -570,7 +563,6 @@ namespace Server.Items
             var resourceType = typeRes ?? craftItem.Resources[0].ItemType;
 
             Resource = CraftResources.GetFromType(resourceType);
-            PlayerConstructed = true;
             Identified = true;
 
             var context = craftSystem.GetContext(from);

--- a/Projects/UOContent/Items/Clothing/BaseClothing.Migrations.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.Migrations.cs
@@ -2,6 +2,22 @@ namespace Server.Items;
 
 public partial class BaseClothing
 {
+    // PlayerConstructed moved onto Item
+    private void MigrateFrom(V7Content content)
+    {
+        _resource = content.Resource ?? DefaultResource;
+        _attributes = content.Attributes ?? AttributesDefaultValue();
+        _clothingAttributes = content.ClothingAttributes ?? ClothingAttributesDefaultValue();
+        _skillBonuses = content.SkillBonuses ?? SkillBonusesDefaultValue();
+        _resistances = content.Resistances ?? ResistancesDefaultValue();
+        _maxHitPoints = content.MaxHitPoints ?? 0;
+        _hitPoints = content.HitPoints ?? 0;
+        PlayerConstructed = content.PlayerConstructed;
+        _crafter = content.Crafter;
+        _quality = content.Quality ?? ClothingQuality.Regular;
+        _strReq = content.StrRequirement ?? -1;
+    }
+
     private void MigrateFrom(V6Content content)
     {
         _resource = content.RawResource ?? DefaultResource;
@@ -10,7 +26,7 @@ public partial class BaseClothing
         _skillBonuses = content.SkillBonuses ?? SkillBonusesDefaultValue();
         _resistances = content.Resistances ?? ResistancesDefaultValue();
         _maxHitPoints = content.MaxHitPoints ?? 0;
-        _playerConstructed = content.PlayerConstructed;
+        PlayerConstructed = content.PlayerConstructed;
         Timer.DelayCall((item, crafter) => item._crafter = crafter?.RawName, this, content.Crafter);
         _quality = content.Quality ?? ClothingQuality.Regular;
         _strReq = content.StrRequirement ?? -1;

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -22,7 +22,7 @@ namespace Server.Items
         int MaxArcaneCharges { get; set; }
     }
 
-    [SerializationGenerator(7, false)]
+    [SerializationGenerator(8, false)]
     public abstract partial class BaseClothing
         : Item, IDyable, IScissorable, IFactionItem, ICraftable, IWearableDurability, IAosItem
     {
@@ -82,30 +82,23 @@ namespace Server.Items
         [SerializableFieldSaveFlag(5)]
         private bool ShouldSerializeMaxHitPoints() => _maxHitPoints != 0;
 
+        [InvalidateProperties]
         [SerializableField(7)]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
-        private bool _playerConstructed;
+        private string _crafter;
 
         [SerializableFieldSaveFlag(7)]
-        private bool ShouldSerializePlayerConstructed() => _playerConstructed;
+        private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
         [InvalidateProperties]
         [SerializableField(8)]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
-        private string _crafter;
-
-        [SerializableFieldSaveFlag(8)]
-        private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
-
-        [InvalidateProperties]
-        [SerializableField(9)]
-        [SerializedCommandProperty(AccessLevel.GameMaster)]
         private ClothingQuality _quality = ClothingQuality.Regular;
 
-        [SerializableFieldSaveFlag(9)]
+        [SerializableFieldSaveFlag(8)]
         private bool ShouldSerializeQuality() => _quality != ClothingQuality.Regular;
 
-        // Field 10
+        // Field 9
         private int _strReq = -1;
 
         private FactionItem _factionState;
@@ -139,7 +132,7 @@ namespace Server.Items
             }
         }
 
-        [SerializableProperty(10, useField: nameof(_strReq))]
+        [SerializableProperty(9, useField: nameof(_strReq))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int StrRequirement
         {
@@ -152,7 +145,7 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(10)]
+        [SerializableFieldSaveFlag(9)]
         private bool ShouldSerializeStrReq() => _strReq != -1;
 
         public virtual CraftResource DefaultResource => CraftResource.None;
@@ -206,8 +199,6 @@ namespace Server.Items
             {
                 Hue = resHue;
             }
-
-            PlayerConstructed = true;
 
             var context = craftSystem.GetContext(from);
 

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.Migrations.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.Migrations.cs
@@ -1,0 +1,42 @@
+using Server.Engines.Craft;
+
+namespace Server.Items;
+
+public partial class BaseWeapon
+{
+    // PlayerConstructed moved onto Item
+    private void MigrateFrom(V10Content content)
+    {
+        _damageLevel = content.DamageLevel ?? WeaponDamageLevel.Regular;
+        _accuracyLevel = content.AccuracyLevel ?? WeaponAccuracyLevel.Regular;
+        _durabilityLevel = content.DurabilityLevel ?? WeaponDurabilityLevel.Regular;
+        _quality = content.Quality ?? WeaponQuality.Regular;
+        _hitPoints = content.HitPoints ?? 0;
+        _maxHitPoints = content.MaxHitPoints ?? 0;
+        _slayer = content.Slayer ?? SlayerName.None;
+        _poison = content.Poison;
+        _poisonCharges = content.PoisonCharges ?? 0;
+        _crafter = content.Crafter;
+        _identified = content.Identified;
+        _strRequirement = content.StrRequirement ?? -1;
+        _dexRequirement = content.DexRequirement ?? -1;
+        _intRequirement = content.IntRequirement ?? -1;
+        _minDamage = content.MinDamage ?? -1;
+        _maxDamage = content.MaxDamage ?? -1;
+        _hitSound = content.HitSound ?? -1;
+        _missSound = content.MissSound ?? -1;
+        _speed = content.Speed ?? -1;
+        _maxRange = content.MaxRange ?? -1;
+        _skill = content.Skill ?? (SkillName)(-1);
+        _type = content.Type ?? (WeaponType)(-1);
+        _animation = content.Animation ?? (WeaponAnimation)(-1);
+        _resource = content.Resource ?? CraftResource.Iron;
+        _attributes = content.Attributes ?? AttributesDefaultValue();
+        _weaponAttributes = content.WeaponAttributes ?? WeaponAttributesDefaultValue();
+        PlayerConstructed = content.PlayerConstructed;
+        _skillBonuses = content.SkillBonuses ?? SkillBonusesDefaultValue();
+        _slayer2 = content.Slayer2 ?? SlayerName.None;
+        _aosElementDamages = content.AosElementDamages ?? AosElementAttributesDefaultValue();
+        _engravedText = content.EngravedText;
+    }
+}

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -27,7 +27,7 @@ public interface ISlayer
     SlayerName Slayer2 { get; set; }
 }
 
-[SerializationGenerator(10, false)]
+[SerializationGenerator(11, false)]
 public abstract partial class BaseWeapon
     : Item, IWeapon, IFactionItem, ICraftable, ISlayer, IDurability, IAosItem, IIdentifiable
 {
@@ -141,53 +141,45 @@ public abstract partial class BaseWeapon
     [SerializableFieldDefault(25)]
     private AosWeaponAttributes WeaponAttributesDefaultValue() => new(this);
 
-    [SerializableField(26)]
-    [SerializedCommandProperty(AccessLevel.GameMaster)]
-    private bool _playerConstructed;
-
-    [SerializableFieldSaveFlag(26)]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool ShouldSerializePlayerConstructed() => _playerConstructed;
-
     [SerializedIgnoreDupe]
-    [SerializableField(27, setter: "private")]
+    [SerializableField(26, setter: "private")]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosSkillBonuses _skillBonuses;
 
-    [SerializableFieldSaveFlag(27)]
+    [SerializableFieldSaveFlag(26)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeSkillBonuses() => !_skillBonuses.IsEmpty;
 
-    [SerializableFieldDefault(27)]
+    [SerializableFieldDefault(26)]
     private AosSkillBonuses SkillBonusesDefaultValue() => new(this);
 
     [InvalidateProperties]
-    [SerializableField(28)]
+    [SerializableField(27)]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private SlayerName _slayer2;
 
-    [SerializableFieldSaveFlag(28)]
+    [SerializableFieldSaveFlag(27)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeSlayer2() => _slayer2 != SlayerName.None;
 
     [SerializedIgnoreDupe]
-    [SerializableField(29, setter: "private")]
+    [SerializableField(28, setter: "private")]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosElementAttributes _aosElementDamages;
 
-    [SerializableFieldSaveFlag(29)]
+    [SerializableFieldSaveFlag(28)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeElementAttributes() => !_aosElementDamages.IsEmpty;
 
-    [SerializableFieldDefault(29)]
+    [SerializableFieldDefault(28)]
     private AosElementAttributes AosElementAttributesDefaultValue() => new(this);
 
     [InvalidateProperties]
-    [SerializableField(30)]
+    [SerializableField(29)]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private string _engravedText;
 
-    [SerializableFieldSaveFlag(30)]
+    [SerializableFieldSaveFlag(29)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeEngravedText() => !string.IsNullOrEmpty(_engravedText);
 
@@ -674,7 +666,6 @@ public abstract partial class BaseWeapon
             Crafter = from.RawName;
         }
 
-        PlayerConstructed = true;
         Identified = true;
 
         var resourceType = typeRes ?? craftItem.Resources[0].ItemType;

--- a/Projects/UOContent/Migrations/Server.Items.BaseArmor.v10.json
+++ b/Projects/UOContent/Migrations/Server.Items.BaseArmor.v10.json
@@ -1,0 +1,207 @@
+{
+  "version": 10,
+  "type": "Server.Items.BaseArmor",
+  "properties": [
+    {
+      "name": "Attributes",
+      "type": "Server.AosAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "ArmorAttributes",
+      "type": "Server.AosArmorAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "PhysicalBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "FireBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "ColdBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "PoisonBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "EnergyBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Identified",
+      "type": "bool",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "MaxHitPoints",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "HitPoints",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Crafter",
+      "type": "string",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Quality",
+      "type": "Server.Items.ArmorQuality",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Durability",
+      "type": "Server.Items.ArmorDurabilityLevel",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "ProtectionLevel",
+      "type": "Server.Items.ArmorProtectionLevel",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Resource",
+      "type": "Server.Items.CraftResource",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "BaseArmorRating",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "StrBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "DexBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "IntBonus",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "StrRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "DexRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "IntRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "MeditationAllowance",
+      "type": "Server.Items.ArmorMeditationAllowance",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "SkillBonuses",
+      "type": "Server.AosSkillBonuses",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.BaseClothing.v8.json
+++ b/Projects/UOContent/Migrations/Server.Items.BaseClothing.v8.json
@@ -1,0 +1,90 @@
+{
+  "version": 8,
+  "type": "Server.Items.BaseClothing",
+  "properties": [
+    {
+      "name": "Resource",
+      "type": "Server.Items.CraftResource",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Attributes",
+      "type": "Server.AosAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "ClothingAttributes",
+      "type": "Server.AosArmorAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "SkillBonuses",
+      "type": "Server.AosSkillBonuses",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "Resistances",
+      "type": "Server.AosElementAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "MaxHitPoints",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "HitPoints",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "EncodedInt"
+      ]
+    },
+    {
+      "name": "Crafter",
+      "type": "string",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Quality",
+      "type": "Server.Items.ClothingQuality",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "StrRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.BaseWeapon.v11.json
+++ b/Projects/UOContent/Migrations/Server.Items.BaseWeapon.v11.json
@@ -1,0 +1,246 @@
+{
+  "version": 11,
+  "type": "Server.Items.BaseWeapon",
+  "properties": [
+    {
+      "name": "DamageLevel",
+      "type": "Server.Items.WeaponDamageLevel",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "AccuracyLevel",
+      "type": "Server.Items.WeaponAccuracyLevel",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "DurabilityLevel",
+      "type": "Server.Items.WeaponDurabilityLevel",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Quality",
+      "type": "Server.Items.WeaponQuality",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "HitPoints",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "MaxHitPoints",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Slayer",
+      "type": "Server.Items.SlayerName",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Poison",
+      "type": "Server.Poison",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveUOTypeMigrationRule",
+      "ruleArguments": [
+        "Poison"
+      ]
+    },
+    {
+      "name": "PoisonCharges",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Crafter",
+      "type": "string",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Identified",
+      "type": "bool",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "StrRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "DexRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "IntRequirement",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "MinDamage",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "MaxDamage",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "HitSound",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "MissSound",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Speed",
+      "type": "float",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "MaxRange",
+      "type": "int",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Skill",
+      "type": "Server.SkillName",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Type",
+      "type": "Server.Items.WeaponType",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Animation",
+      "type": "Server.Items.WeaponAnimation",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Resource",
+      "type": "Server.Items.CraftResource",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Attributes",
+      "type": "Server.AosAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "WeaponAttributes",
+      "type": "Server.AosWeaponAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "SkillBonuses",
+      "type": "Server.AosSkillBonuses",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "Slayer2",
+      "type": "Server.Items.SlayerName",
+      "usesSaveFlag": true,
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "AosElementDamages",
+      "type": "Server.AosElementAttributes",
+      "usesSaveFlag": true,
+      "rule": "RawSerializableMigrationRule",
+      "ruleArguments": [
+        "DeserializationRequiresParent"
+      ]
+    },
+    {
+      "name": "EngravedText",
+      "type": "string",
+      "usesSaveFlag": true,
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #2573. That change made `SmallBOD.EndCombine` require a player-crafted item, but it could only read provenance off `BaseArmor`, `BaseWeapon` and `BaseClothing`, because those are the only three classes that track it — hence the hand-enumerated `armor?.PlayerConstructed ?? clothing?.PlayerConstructed ?? weapon?.PlayerConstructed ?? false`.

The gap is structural rather than cosmetic. `PlayerConstructed` is set inside each base's `OnCraft`, so it can only ever reach types implementing `ICraftable`. Most craftables do not — the tinkering catalogue alone is largely plain `Item` subclasses — so any rule keyed on "was this actually crafted" has nothing to key on for those types.

## What changed

Provenance moves to `Item` and is stamped centrally in `CraftItem`, immediately after the item is constructed and before the `ICraftable` dispatch, covering both the AOS and T2A craft paths. The three `OnCraft` overrides drop their now-redundant assignment and inherit `Item`'s property, so no call site outside them changes — `Resmelt` and `SalvageBag` still read `armor.PlayerConstructed` and still compile unchanged. `SmallBOD`'s three-way null-coalescing chain collapses to `item.PlayerConstructed`.

`OnCraft` is only ever invoked from `CraftItem` (the other three call sites are `base.OnCraft` chaining), so removing those assignments has no other reachable effect.

## Storage cost: none

`Item`'s `SaveFlag` word is written as a fixed-width `int`, not an encoded one, so occupying bit `0x08000000` changes no record lengths. Items that are not player-constructed serialize byte for byte as before, and crafted ones differ by a single bit in a field already being written.

`Item` itself needs no version bump: a bare `SaveFlag` bit is self-describing, so records written before it existed lack it and read `false`.

## Version bumps

The three content classes do need one, since removing a serialized field changes their layout:

| Class | Version | Field removed |
|---|---|---|
| `BaseArmor` | 9 → 10 | 24 (was last, nothing renumbered) |
| `BaseClothing` | 7 → 8 | 7 (fields 8–10 shift down) |
| `BaseWeapon` | 10 → 11 | 26 (fields 27–30 shift down) |

Each gets a `MigrateFrom` for its previous version that assigns the old bool to the inherited property, so existing crafted armour, weapons and clothing keep their provenance across the upgrade. `Item.Deserialize` runs first and reads the absent bit as `false`, then the migration overwrites it — the generated `Deserialize` calls `base.Deserialize` before dispatching, so the ordering holds. `BaseWeapon` had no migrations file and gains one.

The renumbering is not stylistic: the generator requires contiguous field ordering and rejects a hole with `SG3005: Expected field 'Crafter' with order 7 but found 8`.

New schema JSONs (`BaseArmor.v10`, `BaseClothing.v8`, `BaseWeapon.v11`) are generated by `ModernUOSchemaGenerator` and committed alongside.

## One thing worth a second opinion

The new property is a plain auto-property on `Item`, so it does not call `this.MarkDirty()` the way the codegen setters it replaces did. `MarkDirty` is currently a no-op (`// TODO: Add dirty tracking back`) and no property in `Item.cs` calls it, so this matches the file as it stands — but it is worth noting if dirty tracking comes back.

## Verification

Full solution builds in Release with 0 errors and 0 warnings; 1516 tests pass (815 `Server.Tests`, 701 `UOContent.Tests`).
