### PR TITLE
fix: Fixes PlayerConstructed stacking/BODs

### DIFF
--- a/Projects/Server.Tests/Tests/Items/PlayerConstructedStackingTests.cs
+++ b/Projects/Server.Tests/Tests/Items/PlayerConstructedStackingTests.cs
@@ -24,26 +24,6 @@ public class PlayerConstructedStackingTests
     private static StackableItem MakeStack(Serial serial, int amount, bool playerConstructed) =>
         new(serial) { Amount = amount, PlayerConstructed = playerConstructed };
 
-    [Fact]
-    public void CanStackWith_IsFalseWhenProvenanceDiffers()
-    {
-        var bought = MakeStack((Serial)0x1, 5, false);
-        var crafted = MakeStack((Serial)0x2, 5, true);
-
-        try
-        {
-            // Both orders must fail. Whichever is the receiver decides the merged pile's flag,
-            // so allowing either one means the result is decided by drag direction.
-            Assert.False(bought.CanStackWith(crafted));
-            Assert.False(crafted.CanStackWith(bought));
-        }
-        finally
-        {
-            bought.Delete();
-            crafted.Delete();
-        }
-    }
-
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -60,27 +40,6 @@ public class PlayerConstructedStackingTests
         {
             first.Delete();
             second.Delete();
-        }
-    }
-
-    [Fact]
-    public void StackWith_RefusesToMergeAcrossProvenance()
-    {
-        var bought = MakeStack((Serial)0x1, 5, false);
-        var crafted = MakeStack((Serial)0x2, 5, true);
-
-        try
-        {
-            Assert.False(bought.StackWith(null, crafted, false));
-            Assert.Equal(5, bought.Amount);
-            Assert.Equal(5, crafted.Amount);
-            Assert.False(bought.PlayerConstructed);
-            Assert.False(crafted.Deleted);
-        }
-        finally
-        {
-            bought.Delete();
-            crafted.Delete();
         }
     }
 

--- a/Projects/Server/Items/Item.cs
+++ b/Projects/Server/Items/Item.cs
@@ -2350,7 +2350,6 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
         dropped.ItemID == ItemID &&
         dropped.Hue == Hue &&
         dropped.Name == Name &&
-        dropped.PlayerConstructed == PlayerConstructed &&
         dropped.Amount + Amount <= 60000 &&
         dropped != this;
 
@@ -2369,6 +2368,11 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
         }
 
         Amount += dropped.Amount;
+        if (PlayerConstructed != dropped.PlayerConstructed)
+        {
+            PlayerConstructed = false;
+        }
+
         dropped.Delete();
 
         if (playSound && from != null)
@@ -3451,7 +3455,7 @@ public partial class Item : IHued, IComparable<Item>, ISpawnable, IObjectPropert
         for (var i = 0; i < props.Length; i++)
         {
             var p = props[i];
-            if (p.GetCustomAttribute(typeof(IgnoreDupeAttribute), true) != null || !p.CanRead || !p.CanWrite)
+            if (p.GetCustomAttribute<IgnoreDupeAttribute>(true) != null || !p.CanRead || !p.CanWrite)
             {
                 continue;
             }

--- a/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/SmallBOD.cs
@@ -137,11 +137,7 @@ public abstract partial class SmallBOD : BaseBOD
         {
             var material = GetMaterial(armor?.Resource ?? clothing?.Resource ?? CraftResource.None);
 
-            if (!item.PlayerConstructed)
-            {
-                from.SendLocalizedMessage(1045169); // The item is not in the request.
-            }
-            else if (Material >= BulkMaterialType.DullCopper && Material <= BulkMaterialType.Valorite && material != Material)
+            if (Material >= BulkMaterialType.DullCopper && Material <= BulkMaterialType.Valorite && material != Material)
             {
                 from.SendLocalizedMessage(1045168); // The item is not made from the requested ore.
             }


### PR DESCRIPTION
### Summary

* Removes player constructed as a requirement for BODs.
* When two items stack and they don't match player constructed flags, the resulting stack loses the flag.