### PR TITLE
refactor: fold serializable property setters into v4 field hooks

### DIFF
--- a/Projects/UOContent/Engines/CannedEvil/ChampionSkullBrazier.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSkullBrazier.cs
@@ -33,17 +33,13 @@ public partial class ChampionSkullBrazier : AddonComponent
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private ChampionSkullPlatform _platform;
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public Item Skull
+    [SerializableField(2, fieldChanged: nameof(OnSkullChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private Item _skull;
+
+    private void OnSkullChanged(Item oldValue, Item newValue)
     {
-        get => _skull;
-        set
-        {
-            _skull = value;
-            this.MarkDirty();
-            _platform?.Validate();
-        }
+        _platform?.Validate();
     }
 
     public override int LabelNumber => 1049489 + (int)_type;

--- a/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
+++ b/Projects/UOContent/Engines/CannedEvil/ChampionSpawn.cs
@@ -203,47 +203,38 @@ public partial class ChampionSpawn : Item
         }
     }
 
-    [SerializableProperty(3)]
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
-    public int MaxLevel
+    [SerializableField(3, allowFieldChange: nameof(AllowMaxLevelChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
+    private int _maxLevel;
+
+    private bool AllowMaxLevelChange(ref int value)
     {
-        get => _maxLevel;
-        set => _maxLevel = Math.Clamp(value, 0, 18);
+        value = Math.Clamp(value, 0, 18);
+        return true;
     }
 
-    [SerializableProperty(9)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public Rectangle2D SpawnArea
+    [SerializableField(9, fieldChanged: nameof(OnSpawnAreaChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private Rectangle2D _spawnArea;
+
+    private void OnSpawnAreaChanged(Rectangle2D oldValue, Rectangle2D newValue)
     {
-        get => _spawnArea;
-        set
-        {
-            _spawnArea = value;
-            this.MarkDirty();
-            InvalidateProperties();
-            UpdateRegion();
-        }
+        UpdateRegion();
     }
 
-    [SerializableProperty(11)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Kills
+    [SerializableField(11, fieldChanged: nameof(OnKillsChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _kills;
+
+    private void OnKillsChanged(int oldValue, int newValue)
     {
-        get => _kills;
-        set
+        var n = _kills / (double)MaxKills;
+        var p = (int)(n * 100);
+        if (p < 90)
         {
-            _kills = value;
-            this.MarkDirty();
-
-            var n = _kills / (double)MaxKills;
-            var p = (int)(n * 100);
-
-            if (p < 90)
-            {
-                SetWhiteSkullCount(p / 20);
-            }
-
-            InvalidateProperties();
+            SetWhiteSkullCount(p / 20);
         }
     }
 

--- a/Projects/UOContent/Engines/ConPVP/Trophy.cs
+++ b/Projects/UOContent/Engines/ConPVP/Trophy.cs
@@ -64,17 +64,13 @@ public partial class Trophy : Item
         UpdateStyle();
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public TrophyRank Rank
+    [SerializableField(1, fieldChanged: nameof(OnRankChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private TrophyRank _rank;
+
+    private void OnRankChanged(TrophyRank oldValue, TrophyRank newValue)
     {
-        get => _rank;
-        set
-        {
-            _rank = value;
-            UpdateStyle();
-            this.MarkDirty();
-        }
+        UpdateStyle();
     }
 
     private void Deserialize(IGenericReader reader, int version)

--- a/Projects/UOContent/Engines/Khaldun/PuzzleChest.cs
+++ b/Projects/UOContent/Engines/Khaldun/PuzzleChest.cs
@@ -237,16 +237,12 @@ namespace Server.Items
             }
         }
 
-        [SerializableProperty(0)]
-        public PuzzleChestSolution Solution
+        [SerializableField(0, fieldChanged: nameof(OnSolutionChanged))]
+        private PuzzleChestSolution _solution;
+
+        private void OnSolutionChanged(PuzzleChestSolution oldValue, PuzzleChestSolution newValue)
         {
-            get => _solution;
-            set
-            {
-                _solution = value;
-                InitHints();
-                this.MarkDirty();
-            }
+            InitHints();
         }
 
         public PuzzleChestCylinder FirstHint

--- a/Projects/UOContent/Engines/Plants/PlantItem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantItem.cs
@@ -123,49 +123,35 @@ public partial class PlantItem : Item, ISecurable
 
     private bool ShouldSerializePlantStatus() => _plantStatus != PlantStatus.BowlOfDirt;
 
-    [SerializableProperty(2)]
+    [SerializableField(2, fieldChanged: nameof(OnPlantTypeChanged))]
     [SaveFlag(nameof(ShouldSerializePlantType))]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public PlantType PlantType
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private PlantType _plantType;
+
+    private void OnPlantTypeChanged(PlantType oldValue, PlantType newValue)
     {
-        get => _plantType;
-        set
-        {
-            _plantType = value;
-            Update();
-        }
+        Update();
     }
 
     private bool ShouldSerializePlantType() => (int)_plantType != 0;
 
-    [SerializableProperty(3)]
+    [SerializableField(3, fieldChanged: nameof(OnPlantHueChanged))]
     [SaveFlag(nameof(ShouldSerializePlantHue))]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public PlantHue PlantHue
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private PlantHue _plantHue;
+
+    private void OnPlantHueChanged(PlantHue oldValue, PlantHue newValue)
     {
-        get => _plantHue;
-        set
-        {
-            _plantHue = value;
-            Update();
-        }
+        Update();
     }
 
     private bool ShouldSerializePlantHue() => _plantHue != PlantHue.None;
 
-    [SerializableProperty(4)]
+    [SerializableField(4)]
     [SaveFlag(nameof(ShouldSerializeShowType))]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public bool ShowType
-    {
-        get => _showType;
-        set
-        {
-            _showType = value;
-            InvalidateProperties();
-            this.MarkDirty();
-        }
-    }
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private bool _showType;
 
     private bool ShouldSerializeShowType() => _showType;
 

--- a/Projects/UOContent/Engines/Plants/PlantSystem.cs
+++ b/Projects/UOContent/Engines/Plants/PlantSystem.cs
@@ -97,43 +97,40 @@ namespace Server.Engines.Plants
 
         public bool IsFullWater => _water >= 4;
 
-        [SerializableProperty(3)]
+        [SerializableField(3, fieldChanged: nameof(OnWaterChanged), allowFieldChange: nameof(AllowWaterChange))]
         [SaveFlag(nameof(ShouldSerializeWater))]
-        public int Water
+        private int _water;
+
+        private bool AllowWaterChange(ref int value)
         {
-            get => _water;
-            set
-            {
-                _water = Math.Clamp(value, 0, 4);
-                Plant.InvalidateProperties();
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 4);
+            return true;
+        }
+
+        private void OnWaterChanged(int oldValue, int newValue)
+        {
+            Plant.InvalidateProperties();
         }
 
         private bool ShouldSerializeWater() => _water != 0;
 
-        [SerializableProperty(4)]
+        [SerializableField(4, fieldChanged: nameof(OnHitsChanged), allowFieldChange: nameof(AllowHitsChange))]
         [SaveFlag(nameof(ShouldSerializeHits))]
-        public int Hits
+        private int _hits;
+
+        private bool AllowHitsChange(ref int value)
         {
-            get => _hits;
-            set
+            value = Math.Clamp(value, 0, MaxHits);
+            return true;
+        }
+
+        private void OnHitsChanged(int oldValue, int newValue)
+        {
+            if (_hits == 0)
             {
-                if (_hits == value)
-                {
-                    return;
-                }
-
-                _hits = Math.Clamp(value, 0, MaxHits);
-
-                if (_hits == 0)
-                {
-                    Plant.Die();
-                }
-
-                Plant.InvalidateProperties();
-                MarkDirty();
+                Plant.Die();
             }
+            Plant.InvalidateProperties();
         }
 
         private bool ShouldSerializeHits() => _hits != 0;
@@ -149,122 +146,106 @@ namespace Server.Engines.Plants
                 _     => PlantHealth.Vibrant
             };
 
-        [SerializableProperty(5)]
+        [SerializableField(5, allowFieldChange: nameof(AllowInfestationChange))]
         [SaveFlag(nameof(ShouldSerializeInfestation))]
-        public int Infestation
+        private int _infestation;
+
+        private bool AllowInfestationChange(ref int value)
         {
-            get => _infestation;
-            set
-            {
-                _infestation = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializeInfestation() => _infestation != 0;
 
-        [SerializableProperty(6)]
+        [SerializableField(6, allowFieldChange: nameof(AllowFungusChange))]
         [SaveFlag(nameof(ShouldSerializeFungus))]
-        public int Fungus
+        private int _fungus;
+
+        private bool AllowFungusChange(ref int value)
         {
-            get => _fungus;
-            set
-            {
-                _fungus = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializeFungus() => _fungus != 0;
 
-        [SerializableProperty(7)]
+        [SerializableField(7, allowFieldChange: nameof(AllowPoisonChange))]
         [SaveFlag(nameof(ShouldSerializePoison))]
-        public int Poison
+        private int _poison;
+
+        private bool AllowPoisonChange(ref int value)
         {
-            get => _poison;
-            set
-            {
-                _poison = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializePoison() => _poison != 0;
 
-        [SerializableProperty(8)]
+        [SerializableField(8, allowFieldChange: nameof(AllowDiseaseChange))]
         [SaveFlag(nameof(ShouldSerializeDisease))]
-        public int Disease
+        private int _disease;
+
+        private bool AllowDiseaseChange(ref int value)
         {
-            get => _disease;
-            set
-            {
-                _disease = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializeDisease() => _disease != 0;
 
         public bool IsFullPoisonPotion => _poisonPotion >= 2;
 
-        [SerializableProperty(9)]
+        [SerializableField(9, allowFieldChange: nameof(AllowPoisonPotionChange))]
         [SaveFlag(nameof(ShouldSerializePoisonPotion))]
-        public int PoisonPotion
+        private int _poisonPotion;
+
+        private bool AllowPoisonPotionChange(ref int value)
         {
-            get => _poisonPotion;
-            set
-            {
-                _poisonPotion = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializePoisonPotion() => _poisonPotion != 0;
 
         public bool IsFullCurePotion => _curePotion >= 2;
 
-        [SerializableProperty(10)]
+        [SerializableField(10, allowFieldChange: nameof(AllowCurePotionChange))]
         [SaveFlag(nameof(ShouldSerializeCurePotion))]
-        public int CurePotion
+        private int _curePotion;
+
+        private bool AllowCurePotionChange(ref int value)
         {
-            get => _curePotion;
-            set
-            {
-                _curePotion = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializeCurePotion() => _curePotion != 0;
 
         public bool IsFullHealPotion => _healPotion >= 2;
 
-        [SerializableProperty(11)]
+        [SerializableField(11, allowFieldChange: nameof(AllowHealPotionChange))]
         [SaveFlag(nameof(ShouldSerializeHealPotion))]
-        public int HealPotion
+        private int _healPotion;
+
+        private bool AllowHealPotionChange(ref int value)
         {
-            get => _healPotion;
-            set
-            {
-                _healPotion = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializeHealPotion() => _healPotion != 0;
 
         public bool IsFullStrengthPotion => _strengthPotion >= 2;
 
-        [SerializableProperty(12)]
+        [SerializableField(12, allowFieldChange: nameof(AllowStrengthPotionChange))]
         [SaveFlag(nameof(ShouldSerializeStrengthPotion))]
-        public int StrengthPotion
+        private int _strengthPotion;
+
+        private bool AllowStrengthPotionChange(ref int value)
         {
-            get => _strengthPotion;
-            set
-            {
-                _strengthPotion = Math.Clamp(value, 0, 2);
-                MarkDirty();
-            }
+            value = Math.Clamp(value, 0, 2);
+            return true;
         }
 
         private bool ShouldSerializeStrengthPotion() => _strengthPotion != 0;
@@ -301,44 +282,52 @@ namespace Server.Engines.Plants
 
         private bool ShouldSerializeSeedHue() => _pollinated;
 
-        [SerializableProperty(16)]
+        [SerializableField(16, allowFieldChange: nameof(AllowAvailableSeedsChange))]
         [SaveFlag(nameof(ShouldSerializeAvailableSeeds))]
-        public int AvailableSeeds
+        private int _availableSeeds;
+
+        private bool AllowAvailableSeedsChange(ref int value)
         {
-            get => _availableSeeds;
-            set => _availableSeeds = Math.Max(value, 0);
+            value = Math.Max(value, 0);
+            return true;
         }
 
         private bool ShouldSerializeAvailableSeeds() => _availableSeeds != 0;
 
-        [SerializableProperty(17)]
+        [SerializableField(17, allowFieldChange: nameof(AllowLeftSeedsChange))]
         [SaveFlag(nameof(ShouldSerializeLeftSeeds), nameof(LeftSeedsDefaultValue))]
-        public int LeftSeeds
+        private int _leftSeeds;
+
+        private bool AllowLeftSeedsChange(ref int value)
         {
-            get => _leftSeeds;
-            set => _leftSeeds = Math.Max(value, 0);
+            value = Math.Max(value, 0);
+            return true;
         }
 
         private bool ShouldSerializeLeftSeeds() => _leftSeeds != 8;
 
         private int LeftSeedsDefaultValue() => 8;
 
-        [SerializableProperty(18)]
+        [SerializableField(18, allowFieldChange: nameof(AllowAvailableResourcesChange))]
         [SaveFlag(nameof(ShouldSerializeAvailableResources))]
-        public int AvailableResources
+        private int _availableResources;
+
+        private bool AllowAvailableResourcesChange(ref int value)
         {
-            get => _availableResources;
-            set => _availableResources = Math.Max(value, 0);
+            value = Math.Max(value, 0);
+            return true;
         }
 
         private bool ShouldSerializeAvailableResources() => _availableResources != 0;
 
-        [SerializableProperty(19)]
+        [SerializableField(19, allowFieldChange: nameof(AllowLeftResourcesChange))]
         [SaveFlag(nameof(ShouldSerializeLeftResources), nameof(LeftResourcesDefaultValue))]
-        public int LeftResources
+        private int _leftResources;
+
+        private bool AllowLeftResourcesChange(ref int value)
         {
-            get => _leftResources;
-            set => _leftResources = Math.Max(value, 0);
+            value = Math.Max(value, 0);
+            return true;
         }
 
         private bool ShouldSerializeLeftResources() => _leftResources != 8;

--- a/Projects/UOContent/Engines/Plants/Seed.cs
+++ b/Projects/UOContent/Engines/Plants/Seed.cs
@@ -35,18 +35,14 @@ public partial class Seed : Item
 
     public override double DefaultWeight => 1.0;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    [SerializableProperty(1)]
-    public PlantHue PlantHue
+    [SerializableField(1, fieldChanged: nameof(OnPlantHueChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private PlantHue _plantHue;
+
+    private void OnPlantHueChanged(PlantHue oldValue, PlantHue newValue)
     {
-        get => _plantHue;
-        set
-        {
-            _plantHue = value;
-            Hue = PlantHueInfo.GetInfo(value).Hue;
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        Hue = PlantHueInfo.GetInfo(newValue).Hue;
     }
 
     public override int LabelNumber => 1060810; // seed

--- a/Projects/UOContent/Engines/Player Murder System/MurderContext.cs
+++ b/Projects/UOContent/Engines/Player Murder System/MurderContext.cs
@@ -16,12 +16,14 @@ public partial class MurderContext
     [SerializedCommandProperty(AccessLevel.GameMaster)]
     private TimeSpan _longTermElapse;
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int ShortTermMurders
+    [SerializableField(2, allowFieldChange: nameof(AllowShortTermMurdersChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private int _shortTermMurders;
+
+    private bool AllowShortTermMurdersChange(ref int value)
     {
-        get => _shortTermMurders;
-        set => _shortTermMurders = Math.Max(value, 0);
+        value = Math.Max(value, 0);
+        return true;
     }
 
     [SerializableField(3)]

--- a/Projects/UOContent/Engines/Quests/The Summoning/Items/SummoningAltar.cs
+++ b/Projects/UOContent/Engines/Quests/The Summoning/Items/SummoningAltar.cs
@@ -12,16 +12,12 @@ public partial class SummoningAltar : AbbatoirAddon
     {
     }
 
-    [SerializableProperty(0)]
-    public BoneDemon Daemon
+    [SerializableField(0, fieldChanged: nameof(OnDaemonChanged))]
+    private BoneDemon _daemon;
+
+    private void OnDaemonChanged(BoneDemon oldValue, BoneDemon newValue)
     {
-        get => _daemon;
-        set
-        {
-            _daemon = value;
-            CheckDaemon();
-            this.MarkDirty();
-        }
+        CheckDaemon();
     }
 
     public void CheckDaemon()

--- a/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
+++ b/Projects/UOContent/Engines/Spawners/BaseSpawner.cs
@@ -311,26 +311,20 @@ public abstract partial class BaseSpawner : Item, ISpawner
         }
     }
 
-    [SerializableProperty(8)]
-    [CommandProperty(AccessLevel.Developer)]
-    public int Count
+    [SerializableField(8, fieldChanged: nameof(OnCountChanged))]
+    [SerializedCommandProperty(AccessLevel.Developer)]
+    [InvalidateProperties]
+    private int _count;
+
+    private void OnCountChanged(int oldValue, int newValue)
     {
-        get => _count;
-        set
+        if (IsFull)
         {
-            _count = value;
-
-            if (IsFull)
-            {
-                _timer?.Stop();
-            }
-            else if (_timer?.Running != true)
-            {
-                DoTimer();
-            }
-
-            InvalidateProperties();
-            this.MarkDirty();
+            _timer?.Stop();
+        }
+        else if (_timer?.Running != true)
+        {
+            DoTimer();
         }
     }
 

--- a/Projects/UOContent/Engines/Treasures of Tokuno/GreaterArtifacts.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/GreaterArtifacts.cs
@@ -332,27 +332,22 @@ public partial class PigmentsOfTokuno : BasePigmentsOfTokuno
     [Constructible]
     public PigmentsOfTokuno(PigmentType type, int uses) : base(uses) => Type = type;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public PigmentType Type
+    [SerializableField(0, fieldChanged: nameof(OnTypeChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private PigmentType _type;
+
+    private void OnTypeChanged(PigmentType oldValue, PigmentType newValue)
     {
-        get => _type;
-        set
+        var v = (int)_type;
+        if (v >= 0 && v < _table.Length)
         {
-            _type = value;
-
-            var v = (int)_type;
-
-            if (v >= 0 && v < _table.Length)
-            {
-                Hue = _table[v][0];
-                Label = _table[v][1];
-            }
-            else
-            {
-                Hue = 0;
-                Label = -1;
-            }
+            Hue = _table[v][0];
+            Label = _table[v][1];
+        }
+        else
+        {
+            Hue = 0;
+            Label = -1;
         }
     }
 

--- a/Projects/UOContent/Engines/Treasures of Tokuno/LesserArtifacts.cs
+++ b/Projects/UOContent/Engines/Treasures of Tokuno/LesserArtifacts.cs
@@ -617,27 +617,22 @@ public partial class LesserPigmentsOfTokuno : BasePigmentsOfTokuno
     [Constructible]
     public LesserPigmentsOfTokuno(LesserPigmentType type) : base(1) => Type = type;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public LesserPigmentType Type
+    [SerializableField(0, fieldChanged: nameof(OnTypeChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private LesserPigmentType _type;
+
+    private void OnTypeChanged(LesserPigmentType oldValue, LesserPigmentType newValue)
     {
-        get => _type;
-        set
+        var v = (int)_type;
+        if (v >= 0 && v < _table.Length)
         {
-            _type = value;
-
-            var v = (int)_type;
-
-            if (v >= 0 && v < _table.Length)
-            {
-                Hue = _table[v][0];
-                Label = _table[v][1];
-            }
-            else
-            {
-                Hue = 0;
-                Label = -1;
-            }
+            Hue = _table[v][0];
+            Label = _table[v][1];
+        }
+        else
+        {
+            Hue = 0;
+            Label = -1;
         }
     }
 

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatue.cs
@@ -79,45 +79,33 @@ public partial class CharacterStatue : Mobile, IRewardItem
         InvalidateHues();
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public StatueType StatueType
+    [SerializableField(0, fieldChanged: nameof(OnStatueTypeChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private StatueType _statueType;
+
+    private void OnStatueTypeChanged(StatueType oldValue, StatueType newValue)
     {
-        get => _statueType;
-        set
-        {
-            _statueType = value;
-            InvalidateHues();
-            InvalidatePose();
-            this.MarkDirty();
-        }
+        InvalidateHues();
+        InvalidatePose();
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public StatuePose Pose
+    [SerializableField(1, fieldChanged: nameof(OnPoseChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private StatuePose _pose;
+
+    private void OnPoseChanged(StatuePose oldValue, StatuePose newValue)
     {
-        get => _pose;
-        set
-        {
-            _pose = value;
-            InvalidatePose();
-            this.MarkDirty();
-        }
+        InvalidatePose();
     }
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public StatueMaterial Material
+    [SerializableField(2, fieldChanged: nameof(OnMaterialChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private StatueMaterial _material;
+
+    private void OnMaterialChanged(StatueMaterial oldValue, StatueMaterial newValue)
     {
-        get => _material;
-        set
-        {
-            _material = value;
-            InvalidateHues();
-            InvalidatePose();
-            this.MarkDirty();
-        }
+        InvalidateHues();
+        InvalidatePose();
     }
 
     public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatueMaker.cs
+++ b/Projects/UOContent/Engines/Veteran Rewards/Character Statue Maker/CharacterStatueMaker.cs
@@ -25,17 +25,13 @@ public partial class CharacterStatueMaker : Item, IRewardItem
 
     public override int LabelNumber => 1076173; // Character Statue Maker
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public StatueType StatueType
+    [SerializableField(1, fieldChanged: nameof(OnStatueTypeChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private StatueType _statueType;
+
+    private void OnStatueTypeChanged(StatueType oldValue, StatueType newValue)
     {
-        get => _statueType;
-        set
-        {
-            _statueType = value;
-            InvalidateHue();
-            this.MarkDirty();
-        }
+        InvalidateHue();
     }
 
     public override void OnDoubleClick(Mobile from)

--- a/Projects/UOContent/Items/Addons/BaseAddon.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddon.cs
@@ -63,22 +63,14 @@ namespace Server.Items
             }
         }
 
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public CraftResource Resource
-        {
-            get => _resource;
-            set
-            {
-                if (_resource != value)
-                {
-                    _resource = value;
-                    Hue = CraftResources.GetHue(_resource);
+        [SerializableField(1, fieldChanged: nameof(OnResourceChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private CraftResource _resource;
 
-                    InvalidateProperties();
-                    this.MarkDirty();
-                }
-            }
+        private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+        {
+            Hue = CraftResources.GetHue(_resource);
         }
 
         Item IAddon.Deed => Deed;

--- a/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddonContainer.cs
@@ -41,22 +41,14 @@ namespace Server.Items
             }
         }
 
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public CraftResource Resource
-        {
-            get => _resource;
-            set
-            {
-                if (_resource != value)
-                {
-                    _resource = value;
-                    Hue = CraftResources.GetHue(_resource);
+        [SerializableField(1, fieldChanged: nameof(OnResourceChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private CraftResource _resource;
 
-                    InvalidateProperties();
-                    this.MarkDirty();
-                }
-            }
+        private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+        {
+            Hue = CraftResources.GetHue(_resource);
         }
 
         public virtual bool RetainDeedHue => false;

--- a/Projects/UOContent/Items/Addons/BaseAddonContainerDeed.cs
+++ b/Projects/UOContent/Items/Addons/BaseAddonContainerDeed.cs
@@ -23,22 +23,14 @@ public abstract partial class BaseAddonContainerDeed : Item, ICraftable
 
     public abstract BaseAddonContainer Addon { get; }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(_resource);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(_resource);
     }
 
     public virtual int OnCraft(

--- a/Projects/UOContent/Items/Addons/FlourMillEastAddon.cs
+++ b/Projects/UOContent/Items/Addons/FlourMillEastAddon.cs
@@ -48,17 +48,19 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public int MaxFlour => 2;
 
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int CurFlour
+        [SerializableField(0, fieldChanged: nameof(OnCurFlourChanged), allowFieldChange: nameof(AllowCurFlourChange))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private int _curFlour;
+
+        private bool AllowCurFlourChange(ref int value)
         {
-            get => _curFlour;
-            set
-            {
-                _curFlour = Math.Clamp(value, 0, MaxFlour);
-                UpdateStage();
-                this.MarkDirty();
-            }
+            value = Math.Clamp(value, 0, MaxFlour);
+            return true;
+        }
+
+        private void OnCurFlourChanged(int oldValue, int newValue)
+        {
+            UpdateStage();
         }
 
         public void StartWorking(Mobile from)

--- a/Projects/UOContent/Items/Addons/FlourMillSouthAddon.cs
+++ b/Projects/UOContent/Items/Addons/FlourMillSouthAddon.cs
@@ -35,16 +35,19 @@ namespace Server.Items
         [CommandProperty(AccessLevel.GameMaster)]
         public int MaxFlour => 2;
 
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int CurFlour
+        [SerializableField(0, fieldChanged: nameof(OnCurFlourChanged), allowFieldChange: nameof(AllowCurFlourChange))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private int _curFlour;
+
+        private bool AllowCurFlourChange(ref int value)
         {
-            get => _curFlour;
-            set
-            {
-                _curFlour = Math.Max(0, Math.Min(value, MaxFlour));
-                UpdateStage();
-            }
+            value = Math.Max(0, Math.Min(value, MaxFlour));
+            return true;
+        }
+
+        private void OnCurFlourChanged(int oldValue, int newValue)
+        {
+            UpdateStage();
         }
 
         public void StartWorking(Mobile from)

--- a/Projects/UOContent/Items/Addons/SHTeleporter.cs
+++ b/Projects/UOContent/Items/Addons/SHTeleporter.cs
@@ -25,35 +25,27 @@ namespace Server.Items
             _teleOffset = offset;
         }
 
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public bool Active
-        {
-            get => _active;
-            set
-            {
-                _active = value;
+        [SerializableField(0, fieldChanged: nameof(OnActiveChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private bool _active;
 
-                if (Addon is SHTeleporter sourceAddon)
-                {
-                    sourceAddon.ChangeActive(value);
-                }
+        private void OnActiveChanged(bool oldValue, bool newValue)
+        {
+            if (Addon is SHTeleporter sourceAddon)
+            {
+                sourceAddon.ChangeActive(newValue);
             }
         }
 
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public SHTeleComponent TeleDest
-        {
-            get => _teleDest;
-            set
-            {
-                _teleDest = value;
+        [SerializableField(1, fieldChanged: nameof(OnTeleDestChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private SHTeleComponent _teleDest;
 
-                if (Addon is SHTeleporter sourceAddon)
-                {
-                    sourceAddon.ChangeDest(value);
-                }
+        private void OnTeleDestChanged(SHTeleComponent oldValue, SHTeleComponent newValue)
+        {
+            if (Addon is SHTeleporter sourceAddon)
+            {
+                sourceAddon.ChangeDest(newValue);
             }
         }
 

--- a/Projects/UOContent/Items/Aquarium/AquariumState.cs
+++ b/Projects/UOContent/Items/Aquarium/AquariumState.cs
@@ -30,19 +30,14 @@ namespace Server.Items
 
         public AquariumState(Aquarium parent) => _aquarium = parent;
 
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int State
+        [SerializableField(0, allowFieldChange: nameof(AllowStateChange))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private int _state;
+
+        private bool AllowStateChange(ref int value)
         {
-            get => _state;
-            set
-            {
-                if (_state != value)
-                {
-                    _state = Math.Clamp(value, 0, 4);
-                    MarkDirty();
-                }
-            }
+            value = Math.Clamp(value, 0, 4);
+            return true;
         }
 
         [SerializableField(1)]

--- a/Projects/UOContent/Items/Armor/BaseArmor.cs
+++ b/Projects/UOContent/Items/Armor/BaseArmor.cs
@@ -219,25 +219,16 @@ namespace Server.Items
 
         private bool ShouldSerializeDurability() => _durability != ArmorDurabilityLevel.Regular;
 
-        [SerializableProperty(13)]
+        [SerializableField(13, fieldChanged: nameof(OnProtectionLevelChanged))]
         [SaveFlag(nameof(ShouldSerializeProtectionLevel))]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public ArmorProtectionLevel ProtectionLevel
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private ArmorProtectionLevel _protectionLevel;
+
+        private void OnProtectionLevelChanged(ArmorProtectionLevel oldValue, ArmorProtectionLevel newValue)
         {
-            get => _protectionLevel;
-            set
-            {
-                if (_protectionLevel != value)
-                {
-                    _protectionLevel = value;
-
-                    Invalidate();
-                    InvalidateProperties();
-
-                    (Parent as Mobile)?.UpdateResistances();
-                    this.MarkDirty();
-                }
-            }
+            Invalidate();
+            (Parent as Mobile)?.UpdateResistances();
         }
 
         private bool ShouldSerializeProtectionLevel() => _protectionLevel != ArmorProtectionLevel.Regular;

--- a/Projects/UOContent/Items/Armor/Leather/LeafGloves.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeafGloves.cs
@@ -33,32 +33,26 @@ namespace Server.Items
 
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 
+        [SerializableField(0, fieldChanged: nameof(OnCurArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int CurArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _curArcaneCharges;
+
+        private void OnCurArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _curArcaneCharges;
-            set
-            {
-                _curArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-            }
+            Update();
         }
 
+        [SerializableField(1, fieldChanged: nameof(OnMaxArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int MaxArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _maxArcaneCharges;
+
+        private void OnMaxArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _maxArcaneCharges;
-            set
-            {
-                _maxArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-            }
+            Update();
         }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Armor/Leather/LeatherGloves.cs
+++ b/Projects/UOContent/Items/Armor/Leather/LeatherGloves.cs
@@ -32,32 +32,26 @@ namespace Server.Items
 
         public override ArmorMeditationAllowance DefMedAllowance => ArmorMeditationAllowance.All;
 
+        [SerializableField(0, fieldChanged: nameof(OnCurArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int CurArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _curArcaneCharges;
+
+        private void OnCurArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _curArcaneCharges;
-            set
-            {
-                _curArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-            }
+            Update();
         }
 
+        [SerializableField(1, fieldChanged: nameof(OnMaxArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int MaxArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _maxArcaneCharges;
+
+        private void OnMaxArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _maxArcaneCharges;
-            set
-            {
-                _maxArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-            }
+            Update();
         }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Clothing/BaseClothing.cs
+++ b/Projects/UOContent/Items/Clothing/BaseClothing.cs
@@ -113,19 +113,15 @@ namespace Server.Items
             Resistances = new AosElementAttributes(this);
         }
 
-        [SerializableProperty(0)]
+        [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
         [SaveFlag(nameof(ShouldSerializeResource))]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public CraftResource Resource
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private CraftResource _resource;
+
+        private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
         {
-            get => _resource;
-            set
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(_resource);
-                InvalidateProperties();
-                this.MarkDirty();
-            }
+            Hue = CraftResources.GetHue(_resource);
         }
 
         [SerializableProperty(9, useField: nameof(_strReq))]

--- a/Projects/UOContent/Items/Clothing/Cloaks.cs
+++ b/Projects/UOContent/Items/Clothing/Cloaks.cs
@@ -22,34 +22,26 @@ namespace Server.Items
 
         public override double DefaultWeight => 5.0;
 
+        [SerializableField(0, fieldChanged: nameof(OnCurArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int CurArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _curArcaneCharges;
+
+        private void OnCurArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _curArcaneCharges;
-            set
-            {
-                _curArcaneCharges = value;
-                this.MarkDirty();
-                InvalidateProperties();
-                Update();
-            }
+            Update();
         }
 
+        [SerializableField(1, fieldChanged: nameof(OnMaxArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int MaxArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _maxArcaneCharges;
+
+        private void OnMaxArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _maxArcaneCharges;
-            set
-            {
-                _maxArcaneCharges = value;
-                this.MarkDirty();
-                InvalidateProperties();
-                Update();
-            }
+            Update();
         }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Clothing/OuterTorso.cs
+++ b/Projects/UOContent/Items/Clothing/OuterTorso.cs
@@ -325,34 +325,26 @@ namespace Server.Items
 
         public override double DefaultWeight => 3.0;
 
+        [SerializableField(0, fieldChanged: nameof(OnCurArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int CurArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _curArcaneCharges;
+
+        private void OnCurArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _curArcaneCharges;
-            set
-            {
-                _curArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-                this.MarkDirty();
-            }
+            Update();
         }
 
+        [SerializableField(1, fieldChanged: nameof(OnMaxArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int MaxArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _maxArcaneCharges;
+
+        private void OnMaxArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _maxArcaneCharges;
-            set
-            {
-                _maxArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-                this.MarkDirty();
-            }
+            Update();
         }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Clothing/Shoes.cs
+++ b/Projects/UOContent/Items/Clothing/Shoes.cs
@@ -70,19 +70,15 @@ namespace Server.Items
 
         public override CraftResource DefaultResource => CraftResource.RegularLeather;
 
+        [SerializableField(1, fieldChanged: nameof(OnMaxArcaneChargesChanged))]
         [EncodedInt]
-        [SerializableProperty(1)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int MaxArcaneCharges
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private int _maxArcaneCharges;
+
+        private void OnMaxArcaneChargesChanged(int oldValue, int newValue)
         {
-            get => _maxArcaneCharges;
-            set
-            {
-                _maxArcaneCharges = value;
-                InvalidateProperties();
-                Update();
-                this.MarkDirty();
-            }
+            Update();
         }
 
         [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
+++ b/Projects/UOContent/Items/Construction/Doors/BaseDoor.cs
@@ -74,43 +74,31 @@ public abstract partial class BaseDoor : Item, ILockable, ITelekinesisable
         Movable = false;
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public bool Open
+    [SerializableField(1, fieldChanged: nameof(OnOpenChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private bool _open;
+
+    private void OnOpenChanged(bool oldValue, bool newValue)
     {
-        get => _open;
-        set
+        ItemID = _open ? _openedId : _closedId;
+        if (_open)
         {
-            if (_open != value)
-            {
-                _open = value;
-
-                ItemID = _open ? _openedId : _closedId;
-
-                if (_open)
-                {
-                    Location = new Point3D(X + _offset.X, Y + _offset.Y, Z + _offset.Z);
-                }
-                else
-                {
-                    Location = new Point3D(X - _offset.X, Y - _offset.Y, Z - _offset.Z);
-                }
-
-                Effects.PlaySound(this, _open ? OpenedSound : ClosedSound);
-
-                if (_open)
-                {
-                    _timer ??= new InternalTimer(this);
-                    _timer.Start();
-                }
-                else
-                {
-                    _timer.Stop();
-                    _timer = null;
-                }
-
-                this.MarkDirty();
-            }
+            Location = new Point3D(X + _offset.X, Y + _offset.Y, Z + _offset.Z);
+        }
+        else
+        {
+            Location = new Point3D(X - _offset.X, Y - _offset.Y, Z - _offset.Z);
+        }
+        Effects.PlaySound(this, _open ? OpenedSound : ClosedSound);
+        if (_open)
+        {
+            _timer ??= new InternalTimer(this);
+            _timer.Start();
+        }
+        else
+        {
+            _timer.Stop();
+            _timer = null;
         }
     }
 

--- a/Projects/UOContent/Items/Containers/MarkContainer.cs
+++ b/Projects/UOContent/Items/Containers/MarkContainer.cs
@@ -62,23 +62,19 @@ public partial class MarkContainer : LockableContainer
         }
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public bool AutoLock
-    {
-        get => _autoLock;
-        set
-        {
-            _autoLock = value;
+    [SerializableField(0, fieldChanged: nameof(OnAutoLockChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private bool _autoLock;
 
-            if (!_autoLock)
-            {
-                StopTimer();
-            }
-            else if (!Locked)
-            {
-                _relockTimer ??= new InternalTimer(this);
-            }
+    private void OnAutoLockChanged(bool oldValue, bool newValue)
+    {
+        if (!_autoLock)
+        {
+            StopTimer();
+        }
+        else if (!Locked)
+        {
+            _relockTimer ??= new InternalTimer(this);
         }
     }
 

--- a/Projects/UOContent/Items/Deeds/DragonBardingDeed.cs
+++ b/Projects/UOContent/Items/Deeds/DragonBardingDeed.cs
@@ -28,17 +28,14 @@ public partial class DragonBardingDeed : Item, ICraftable
 
     public override int LabelNumber => _exceptional ? 1053181 : 1053012; // dragon barding deed
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
+    [SerializableField(2, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
+
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
     {
-        get => _resource;
-        set
-        {
-            _resource = value;
-            Hue = CraftResources.GetHue(value);
-            InvalidateProperties();
-        }
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public int OnCraft(

--- a/Projects/UOContent/Items/Food/Beverage.cs
+++ b/Projects/UOContent/Items/Food/Beverage.cs
@@ -324,27 +324,21 @@ public abstract partial class BaseBeverage : Item, IHasQuantity
     [CommandProperty(AccessLevel.GameMaster)]
     public bool IsFull => _quantity >= MaxQuantity;
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public BeverageType Content
+    [SerializableField(2, fieldChanged: nameof(OnContentChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private BeverageType _content;
+
+    private void OnContentChanged(BeverageType oldValue, BeverageType newValue)
     {
-        get => _content;
-        set
+        var itemID = ComputeItemID();
+        if (itemID > 0)
         {
-            _content = value;
-
-            InvalidateProperties();
-
-            var itemID = ComputeItemID();
-
-            if (itemID > 0)
-            {
-                ItemID = itemID;
-            }
-            else
-            {
-                Delete();
-            }
+            ItemID = itemID;
+        }
+        else
+        {
+            Delete();
         }
     }
 

--- a/Projects/UOContent/Items/Food/Cooking.cs
+++ b/Projects/UOContent/Items/Food/Cooking.cs
@@ -76,25 +76,25 @@ public partial class SackFlour : Item, IHasQuantity
 
     public override double DefaultWeight => 5.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Quantity
+    [SerializableField(0, fieldChanged: nameof(OnQuantityChanged), allowFieldChange: nameof(AllowQuantityChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private int _quantity;
+
+    private bool AllowQuantityChange(ref int value)
     {
-        get => _quantity;
-        set
+        value = Math.Min(20, Math.Max(0, value));
+        return true;
+    }
+
+    private void OnQuantityChanged(int oldValue, int newValue)
+    {
+        if (_quantity == 0)
         {
-            _quantity = Math.Min(20, Math.Max(0, value));
-
-            if (_quantity == 0)
-            {
-                Delete();
-            }
-            else if (_quantity < 20 && ItemID is 0x1039 or 0x1045)
-            {
-                ++ItemID;
-            }
-
-            this.MarkDirty();
+            Delete();
+        }
+        else if (_quantity < 20 && ItemID is 0x1039 or 0x1045)
+        {
+            ++ItemID;
         }
     }
 

--- a/Projects/UOContent/Items/Games/Mahjong/MahjongGame.cs
+++ b/Projects/UOContent/Items/Games/Mahjong/MahjongGame.cs
@@ -55,55 +55,33 @@ public partial class MahjongGame : Item, ISecurable
 
     public override double DefaultWeight => 5.0;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    [SerializableProperty(6)]
-    public bool ShowScores
+    [SerializableField(6, fieldChanged: nameof(OnShowScoresChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private bool _showScores;
+
+    private void OnShowScoresChanged(bool oldValue, bool newValue)
     {
-        get => _showScores;
-        set
+        if (newValue)
         {
-            if (_showScores == value)
-            {
-                return;
-            }
-
-            _showScores = value;
-
-            if (value)
-            {
-                _players.SendPlayersPacket(true, true);
-            }
-
-            _players.SendGeneralPacket(true, true);
-            _players.SendLocalizedMessage(value ? 1062777 : 1062778); // The dealer has enabled/disabled score display.
-            this.MarkDirty();
+            _players.SendPlayersPacket(true, true);
         }
+        _players.SendGeneralPacket(true, true);
+        _players.SendLocalizedMessage(newValue ? 1062777 : 1062778); // The dealer has enabled/disabled score display.
     }
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    [SerializableProperty(7)]
-    public bool SpectatorVision
+    [SerializableField(7, fieldChanged: nameof(OnSpectatorVisionChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private bool _spectatorVision;
+
+    private void OnSpectatorVisionChanged(bool oldValue, bool newValue)
     {
-        get => _spectatorVision;
-        set
+        if (_players.IsInGamePlayer(_players.DealerPosition))
         {
-            if (_spectatorVision == value)
-            {
-                return;
-            }
-
-            _spectatorVision = value;
-
-            if (_players.IsInGamePlayer(_players.DealerPosition))
-            {
-                _players.Dealer.NetState.SendMahjongGeneralInfo(this);
-            }
-
-            _players.SendTilesPacket(false, true);
-            _players.SendLocalizedMessage(value ? 1062715 : 1062716); // The dealer has enabled/disabled Spectator Vision.
-            InvalidateProperties();
-            this.MarkDirty();
+            _players.Dealer.NetState.SendMahjongGeneralInfo(this);
         }
+        _players.SendTilesPacket(false, true);
+        _players.SendLocalizedMessage(newValue ? 1062715 : 1062716); // The dealer has enabled/disabled Spectator Vision.
     }
 
     private void BuildHorizontalWall(

--- a/Projects/UOContent/Items/Jewels/BaseJewel.cs
+++ b/Projects/UOContent/Items/Jewels/BaseJewel.cs
@@ -93,16 +93,13 @@ public abstract partial class BaseJewel : Item, ICraftable, IAosItem
         }
     }
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
+    [SerializableField(2, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private CraftResource _resource;
+
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
     {
-        get => _resource;
-        set
-        {
-            _resource = value;
-            Hue = CraftResources.GetHue(_resource);
-        }
+        Hue = CraftResources.GetHue(_resource);
     }
 
     public override int PhysicalResistance => Resistances.Physical;

--- a/Projects/UOContent/Items/Misc/CommunicationCrystals.cs
+++ b/Projects/UOContent/Items/Misc/CommunicationCrystals.cs
@@ -275,7 +275,15 @@ public partial class BroadcastCrystal : Item
 [SerializationGenerator(0)]
 public partial class ReceiverCrystal : Item
 {
+    [SerializableField(0, fieldChanged: nameof(OnSenderChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
     private BroadcastCrystal _sender;
+
+    private void OnSenderChanged(BroadcastCrystal oldValue, BroadcastCrystal newValue)
+    {
+        oldValue?.RemoveReceiver(this);
+        newValue?.AddReceiver(this);
+    }
 
     [Constructible]
     public ReceiverCrystal() : base(0x1ED0) => Light = LightType.Circle150;
@@ -294,20 +302,6 @@ public partial class ReceiverCrystal : Item
         {
             ItemID = value ? 0x1ED1 : 0x1ED0;
             InvalidateProperties();
-        }
-    }
-
-    [SerializableProperty(0, useField: nameof(_sender))]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public BroadcastCrystal Sender
-    {
-        get => _sender;
-        set
-        {
-            _sender?.RemoveReceiver(this);
-            _sender = value;
-            value?.AddReceiver(this);
-            this.MarkDirty();
         }
     }
 

--- a/Projects/UOContent/Items/Misc/MorphItem.cs
+++ b/Projects/UOContent/Items/Misc/MorphItem.cs
@@ -30,20 +30,24 @@ public partial class MorphItem : Item
         _outsideRange = outRange;
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int OutsideRange
+    [SerializableField(0, allowFieldChange: nameof(AllowOutsideRangeChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private int _outsideRange;
+
+    private bool AllowOutsideRangeChange(ref int value)
     {
-        get => _outsideRange;
-        set => _outsideRange = Math.Clamp(value, 0, 18);
+        value = Math.Clamp(value, 0, 18);
+        return true;
     }
 
-    [SerializableProperty(3)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int InsideRange
+    [SerializableField(3, allowFieldChange: nameof(AllowInsideRangeChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private int _insideRange;
+
+    private bool AllowInsideRangeChange(ref int value)
     {
-        get => _insideRange;
-        set => _insideRange = Math.Clamp(value, 0, 18);
+        value = Math.Clamp(value, 0, 18);
+        return true;
     }
 
     [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Misc/WarningItem.cs
+++ b/Projects/UOContent/Items/Misc/WarningItem.cs
@@ -14,7 +14,15 @@ public partial class WarningItem : Item
     private TextDefinition _warningMessage;
 
     // Field 1
+    [SerializableField(1, allowFieldChange: nameof(AllowRangeChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
     private int _range;
+
+    private bool AllowRangeChange(ref int value)
+    {
+        value = Math.Min(value, 18);
+        return true;
+    }
 
     [SerializableField(2)]
     private TimeSpan _resetDelay;
@@ -37,18 +45,6 @@ public partial class WarningItem : Item
 
         _warningMessage = warning;
         _range = Math.Min(range, 18);
-    }
-
-    [CommandProperty(AccessLevel.GameMaster)]
-    [SerializableProperty(1, useField: nameof(_range))]
-    public int Range
-    {
-        get => _range;
-        set
-        {
-            _range = Math.Min(value, 18);
-            this.MarkDirty();
-        }
     }
 
     public virtual bool OnlyToTriggerer => false;

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ingots.cs
@@ -16,22 +16,14 @@ public abstract partial class BaseIngot : Item, ICommodity
 
     public override double DefaultWeight => 0.1;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public override int LabelNumber

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Ore.cs
@@ -17,22 +17,14 @@ public abstract partial class BaseOre : Item
         _resource = resource;
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public override int LabelNumber

--- a/Projects/UOContent/Items/Resources/Blacksmithing/Scales.cs
+++ b/Projects/UOContent/Items/Resources/Blacksmithing/Scales.cs
@@ -14,22 +14,14 @@ public abstract partial class BaseScales : Item, ICommodity
         _resource = resource;
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public override int LabelNumber => 1053139; // dragon scales

--- a/Projects/UOContent/Items/Resources/Masonry/Granite.cs
+++ b/Projects/UOContent/Items/Resources/Masonry/Granite.cs
@@ -15,22 +15,14 @@ public abstract partial class BaseGranite : Item
 
     public override double DefaultWeight => Core.ML ? 1.0 : 10.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public override int LabelNumber => 1044607; // high quality granite

--- a/Projects/UOContent/Items/Resources/Tailor/Hides.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Hides.cs
@@ -15,22 +15,14 @@ public abstract partial class BaseHides : Item, ICommodity
 
     public override double DefaultWeight => 5.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public override int LabelNumber

--- a/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
+++ b/Projects/UOContent/Items/Resources/Tailor/Leathers.cs
@@ -15,22 +15,14 @@ public abstract partial class BaseLeather : Item, ICommodity
 
     public override double DefaultWeight => 1.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public override int LabelNumber

--- a/Projects/UOContent/Items/Skill Items/Carpenter Items/Board.cs
+++ b/Projects/UOContent/Items/Skill Items/Carpenter Items/Board.cs
@@ -21,22 +21,14 @@ public partial class Board : Item, ICommodity
         Hue = CraftResources.GetHue(resource);
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     int ICommodity.DescriptionNumber

--- a/Projects/UOContent/Items/Skill Items/Fishing/Misc/MessageInABottle.cs
+++ b/Projects/UOContent/Items/Skill Items/Fishing/Misc/MessageInABottle.cs
@@ -25,16 +25,14 @@ public partial class MessageInABottle : Item
 
     public override int LabelNumber => 1041080; // a message in a bottle
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Level
+    [SerializableField(0, allowFieldChange: nameof(AllowLevelChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private int _level;
+
+    private bool AllowLevelChange(ref int value)
     {
-        get => _level;
-        set
-        {
-            _level = Math.Max(1, Math.Min(value, 4));
-            this.MarkDirty();
-        }
+        value = Math.Max(1, Math.Min(value, 4));
+        return true;
     }
 
     public static int GetRandomLevel()

--- a/Projects/UOContent/Items/Skill Items/Fishing/Misc/SOS.cs
+++ b/Projects/UOContent/Items/Skill Items/Fishing/Misc/SOS.cs
@@ -103,18 +103,20 @@ public partial class SOS : Item
     [CommandProperty(AccessLevel.GameMaster)]
     public bool IsAncient => _level >= 4;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Level
+    [SerializableField(0, fieldChanged: nameof(OnLevelChanged), allowFieldChange: nameof(AllowLevelChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _level;
+
+    private bool AllowLevelChange(ref int value)
     {
-        get => _level;
-        set
-        {
-            _level = Math.Max(1, Math.Min(value, 4));
-            UpdateHue();
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Max(1, Math.Min(value, 4));
+        return true;
+    }
+
+    private void OnLevelChanged(int oldValue, int newValue)
+    {
+        UpdateHue();
     }
 
     public void UpdateHue() => Hue = IsAncient ? 0x481 : 0;

--- a/Projects/UOContent/Items/Skill Items/Lumberjack/Log.cs
+++ b/Projects/UOContent/Items/Skill Items/Lumberjack/Log.cs
@@ -28,22 +28,14 @@ public partial class Log : Item, ICommodity, IAxe
 
     public override double DefaultWeight => 2.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
-    {
-        get => _resource;
-        set
-        {
-            if (_resource != value)
-            {
-                _resource = value;
-                Hue = CraftResources.GetHue(value);
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
 
-                InvalidateProperties();
-                this.MarkDirty();
-            }
-        }
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
+    {
+        Hue = CraftResources.GetHue(newValue);
     }
 
     public virtual bool Axe(Mobile from, BaseAxe axe) => TryCreateBoards(from, 0, new Board());

--- a/Projects/UOContent/Items/Skill Items/Magical/Misc/RecallRune.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Misc/RecallRune.cs
@@ -47,36 +47,24 @@ public partial class RecallRune : Item
         }
     }
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
-    public bool Marked
+    [SerializableField(2, fieldChanged: nameof(OnMarkedChanged))]
+    [SerializedCommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private bool _marked;
+
+    private void OnMarkedChanged(bool oldValue, bool newValue)
     {
-        get => _marked;
-        set
-        {
-            if (_marked != value)
-            {
-                _marked = value;
-                CalculateHue();
-                InvalidateProperties();
-            }
-        }
+        CalculateHue();
     }
 
-    [SerializableProperty(4)]
-    [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
-    public Map TargetMap
+    [SerializableField(4, fieldChanged: nameof(OnTargetMapChanged))]
+    [SerializedCommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private Map _targetMap;
+
+    private void OnTargetMapChanged(Map oldValue, Map newValue)
     {
-        get => _targetMap;
-        set
-        {
-            if (_targetMap != value)
-            {
-                _targetMap = value;
-                CalculateHue();
-                InvalidateProperties();
-            }
-        }
+        CalculateHue();
     }
 
     private void Deserialize(IGenericReader reader, int version)

--- a/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
+++ b/Projects/UOContent/Items/Skill Items/Magical/Spellbook.cs
@@ -133,28 +133,19 @@ public partial class Spellbook : Item, ICraftable, ISlayer, IAosItem
     public virtual int BookOffset => 0;
     public virtual int BookCount => 64;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    [SerializableProperty(7)]
-    public ulong Content
+    [SerializableField(7, fieldChanged: nameof(OnContentChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private ulong _content;
+
+    private void OnContentChanged(ulong oldValue, ulong newValue)
     {
-        get => _content;
-        set
+        // This assignment will mark it as dirty
+        SpellCount = 0;
+        while (newValue > 0)
         {
-            if (_content != value)
-            {
-                _content = value;
-
-                // This assignment will mark it as dirty
-                SpellCount = 0;
-
-                while (value > 0)
-                {
-                    _spellCount += (int)(value & 0x1);
-                    value >>= 1;
-                }
-
-                InvalidateProperties();
-            }
+            _spellCount += (int)(newValue & 0x1);
+            newValue >>= 1;
         }
     }
 

--- a/Projects/UOContent/Items/Skill Items/Misc/RepairDeed.cs
+++ b/Projects/UOContent/Items/Skill Items/Misc/RepairDeed.cs
@@ -62,17 +62,15 @@ public partial class RepairDeed : Item
 
     public override bool DisplayLootType => false;
 
-    [CommandProperty(AccessLevel.GameMaster)]
-    [SerializableProperty(1)]
-    public double SkillLevel
+    [SerializableField(1, allowFieldChange: nameof(AllowSkillLevelChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private double _skillLevel;
+
+    private bool AllowSkillLevelChange(ref double value)
     {
-        get => _skillLevel;
-        set
-        {
-            _skillLevel = Math.Clamp(value, 0, 120.0);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, 120.0);
+        return true;
     }
 
     public override void AddNameProperty(IPropertyList list)

--- a/Projects/UOContent/Items/Skill Items/Musical Instruments/BaseInstrument.cs
+++ b/Projects/UOContent/Items/Skill Items/Musical Instruments/BaseInstrument.cs
@@ -74,16 +74,13 @@ public abstract partial class BaseInstrument : Item, ICraftable, ISlayer
         }
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public DateTime LastReplenished
+    [SerializableField(1, fieldChanged: nameof(OnLastReplenishedChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private DateTime _lastReplenished;
+
+    private void OnLastReplenishedChanged(DateTime oldValue, DateTime newValue)
     {
-        get => _lastReplenished;
-        set
-        {
-            _lastReplenished = value;
-            CheckReplenishUses();
-        }
+        CheckReplenishUses();
     }
 
     [SerializableProperty(3)]

--- a/Projects/UOContent/Items/Skill Items/Tailor Items/Dyetubs/DyeTub.cs
+++ b/Projects/UOContent/Items/Skill Items/Tailor Items/Dyetubs/DyeTub.cs
@@ -41,20 +41,13 @@ namespace Server.Items
 
         public virtual bool AllowDyables => true;
 
-        [SerializableProperty(2)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int DyedHue
-        {
-            get => _dyedHue;
-            set
-            {
-                if (_redyable)
-                {
-                    _dyedHue = value;
-                    Hue = value;
-                }
-            }
-        }
+        [SerializableField(2, allowFieldChange: nameof(AllowDyedHueChange), fieldChanged: nameof(OnDyedHueChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private int _dyedHue;
+
+        private bool AllowDyedHueChange(ref int value) => _redyable;
+
+        private void OnDyedHueChanged(int oldValue, int newValue) => Hue = newValue;
 
         // Three metallic tubs now.
         public virtual bool MetallicHues => false;

--- a/Projects/UOContent/Items/Skill Items/Tools/BaseRunicTool.cs
+++ b/Projects/UOContent/Items/Skill Items/Tools/BaseRunicTool.cs
@@ -60,17 +60,14 @@ public abstract partial class BaseRunicTool : BaseTool
 
     public BaseRunicTool(CraftResource resource, int uses, int itemID) : base(uses, itemID) => _resource = resource;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public CraftResource Resource
+    [SerializableField(0, fieldChanged: nameof(OnResourceChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private CraftResource _resource;
+
+    private void OnResourceChanged(CraftResource oldValue, CraftResource newValue)
     {
-        get => _resource;
-        set
-        {
-            _resource = value;
-            Hue = CraftResources.GetHue(_resource);
-            InvalidateProperties();
-        }
+        Hue = CraftResources.GetHue(_resource);
     }
 
     private void Deserialize(IGenericReader reader, int version)

--- a/Projects/UOContent/Items/Special/8th Anniversary Items/FountainOfLife.cs
+++ b/Projects/UOContent/Items/Special/8th Anniversary Items/FountainOfLife.cs
@@ -54,17 +54,15 @@ public partial class FountainOfLife : BaseAddonContainer
     public override int DefaultDropSound => 66;
     public override int DefaultMaxItems => 125;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Charges
+    [SerializableField(0, allowFieldChange: nameof(AllowChargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _charges;
+
+    private bool AllowChargesChange(ref int value)
     {
-        get => _charges;
-        set
-        {
-            _charges = Math.Min(value, MaxCharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Min(value, MaxCharges);
+        return true;
     }
 
     public override bool OnDragLift(Mobile from) => false;
@@ -183,16 +181,14 @@ public partial class FountainOfLifeDeed : BaseAddonContainerDeed
     public override int LabelNumber => 1075197; // Fountain of Life
     public override BaseAddonContainer Addon => new FountainOfLife(_charges);
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Charges
+    [SerializableField(0, allowFieldChange: nameof(AllowChargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _charges;
+
+    private bool AllowChargesChange(ref int value)
     {
-        get => _charges;
-        set
-        {
-            _charges = Math.Min(value, FountainOfLife.MaxCharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Min(value, FountainOfLife.MaxCharges);
+        return true;
     }
 }

--- a/Projects/UOContent/Items/Special/Heritage Items/FruitTrees.cs
+++ b/Projects/UOContent/Items/Special/Heritage Items/FruitTrees.cs
@@ -14,12 +14,14 @@ public abstract partial class BaseFruitTreeAddon : BaseAddon
     public abstract override BaseAddonDeed Deed { get; }
     public abstract Item Fruit { get; }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Fruits
+    [SerializableField(0, allowFieldChange: nameof(AllowFruitsChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private int _fruits;
+
+    private bool AllowFruitsChange(ref int value)
     {
-        get => _fruits;
-        set => _fruits = Math.Max(value, 0);
+        value = Math.Max(value, 0);
+        return true;
     }
 
     public override void OnComponentUsed(AddonComponent c, Mobile from)

--- a/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
+++ b/Projects/UOContent/Items/Special/House Raffle/HouseRaffleStone.cs
@@ -146,34 +146,24 @@ public partial class HouseRaffleStone : Item
         }
     }
 
-    [SerializableProperty(3)]
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Seer)]
-    public Rectangle2D PlotBounds
-    {
-        get => _plotBounds;
-        set
-        {
-            _plotBounds = value;
+    [SerializableField(3, fieldChanged: nameof(OnPlotBoundsChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Seer)]
+    [InvalidateProperties]
+    private Rectangle2D _plotBounds;
 
-            InvalidateRegion();
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+    private void OnPlotBoundsChanged(Rectangle2D oldValue, Rectangle2D newValue)
+    {
+        InvalidateRegion();
     }
 
-    [SerializableProperty(4)]
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Seer)]
-    public Map PlotFacet
-    {
-        get => _plotFacet;
-        set
-        {
-            _plotFacet = value;
+    [SerializableField(4, fieldChanged: nameof(OnPlotFacetChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Seer)]
+    [InvalidateProperties]
+    private Map _plotFacet;
 
-            InvalidateRegion();
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+    private void OnPlotFacetChanged(Map oldValue, Map newValue)
+    {
+        InvalidateRegion();
     }
 
     [CommandProperty(AccessLevel.GameMaster)]
@@ -190,17 +180,15 @@ public partial class HouseRaffleStone : Item
         }
     }
 
-    [SerializableProperty(6)]
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Seer)]
-    public int TicketPrice
+    [SerializableField(6, allowFieldChange: nameof(AllowTicketPriceChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Seer)]
+    [InvalidateProperties]
+    private int _ticketPrice;
+
+    private bool AllowTicketPriceChange(ref int value)
     {
-        get => _ticketPrice;
-        set
-        {
-            _ticketPrice = Math.Max(0, value);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Max(0, value);
+        return true;
     }
 
     public override string DefaultName => "a house raffle stone";

--- a/Projects/UOContent/Items/Special/MonsterStatuette.cs
+++ b/Projects/UOContent/Items/Special/MonsterStatuette.cs
@@ -162,21 +162,15 @@ public partial class MonsterStatuette : Item, IRewardItem, IGumpToggleItem
             _                                   => fallback
         };
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public MonsterStatuetteType Type
+    [SerializableField(0, fieldChanged: nameof(OnTypeChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private MonsterStatuetteType _type;
+
+    private void OnTypeChanged(MonsterStatuetteType oldValue, MonsterStatuetteType newValue)
     {
-        get => _type;
-        set
-        {
-            _type = value;
-            ItemID = MonsterStatuetteInfo.GetInfo(_type).ItemID;
-
-            Hue = GetStatuetteHue(_type, Hue);
-
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        ItemID = MonsterStatuetteInfo.GetInfo(_type).ItemID;
+        Hue = GetStatuetteHue(_type, Hue);
     }
 
     public override int LabelNumber => MonsterStatuetteInfo.GetInfo(_type).LabelNumber;

--- a/Projects/UOContent/Items/Special/Solen Items/BagOfSending.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BagOfSending.cs
@@ -36,50 +36,41 @@ public partial class BagOfSending : Item, TranslocationItem
 
     public override int LabelNumber => 1054104; // a bag of sending
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public BagOfSendingHue BagOfSendingHue
-    {
-        get => _bagOfSendingHue;
-        set
-        {
-            _bagOfSendingHue = value;
+    [SerializableField(0, fieldChanged: nameof(OnBagOfSendingHueChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    private BagOfSendingHue _bagOfSendingHue;
 
-            Hue = value switch
-            {
-                BagOfSendingHue.Yellow => 0x8A5,
-                BagOfSendingHue.Blue   => 0x8AD,
-                BagOfSendingHue.Red    => 0x89B,
-                _                      => Hue
-            };
-            this.MarkDirty();
-        }
+    private void OnBagOfSendingHueChanged(BagOfSendingHue oldValue, BagOfSendingHue newValue)
+    {
+        Hue = newValue switch
+        {
+            BagOfSendingHue.Yellow => 0x8A5,
+            BagOfSendingHue.Blue   => 0x8AD,
+            BagOfSendingHue.Red    => 0x89B,
+            _                      => Hue
+        };
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Charges
+    [SerializableField(1, allowFieldChange: nameof(AllowChargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _charges;
+
+    private bool AllowChargesChange(ref int value)
     {
-        get => _charges;
-        set
-        {
-            _charges = Math.Clamp(value, 0, MaxCharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, MaxCharges);
+        return true;
     }
 
-    [SerializableProperty(2)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Recharges
+    [SerializableField(2, allowFieldChange: nameof(AllowRechargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _recharges;
+
+    private bool AllowRechargesChange(ref int value)
     {
-        get => _recharges;
-        set
-        {
-            _recharges = Math.Clamp(value, 0, MaxRecharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, MaxRecharges);
+        return true;
     }
 
     [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Special/Solen Items/BallOfSummoning.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BallOfSummoning.cs
@@ -29,30 +29,26 @@ public partial class BallOfSummoning : Item, TranslocationItem
 
     public override double DefaultWeight => 10.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Recharges
+    [SerializableField(0, allowFieldChange: nameof(AllowRechargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _recharges;
+
+    private bool AllowRechargesChange(ref int value)
     {
-        get => _recharges;
-        set
-        {
-            _recharges = Math.Clamp(value, 0, MaxRecharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, MaxRecharges);
+        return true;
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Charges
+    [SerializableField(1, allowFieldChange: nameof(AllowChargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _charges;
+
+    private bool AllowChargesChange(ref int value)
     {
-        get => _charges;
-        set
-        {
-            _charges = Math.Clamp(value, 0, MaxCharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, MaxCharges);
+        return true;
     }
 
     [SerializableProperty(2)]

--- a/Projects/UOContent/Items/Special/Solen Items/BraceletOfBinding.cs
+++ b/Projects/UOContent/Items/Special/Solen Items/BraceletOfBinding.cs
@@ -27,30 +27,26 @@ public partial class BraceletOfBinding : BaseBracelet, TranslocationItem
 
     public override double DefaultWeight => 1.0;
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Recharges
+    [SerializableField(0, allowFieldChange: nameof(AllowRechargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _recharges;
+
+    private bool AllowRechargesChange(ref int value)
     {
-        get => _recharges;
-        set
-        {
-            _recharges = Math.Clamp(value, 0, MaxRecharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, MaxRecharges);
+        return true;
     }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Charges
+    [SerializableField(1, allowFieldChange: nameof(AllowChargesChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _charges;
+
+    private bool AllowChargesChange(ref int value)
     {
-        get => _charges;
-        set
-        {
-            _charges = Math.Clamp(value, 0, MaxCharges);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        value = Math.Clamp(value, 0, MaxCharges);
+        return true;
     }
 
     [SerializableProperty(3)]

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -83,20 +83,14 @@ public partial class SoulStone : Item, ISecurable
         }
     }
 
-    [SerializableProperty(6)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public double SkillValue
+    [SerializableField(6, fieldChanged: nameof(OnSkillValueChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private double _skillValue;
+
+    private void OnSkillValueChanged(double oldValue, double newValue)
     {
-        get => _skillValue;
-        set
-        {
-            _skillValue = value;
-
-            ItemID = IsEmpty ? _inactiveItemID : _activeItemID;
-
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+        ItemID = IsEmpty ? _inactiveItemID : _activeItemID;
     }
 
     [CommandProperty(AccessLevel.GameMaster)]

--- a/Projects/UOContent/Items/Suits/BaseSuit.cs
+++ b/Projects/UOContent/Items/Suits/BaseSuit.cs
@@ -17,20 +17,9 @@ public abstract partial class BaseSuit : Item
 
     public override double DefaultWeight => 1.0;
 
-    [SerializableProperty(0)]
-    public AccessLevel AccessLevel
-    {
-        get => _accessLevel;
-        set
-        {
-            var oldAccessLevel = _accessLevel;
-            _accessLevel = value;
-            InvalidateProperties();
-            this.MarkDirty();
-
-            OnAccessLevelChanged(oldAccessLevel, _accessLevel);
-        }
-    }
+    [SerializableField(0, fieldChanged: nameof(OnAccessLevelChanged))]
+    [InvalidateProperties]
+    private AccessLevel _accessLevel;
 
     public virtual void OnAccessLevelChanged(AccessLevel oldAccessLevel, AccessLevel accessLevel)
     {

--- a/Projects/UOContent/Items/Talismans/BaseTalisman.cs
+++ b/Projects/UOContent/Items/Talismans/BaseTalisman.cs
@@ -279,23 +279,17 @@ public partial class BaseTalisman : Item, IAosItem
     public override int LabelNumber => 1071023; // Talisman
     public virtual bool ForceShowName => false; // used to override default summoner/removal name
 
-    [SerializableProperty(10)]
+    [SerializableField(10, fieldChanged: nameof(OnChargesChanged))]
     [SaveFlag(nameof(ShouldSerializeCharges))]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public int Charges
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private int _charges;
+
+    private void OnChargesChanged(int oldValue, int newValue)
     {
-        get => _charges;
-        set
+        if (_chargeTime > 0)
         {
-            _charges = value;
-
-            if (_chargeTime > 0)
-            {
-                StartTimer();
-            }
-
-            InvalidateProperties();
-            this.MarkDirty();
+            StartTimer();
         }
     }
 

--- a/Projects/UOContent/Misc/ShardPoller.cs
+++ b/Projects/UOContent/Misc/ShardPoller.cs
@@ -36,16 +36,14 @@ public partial class ShardPoller : Item
         Movable = false;
     }
 
-    [SerializableProperty(0)]
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
-    public string Title
+    [SerializableField(0, allowFieldChange: nameof(AllowTitleChange))]
+    [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
+    private string _title;
+
+    private bool AllowTitleChange(ref string value)
     {
-        get => _title;
-        set
-        {
-            _title = ShardPollPrompt.UrlToHref(value);
-            this.MarkDirty();
-        }
+        value = ShardPollPrompt.UrlToHref(value);
+        return true;
     }
 
     [CommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
@@ -54,31 +52,20 @@ public partial class ShardPoller : Item
             ? TimeSpan.Zero
             : Utility.Max(StartTime + Duration - Core.Now, TimeSpan.Zero);
 
-    [SerializableProperty(3)]
-    [CommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
-    public bool Active
+    [SerializableField(3, fieldChanged: nameof(OnActiveChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster, AccessLevel.Administrator)]
+    private bool _active;
+
+    private void OnActiveChanged(bool oldValue, bool newValue)
     {
-        get => _active;
-        set
+        if (_active)
         {
-            if (_active == value)
-            {
-                return;
-            }
-
-            _active = value;
-
-            if (_active)
-            {
-                StartTime = Core.Now;
-                _activePollers.Add(this);
-            }
-            else
-            {
-                _activePollers.Remove(this);
-            }
-
-            this.MarkDirty();
+            StartTime = Core.Now;
+            _activePollers.Add(this);
+        }
+        else
+        {
+            _activePollers.Remove(this);
         }
     }
 
@@ -250,15 +237,12 @@ public partial class ShardPollOption
         }
     }
 
-    [SerializableProperty(0)]
-    public string Title
+    [SerializableField(0, fieldChanged: nameof(OnTitleChanged))]
+    private string _title;
+
+    private void OnTitleChanged(string oldValue, string newValue)
     {
-        get => _title;
-        set
-        {
-            _title = value;
-            _lineBreaks = -1;
-        }
+        _lineBreaks = -1;
     }
 
     public int Votes => Voters.Length;

--- a/Projects/UOContent/Mobiles/Animals/Misc/Sheep.cs
+++ b/Projects/UOContent/Mobiles/Animals/Misc/Sheep.cs
@@ -43,18 +43,14 @@ namespace Server.Mobiles
 
         public override string CorpseName => "a sheep corpse";
 
+        [SerializableField(0, fieldChanged: nameof(OnNextWoolTimeChanged))]
         [DeltaDateTime]
-        [SerializableProperty(0)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public DateTime NextWoolTime
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private DateTime _nextWoolTime;
+
+        private void OnNextWoolTimeChanged(DateTime oldValue, DateTime newValue)
         {
-            get => _nextWoolTime;
-            set
-            {
-                _nextWoolTime = value;
-                SheepBody();
-                this.MarkDirty();
-            }
+            SheepBody();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/Ethereals.cs
@@ -40,43 +40,27 @@ namespace Server.Mobiles
 
         public override double DefaultWeight => 1.0;
 
-        [SerializableProperty(2)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int MountedID
-        {
-            get => _mountedID;
-            set
-            {
-                if (_mountedID != value)
-                {
-                    _mountedID = value;
+        [SerializableField(2, fieldChanged: nameof(OnMountedIDChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private int _mountedID;
 
-                    if (_rider != null)
-                    {
-                        ItemID = value;
-                    }
-                    this.MarkDirty();
-                }
+        private void OnMountedIDChanged(int oldValue, int newValue)
+        {
+            if (_rider != null)
+            {
+                ItemID = newValue;
             }
         }
 
-        [SerializableProperty(3)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public int RegularID
-        {
-            get => _regularID;
-            set
-            {
-                if (_regularID != value)
-                {
-                    _regularID = value;
+        [SerializableField(3, fieldChanged: nameof(OnRegularIDChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private int _regularID;
 
-                    if (_rider == null)
-                    {
-                        ItemID = value;
-                    }
-                    this.MarkDirty();
-                }
+        private void OnRegularIDChanged(int oldValue, int newValue)
+        {
+            if (_rider == null)
+            {
+                ItemID = newValue;
             }
         }
 
@@ -127,17 +111,15 @@ namespace Server.Mobiles
 
         private bool ShouldSerializeRider() => _rider != null;
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(5)]
+        [SerializableField(5, allowFieldChange: nameof(AllowStepsChange))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
         [SaveFlag(nameof(ShouldSerializeSteps))]
-        public int Steps
+        private int _steps;
+
+        private bool AllowStepsChange(ref int value)
         {
-            get => _steps;
-            set
-            {
-                _steps = Math.Clamp(value, 0, StepsMax);
-                this.MarkDirty();
-            }
+            value = Math.Clamp(value, 0, StepsMax);
+            return true;
         }
 
         private bool ShouldSerializeSteps() => _steps != StepsMax;

--- a/Projects/UOContent/Mobiles/Animals/Mounts/SwampDragon.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/SwampDragon.cs
@@ -62,48 +62,37 @@ namespace Server.Mobiles
         [SerializableField(3)]
         private int _bardingHP;
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(2)]
-        public bool HasBarding
-        {
-            get => _hasBarding;
-            set
-            {
-                _hasBarding = value;
+        [SerializableField(2, fieldChanged: nameof(OnHasBardingChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private bool _hasBarding;
 
-                if (_hasBarding)
-                {
-                    Hue = CraftResources.GetHue(_bardingResource);
-                    Body = 0x31F;
-                    ItemID = 0x3EBE;
-                }
-                else
-                {
-                    Hue = 0x851;
-                    Body = 0x31A;
-                    ItemID = 0x3EBD;
-                }
-                InvalidateProperties();
-                this.MarkDirty();
+        private void OnHasBardingChanged(bool oldValue, bool newValue)
+        {
+            if (_hasBarding)
+            {
+                Hue = CraftResources.GetHue(_bardingResource);
+                Body = 0x31F;
+                ItemID = 0x3EBE;
+            }
+            else
+            {
+                Hue = 0x851;
+                Body = 0x31A;
+                ItemID = 0x3EBD;
             }
         }
 
-        [CommandProperty(AccessLevel.GameMaster)]
-        [SerializableProperty(4)]
-        public CraftResource BardingResource
+        [SerializableField(4, fieldChanged: nameof(OnBardingResourceChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        [InvalidateProperties]
+        private CraftResource _bardingResource;
+
+        private void OnBardingResourceChanged(CraftResource oldValue, CraftResource newValue)
         {
-            get => _bardingResource;
-            set
+            if (_hasBarding)
             {
-                _bardingResource = value;
-
-                if (_hasBarding)
-                {
-                    Hue = CraftResources.GetHue(value);
-                }
-
-                InvalidateProperties();
-                this.MarkDirty();
+                Hue = CraftResources.GetHue(newValue);
             }
         }
 

--- a/Projects/UOContent/Mobiles/Hireables/BaseHire.cs
+++ b/Projects/UOContent/Mobiles/Hireables/BaseHire.cs
@@ -23,19 +23,14 @@ public partial class BaseHire : BaseCreature
 
     public int GoldOnDeath { get; set; }
 
-    [SerializableProperty(1)]
-    [CommandProperty(AccessLevel.GameMaster)]
-    public bool IsHired
-    {
-        get => _isHired;
-        set
-        {
-            _isHired = value;
+    [SerializableField(1, fieldChanged: nameof(OnIsHiredChanged))]
+    [SerializedCommandProperty(AccessLevel.GameMaster)]
+    [InvalidateProperties]
+    private bool _isHired;
 
-            Delta(MobileDelta.Noto);
-            InvalidateProperties();
-            this.MarkDirty();
-        }
+    private void OnIsHiredChanged(bool oldValue, bool newValue)
+    {
+        Delta(MobileDelta.Noto);
     }
 
     public BaseHire(AIType AI) : base(AI, FightMode.Aggressor)

--- a/Projects/UOContent/Mobiles/Vendors/Barkeeper/PlayerBarkeeper.cs
+++ b/Projects/UOContent/Mobiles/Vendors/Barkeeper/PlayerBarkeeper.cs
@@ -148,18 +148,13 @@ public partial class PlayerBarkeeper : BaseVendor
         LoadSBInfo();
     }
 
-    [SerializableProperty(0)]
-    public BaseHouse House
-    {
-        get => _house;
-        set
-        {
-            _house?.PlayerBarkeepers.Remove(this);
-            value?.PlayerBarkeepers.Add(this);
+    [SerializableField(0, fieldChanged: nameof(OnHouseChanged))]
+    private BaseHouse _house;
 
-            _house = value;
-            this.MarkDirty();
-        }
+    private void OnHouseChanged(BaseHouse oldValue, BaseHouse newValue)
+    {
+        oldValue?.PlayerBarkeepers.Remove(this);
+        newValue?.PlayerBarkeepers.Add(this);
     }
 
     public override bool IsActiveBuyer => false;

--- a/Projects/UOContent/Mobiles/Vendors/PlayerVendor.cs
+++ b/Projects/UOContent/Mobiles/Vendors/PlayerVendor.cs
@@ -94,18 +94,13 @@ public partial class PlayerVendor : Mobile
 
     public PlayerVendorPlaceholder Placeholder { get; set; }
 
-    [SerializableProperty(2)]
-    public BaseHouse House
-    {
-        get => _house;
-        set
-        {
-            _house?.PlayerVendors.Remove(this);
-            value?.PlayerVendors.Add(this);
+    [SerializableField(2, fieldChanged: nameof(OnHouseChanged))]
+    private BaseHouse _house;
 
-            _house = value;
-            this.MarkDirty();
-        }
+    private void OnHouseChanged(BaseHouse oldValue, BaseHouse newValue)
+    {
+        oldValue?.PlayerVendors.Remove(this);
+        newValue?.PlayerVendors.Add(this);
     }
 
     public int ChargePerDay

--- a/Projects/UOContent/Mobiles/Vendors/VendorItem.cs
+++ b/Projects/UOContent/Mobiles/Vendors/VendorItem.cs
@@ -32,18 +32,20 @@ public partial class VendorItem
     public string FormattedPrice =>
         Core.ML ? Price.ToString("N0", CultureInfo.GetCultureInfo("en-US")) : Price.ToString();
 
-    [SerializableProperty(2)]
-    public string Description
-    {
-        get => _description;
-        set
-        {
-            _description = value ?? "";
+    [SerializableField(2, fieldChanged: nameof(OnDescriptionChanged), allowFieldChange: nameof(AllowDescriptionChange))]
+    private string _description;
 
-            if (Valid)
-            {
-                Item.InvalidateProperties();
-            }
+    private bool AllowDescriptionChange(ref string value)
+    {
+        value = value ?? "";
+        return true;
+    }
+
+    private void OnDescriptionChanged(string oldValue, string newValue)
+    {
+        if (Valid)
+        {
+            Item.InvalidateProperties();
         }
     }
 

--- a/Projects/UOContent/Multis/Boats/BaseBoat.cs
+++ b/Projects/UOContent/Multis/Boats/BaseBoat.cs
@@ -136,31 +136,23 @@ namespace Server.Multis
             }
         }
 
+        [SerializableField(3, fieldChanged: nameof(OnTimeOfDecayChanged))]
         [DeltaDateTime]
-        [SerializableProperty(3)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public DateTime TimeOfDecay
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private DateTime _timeOfDecay;
+
+        private void OnTimeOfDecayChanged(DateTime oldValue, DateTime newValue)
         {
-            get => _timeOfDecay;
-            set
-            {
-                _timeOfDecay = value;
-                TillerMan?.InvalidateProperties();
-                this.MarkDirty();
-            }
+            TillerMan?.InvalidateProperties();
         }
 
-        [SerializableProperty(10)]
-        [CommandProperty(AccessLevel.GameMaster)]
-        public string ShipName
+        [SerializableField(10, fieldChanged: nameof(OnShipNameChanged))]
+        [SerializedCommandProperty(AccessLevel.GameMaster)]
+        private string _shipName;
+
+        private void OnShipNameChanged(string oldValue, string newValue)
         {
-            get => _shipName;
-            set
-            {
-                _shipName = value;
-                TillerMan?.InvalidateProperties();
-                this.MarkDirty();
-            }
+            TillerMan?.InvalidateProperties();
         }
 
         [CommandProperty(AccessLevel.GameMaster)]


### PR DESCRIPTION
## Summary

Folds **113** hand-written `[SerializableProperty]` members into plain `[SerializableField]` declarations using the v4 setter hooks — value coercion/vetoes via `allowFieldChange`, post-change side effects via `fieldChanged` (whose `oldValue` parameter covers the old-house/old-sender unsubscribe patterns). Net **-450 lines** of setter boilerplate.

```cs
// before
[SerializableProperty(1)]
[CommandProperty(AccessLevel.GameMaster)]
public int Charges
{
    get => _charges;
    set
    {
        _charges = Math.Clamp(value, 0, MaxCharges);
        InvalidateProperties();
        this.MarkDirty();
    }
}

// after
[SerializableField(1, allowFieldChange: nameof(AllowChargesChange))]
[SerializedCommandProperty(AccessLevel.GameMaster)]
[InvalidateProperties]
private int _charges;

private bool AllowChargesChange(ref int value)
{
    value = Math.Clamp(value, 0, MaxCharges);
    return true;
}
```

## How sites were selected

A classifier parsed all 204 `[SerializableProperty]` sites and converted only those matching strict shapes: getter is exactly `get => _field;`, the assignment comes first (after at most an equality guard), and relocated side effects contain no `return`, no `value` mutation, and no field re-assignment. Everything else was left alone deliberately:

- **~34 custom getters** (fallback defaults like `_x == -1 ? Default : _x`, self-healing refs) — no setter hook can express these.
- **~35 pre-assignment logic** (durability Unscale/Scale sandwiches, old-state captures like PotionKeg's pile weight).
- **virtual/override members, name-mismatched backing fields (`m_`), exotic semantics** (guards' `Focus` does work on *equal* assignment; `ChampionSpawn.Active` never assigns its field).

Five sites the classifier refused were converted by hand where the hooks fit cleanly: `ReceiverCrystal.Sender`, `PlayerVendor.House`, `PlayerBarkeeper.House` (old-value unsubscribe via `oldValue`), `BaseSuit.AccessLevel` (its existing virtual `OnAccessLevelChanged` already had the exact callback shape), and `DyeTub.DyedHue` (a true veto: `AllowDyedHueChange(ref int value) => _redyable`).

## Verification

- Build: **0 errors, 0 warnings**.
- **Schema regeneration produces zero Migrations changes** — the conversion is wire- and schema-neutral by construction (same orders, types, and property names), and CI's schema diff check enforces it.
- **835 + 708 tests green.**

## Behavioral notes (all strict improvements, called out for review)

- Generated setters skip everything when the incoming value equals the current one; a few converted setters previously re-ran side effects on equal assignment (redundant `Update()`-style refreshes).
- Generated setters always `MarkDirty()` on change; several converted setters never did (e.g. `DyeTub.DyedHue`, `MorphItem` ranges) — their changes only persisted if something else dirtied the entity. Those latent persistence bugs are fixed by construction.