### PR TITLE
feat: adopt serialization generator v4 (field-side linkage, anchored timers)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "modernuoschemagenerator": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "commands": [
         "ModernUOSchemaGenerator"
       ]

--- a/Projects/Server/Items/Container.cs
+++ b/Projects/Server/Items/Container.cs
@@ -44,10 +44,10 @@ public partial class Container : Item
     internal int _version;
 
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeLiftOverride))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private bool _liftOverride;
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializeLiftOverride() => _liftOverride;
 
     public Container(int itemID) : base(itemID)
@@ -84,6 +84,7 @@ public partial class Container : Item
 
     [EncodedInt]
     [SerializableProperty(0)]
+    [SaveFlag(nameof(ShouldSerializeMaxItems), nameof(MaxItemsDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int MaxItems
     {
@@ -96,14 +97,13 @@ public partial class Container : Item
         }
     }
 
-    [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeMaxItems() => _maxItems != -1;
 
-    [SerializableFieldDefault(0)]
     private int MaxItemsDefaultValue() => -1;
 
     [EncodedInt]
     [SerializableProperty(1)]
+    [SaveFlag(nameof(ShouldSerializeGumpId), nameof(GumpIDDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int GumpID
     {
@@ -115,14 +115,13 @@ public partial class Container : Item
         }
     }
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeGumpId() => _gumpID != -1;
 
-    [SerializableFieldDefault(1)]
     private int GumpIDDefaultValue() => -1;
 
     [EncodedInt]
     [SerializableProperty(2)]
+    [SaveFlag(nameof(ShouldSerializeDropSound), nameof(DropSoundDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int DropSound
     {
@@ -134,10 +133,8 @@ public partial class Container : Item
         }
     }
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeDropSound() => _dropSound != -1;
 
-    [SerializableFieldDefault(2)]
     private int DropSoundDefaultValue() => -1;
 
     [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/Server/Mobiles/Mods/ResistanceMod.cs
+++ b/Projects/Server/Mobiles/Mods/ResistanceMod.cs
@@ -21,17 +21,15 @@ namespace Server;
 [SerializationGenerator(0)]
 public partial class ResistanceMod : MobileMod
 {
-    [SerializableField(0)]
+    [SerializableField(0, fieldChanged: nameof(OnTypeChanged))]
     private ResistanceType _type;
 
-    [SerializableFieldChanged(0)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void OnTypeChanged(ResistanceType oldValue, ResistanceType newValue) => Owner?.UpdateResistances();
 
-    [SerializableField(1)]
+    [SerializableField(1, fieldChanged: nameof(OnOffsetChanged))]
     private int _offset;
 
-    [SerializableFieldChanged(1)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void OnOffsetChanged(int oldValue, int newValue) => Owner?.UpdateResistances();
 

--- a/Projects/Server/Mobiles/Mods/SkillMod.cs
+++ b/Projects/Server/Mobiles/Mods/SkillMod.cs
@@ -21,11 +21,11 @@ namespace Server;
 [SerializationGenerator(0)]
 public abstract partial class SkillMod : MobileMod
 {
-    [SerializableField(0, fieldChanged: nameof(OnObeCapChanged))]
+    [SerializableField(0, fieldChanged: nameof(OnObeyCapChanged))]
     private bool _obeyCap;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void OnObeCapChanged(bool oldValue, bool newValue) => Owner?.Skills[_skill]?.Update();
+    private void OnObeyCapChanged(bool oldValue, bool newValue) => Owner?.Skills[_skill]?.Update();
 
     [SerializableField(1, fieldChanged: nameof(OnSkillChanged))]
     private SkillName _skill;

--- a/Projects/Server/Mobiles/Mods/SkillMod.cs
+++ b/Projects/Server/Mobiles/Mods/SkillMod.cs
@@ -21,33 +21,29 @@ namespace Server;
 [SerializationGenerator(0)]
 public abstract partial class SkillMod : MobileMod
 {
-    [SerializableField(0)]
+    [SerializableField(0, fieldChanged: nameof(OnObeCapChanged))]
     private bool _obeyCap;
 
-    [SerializableFieldChanged(0)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void OnObeCapChanged(bool oldValue, bool newValue) => Owner?.Skills[_skill]?.Update();
 
-    [SerializableField(1)]
+    [SerializableField(1, fieldChanged: nameof(OnSkillChanged))]
     private SkillName _skill;
 
-    [SerializableFieldChanged(1)]
     private void OnSkillChanged(SkillName oldValue, SkillName newValue)
     {
         Owner?.Skills[newValue]?.Update();
         Owner?.Skills[oldValue]?.Update();
     }
 
-    [SerializableField(2)]
+    [SerializableField(2, fieldChanged: nameof(OnRelativeChanged))]
     private bool _relative;
 
-    [SerializableFieldChanged(2)]
     private void OnRelativeChanged(bool oldValue, bool newValue) => Owner?.Skills[_skill]?.Update();
 
-    [SerializableField(3)]
+    [SerializableField(3, fieldChanged: nameof(OnValueChanged))]
     private double _value;
 
-    [SerializableFieldChanged(3)]
     private void OnValueChanged(double oldValue, double newValue) => Owner?.Skills[_skill]?.Update();
 
     public SkillMod(Mobile owner) : base(owner)

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -39,8 +39,8 @@
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.4" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.11" />
 
-        <PackageReference Include="ModernUO.Serialization.Annotations" Version="3.0.0" />
-        <PackageReference Include="ModernUO.Serialization.Generator" Version="3.0.0" PrivateAssets="all" />
+        <PackageReference Include="ModernUO.Serialization.Annotations" Version="4.0.0" />
+        <PackageReference Include="ModernUO.Serialization.Generator" Version="4.0.0" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
         <AdditionalFiles Include="Migrations/*.v*.json" />

--- a/Projects/UOContent/Engines/Bulk Orders/Books/BOBFilter.cs
+++ b/Projects/UOContent/Engines/Bulk Orders/Books/BOBFilter.cs
@@ -6,27 +6,27 @@ namespace Server.Engines.BulkOrders;
 public partial class BOBFilter
 {
     [SerializableField(0)]
+    [SaveFlag(nameof(ShouldSerializeType))]
     private int _type;
 
-    [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeType() => _type != 0;
 
     [SerializableField(1)]
+    [SaveFlag(nameof(ShouldSerializeQuality))]
     private int _quality;
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeQuality() => _quality != 0;
 
     [SerializableField(2)]
+    [SaveFlag(nameof(ShouldSerializeMaterial))]
     private int _material;
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeMaterial() => _material != 0;
 
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeQuantity))]
     private int _quantity;
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializeQuantity() => _quantity != 0;
 
     private void Deserialize(IGenericReader reader, int version)

--- a/Projects/UOContent/Engines/CannedEvil/ChampionTitleContext.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionTitleContext.cs
@@ -51,9 +51,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(1)]
+    [SaveFlag(nameof(ShouldSerializeAbyss))]
     private ChampionTitle _abyss;
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeAbyss() => _abyss != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -71,9 +71,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(2)]
+    [SaveFlag(nameof(ShouldSerializeArachnid))]
     private ChampionTitle _arachnid;
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeArachnid() => _arachnid != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -91,9 +91,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeColdBlood))]
     private ChampionTitle _coldBlood;
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializeColdBlood() => _coldBlood != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -111,9 +111,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(4)]
+    [SaveFlag(nameof(ShouldSerializeForestLord))]
     private ChampionTitle _forestLord;
 
-    [SerializableFieldSaveFlag(4)]
     private bool ShouldSerializeForestLord() => _forestLord != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -131,9 +131,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(5)]
+    [SaveFlag(nameof(ShouldSerializeVerminHorde))]
     private ChampionTitle _verminHorde;
 
-    [SerializableFieldSaveFlag(5)]
     private bool ShouldSerializeVerminHorde() => _verminHorde != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -151,9 +151,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(6)]
+    [SaveFlag(nameof(ShouldSerializeUnholyTerror))]
     private ChampionTitle _unholyTerror;
 
-    [SerializableFieldSaveFlag(6)]
     private bool ShouldSerializeUnholyTerror() => _unholyTerror != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -171,9 +171,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(7)]
+    [SaveFlag(nameof(ShouldSerializeSleepingDragon))]
     private ChampionTitle _sleepingDragon;
 
-    [SerializableFieldSaveFlag(7)]
     private bool ShouldSerializeSleepingDragon() => _sleepingDragon != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -191,9 +191,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(8)]
+    [SaveFlag(nameof(ShouldSerializeCorrupt))]
     private ChampionTitle _corrupt;
 
-    [SerializableFieldSaveFlag(8)]
     private bool ShouldSerializeCorrupt() => _corrupt != null;
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -211,9 +211,9 @@ public partial class ChampionTitleContext
     }
 
     [SerializableField(9)]
+    [SaveFlag(nameof(ShouldSerializeGlade))]
     private ChampionTitle _glade;
 
-    [SerializableFieldSaveFlag(9)]
     private bool ShouldSerializeGlade() => _glade != null;
 
     [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/BombingRun.cs
@@ -830,10 +830,9 @@ public partial class BRBomb : Item
 [SerializationGenerator(0, false)]
 public partial class BRGoal : BaseAddon
 {
-    [SerializableField(0)]
+    [SerializableField(0, fieldChanged: nameof(OnNorthChanged))]
     private bool _north;
 
-    [SerializableFieldChanged(0)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void OnNorthChanged(bool oldValue, bool newValue) => Remake();
 

--- a/Projects/UOContent/Engines/ConPVP/Games/KingOfTheHill.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/KingOfTheHill.cs
@@ -252,10 +252,9 @@ public partial class HillOfTheKing : Item
 public partial class KHBoard : Item
 {
     [SerializedCommandProperty(AccessLevel.GameMaster)]
-    [SerializableField(0)]
+    [SerializableField(0, fieldChanged: nameof(OnControllerChanged))]
     private KHController _controller;
 
-    [SerializableFieldChanged(0)]
     private void OnControllerChanged(KHController oldValue, KHController newValue)
     {
         oldValue?.RemoveBoard(this);

--- a/Projects/UOContent/Engines/Plants/PlantItem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantItem.cs
@@ -37,17 +37,17 @@ public partial class PlantItem : Item, ISecurable
 
     [SerializedIgnoreDupe]
     [SerializableField(0)]
+    [SaveFlag(nameof(ShouldSerializeSecureLevel))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private SecureLevel _level;
 
-    [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeSecureLevel() => (int)_level != 0;
 
     [SerializedIgnoreDupe]
     [SerializableField(5, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializePlantSystem))]
     private PlantSystem _plantSystem;
 
-    [SerializableFieldSaveFlag(5)]
     private bool ShouldSerializePlantSystem() => _plantStatus < PlantStatus.DecorativePlant;
 
     // For clients older than 7.0.12.0
@@ -82,6 +82,7 @@ public partial class PlantItem : Item, ISecurable
 
     [CommandProperty(AccessLevel.GameMaster)]
     [SerializableProperty(1)]
+    [SaveFlag(nameof(ShouldSerializePlantStatus))]
     public PlantStatus PlantStatus
     {
         get => _plantStatus;
@@ -120,10 +121,10 @@ public partial class PlantItem : Item, ISecurable
         }
     }
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializePlantStatus() => _plantStatus != PlantStatus.BowlOfDirt;
 
     [SerializableProperty(2)]
+    [SaveFlag(nameof(ShouldSerializePlantType))]
     [CommandProperty(AccessLevel.GameMaster)]
     public PlantType PlantType
     {
@@ -135,10 +136,10 @@ public partial class PlantItem : Item, ISecurable
         }
     }
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializePlantType() => (int)_plantType != 0;
 
     [SerializableProperty(3)]
+    [SaveFlag(nameof(ShouldSerializePlantHue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public PlantHue PlantHue
     {
@@ -150,10 +151,10 @@ public partial class PlantItem : Item, ISecurable
         }
     }
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializePlantHue() => _plantHue != PlantHue.None;
 
     [SerializableProperty(4)]
+    [SaveFlag(nameof(ShouldSerializeShowType))]
     [CommandProperty(AccessLevel.GameMaster)]
     public bool ShowType
     {
@@ -166,7 +167,6 @@ public partial class PlantItem : Item, ISecurable
         }
     }
 
-    [SerializableFieldSaveFlag(4)]
     private bool ShouldSerializeShowType() => _showType;
 
     [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Engines/Plants/PlantSystem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantSystem.cs
@@ -33,24 +33,24 @@ namespace Server.Engines.Plants
         private PlantItem _plant;
 
         [SerializableField(0)]
+        [SaveFlag(nameof(ShouldSerializeFertileDirt))]
         private bool _fertileDirt;
 
-        [SerializableFieldSaveFlag(0)]
         private bool ShouldSerializeFertileDirt() => _fertileDirt;
 
         [SerializableField(1)]
         private DateTime _nextGrowth;
 
         [SerializableField(2, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeGrowthIndicator))]
         private PlantGrowthIndicator _growthIndicator;
 
-        [SerializableFieldSaveFlag(2)]
         private bool ShouldSerializeGrowthIndicator() => _growthIndicator != PlantGrowthIndicator.None;
 
         [SerializableField(13)]
+        [SaveFlag(nameof(ShouldSerializePollinated))]
         private bool _pollinated;
 
-        [SerializableFieldSaveFlag(13)]
         private bool ShouldSerializePollinated() => _pollinated;
 
         public PlantSystem(PlantItem plant)
@@ -98,6 +98,7 @@ namespace Server.Engines.Plants
         public bool IsFullWater => _water >= 4;
 
         [SerializableProperty(3)]
+        [SaveFlag(nameof(ShouldSerializeWater))]
         public int Water
         {
             get => _water;
@@ -109,10 +110,10 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(3)]
         private bool ShouldSerializeWater() => _water != 0;
 
         [SerializableProperty(4)]
+        [SaveFlag(nameof(ShouldSerializeHits))]
         public int Hits
         {
             get => _hits;
@@ -135,7 +136,6 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(4)]
         private bool ShouldSerializeHits() => _hits != 0;
 
         public int MaxHits => 10 + (int)Plant.PlantStatus * 2;
@@ -150,6 +150,7 @@ namespace Server.Engines.Plants
             };
 
         [SerializableProperty(5)]
+        [SaveFlag(nameof(ShouldSerializeInfestation))]
         public int Infestation
         {
             get => _infestation;
@@ -160,10 +161,10 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(5)]
         private bool ShouldSerializeInfestation() => _infestation != 0;
 
         [SerializableProperty(6)]
+        [SaveFlag(nameof(ShouldSerializeFungus))]
         public int Fungus
         {
             get => _fungus;
@@ -174,10 +175,10 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(6)]
         private bool ShouldSerializeFungus() => _fungus != 0;
 
         [SerializableProperty(7)]
+        [SaveFlag(nameof(ShouldSerializePoison))]
         public int Poison
         {
             get => _poison;
@@ -188,10 +189,10 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(7)]
         private bool ShouldSerializePoison() => _poison != 0;
 
         [SerializableProperty(8)]
+        [SaveFlag(nameof(ShouldSerializeDisease))]
         public int Disease
         {
             get => _disease;
@@ -202,12 +203,12 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(8)]
         private bool ShouldSerializeDisease() => _disease != 0;
 
         public bool IsFullPoisonPotion => _poisonPotion >= 2;
 
         [SerializableProperty(9)]
+        [SaveFlag(nameof(ShouldSerializePoisonPotion))]
         public int PoisonPotion
         {
             get => _poisonPotion;
@@ -218,12 +219,12 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(9)]
         private bool ShouldSerializePoisonPotion() => _poisonPotion != 0;
 
         public bool IsFullCurePotion => _curePotion >= 2;
 
         [SerializableProperty(10)]
+        [SaveFlag(nameof(ShouldSerializeCurePotion))]
         public int CurePotion
         {
             get => _curePotion;
@@ -234,12 +235,12 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(10)]
         private bool ShouldSerializeCurePotion() => _curePotion != 0;
 
         public bool IsFullHealPotion => _healPotion >= 2;
 
         [SerializableProperty(11)]
+        [SaveFlag(nameof(ShouldSerializeHealPotion))]
         public int HealPotion
         {
             get => _healPotion;
@@ -250,12 +251,12 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(11)]
         private bool ShouldSerializeHealPotion() => _healPotion != 0;
 
         public bool IsFullStrengthPotion => _strengthPotion >= 2;
 
         [SerializableProperty(12)]
+        [SaveFlag(nameof(ShouldSerializeStrengthPotion))]
         public int StrengthPotion
         {
             get => _strengthPotion;
@@ -266,7 +267,6 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(12)]
         private bool ShouldSerializeStrengthPotion() => _strengthPotion != 0;
 
         public bool HasMaladies => Infestation > 0 || Fungus > 0 || Poison > 0 || Disease > 0 || Water != 2;
@@ -274,6 +274,7 @@ namespace Server.Engines.Plants
         public bool PollenProducing => Plant.IsCrossable && Plant.PlantStatus >= PlantStatus.FullGrownPlant;
 
         [SerializableProperty(14)]
+        [SaveFlag(nameof(ShouldSerializeSeedType))]
         public PlantType SeedType
         {
             get => Pollinated ? _seedType : Plant.PlantType;
@@ -284,10 +285,10 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(14)]
         private bool ShouldSerializeSeedType() => _pollinated;
 
         [SerializableProperty(15)]
+        [SaveFlag(nameof(ShouldSerializeSeedHue))]
         public PlantHue SeedHue
         {
             get => Pollinated ? _seedHue : Plant.PlantHue;
@@ -298,53 +299,50 @@ namespace Server.Engines.Plants
             }
         }
 
-        [SerializableFieldSaveFlag(15)]
         private bool ShouldSerializeSeedHue() => _pollinated;
 
         [SerializableProperty(16)]
+        [SaveFlag(nameof(ShouldSerializeAvailableSeeds))]
         public int AvailableSeeds
         {
             get => _availableSeeds;
             set => _availableSeeds = Math.Max(value, 0);
         }
 
-        [SerializableFieldSaveFlag(16)]
         private bool ShouldSerializeAvailableSeeds() => _availableSeeds != 0;
 
         [SerializableProperty(17)]
+        [SaveFlag(nameof(ShouldSerializeLeftSeeds), nameof(LeftSeedsDefaultValue))]
         public int LeftSeeds
         {
             get => _leftSeeds;
             set => _leftSeeds = Math.Max(value, 0);
         }
 
-        [SerializableFieldSaveFlag(17)]
         private bool ShouldSerializeLeftSeeds() => _leftSeeds != 8;
 
-        [SerializableFieldDefault(17)]
         private int LeftSeedsDefaultValue() => 8;
 
         [SerializableProperty(18)]
+        [SaveFlag(nameof(ShouldSerializeAvailableResources))]
         public int AvailableResources
         {
             get => _availableResources;
             set => _availableResources = Math.Max(value, 0);
         }
 
-        [SerializableFieldSaveFlag(18)]
         private bool ShouldSerializeAvailableResources() => _availableResources != 0;
 
         [SerializableProperty(19)]
+        [SaveFlag(nameof(ShouldSerializeLeftResources), nameof(LeftResourcesDefaultValue))]
         public int LeftResources
         {
             get => _leftResources;
             set => _leftResources = Math.Max(value, 0);
         }
 
-        [SerializableFieldSaveFlag(19)]
         private bool ShouldSerializeLeftResources() => _leftResources != 8;
 
-        [SerializableFieldDefault(19)]
         private int LeftResourcesDefaultValue() => 8;
 
         public void Reset(bool potions)

--- a/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
@@ -54,10 +54,10 @@ public abstract partial class BaseSpawner : Item, ISpawner
     [SerializedCommandProperty(AccessLevel.Developer)]
     private Guid _guid;
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeReturnOnDeactivate() => _returnOnDeactivate;
 
     [SerializableField(1)]
+    [SaveFlag(nameof(ShouldSerializeReturnOnDeactivate))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private bool _returnOnDeactivate;
 
@@ -67,48 +67,46 @@ public abstract partial class BaseSpawner : Item, ISpawner
 
     private int _walkingRange = -1;
 
-    [SerializableFieldSaveFlag(4)]
     private bool ShouldSerializeWayPoint() => _wayPoint != null;
 
     [SerializableField(4)]
+    [SaveFlag(nameof(ShouldSerializeWayPoint))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private WayPoint _wayPoint;
 
-    [SerializableFieldSaveFlag(5)]
     private bool ShouldSerializeGroup() => _group;
 
     [InvalidateProperties]
     [SerializableField(5)]
+    [SaveFlag(nameof(ShouldSerializeGroup))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private bool _group;
 
-    [SerializableFieldSaveFlag(6)]
     private bool ShouldSerializeMinDelay() => _minDelay != DefaultMinDelay;
 
-    [SerializableFieldDefault(6)]
     private TimeSpan MinDelayDefault() => DefaultMinDelay;
 
     [InvalidateProperties]
     [SerializableField(6)]
+    [SaveFlag(nameof(ShouldSerializeMinDelay), nameof(MinDelayDefault))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private TimeSpan _minDelay;
 
-    [SerializableFieldSaveFlag(7)]
     private bool ShouldSerializeMaxDelay() => _maxDelay != DefaultMaxDelay;
 
-    [SerializableFieldDefault(7)]
     private TimeSpan MaxDelayDefault() => DefaultMaxDelay;
 
     [InvalidateProperties]
     [SerializableField(7)]
+    [SaveFlag(nameof(ShouldSerializeMaxDelay), nameof(MaxDelayDefault))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private TimeSpan _maxDelay;
 
-    [SerializableFieldSaveFlag(9)]
     private bool ShouldSerializeTeam() => _team != 0;
 
     [InvalidateProperties]
     [SerializableField(9)]
+    [SaveFlag(nameof(ShouldSerializeTeam))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private int _team;
 
@@ -125,29 +123,29 @@ public abstract partial class BaseSpawner : Item, ISpawner
     /// If true, the home location of the spawn is the location where it spawned
     /// If false, the home location of the spawn is the location of the spawner
     /// </summary>
-    [SerializableFieldSaveFlag(11)]
     private bool ShouldSerializeSpawnLocationIsHome() => _spawnLocationIsHome;
 
     [InvalidateProperties]
     [SerializableField(11)]
+    [SaveFlag(nameof(ShouldSerializeSpawnLocationIsHome))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private bool _spawnLocationIsHome;
 
-    [SerializableFieldSaveFlag(12)]
     private bool ShouldSerializeEnd() => _end != default;
 
     [SerializableField(12)]
+    [SaveFlag(nameof(ShouldSerializeEnd))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private DateTime _end;
 
     /// <summary>
     /// Controls how spawn position optimization is handled.
     /// </summary>
-    [SerializableFieldSaveFlag(13)]
     private bool ShouldSerializeSpawnPositionMode() =>
         _spawnPositionMode is not SpawnPositionMode.Automatic and not SpawnPositionMode.Abandoned;
 
     [SerializableField(13)]
+    [SaveFlag(nameof(ShouldSerializeSpawnPositionMode))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private SpawnPositionMode _spawnPositionMode;
 
@@ -156,13 +154,12 @@ public abstract partial class BaseSpawner : Item, ISpawner
     /// <summary>
     /// Maximum number of random position attempts before engaging optimization.
     /// </summary>
-    [SerializableFieldSaveFlag(14)]
     private bool ShouldSerializeMaxSpawnAttempts() => _maxSpawnAttempts != DefaultMaxSpawnAttempts;
 
-    [SerializableFieldDefault(14)]
     private int MaxSpawnAttemptsDefault() => DefaultMaxSpawnAttempts;
 
     [SerializableField(14)]
+    [SaveFlag(nameof(ShouldSerializeMaxSpawnAttempts), nameof(MaxSpawnAttemptsDefault))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private int _maxSpawnAttempts;
 

--- a/Projects/UOContent/Engines/Spawners/Spawner.cs
+++ b/Projects/UOContent/Engines/Spawners/Spawner.cs
@@ -10,17 +10,17 @@ public partial class Spawner : BaseSpawner
     /// When true, enables proactive spiral scanning to find valid spawn positions.
     /// Only relevant when SpawnPositionMode is Automatic or Enabled.
     /// </summary>
-    [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeUseSpiralScan() => _useSpiralScan;
 
     [SerializableField(0)]
+    [SaveFlag(nameof(ShouldSerializeUseSpiralScan))]
     [SerializedCommandProperty(AccessLevel.Developer)]
     private bool _useSpiralScan;
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeSpawnBounds() => _spawnBounds != default;
 
     [SerializableProperty(1)]
+    [SaveFlag(nameof(ShouldSerializeSpawnBounds))]
     [CommandProperty(AccessLevel.Developer)]
     public override Rectangle3D SpawnBounds
     {

--- a/Projects/UOContent/Engines/Virtues/VirtueContext.cs
+++ b/Projects/UOContent/Engines/Virtues/VirtueContext.cs
@@ -10,97 +10,97 @@ public partial class VirtueContext
 {
     [DeltaDateTime]
     [SerializableField(0)]
+    [SaveFlag(nameof(ShouldSerializeLastSacrificeGain))]
     [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
     private DateTime _lastSacrificeGain;
 
-    [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeLastSacrificeGain() => !SacrificeVirtue.CanGain(this);
 
     [DeltaDateTime]
     [SerializableField(1)]
+    [SaveFlag(nameof(ShouldSerializeLastSacrificeLoss))]
     [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
     private DateTime _lastSacrificeLoss;
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeLastSacrificeLoss() => !SacrificeVirtue.CanAtrophy(this);
 
     [SerializableField(2)]
+    [SaveFlag(nameof(ShouldSerializeAvailableResurrects))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _availableResurrects;
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeAvailableResurrects() => _availableResurrects > 0;
 
     [DeltaDateTime]
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeLastJusticeLoss))]
     [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
     private DateTime _lastJusticeLoss;
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializeLastJusticeLoss() => !JusticeVirtue.CanAtrophy(this);
 
     [DeltaDateTime]
     [SerializableField(4)]
+    [SaveFlag(nameof(ShouldSerializeLastCompassionLoss))]
     [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
     private DateTime _lastCompassionLoss;
 
-    [SerializableFieldSaveFlag(4)]
     private bool ShouldSerializeLastCompassionLoss() => !CompassionVirtue.CanAtrophy(this);
 
     [DeltaDateTime]
     [SerializableField(5)]
+    [SaveFlag(nameof(ShouldSerializeNextCompassionDay))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private DateTime _nextCompassionDay;
 
-    [SerializableFieldSaveFlag(5)]
     private bool ShouldSerializeNextCompassionDay() => _nextCompassionDay > Core.Now;
 
     [SerializableField(6)]
+    [SaveFlag(nameof(ShouldSerializeCompassionGains))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _compassionGains;
 
-    [SerializableFieldSaveFlag(6)]
     private bool ShouldSerializeCompassionGains() => _compassionGains > 0;
 
     [DeltaDateTime]
     [SerializableField(7)]
+    [SaveFlag(nameof(ShouldSerializeValorLoss))]
     [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
     private DateTime _lastValorLoss;
 
-    [SerializableFieldSaveFlag(7)]
     private bool ShouldSerializeValorLoss() => !ValorVirtue.CanAtrophy(this);
 
     [DeltaDateTime]
     [SerializableField(8)]
+    [SaveFlag(nameof(ShouldSerializeLastHonorUse))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private DateTime _lastHonorUse;
 
-    [SerializableFieldSaveFlag(8)]
     private bool ShouldSerializeLastHonorUse() => !HonorVirtue.CanUse(this);
 
     [SerializableField(9)]
+    [SaveFlag(nameof(ShouldSerializeHonorActive))]
     [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
     private bool _honorActive;
 
-    [SerializableFieldSaveFlag(9)]
     private bool ShouldSerializeHonorActive() => _honorActive;
 
     [SerializableField(10)]
+    [SaveFlag(nameof(ShouldSerializeJusticeProtection))]
     private PlayerMobile _justiceProtection;
 
-    [SerializableFieldSaveFlag(10)]
     private bool ShouldSerializeJusticeProtection() => _justiceProtection != null && _justiceStatus != JusticeProtectorStatus.None;
 
     [SerializableField(11)]
+    [SaveFlag(nameof(ShouldSerializeJusticeStatus))]
     private JusticeProtectorStatus _justiceStatus;
 
-    [SerializableFieldSaveFlag(11)]
     private bool ShouldSerializeJusticeStatus() => _justiceProtection != null && _justiceStatus != JusticeProtectorStatus.None;
 
     [SerializableField(12, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeValues))]
     private int[] _values;
 
-    [SerializableFieldSaveFlag(12)]
     private bool ShouldSerializeValues()
     {
         if (_values == null)

--- a/Projects/UOContent/Items/Aquarium/Aquarium.cs
+++ b/Projects/UOContent/Items/Aquarium/Aquarium.cs
@@ -31,9 +31,9 @@ namespace Server.Items
         private bool m_EvaluateDay;
 
         [SerializableField(0, setter: "private")]
+        [DeserializeTimer(nameof(DeserializeEvaluateTimer), wallClock: true)]
         private Timer _evaluateTimer;
 
-        [DeserializeTimerField(0)]
         private void DeserializeEvaluateTimer(TimeSpan delay)
         {
             _evaluateTimer = Timer.DelayCall(delay, EvaluationInterval, Evaluate);

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -18,95 +18,92 @@ namespace Server.Items
     {
         [SerializedIgnoreDupe]
         [SerializableField(0, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeAosAttributes), nameof(AttributesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         private AosAttributes _attributes;
 
-        [SerializableFieldSaveFlag(0)]
         private bool ShouldSerializeAosAttributes() => !_attributes.IsEmpty;
 
-        [SerializableFieldDefault(0)]
         private AosAttributes AttributesDefaultValue() => new(this);
 
         [SerializedIgnoreDupe]
         [SerializableField(1, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeArmorAttributes), nameof(ArmorAttributesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         private AosArmorAttributes _armorAttributes;
 
-        [SerializableFieldSaveFlag(1)]
         private bool ShouldSerializeArmorAttributes() => !_armorAttributes.IsEmpty;
 
-        [SerializableFieldDefault(1)]
         private AosArmorAttributes ArmorAttributesDefaultValue() => new(this);
 
         [EncodedInt]
         [InvalidateProperties]
         [SerializableField(2)]
+        [SaveFlag(nameof(ShouldSerializePhysicalBonus))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _physicalBonus;
 
-        [SerializableFieldSaveFlag(2)]
         private bool ShouldSerializePhysicalBonus() => _physicalBonus != 0;
 
         [EncodedInt]
         [InvalidateProperties]
         [SerializableField(3)]
+        [SaveFlag(nameof(ShouldSerializeFireBonus))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _fireBonus;
 
-        [SerializableFieldSaveFlag(3)]
         private bool ShouldSerializeFireBonus() => _fireBonus != 0;
 
         [EncodedInt]
         [InvalidateProperties]
         [SerializableField(4)]
+        [SaveFlag(nameof(ShouldSerializeColdBonus))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _coldBonus;
 
-        [SerializableFieldSaveFlag(4)]
         private bool ShouldSerializeColdBonus() => _coldBonus != 0;
 
         [EncodedInt]
         [InvalidateProperties]
         [SerializableField(5)]
+        [SaveFlag(nameof(ShouldSerializePoisonBonus))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _poisonBonus;
 
-        [SerializableFieldSaveFlag(5)]
         private bool ShouldSerializePoisonBonus() => _poisonBonus != 0;
 
         [EncodedInt]
         [InvalidateProperties]
         [SerializableField(6)]
+        [SaveFlag(nameof(ShouldSerializeEnergyBonus))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _energyBonus;
 
-        [SerializableFieldSaveFlag(6)]
         private bool ShouldSerializeEnergyBonus() => _energyBonus != 0;
 
         [SerializableField(7)]
+        [SaveFlag(nameof(ShouldSerializeIdentified))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private bool _identified;
 
-        [SerializableFieldSaveFlag(7)]
         private bool ShouldSerializeIdentified() => _identified;
 
         [EncodedInt]
         [SerializableField(8)]
+        [SaveFlag(nameof(ShouldSerializeMaxHitPoints))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _maxHitPoints;
 
-        [SerializableFieldSaveFlag(8)]
         private bool ShouldSerializeMaxHitPoints() => _maxHitPoints != 0;
 
         [InvalidateProperties]
         [SerializableField(10)]
+        [SaveFlag(nameof(ShouldSerializeCrafter))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private string _crafter;
 
-        [SerializableFieldSaveFlag(10)]
         private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
-        [SerializableFieldSaveFlag(14)]
         private bool ShouldSerializeResource() => _resource != DefaultResource;
 
         // Field 15
@@ -135,13 +132,12 @@ namespace Server.Items
 
         [SerializedIgnoreDupe]
         [SerializableField(23, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeSkillBonuses), nameof(SkillBonusesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosSkillBonuses _skillBonuses;
 
-        [SerializableFieldSaveFlag(23)]
         private bool ShouldSerializeSkillBonuses() => !_skillBonuses.IsEmpty;
 
-        [SerializableFieldDefault(23)]
         private AosSkillBonuses SkillBonusesDefaultValue() => new(this);
 
         private FactionItem m_FactionState;
@@ -190,6 +186,7 @@ namespace Server.Items
         public virtual int OldIntReq => 0;
 
         [SerializableProperty(11)]
+        [SaveFlag(nameof(ShouldSerializeArmorQuality), nameof(QualityDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public ArmorQuality Quality
         {
@@ -202,13 +199,12 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(11)]
         private bool ShouldSerializeArmorQuality() => _quality != ArmorQuality.Regular;
 
-        [SerializableFieldDefault(11)]
         private ArmorQuality QualityDefaultValue() => ArmorQuality.Regular;
 
         [SerializableProperty(12)]
+        [SaveFlag(nameof(ShouldSerializeDurability))]
         [CommandProperty(AccessLevel.GameMaster)]
         public ArmorDurabilityLevel Durability
         {
@@ -221,10 +217,10 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(12)]
         private bool ShouldSerializeDurability() => _durability != ArmorDurabilityLevel.Regular;
 
         [SerializableProperty(13)]
+        [SaveFlag(nameof(ShouldSerializeProtectionLevel))]
         [CommandProperty(AccessLevel.GameMaster)]
         public ArmorProtectionLevel ProtectionLevel
         {
@@ -244,10 +240,10 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(13)]
         private bool ShouldSerializeProtectionLevel() => _protectionLevel != ArmorProtectionLevel.Regular;
 
         [SerializableProperty(14)]
+        [SaveFlag(nameof(ShouldSerializeResource), nameof(ResourceDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public CraftResource Resource
         {
@@ -273,11 +269,11 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldDefault(14)]
         private CraftResource ResourceDefaultValue() => DefaultResource;
 
         [EncodedInt]
         [SerializableProperty(15, useField: nameof(_armorBase))]
+        [SaveFlag(nameof(ShouldSerializeArmorBase), nameof(ArmorBaseDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int BaseArmorRating
         {
@@ -290,10 +286,8 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(15)]
         private bool ShouldSerializeArmorBase() => _armorBase != -1;
 
-        [SerializableFieldDefault(15)]
         private int ArmorBaseDefaultValue() => -1;
 
         public double BaseArmorRatingScaled => BaseArmorRating * ArmorScalar;
@@ -343,6 +337,7 @@ namespace Server.Items
 
         [EncodedInt]
         [SerializableProperty(16, useField: nameof(_strBonus))]
+        [SaveFlag(nameof(ShouldSerializeStrBonus), nameof(StrBonusDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int StrBonus
         {
@@ -355,14 +350,13 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(16)]
         private bool ShouldSerializeStrBonus() => _strBonus != -1;
 
-        [SerializableFieldDefault(16)]
         private int StrBonusDefaultValue() => -1;
 
         [EncodedInt]
         [SerializableProperty(17, useField: nameof(_dexBonus))]
+        [SaveFlag(nameof(ShouldSerializeDexBonus), nameof(DexBonusDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int DexBonus
         {
@@ -375,14 +369,13 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(17)]
         private bool ShouldSerializeDexBonus() => _dexBonus != -1;
 
-        [SerializableFieldDefault(17)]
         private int DexBonusDefaultValue() => -1;
 
         [EncodedInt]
         [SerializableProperty(18, useField: nameof(_intBonus))]
+        [SaveFlag(nameof(ShouldSerializeIntBonus), nameof(IntBonusDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int IntBonus
         {
@@ -395,14 +388,13 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(18)]
         private bool ShouldSerializeIntBonus() => _intBonus != -1;
 
-        [SerializableFieldDefault(18)]
         private int IntBonusDefaultValue() => -1;
 
         [EncodedInt]
         [SerializableProperty(19, useField: nameof(_strReq))]
+        [SaveFlag(nameof(ShouldSerializeStrReq), nameof(StrReqDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int StrRequirement
         {
@@ -415,14 +407,13 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(19)]
         private bool ShouldSerializeStrReq() => _strReq != -1;
 
-        [SerializableFieldDefault(19)]
         private int StrReqDefaultValue() => -1;
 
         [EncodedInt]
         [SerializableProperty(20, useField: nameof(_dexReq))]
+        [SaveFlag(nameof(ShouldSerializeDexReq), nameof(DexReqDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int DexRequirement
         {
@@ -435,14 +426,13 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(20)]
         private bool ShouldSerializeDexReq() => _dexReq != -1;
 
-        [SerializableFieldDefault(20)]
         private int DexReqDefaultValue() => -1;
 
         [EncodedInt]
         [SerializableProperty(21, useField: nameof(_intReq))]
+        [SaveFlag(nameof(ShouldSerializeIntReq), nameof(IntReqDefaultValue))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int IntRequirement
         {
@@ -455,13 +445,12 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(21)]
         private bool ShouldSerializeIntReq() => _intReq != -1;
 
-        [SerializableFieldDefault(21)]
         private int IntReqDefaultValue() => -1;
 
         [SerializableProperty(22, useField: nameof(_meditate))]
+        [SaveFlag(nameof(ShouldSerializeMeditationAllowance))]
         [CommandProperty(AccessLevel.GameMaster)]
         public AMA MeditationAllowance
         {
@@ -473,7 +462,6 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(22)]
         private bool ShouldSerializeMeditationAllowance() => _meditate >= AMA.All;
 
         public virtual double ArmorScalar
@@ -689,6 +677,7 @@ namespace Server.Items
 
         [EncodedInt]
         [SerializableProperty(9)]
+        [SaveFlag(nameof(ShouldSerializeHitPoints))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int HitPoints
         {
@@ -716,7 +705,6 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(9)]
         private bool ShouldSerializeHitPoints() => _hitPoints != 0;
 
         public virtual int InitMinHits => 0;

--- a/Projects/UOContent/Items/Armor/Glasses/ElvenGlasses.cs
+++ b/Projects/UOContent/Items/Armor/Glasses/ElvenGlasses.cs
@@ -31,13 +31,12 @@ namespace Server.Items
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 
         [SerializableField(0, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeWeaponAttributes), nameof(WeaponAttributesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         public AosWeaponAttributes _weaponAttributes;
 
-        [SerializableFieldSaveFlag(0)]
         private bool ShouldSerializeWeaponAttributes() => !_weaponAttributes.IsEmpty;
 
-        [SerializableFieldDefault(0)]
         private AosWeaponAttributes WeaponAttributesDefaultValue() => new(this);
 
         public override void AppendChildNameProperties(IPropertyList list)

--- a/Projects/UOContent/Items/Books/BaseBook.cs
+++ b/Projects/UOContent/Items/Books/BaseBook.cs
@@ -19,41 +19,38 @@ namespace Server.Items
         [InternString]
         [InvalidateProperties]
         [SerializableField(1)]
+        [SaveFlag(nameof(ShouldSerializeTitle), nameof(TitleDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private string _title;
 
-        [SerializableFieldSaveFlag(1)]
         private bool ShouldSerializeTitle() => _title != DefaultContent?.Title;
 
-        [SerializableFieldDefault(1)]
         private string TitleDefaultValue() => DefaultContent?.Title;
 
         [InvalidateProperties]
         [SerializableField(2)]
+        [SaveFlag(nameof(ShouldSerializeAuthor), nameof(AuthorDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private string _author;
 
-        [SerializableFieldSaveFlag(2)]
         private bool ShouldSerializeAuthor() => _author != DefaultContent?.Author;
 
-        [SerializableFieldDefault(2)]
         private string AuthorDefaultValue() => DefaultContent?.Author;
 
         [SerializableField(3)]
+        [SaveFlag(nameof(ShouldSerializeWritable))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private bool _writable;
 
-        [SerializableFieldSaveFlag(3)]
         private bool ShouldSerializeWritable() => _writable;
 
         [SerializedIgnoreDupe]
         [SerializableField(4, setter: "protected")]
+        [SaveFlag(nameof(ShouldSerializePages), nameof(PagesDefaultValue))]
         private BookPageInfo[] _pages;
 
-        [SerializableFieldSaveFlag(4)]
         private bool ShouldSerializePages() => DefaultContent?.IsMatch(_pages) != true;
 
-        [SerializableFieldDefault(4)]
         private BookPageInfo[] PagesDefaultValue() => DefaultContent?.Copy() ?? Array.Empty<BookPageInfo>();
 
         [Constructible]

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -26,76 +26,71 @@ namespace Server.Items
     public abstract partial class BaseClothing
         : Item, IDyable, IScissorable, IFactionItem, ICraftable, IWearableDurability, IAosItem
     {
-        [SerializableFieldSaveFlag(0)]
         private bool ShouldSerializeResource() => _resource != DefaultResource;
 
         [SerializedIgnoreDupe]
         [SerializableField(1, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeAttributes), nameof(AttributesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         private AosAttributes _attributes;
 
-        [SerializableFieldSaveFlag(1)]
         private bool ShouldSerializeAttributes() => !_attributes.IsEmpty;
 
-        [SerializableFieldDefault(1)]
         private AosAttributes AttributesDefaultValue() => new(this);
 
         [SerializedIgnoreDupe]
         [SerializableField(2, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeClothingAttributes), nameof(ClothingAttributesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         private AosArmorAttributes _clothingAttributes;
 
-        [SerializableFieldSaveFlag(2)]
         private bool ShouldSerializeClothingAttributes() => !_clothingAttributes.IsEmpty;
 
-        [SerializableFieldDefault(2)]
         private AosArmorAttributes ClothingAttributesDefaultValue() => new(this);
 
         [SerializedIgnoreDupe]
         [SerializableField(3, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeSkillBonuses), nameof(SkillBonusesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         private AosSkillBonuses _skillBonuses;
 
-        [SerializableFieldSaveFlag(3)]
         private bool ShouldSerializeSkillBonuses() => !_skillBonuses.IsEmpty;
 
-        [SerializableFieldDefault(3)]
         private AosSkillBonuses SkillBonusesDefaultValue() => new(this);
 
         [SerializedIgnoreDupe]
         [SerializableField(4, setter: "private")]
+        [SaveFlag(nameof(ShouldSerializeResistances), nameof(ResistancesDefaultValue))]
         [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
         private AosElementAttributes _resistances;
 
-        [SerializableFieldSaveFlag(4)]
         private bool ShouldSerializeResistances() => !_resistances.IsEmpty;
 
-        [SerializableFieldDefault(4)]
         private AosElementAttributes ResistancesDefaultValue() => new(this);
 
         [EncodedInt]
         [InvalidateProperties]
         [SerializableField(5)]
+        [SaveFlag(nameof(ShouldSerializeMaxHitPoints))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _maxHitPoints;
 
-        [SerializableFieldSaveFlag(5)]
         private bool ShouldSerializeMaxHitPoints() => _maxHitPoints != 0;
 
         [InvalidateProperties]
         [SerializableField(7)]
+        [SaveFlag(nameof(ShouldSerializeCrafter))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private string _crafter;
 
-        [SerializableFieldSaveFlag(7)]
         private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
         [InvalidateProperties]
         [SerializableField(8)]
+        [SaveFlag(nameof(ShouldSerializeQuality))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private ClothingQuality _quality = ClothingQuality.Regular;
 
-        [SerializableFieldSaveFlag(8)]
         private bool ShouldSerializeQuality() => _quality != ClothingQuality.Regular;
 
         // Field 9
@@ -119,6 +114,7 @@ namespace Server.Items
         }
 
         [SerializableProperty(0)]
+        [SaveFlag(nameof(ShouldSerializeResource))]
         [CommandProperty(AccessLevel.GameMaster)]
         public CraftResource Resource
         {
@@ -133,6 +129,7 @@ namespace Server.Items
         }
 
         [SerializableProperty(9, useField: nameof(_strReq))]
+        [SaveFlag(nameof(ShouldSerializeStrReq))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int StrRequirement
         {
@@ -145,7 +142,6 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(9)]
         private bool ShouldSerializeStrReq() => _strReq != -1;
 
         public virtual CraftResource DefaultResource => CraftResource.None;
@@ -299,6 +295,7 @@ namespace Server.Items
 
         [EncodedInt]
         [SerializableProperty(6)]
+        [SaveFlag(nameof(ShouldSerializeHitPoints))]
         [CommandProperty(AccessLevel.GameMaster)]
         public int HitPoints
         {
@@ -324,7 +321,6 @@ namespace Server.Items
             }
         }
 
-        [SerializableFieldSaveFlag(6)]
         private bool ShouldSerializeHitPoints() => _hitPoints != 0;
 
         public virtual int InitMinHits => 0;

--- a/Projects/UOContent/Items/Clothing/OuterTorso.cs
+++ b/Projects/UOContent/Items/Clothing/OuterTorso.cs
@@ -37,21 +37,22 @@ namespace Server.Items
         public override double DefaultWeight => 3.0;
     }
 
-    [SerializationGenerator(3, false)]
+    [SerializationGenerator(4, false)]
     public partial class DeathRobe : Robe
     {
         private static readonly TimeSpan m_DefaultDecayTime = TimeSpan.FromMinutes(1.0);
 
-        [TimerDrift]
         [SerializableField(0)]
+        [DeserializeTimer(nameof(DeserializeDecayTimer))]
         private Timer _decayTimer;
 
-        [DeserializeTimerField(0)]
-        private void DeserializeDecayTimer(TimeSpan delay)
+        private void DeserializeDecayTimer(TimeSpan delay) => BeginDecay(delay);
+
+        private void MigrateFrom(V3Content content)
         {
-            if (delay != TimeSpan.MinValue)
+            if (content.DecayTimerDelay != TimeSpan.MinValue)
             {
-                BeginDecay(delay);
+                DeserializeDecayTimer(content.DecayTimerDelay);
             }
         }
 

--- a/Projects/UOContent/Items/Clothing/Shoes.cs
+++ b/Projects/UOContent/Items/Clothing/Shoes.cs
@@ -54,11 +54,10 @@ namespace Server.Items
     {
         [EncodedInt]
         [InvalidateProperties]
-        [SerializableField(0)]
+        [SerializableField(0, fieldChanged: nameof(OnCurArcaneChargesChanged))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         private int _curArcaneCharges;
 
-        [SerializableFieldChanged(0)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void OnCurArcaneChargesChanged(int oldValue, int newValue) => Update();
 

--- a/Projects/UOContent/Items/Containers/Fillable Containers/FillableContainer.cs
+++ b/Projects/UOContent/Items/Containers/Fillable Containers/FillableContainer.cs
@@ -3,19 +3,22 @@ using ModernUO.Serialization;
 
 namespace Server.Items;
 
-[SerializationGenerator(2, false)]
+[SerializationGenerator(3, false)]
 public abstract partial class FillableContainer : LockableContainer
 {
-    [TimerDrift]
     [SerializableField(1)]
+    [DeserializeTimer(nameof(DeserializeRespawnTimer))]
     private Timer _respawnTimer;
 
-    [DeserializeTimerField(1)]
-    private void DeserializeRespawnTimer(TimeSpan delay)
+    private void DeserializeRespawnTimer(TimeSpan delay) => _respawnTimer = Timer.DelayCall(delay, Respawn);
+
+    private void MigrateFrom(V2Content content)
     {
-        if (delay > TimeSpan.MinValue)
+        _contentType = content.ContentType;
+
+        if (content.RespawnTimerDelay != TimeSpan.MinValue)
         {
-            _respawnTimer = Timer.DelayCall(delay, Respawn);
+            DeserializeRespawnTimer(content.RespawnTimerDelay);
         }
     }
 

--- a/Projects/UOContent/Items/Containers/MarkContainer.cs
+++ b/Projects/UOContent/Items/Containers/MarkContainer.cs
@@ -3,19 +3,31 @@ using ModernUO.Serialization;
 
 namespace Server.Items;
 
-[SerializationGenerator(0, false)]
+[SerializationGenerator(1, false)]
 public partial class MarkContainer : LockableContainer
 {
-    [TimerDrift]
     [SerializableField(1, getter: "private", setter: "private")]
+    [DeserializeTimer(nameof(DeserializeRelockTimer))]
     private InternalTimer _relockTimer;
 
-    [DeserializeTimerField(1)]
     private void DeserializeRelockTimer(TimeSpan delay)
     {
         if (!Locked && _autoLock)
         {
             _relockTimer = new InternalTimer(this, delay);
+        }
+    }
+
+    private void MigrateFrom(V0Content content)
+    {
+        _autoLock = content.AutoLock;
+        _targetMap = content.TargetMap;
+        _target = content.Target;
+        _description = content.Description;
+
+        if (content.RelockTimerDelay != TimeSpan.MinValue)
+        {
+            DeserializeRelockTimer(content.RelockTimerDelay);
         }
     }
 

--- a/Projects/UOContent/Items/Containers/TreasureMapChest.cs
+++ b/Projects/UOContent/Items/Containers/TreasureMapChest.cs
@@ -9,7 +9,7 @@ using Server.Network;
 
 namespace Server.Items;
 
-[SerializationGenerator(3, false)]
+[SerializationGenerator(4, false)]
 public partial class TreasureMapChest : LockableContainer
 {
     [Tidy]
@@ -29,17 +29,30 @@ public partial class TreasureMapChest : LockableContainer
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _level;
 
-    [TimerDrift]
     [SerializableField(4)]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [DeserializeTimer(nameof(DeserializeExpireTimer))]
     private Timer _expireTimer;
 
-    [DeserializeTimerField(4)]
     private void DeserializeExpireTimer(TimeSpan delay)
     {
         if (!_temporary)
         {
             _expireTimer = Timer.DelayCall(delay, Delete);
+        }
+    }
+
+    private void MigrateFrom(V3Content content)
+    {
+        _guardians = content.Guardians;
+        _temporary = content.Temporary;
+        _owner = content.Owner;
+        _level = content.Level;
+        _lifted = content.Lifted;
+
+        if (content.ExpireTimerDelay != TimeSpan.MinValue)
+        {
+            DeserializeExpireTimer(content.ExpireTimerDelay);
         }
     }
 

--- a/Projects/UOContent/Items/Lights/BaseLight.cs
+++ b/Projects/UOContent/Items/Lights/BaseLight.cs
@@ -3,7 +3,7 @@ using ModernUO.Serialization;
 
 namespace Server.Items;
 
-[SerializationGenerator(1, false)]
+[SerializationGenerator(2, false)]
 public abstract partial class BaseLight : Item
 {
     public static readonly bool Burnout = false;
@@ -16,16 +16,28 @@ public abstract partial class BaseLight : Item
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private bool _protected;
 
-    [TimerDrift]
     [SerializableField(4, getter: "private", setter: "private")]
+    [DeserializeTimer(nameof(DeserializeTimer))]
     private Timer _burnTimer;
 
-    [DeserializeTimerField(4)]
     private void DeserializeTimer(TimeSpan delay)
     {
         if (_burning && _duration != TimeSpan.Zero)
         {
             DoTimer(delay);
+        }
+    }
+
+    private void MigrateFrom(V1Content content)
+    {
+        _burntOut = content.BurntOut;
+        _burning = content.Burning;
+        _duration = content.Duration;
+        _protected = content.Protected;
+
+        if (content.BurnTimerDelay != TimeSpan.MinValue)
+        {
+            DeserializeTimer(content.BurnTimerDelay);
         }
     }
 

--- a/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
@@ -86,7 +86,7 @@ public enum CorpseFlag
     OwnerWasAnimatedDead = 0x00000800
 }
 
-[SerializationGenerator(17, false)]
+[SerializationGenerator(18, false)]
 public partial class Corpse : Container, ICarvable
 {
     public static readonly TimeSpan MonsterLootRightSacrifice = TimeSpan.FromMinutes(2.0);
@@ -114,12 +114,36 @@ public partial class Corpse : Container, ICarvable
     [SerializableField(3, getter: "private", setter: "private")]
     private Dictionary<Item, Point3D> _restoreTable;
 
-    [TimerDrift]
     [SerializableField(4, getter: "private", setter: "private")]
+    [DeserializeTimer(nameof(DeserializeDecayTimer))]
     private Timer _decayTimer;
 
-    [DeserializeTimerField(4)]
     private void DeserializeDecayTimer(TimeSpan delay) => BeginDecay(delay);
+
+    private void MigrateFrom(V17Content content)
+    {
+        _restoreEquip = content.RestoreEquip;
+        _flags = content.Flags;
+        _timeOfDeath = content.TimeOfDeath;
+        _restoreTable = content.RestoreTable;
+        _looters = content.Looters;
+        _killer = content.Killer;
+        _aggressors = content.Aggressors;
+        _owner = content.Owner;
+        _corpseName = content.CorpseName;
+        _accessLevel = content.AccessLevel;
+        _guild = content.Guild;
+        _equipItems = content.EquipItems;
+        _hairItemId = content.HairItemId;
+        _hairHue = content.HairHue;
+        _facialHairItemId = content.FacialHairItemId;
+        _facialHairHue = content.FacialHairHue;
+
+        if (content.DecayTimerDelay != TimeSpan.MinValue)
+        {
+            DeserializeDecayTimer(content.DecayTimerDelay);
+        }
+    }
 
     [SerializableField(5, setter: "private")]
     private HashSet<Mobile> _looters;

--- a/Projects/UOContent/Items/Misc/Corpses/DecayedCorpse.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/DecayedCorpse.cs
@@ -3,17 +3,24 @@ using ModernUO.Serialization;
 
 namespace Server.Items;
 
-[SerializationGenerator(2, false)]
+[SerializationGenerator(3, false)]
 public partial class DecayedCorpse : Container
 {
     private static TimeSpan _defaultDecayTime = TimeSpan.FromMinutes(7.0);
 
-    [TimerDrift]
     [SerializableField(0, getter: "private", setter: "private")]
+    [DeserializeTimer(nameof(DeserializeDecayTimer))]
     private Timer _decayTimer;
 
-    [DeserializeTimerField(0)]
     private void DeserializeDecayTimer(TimeSpan delay) => BeginDecay(delay);
+
+    private void MigrateFrom(V2Content content)
+    {
+        if (content.DecayTimerDelay != TimeSpan.MinValue)
+        {
+            DeserializeDecayTimer(content.DecayTimerDelay);
+        }
+    }
 
     public DecayedCorpse(string name) : base(Utility.Random(0xECA, 9))
     {

--- a/Projects/UOContent/Items/Quivers/BaseQuiver.cs
+++ b/Projects/UOContent/Items/Quivers/BaseQuiver.cs
@@ -11,64 +11,62 @@ public partial class BaseQuiver : Container, ICraftable, IAosItem
 
     [SerializedIgnoreDupe]
     [SerializableField(0, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeAosAttributes), nameof(AttributesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosAttributes _attributes;
 
-    [SerializableFieldSaveFlag(0)]
     private bool ShouldSerializeAosAttributes() => !_attributes.IsEmpty;
 
-    [SerializableFieldDefault(0)]
     private AosAttributes AttributesDefaultValue() => new(this);
 
     [InvalidateProperties]
     [SerializableField(1)]
+    [SaveFlag(nameof(ShouldSerializeLowerAmmoCost))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _lowerAmmoCost;
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeLowerAmmoCost() => _lowerAmmoCost != 0;
 
     [InvalidateProperties]
     [SerializableField(2)]
+    [SaveFlag(nameof(ShouldSerializeWeightReduction))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _weightReduction;
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeWeightReduction() => _weightReduction != 0;
 
     [InvalidateProperties]
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeDamageIncrease))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _damageIncrease;
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializeDamageIncrease() => _damageIncrease != 0;
 
     [InvalidateProperties]
     [SerializableField(4)]
+    [SaveFlag(nameof(ShouldSerializeCrafter))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private string _crafter;
 
-    [SerializableFieldSaveFlag(4)]
     private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
     [InvalidateProperties]
     [SerializableField(5)]
+    [SaveFlag(nameof(ShouldSerializeQuality), nameof(QualityDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private ClothingQuality _quality;
 
-    [SerializableFieldSaveFlag(5)]
     private bool ShouldSerializeQuality() => _quality != ClothingQuality.Regular;
 
-    [SerializableFieldDefault(5)]
     private ClothingQuality QualityDefaultValue() => ClothingQuality.Regular;
 
     [InvalidateProperties]
     [SerializableField(6)]
+    [SaveFlag(nameof(ShouldSerializeCapacity))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _capacity;
 
-    [SerializableFieldSaveFlag(6)]
     private bool ShouldSerializeCapacity() => _capacity != 0;
 
     public BaseQuiver(int itemID = 0x2FB7) : base(itemID)

--- a/Projects/UOContent/Items/Skill Items/Magical/Runebook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Runebook.cs
@@ -371,27 +371,27 @@ public partial class RunebookEntry
     private Runebook _runebook;
 
     [SerializableField(0)]
+    [SaveFlag(nameof(ShouldSerializeHouse))]
     private BaseHouse _house;
 
-    [SerializableFieldSaveFlag(0)]
     public bool ShouldSerializeHouse() => _house?.Deleted == false;
 
     [SerializableField(1)]
+    [SaveFlag(nameof(ShouldSerializeLocation))]
     private Point3D _location;
 
-    [SerializableFieldSaveFlag(1)]
     public bool ShouldSerializeLocation() => _house?.Deleted != false;
 
     [SerializableField(2)]
+    [SaveFlag(nameof(ShouldSerializeMap))]
     private Map _map;
 
-    [SerializableFieldSaveFlag(2)]
     public bool ShouldSerializeMap() => _house?.Deleted != false;
 
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeDesc))]
     private string _description;
 
-    [SerializableFieldSaveFlag(3)]
     public bool ShouldSerializeDesc() => _house?.Deleted != false;
 
     public RunebookEntry(

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/FountainOfLife.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/FountainOfLife.cs
@@ -31,6 +31,7 @@ public partial class FountainOfLife : BaseAddonContainer
     public const int MaxCharges = 10;
 
     [SerializableField(1)]
+    [DeserializeTimer(nameof(DeserializeTimer), wallClock: true)]
     private Timer _timer;
 
     [Constructible]
@@ -39,7 +40,6 @@ public partial class FountainOfLife : BaseAddonContainer
         _charges = charges;
     }
 
-    [DeserializeTimerField(1)]
     private void DeserializeTimer(TimeSpan delay)
     {
         _timer = Timer.DelayCall(Utility.Max(delay, TimeSpan.Zero), RechargeTime, Recharge);

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -128,136 +128,131 @@ public partial class BaseTalisman : Item, IAosItem
 
     [SerializedIgnoreDupe]
     [SerializableField(0, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeAttributes), nameof(AttributesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosAttributes _attributes;
 
-    [SerializableFieldSaveFlag(0)]
     public bool ShouldSerializeAttributes() => !_attributes.IsEmpty;
 
-    [SerializableFieldDefault(0)]
     private AosAttributes AttributesDefaultValue() => new(this);
 
     [SerializedIgnoreDupe]
     [SerializableField(1, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeSkillBonuses), nameof(SkillBonusesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosSkillBonuses _skillBonuses;
 
-    [SerializableFieldSaveFlag(1)]
     public bool ShouldSerializeSkillBonuses() => !_skillBonuses.IsEmpty;
 
-    [SerializableFieldDefault(1)]
     private AosSkillBonuses SkillBonusesDefaultValue() => new(this);
 
     [SerializedIgnoreDupe]
     [InvalidateProperties]
     [SerializableField(2)]
+    [SaveFlag(nameof(ShouldSerializeProtection), nameof(ProtectionDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private TalismanAttribute _protection;
 
-    [SerializableFieldSaveFlag(2)]
     public bool ShouldSerializeProtection() => !_protection.IsEmpty;
 
-    [SerializableFieldDefault(2)]
     private TalismanAttribute ProtectionDefaultValue() => new();
 
     [SerializedIgnoreDupe]
     [InvalidateProperties]
     [SerializableField(3)]
+    [SaveFlag(nameof(ShouldSerializeKiller), nameof(KillerDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private TalismanAttribute _killer;
 
-    [SerializableFieldSaveFlag(3)]
     public bool ShouldSerializeKiller() => !_killer.IsEmpty;
 
-    [SerializableFieldDefault(3)]
     private TalismanAttribute KillerDefaultValue() => new();
 
     [SerializedIgnoreDupe]
     [InvalidateProperties]
     [SerializableField(4)]
+    [SaveFlag(nameof(ShouldSerializeSummoner), nameof(SummonerDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private TalismanAttribute _summoner;
 
-    [SerializableFieldSaveFlag(4)]
     public bool ShouldSerializeSummoner() => !_summoner.IsEmpty;
 
-    [SerializableFieldDefault(4)]
     private TalismanAttribute SummonerDefaultValue() => new();
 
     [InvalidateProperties]
     [SerializableField(5)]
+    [SaveFlag(nameof(ShouldSerializeRemoval))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private TalismanRemoval _removal;
 
-    [SerializableFieldSaveFlag(5)]
     public bool ShouldSerializeRemoval() => _removal != TalismanRemoval.None;
 
     [InvalidateProperties]
     [SerializableField(6)]
+    [SaveFlag(nameof(ShouldSerializeSkill))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private SkillName _skill;
 
-    [SerializableFieldSaveFlag(6)]
     public bool ShouldSerializeSkill() => (int)_skill != 0;
 
     [EncodedInt]
     [InvalidateProperties]
     [SerializableField(7)]
+    [SaveFlag(nameof(ShouldSerializeSuccessBonus))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _successBonus;
 
-    [SerializableFieldSaveFlag(7)]
     public bool ShouldSerializeSuccessBonus() => _successBonus != 0;
 
     [EncodedInt]
     [InvalidateProperties]
     [SerializableField(8)]
+    [SaveFlag(nameof(ShouldSerializeExceptionalBonus))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _exceptionalBonus;
 
-    [SerializableFieldSaveFlag(8)]
     public bool ShouldSerializeExceptionalBonus() => _exceptionalBonus != 0;
 
     [EncodedInt]
     [InvalidateProperties]
     [SerializableField(9)]
+    [SaveFlag(nameof(ShouldSerializeMaxCharges))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _maxCharges;
 
-    [SerializableFieldSaveFlag(9)]
     public bool ShouldSerializeMaxCharges() => _maxCharges != 0;
 
     [EncodedInt]
     [InvalidateProperties]
     [SerializableField(11)]
+    [SaveFlag(nameof(ShouldSerializeMaxChargeTime))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _maxChargeTime;
 
-    [SerializableFieldSaveFlag(11)]
     public bool ShouldSerializeMaxChargeTime() => _maxChargeTime != 0;
 
     [EncodedInt]
     [InvalidateProperties]
     [SerializableField(12)]
+    [SaveFlag(nameof(ShouldSerializeChargeTime))]
     private int _chargeTime;
 
-    [SerializableFieldSaveFlag(12)]
     public bool ShouldSerializeChargeTime() => _chargeTime != 0;
 
     [InvalidateProperties]
     [SerializableField(13)]
+    [SaveFlag(nameof(ShouldSerializeBlessed))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private bool _blessed;
 
-    [SerializableFieldSaveFlag(13)]
     public bool ShouldSerializeBlessed() => _blessed;
 
     [InvalidateProperties]
     [SerializableField(14)]
+    [SaveFlag(nameof(ShouldSerializeSlayer))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private TalismanSlayerName _slayer;
 
-    [SerializableFieldSaveFlag(14)]
     public bool ShouldSerializeSlayer() => _slayer != TalismanSlayerName.None;
 
     private BaseCreature _creature;
@@ -285,6 +280,7 @@ public partial class BaseTalisman : Item, IAosItem
     public virtual bool ForceShowName => false; // used to override default summoner/removal name
 
     [SerializableProperty(10)]
+    [SaveFlag(nameof(ShouldSerializeCharges))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int Charges
     {
@@ -303,7 +299,6 @@ public partial class BaseTalisman : Item, IAosItem
         }
     }
 
-    [SerializableFieldSaveFlag(10)]
     public bool ShouldSerializeCharges() => _charges != 0;
 
     public static void Configure()

--- a/Projects/UOContent/Items/Weapons/BaseWeapon.cs
+++ b/Projects/UOContent/Items/Weapons/BaseWeapon.cs
@@ -56,130 +56,126 @@ public abstract partial class BaseWeapon
 
     [InvalidateProperties]
     [SerializableField(0)]
+    [SaveFlag(nameof(ShouldSerializeDamageLevel))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private WeaponDamageLevel _damageLevel;
 
-    [SerializableFieldSaveFlag(0)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeDamageLevel() => _damageLevel != WeaponDamageLevel.Regular;
 
     [InvalidateProperties]
     [SerializableField(5)]
+    [SaveFlag(nameof(ShouldSerializeMaxHitPoints))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _maxHitPoints;
 
-    [SerializableFieldSaveFlag(5)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeMaxHitPoints() => _maxHitPoints != 0;
 
     [InvalidateProperties]
     [SerializableField(6)]
+    [SaveFlag(nameof(ShouldSerializeSlayer))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private SlayerName _slayer;
 
-    [SerializableFieldSaveFlag(6)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeSlayer() => _slayer != SlayerName.None;
 
     [InvalidateProperties]
     [SerializableField(7)]
+    [SaveFlag(nameof(ShouldSerializePoison))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private Poison _poison;
 
-    [SerializableFieldSaveFlag(7)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializePoison() => _poison != null;
 
     [InvalidateProperties]
     [SerializableField(8)]
+    [SaveFlag(nameof(ShouldSerializePoisonCharges))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _poisonCharges;
 
-    [SerializableFieldSaveFlag(8)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializePoisonCharges() => _poisonCharges > 0;
 
     [InvalidateProperties]
     [SerializableField(9)]
+    [SaveFlag(nameof(ShouldSerializeCrafter))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private string _crafter;
 
-    [SerializableFieldSaveFlag(9)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeCrafter() => !string.IsNullOrEmpty(_crafter);
 
     [InvalidateProperties]
     [SerializableField(10)]
+    [SaveFlag(nameof(ShouldSerializeIdentified))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private bool _identified;
 
-    [SerializableFieldSaveFlag(10)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeIdentified() => _identified;
 
     [SerializedIgnoreDupe]
     [SerializableField(24, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeAttributes), nameof(AttributesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosAttributes _attributes;
 
-    [SerializableFieldSaveFlag(24)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeAttributes() => !_attributes.IsEmpty;
 
-    [SerializableFieldDefault(24)]
     private AosAttributes AttributesDefaultValue() => new(this);
 
     [SerializedIgnoreDupe]
     [SerializableField(25, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeWeaponAttributes), nameof(WeaponAttributesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosWeaponAttributes _weaponAttributes;
 
-    [SerializableFieldSaveFlag(25)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeWeaponAttributes() => !_weaponAttributes.IsEmpty;
 
-    [SerializableFieldDefault(25)]
     private AosWeaponAttributes WeaponAttributesDefaultValue() => new(this);
 
     [SerializedIgnoreDupe]
     [SerializableField(26, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeSkillBonuses), nameof(SkillBonusesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosSkillBonuses _skillBonuses;
 
-    [SerializableFieldSaveFlag(26)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeSkillBonuses() => !_skillBonuses.IsEmpty;
 
-    [SerializableFieldDefault(26)]
     private AosSkillBonuses SkillBonusesDefaultValue() => new(this);
 
     [InvalidateProperties]
     [SerializableField(27)]
+    [SaveFlag(nameof(ShouldSerializeSlayer2))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private SlayerName _slayer2;
 
-    [SerializableFieldSaveFlag(27)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeSlayer2() => _slayer2 != SlayerName.None;
 
     [SerializedIgnoreDupe]
     [SerializableField(28, setter: "private")]
+    [SaveFlag(nameof(ShouldSerializeElementAttributes), nameof(AosElementAttributesDefaultValue))]
     [SerializedCommandProperty(AccessLevel.GameMaster, canModify: true)]
     private AosElementAttributes _aosElementDamages;
 
-    [SerializableFieldSaveFlag(28)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeElementAttributes() => !_aosElementDamages.IsEmpty;
 
-    [SerializableFieldDefault(28)]
     private AosElementAttributes AosElementAttributesDefaultValue() => new(this);
 
     [InvalidateProperties]
     [SerializableField(29)]
+    [SaveFlag(nameof(ShouldSerializeEngravedText))]
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private string _engravedText;
 
-    [SerializableFieldSaveFlag(29)]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ShouldSerializeEngravedText() => !string.IsNullOrEmpty(_engravedText);
 
@@ -286,6 +282,7 @@ public abstract partial class BaseWeapon
     public bool Consecrated { get; set; }
 
     [SerializableProperty(1)]
+    [SaveFlag(nameof(ShouldSerializeWeaponAccuracy))]
     [CommandProperty(AccessLevel.GameMaster)]
     public WeaponAccuracyLevel AccuracyLevel
     {
@@ -321,10 +318,10 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(1)]
     private bool ShouldSerializeWeaponAccuracy() => _accuracyLevel != WeaponAccuracyLevel.Regular;
 
     [SerializableProperty(2)]
+    [SaveFlag(nameof(ShouldSerializeDurabilityLevel))]
     [CommandProperty(AccessLevel.GameMaster)]
     public WeaponDurabilityLevel DurabilityLevel
     {
@@ -339,10 +336,10 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(2)]
     private bool ShouldSerializeDurabilityLevel() => _durabilityLevel != WeaponDurabilityLevel.Regular;
 
     [SerializableProperty(3)]
+    [SaveFlag(nameof(ShouldSerializeQuality), nameof(QualityDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public WeaponQuality Quality
     {
@@ -357,13 +354,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(3)]
     private bool ShouldSerializeQuality() => _quality != WeaponQuality.Regular;
 
-    [SerializableFieldDefault(3)]
     private WeaponQuality QualityDefaultValue() => WeaponQuality.Regular;
 
     [SerializableProperty(4)]
+    [SaveFlag(nameof(ShouldSerializeHitPoints))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int HitPoints
     {
@@ -387,10 +383,10 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(4)]
     private bool ShouldSerializeHitPoints() => _hitPoints > 0;
 
     [SerializableProperty(11)]
+    [SaveFlag(nameof(ShouldSerializeStrReq), nameof(StrReqDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int StrRequirement
     {
@@ -403,13 +399,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(11)]
     private bool ShouldSerializeStrReq() => _strRequirement != -1;
 
-    [SerializableFieldDefault(11)]
     private int StrReqDefaultValue() => -1;
 
     [SerializableProperty(12)]
+    [SaveFlag(nameof(ShouldSerializeDexReq), nameof(DexReqDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int DexRequirement
     {
@@ -422,13 +417,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(12)]
     private bool ShouldSerializeDexReq() => _dexRequirement != -1;
 
-    [SerializableFieldDefault(12)]
     private int DexReqDefaultValue() => -1;
 
     [SerializableProperty(13)]
+    [SaveFlag(nameof(ShouldSerializeIntReq), nameof(IntReqDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int IntRequirement
     {
@@ -441,13 +435,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(13)]
     private bool ShouldSerializeIntReq() => _intRequirement != -1;
 
-    [SerializableFieldDefault(13)]
     private int IntReqDefaultValue() => -1;
 
     [SerializableProperty(14)]
+    [SaveFlag(nameof(ShouldSerializeMinDamage), nameof(MinDamageDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int MinDamage
     {
@@ -460,13 +453,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(14)]
     private bool ShouldSerializeMinDamage() => _minDamage != -1;
 
-    [SerializableFieldDefault(14)]
     private int MinDamageDefaultValue() => -1;
 
     [SerializableProperty(15)]
+    [SaveFlag(nameof(ShouldSerializeMaxDamage), nameof(MaxDamageDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int MaxDamage
     {
@@ -479,13 +471,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(15)]
     private bool ShouldSerializeMaxDamage() => _maxDamage != -1;
 
-    [SerializableFieldDefault(15)]
     private int MaxDamageDefaultValue() => -1;
 
     [SerializableProperty(16)]
+    [SaveFlag(nameof(ShouldSerializeHitSound), nameof(HitSoundDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int HitSound
     {
@@ -497,13 +488,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(16)]
     private bool ShouldSerializeHitSound() => _hitSound != -1;
 
-    [SerializableFieldDefault(16)]
     private int HitSoundDefaultValue() => -1;
 
     [SerializableProperty(17)]
+    [SaveFlag(nameof(ShouldSerializeMissSound), nameof(MissSoundDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int MissSound
     {
@@ -515,13 +505,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(17)]
     private bool ShouldSerializeMissSound() => _missSound != -1;
 
-    [SerializableFieldDefault(17)]
     private int MissSoundDefaultValue() => -1;
 
     [SerializableProperty(18)]
+    [SaveFlag(nameof(ShouldSerializeSpeed), nameof(SpeedDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public float Speed
     {
@@ -552,13 +541,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(18)]
     private bool ShouldSerializeSpeed() => _speed != -1;
 
-    [SerializableFieldDefault(18)]
     private float SpeedDefaultValue() => -1;
 
     [SerializableProperty(19)]
+    [SaveFlag(nameof(ShouldSerializeMaxRange), nameof(MaxRangeDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public int MaxRange
     {
@@ -571,13 +559,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(19)]
     private bool ShouldSerializeMaxRange() => _maxRange != -1;
 
-    [SerializableFieldDefault(19)]
     private int MaxRangeDefaultValue() => -1;
 
     [SerializableProperty(20)]
+    [SaveFlag(nameof(ShouldSerializeSkill), nameof(SkillNameDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public SkillName Skill
     {
@@ -590,13 +577,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(20)]
     private bool ShouldSerializeSkill() => _skill != (SkillName)(-1);
 
-    [SerializableFieldDefault(20)]
     private SkillName SkillNameDefaultValue() => (SkillName)(-1);
 
     [SerializableProperty(21)]
+    [SaveFlag(nameof(ShouldSerializeType), nameof(TypeDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public WeaponType Type
     {
@@ -608,13 +594,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(21)]
     private bool ShouldSerializeType() => _type != (WeaponType)(-1);
 
-    [SerializableFieldDefault(21)]
     private WeaponType TypeDefaultValue() => (WeaponType)(-1);
 
     [SerializableProperty(22)]
+    [SaveFlag(nameof(ShouldSerializeAnimation), nameof(AnimationDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public WeaponAnimation Animation
     {
@@ -626,13 +611,12 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(22)]
     private bool ShouldSerializeAnimation() => _animation != (WeaponAnimation)(-1);
 
-    [SerializableFieldDefault(22)]
     private WeaponAnimation AnimationDefaultValue() => (WeaponAnimation)(-1);
 
     [SerializableProperty(23)]
+    [SaveFlag(nameof(ShouldSerializeResource), nameof(ResourceDefaultValue))]
     [CommandProperty(AccessLevel.GameMaster)]
     public CraftResource Resource
     {
@@ -648,10 +632,8 @@ public abstract partial class BaseWeapon
         }
     }
 
-    [SerializableFieldSaveFlag(23)]
     private bool ShouldSerializeResource() => _resource != CraftResource.Iron;
 
-    [SerializableFieldDefault(23)]
     private CraftResource ResourceDefaultValue() => CraftResource.Iron;
 
     public virtual int OnCraft(

--- a/Projects/UOContent/Migrations/Server.Items.BaseLight.v2.json
+++ b/Projects/UOContent/Migrations/Server.Items.BaseLight.v2.json
@@ -1,0 +1,43 @@
+{
+  "version": 2,
+  "type": "Server.Items.BaseLight",
+  "properties": [
+    {
+      "name": "BurntOut",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Burning",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Duration",
+      "type": "System.TimeSpan",
+      "rule": "PrimitiveTypeMigrationRule"
+    },
+    {
+      "name": "Protected",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "BurnTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.Corpse.v18.json
+++ b/Projects/UOContent/Migrations/Server.Items.Corpse.v18.json
@@ -1,0 +1,137 @@
+{
+  "version": 18,
+  "type": "Server.Items.Corpse",
+  "properties": [
+    {
+      "name": "RestoreEquip",
+      "type": "System.Collections.Generic.List\u003CServer.Item\u003E",
+      "rule": "ListMigrationRule",
+      "ruleArguments": [
+        "Server.Item",
+        "SerializableInterfaceMigrationRule"
+      ]
+    },
+    {
+      "name": "Flags",
+      "type": "Server.Items.CorpseFlag",
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "TimeOfDeath",
+      "type": "System.DateTime",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        "DeltaTime"
+      ]
+    },
+    {
+      "name": "RestoreTable",
+      "type": "System.Collections.Generic.Dictionary\u003CServer.Item, Server.Point3D\u003E",
+      "rule": "DictionaryMigrationRule",
+      "ruleArguments": [
+        "Server.Item",
+        "SerializableInterfaceMigrationRule",
+        "0",
+        "Server.Point3D",
+        "PrimitiveUOTypeMigrationRule",
+        "1",
+        "Point3D"
+      ]
+    },
+    {
+      "name": "DecayTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    },
+    {
+      "name": "Looters",
+      "type": "System.Collections.Generic.HashSet\u003CServer.Mobile\u003E",
+      "rule": "HashSetMigrationRule",
+      "ruleArguments": [
+        "Server.Mobile",
+        "SerializableInterfaceMigrationRule"
+      ]
+    },
+    {
+      "name": "Killer",
+      "type": "Server.Mobile",
+      "rule": "SerializableInterfaceMigrationRule"
+    },
+    {
+      "name": "Aggressors",
+      "type": "System.Collections.Generic.List\u003CServer.Mobile\u003E",
+      "rule": "ListMigrationRule",
+      "ruleArguments": [
+        "Server.Mobile",
+        "SerializableInterfaceMigrationRule"
+      ]
+    },
+    {
+      "name": "Owner",
+      "type": "Server.Mobile",
+      "rule": "SerializableInterfaceMigrationRule"
+    },
+    {
+      "name": "CorpseName",
+      "type": "string",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "AccessLevel",
+      "type": "Server.AccessLevel",
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "Guild",
+      "type": "Server.Guilds.Guild",
+      "rule": "SerializableInterfaceMigrationRule"
+    },
+    {
+      "name": "EquipItems",
+      "type": "System.Collections.Generic.List\u003CServer.Item\u003E",
+      "rule": "ListMigrationRule",
+      "ruleArguments": [
+        "Server.Item",
+        "SerializableInterfaceMigrationRule"
+      ]
+    },
+    {
+      "name": "HairItemId",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "HairHue",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "FacialHairItemId",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "FacialHairHue",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.DeathRobe.v4.json
+++ b/Projects/UOContent/Migrations/Server.Items.DeathRobe.v4.json
@@ -1,0 +1,14 @@
+{
+  "version": 4,
+  "type": "Server.Items.DeathRobe",
+  "properties": [
+    {
+      "name": "DecayTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.DecayedCorpse.v3.json
+++ b/Projects/UOContent/Migrations/Server.Items.DecayedCorpse.v3.json
@@ -1,0 +1,14 @@
+{
+  "version": 3,
+  "type": "Server.Items.DecayedCorpse",
+  "properties": [
+    {
+      "name": "DecayTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.FillableContainer.v3.json
+++ b/Projects/UOContent/Migrations/Server.Items.FillableContainer.v3.json
@@ -1,0 +1,19 @@
+{
+  "version": 3,
+  "type": "Server.Items.FillableContainer",
+  "properties": [
+    {
+      "name": "ContentType",
+      "type": "Server.Items.FillableContentType",
+      "rule": "EnumMigrationRule"
+    },
+    {
+      "name": "RespawnTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.MarkContainer.v1.json
+++ b/Projects/UOContent/Migrations/Server.Items.MarkContainer.v1.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "type": "Server.Items.MarkContainer",
+  "properties": [
+    {
+      "name": "AutoLock",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "RelockTimer",
+      "type": "Server.Items.MarkContainer.InternalTimer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    },
+    {
+      "name": "TargetMap",
+      "type": "Server.Map",
+      "rule": "PrimitiveUOTypeMigrationRule",
+      "ruleArguments": [
+        "Map"
+      ]
+    },
+    {
+      "name": "Target",
+      "type": "Server.Point3D",
+      "rule": "PrimitiveUOTypeMigrationRule",
+      "ruleArguments": [
+        "Point3D"
+      ]
+    },
+    {
+      "name": "Description",
+      "type": "string",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Items.TreasureMapChest.v4.json
+++ b/Projects/UOContent/Migrations/Server.Items.TreasureMapChest.v4.json
@@ -1,0 +1,57 @@
+{
+  "version": 4,
+  "type": "Server.Items.TreasureMapChest",
+  "properties": [
+    {
+      "name": "Guardians",
+      "type": "System.Collections.Generic.List\u003CServer.Mobile\u003E",
+      "rule": "ListMigrationRule",
+      "ruleArguments": [
+        "@Tidy",
+        "@CanBeNull",
+        "Server.Mobile",
+        "SerializableInterfaceMigrationRule"
+      ]
+    },
+    {
+      "name": "Temporary",
+      "type": "bool",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "Owner",
+      "type": "Server.Mobile",
+      "rule": "SerializableInterfaceMigrationRule"
+    },
+    {
+      "name": "Level",
+      "type": "int",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "ExpireTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    },
+    {
+      "name": "Lifted",
+      "type": "System.Collections.Generic.HashSet\u003CServer.Item\u003E",
+      "rule": "HashSetMigrationRule",
+      "ruleArguments": [
+        "@Tidy",
+        "@CanBeNull",
+        "Server.Item",
+        "SerializableInterfaceMigrationRule"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Migrations/Server.Mobiles.BaseEscortable.v3.json
+++ b/Projects/UOContent/Migrations/Server.Mobiles.BaseEscortable.v3.json
@@ -1,0 +1,43 @@
+{
+  "version": 3,
+  "type": "Server.Mobiles.BaseEscortable",
+  "properties": [
+    {
+      "name": "DestinationString",
+      "type": "string",
+      "rule": "PrimitiveTypeMigrationRule",
+      "ruleArguments": [
+        ""
+      ]
+    },
+    {
+      "name": "DeleteTimer",
+      "type": "Server.Timer",
+      "rule": "TimerMigrationRule",
+      "ruleArguments": [
+        "@AnchoredTimer"
+      ]
+    },
+    {
+      "name": "MlQuestType",
+      "type": "System.Type",
+      "rule": "PrimitiveTypeMigrationRule"
+    },
+    {
+      "name": "MlQuestDestinationMessage",
+      "type": "Server.TextDefinition",
+      "rule": "PrimitiveUOTypeMigrationRule",
+      "ruleArguments": [
+        "TextDefinition"
+      ]
+    },
+    {
+      "name": "MlQuestPaymentMessage",
+      "type": "Server.TextDefinition",
+      "rule": "PrimitiveUOTypeMigrationRule",
+      "ruleArguments": [
+        "TextDefinition"
+      ]
+    }
+  ]
+}

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
@@ -11,19 +11,19 @@ namespace Server.Mobiles
     public partial class EtherealMount : Item, IMount, IMountItem, IRewardItem
     {
         [SerializableField(0)]
+        [SaveFlag(nameof(ShouldSerializeIsDonationItem))]
         [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
         public bool _isDonationItem;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [SerializableFieldSaveFlag(0)]
         public bool ShouldSerializeIsDonationItem() => _isDonationItem;
 
         [SerializableField(1)]
+        [SaveFlag(nameof(ShouldSerializeIsRewardItem))]
         [SerializedCommandProperty(AccessLevel.GameMaster)]
         public bool _isRewardItem;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [SerializableFieldSaveFlag(1)]
         public bool ShouldSerializeIsRewardItem() => _isRewardItem;
 
         [Constructible]
@@ -87,6 +87,7 @@ namespace Server.Mobiles
         public virtual int EtherealHue => 0x4001;
 
         [SerializableProperty(4)]
+        [SaveFlag(nameof(ShouldSerializeRider))]
         [CommandProperty(AccessLevel.GameMaster)]
         public Mobile Rider
         {
@@ -124,11 +125,11 @@ namespace Server.Mobiles
             }
         }
 
-        [SerializableFieldSaveFlag(4)]
         private bool ShouldSerializeRider() => _rider != null;
 
         [CommandProperty(AccessLevel.GameMaster)]
         [SerializableProperty(5)]
+        [SaveFlag(nameof(ShouldSerializeSteps))]
         public int Steps
         {
             get => _steps;
@@ -139,7 +140,6 @@ namespace Server.Mobiles
             }
         }
 
-        [SerializableFieldSaveFlag(5)]
         private bool ShouldSerializeSteps() => _steps != StepsMax;
 
         public virtual int StepsMax => 3840; // Should be same as horse

--- a/Projects/UOContent/Mobiles/Townfolk/BaseEscortable.cs
+++ b/Projects/UOContent/Mobiles/Townfolk/BaseEscortable.cs
@@ -17,7 +17,7 @@ using EDI = Server.Mobiles.EscortDestinationInfo;
 
 namespace Server.Mobiles;
 
-[SerializationGenerator(2, false)]
+[SerializationGenerator(3, false)]
 public partial class BaseEscortable : BaseCreature
 {
     private static readonly ILogger logger = LogFactory.GetLogger(typeof(BaseEscortable));
@@ -158,16 +158,22 @@ public partial class BaseEscortable : BaseCreature
     [SerializableField(0, setter: "private")]
     private string _destinationString;
 
-    [TimerDrift]
     [SerializableField(1)]
+    [DeserializeTimer(nameof(DeserializeDeleteTimer))]
     private Timer _deleteTimer;
 
-    [DeserializeTimerField(1)]
-    private void DeserializeDeleteTimer(TimeSpan delay)
+    private void DeserializeDeleteTimer(TimeSpan delay) => Timer.DelayCall(delay, Delete);
+
+    private void MigrateFrom(V2Content content)
     {
-        if (delay >= TimeSpan.Zero)
+        _destinationString = content.DestinationString;
+        _mlQuestType = content.MlQuestType;
+        _mlQuestDestinationMessage = content.MlQuestDestinationMessage;
+        _mlQuestPaymentMessage = content.MlQuestPaymentMessage;
+
+        if (content.DeleteTimerDelay != TimeSpan.MinValue)
         {
-            Timer.DelayCall(delay, Delete);
+            DeserializeDeleteTimer(content.DeleteTimerDelay);
         }
     }
 

--- a/Projects/UOContent/UOContent.csproj
+++ b/Projects/UOContent/UOContent.csproj
@@ -50,8 +50,8 @@
         <PackageReference Include="ModernUO.CodeGeneratedEvents.Generator" Version="1.0.3.2" PrivateAssets="all" />
         <PackageReference Include="ZstdNet" Version="1.5.7" />
 
-        <PackageReference Include="ModernUO.Serialization.Annotations" Version="3.0.0" />
-        <PackageReference Include="ModernUO.Serialization.Generator" Version="3.0.0" PrivateAssets="all" />
+        <PackageReference Include="ModernUO.Serialization.Annotations" Version="4.0.0" />
+        <PackageReference Include="ModernUO.Serialization.Generator" Version="4.0.0" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
         <AdditionalFiles Include="Migrations/*.v*.json" />


### PR DESCRIPTION
## Summary

Adopts ModernUO.Serialization 4.0.0 across the engine. Three commits, reviewable independently:

1. **Package + tool bump to 4.0.0** (`Server.csproj`, `UOContent.csproj`, `dotnet-tools.json`).
2. **Timers → `[DeserializeTimer]`** — the 8 drifting timers (BaseLight, TreasureMapChest, MarkContainer, FillableContainer, DeathRobe, DecayedCorpse, Corpse, BaseEscortable) now store their next tick as **anchored time**: server downtime no longer consumes the remaining delay, and idle-world saves are byte-stable. This changes their wire format, so each class bumps its serialization version with a `MigrateFrom` that replays the old delta-time read through the migration schema (the new `vN.json` files carry `@AnchoredTimer`; the old ones keep `@TimerDrift`, which the generator reads forever). The 2 wall-clock timers (Aquarium, FountainOfLife) keep their exact format via `wallClock: true` — no bump. Restart methods drop their `TimeSpan.MinValue` sentinel checks: v4 invokes them **only when a timer was actually running at save**.
3. **Linkage → field-side declarations** — 175 conversions across 25 files: `[SerializableFieldSaveFlag(order)]`/`[SerializableFieldDefault(order)]` become `[SaveFlag(nameof(...), nameof(...))]` on the field, and `[SerializableFieldChanged(order)]` becomes the `fieldChanged:` argument of `[SerializableField]`. **Wire-neutral: zero migration schemas changed.**

## Verification

- Solution builds with **0 errors, 0 warnings**; all three 4.0.0 packages verified indexed on nuget.org (no local feed needed).
- **835 + 708 tests green.**
- Generated output inspected: old-version content structs replay `ReadDeltaTime` (e.g. `V3Content.DecayTimerNext = reader.ReadDeltaTime()`), current versions write/read anchored time with the gated restart, and the wall-clock classes emit byte-identical `Write`/`ReadDateTime` framing.
- Schema tool run is committed (CI's `git diff --exit-code` schema check passes): exactly the 8 expected new `vN.json` files, nothing else touched.
- The conversion was scripted with a class-scoped resolver (order → same-class `[SerializableField(order)]`/`[SerializableProperty(order)]`); it planned 175/175 with zero ambiguities before applying.

## Notes

- New `MigrateFrom`s use the content structs' provided `XxxDelay` property, matching the pre-existing idiom in Corpse's and TreasureMapChest's older migrations.
- Follow-up candidate (separate PR, wire-neutral, any time): fold the ~150 eligible hand-written `[SerializableProperty]` setters (clamps, post-change side effects) down to `[SerializableField]` with `allowFieldChange`/`fieldChanged` hooks.