### PR TITLE
fix: creatures track and chase targets reliably around corners

### DIFF
--- a/Projects/UOContent/Mobiles/AI/ArcherAI.cs
+++ b/Projects/UOContent/Mobiles/AI/ArcherAI.cs
@@ -43,12 +43,13 @@ public class ArcherAI : BaseAI
             return true;
         }
 
-        if (!WalkMobileRange(combatant, 1, false, Mobile.RangeFight, Mobile.Weapon.MaxRange))
+        if (!WalkMobileRange(combatant, 1, true, Mobile.RangeFight, Mobile.Weapon.MaxRange))
         {
             this.DebugSayFormatted($"I am still not in range of {combatant.Name}");
 
-            if ((int)Mobile.GetDistanceToSqrt(combatant) > Mobile.RangePerception + 1)
+            if (!Mobile.InRange(combatant, Mobile.ChaseLeashRange))
             {
+
                 this.DebugSayFormatted($"I have lost {combatant.Name}");
 
                 Mobile.Combatant = null;

--- a/Projects/UOContent/Mobiles/AI/ArcherAI.cs
+++ b/Projects/UOContent/Mobiles/AI/ArcherAI.cs
@@ -43,7 +43,7 @@ public class ArcherAI : BaseAI
             return true;
         }
 
-        if (!WalkMobileRange(combatant, 1, true, Mobile.RangeFight, Mobile.Weapon.MaxRange))
+        if (!WalkMobileRange(combatant, 1, false, Mobile.RangeFight, Mobile.Weapon.MaxRange))
         {
             this.DebugSayFormatted($"I am still not in range of {combatant.Name}");
 

--- a/Projects/UOContent/Mobiles/AI/ArcherAI.cs
+++ b/Projects/UOContent/Mobiles/AI/ArcherAI.cs
@@ -49,7 +49,6 @@ public class ArcherAI : BaseAI
 
             if (!Mobile.InRange(combatant, Mobile.ChaseLeashRange))
             {
-
                 this.DebugSayFormatted($"I have lost {combatant.Name}");
 
                 Mobile.Combatant = null;

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AIGroupMovement.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AIGroupMovement.cs
@@ -36,10 +36,32 @@ public abstract partial class BaseAI
         }
     }
 
-    private bool UseGroupMovement(Mobile target) =>
+    /// <summary>
+    /// Crowding refinement for the final approach: engages only near the target when allies
+    /// contest the ring, so creatures spread instead of stacking. Chasing any real distance
+    /// always uses the pathfinding approach primitive.
+    /// </summary>
+    private bool UseGroupMovement(Mobile target, int range) =>
         Mobile.Combatant == target
         && !Mobile.Controlled
-        && CountNearbyAllies(target) > 0;
+        && Mobile.InRange(target, range + 2)
+        && CountCrowdingAllies(target, range) > 0;
+
+    private int CountCrowdingAllies(Mobile target, int range)
+    {
+        var crowding = 0;
+
+        foreach (var m in target.GetMobilesInRange(range + 1))
+        {
+            if (m != Mobile && m.Combatant == target && m is BaseCreature { Controlled: false } bc
+                && bc.Team == Mobile.Team)
+            {
+                crowding++;
+            }
+        }
+
+        return crowding;
+    }
 
     public static bool MoveToWithGroup(BaseAI ai, Mobile target, bool run, int range)
     {
@@ -56,6 +78,7 @@ public abstract partial class BaseAI
         {
             if (optimalPosition == Point3D.Zero)
             {
+
                 return ai.MoveToWithCollisionAvoidance(target, run, range);
             }
 
@@ -68,27 +91,20 @@ public abstract partial class BaseAI
                 direction = GetAdjustedDirection(direction);
             }
 
-            return ai.DoMove(direction, true);
+            var res = ai.DoMoveImpl(direction, true);
+
+            if (res is MoveResult.Success or MoveResult.BadState)
+            {
+                return true;
+            }
+
+            // A blocked or wall-slid step is not progress — route around the obstacle.
+            return ai.ApproachTarget(target, run, range);
         }
         finally
         {
             allies.Dispose();
         }
-    }
-
-    private int CountNearbyAllies(Mobile target)
-    {
-        var allies = 0;
-        foreach (var m in Mobile.GetMobilesInRange(8))
-        {
-            if (m != Mobile && m.Combatant == target && m is BaseCreature { Controlled: false } bc
-                && bc.Team == Mobile.Team)
-            {
-                allies++;
-            }
-        }
-
-        return allies;
     }
 
     private PooledRefList<BaseCreature> GetNearbyAllies(Mobile target)

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AIMovement.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AIMovement.cs
@@ -333,7 +333,6 @@ public abstract partial class BaseAI
         {
             if (target.Location == _approachGaveUpGoalLoc)
             {
-
                 return false;
             }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AIMovement.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AIMovement.cs
@@ -13,6 +13,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.  *
  ************************************************************************/
 
+using System;
 using System.Runtime.CompilerServices;
 using Server.Collections;
 using Server.Items;
@@ -58,7 +59,15 @@ public abstract partial class BaseAI
     public bool CanMoveNow(out double delay)
     {
         delay = 0.0;
-        return Core.TickCount >= NextMove;
+        return Core.TickCount - NextMove >= 0;
+    }
+
+    // Caps movement at one actual step per AI think tick; pacing itself is the timer's
+    // cadence. Half a step keeps the budget below the timer interval so a legitimate
+    // next-tick move is never jitter-throttled.
+    private void ConsumeMoveBudget()
+    {
+        NextMove = Core.TickCount + Math.Max(50, (int)(Mobile.CurrentSpeed * 500));
     }
 
     public virtual bool CheckMove() => !(Mobile.Deleted || Mobile.DisallowAllMoves);
@@ -102,6 +111,8 @@ public abstract partial class BaseAI
             {
                 Mobile.CurrentSpeed = Mobile.PassiveSpeed;
             }
+
+            ConsumeMoveBudget();
 
             return MoveResult.Success;
         }
@@ -151,6 +162,7 @@ public abstract partial class BaseAI
 
             if (Mobile.Move(Mobile.Direction))
             {
+                ConsumeMoveBudget();
                 return MoveResult.SuccessAutoTurn;
             }
         }
@@ -321,6 +333,7 @@ public abstract partial class BaseAI
         {
             if (target.Location == _approachGaveUpGoalLoc)
             {
+
                 return false;
             }
 
@@ -341,22 +354,30 @@ public abstract partial class BaseAI
 
             if (res == MoveResult.BadState)
             {
-                return false; // not allowed to move this tick; not a stall
+                return true; // not allowed to move this tick (frozen/casting/throttled); not a failure
             }
 
             if (res == MoveResult.Success && Mobile.GetDistanceToSqrt(target) < distBefore)
             {
+
                 ResetApproach();
-                return Mobile.InRange(target, range);
+                return true; // healthy en-route progress
             }
+
             // else: fall through; let the PathFollower route around the obstacle.
         }
 
         // PLANNING PATH: a persistent PathFollower, never discarded by a greedy step.
         if (Path == null || Path.Goal != target)
         {
+
             Path = new PathFollower(Mobile, target) { Mover = DoMoveImpl };
         }
+
+        // Sample move-eligibility BEFORE the attempt: a successful step consumes the move
+        // budget, which would mask stall accounting and the progress signal.
+        var couldMove = CanMoveNow(out _) && !IsInBadState();
+        var locBefore = Mobile.Location;
 
         if (Path.Follow(run, range))
         {
@@ -364,8 +385,41 @@ public abstract partial class BaseAI
             return true;
         }
 
-        TrackApproachProgress(target);
-        return false;
+        TrackApproachProgress(target, couldMove);
+
+        // En-route progress is success; failure only when a move-eligible tick took no step
+        // (no working path), or the approach has given up.
+        var progressed = !_approachGaveUp && (Mobile.Location != locBefore || !couldMove);
+
+        return progressed;
+    }
+
+    /// <summary>
+    /// Walks toward a fixed point (e.g. a target's last-known position), pathfinding around
+    /// obstacles. Returns false on arrival or when genuinely unable to make progress.
+    /// </summary>
+    public bool MoveToPoint(IPoint3D goal, bool run)
+    {
+        if (Mobile.Deleted || Mobile.DisallowAllMoves || goal == null)
+        {
+            return false;
+        }
+
+        if (Path?.Goal != goal)
+        {
+            Path = new PathFollower(Mobile, goal) { Mover = DoMoveImpl };
+        }
+
+        var couldMove = CanMoveNow(out _) && !IsInBadState();
+        var locBefore = Mobile.Location;
+
+        if (Path.Follow(run, 1))
+        {
+            Path = null;
+            return false; // arrived
+        }
+
+        return Mobile.Location != locBefore || !couldMove;
     }
 
     /// <summary>
@@ -376,11 +430,11 @@ public abstract partial class BaseAI
     /// gives up and idles. A MOVING goal (an active chase) resets the baseline every tick,
     /// so chases never give up even when the gap holds constant.
     /// </summary>
-    private void TrackApproachProgress(Mobile target)
+    private void TrackApproachProgress(Mobile target, bool couldMove)
     {
-        if (!CanMoveNow(out _))
+        if (!couldMove)
         {
-            return; // a not-yet-due move (stun) is not a stall
+            return; // a tick that was never allowed to move (stun, stall) is not a stall
         }
 
         var dist = Mobile.GetDistanceToSqrt(target);
@@ -408,6 +462,7 @@ public abstract partial class BaseAI
 
         if (++_approachStallTicks >= ApproachGiveUpTicks)
         {
+
             _approachGaveUp = true;
             _approachGaveUpGoalLoc = goalLoc;
             Path = null;
@@ -444,7 +499,7 @@ public abstract partial class BaseAI
             return true;
         }
 
-        if (UseGroupMovement(m))
+        if (UseGroupMovement(m, range))
         {
             return MoveToWithGroup(this, m, shouldRun, range);
         }
@@ -467,7 +522,11 @@ public abstract partial class BaseAI
 
         var direction = Mobile.GetDirectionTo(target);
 
-        if (DoMove(direction, true))
+        // Wall-slide auto-turns must not count as progress, or a creature pinned on
+        // geometry reports success forever.
+        var res = DoMoveImpl(direction, true);
+
+        if (res is MoveResult.Success or MoveResult.BadState)
         {
             return true;
         }
@@ -476,14 +535,14 @@ public abstract partial class BaseAI
         {
             var clockwise = (Direction)(((int)direction + i) % 8);
 
-            if (DoMove(clockwise, true))
+            if (DoMoveImpl(clockwise, true) == MoveResult.Success)
             {
                 return true;
             }
 
             var counterclockwise = (Direction)(((int)direction - i + 8) % 8);
 
-            if (DoMove(counterclockwise, true))
+            if (DoMoveImpl(counterclockwise, true) == MoveResult.Success)
             {
                 return true;
             }

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -26,10 +26,24 @@ namespace Server.Mobiles;
 
 public abstract partial class BaseAI
 {
+    // Last-known-position tracking: recorded while the combatant is in LOS; drives the
+    // guard-time investigation and the instant re-engage.
+    private const int GuardGraceDuration = 10_000;
+    private const int LkpFreshDuration = 30_000;
+    private const int InvestigateDuration = 15_000;
+
     private ActionType _action;
     public long _nextDetectHidden;
     public DateTime _lastOrder = DateTime.MinValue;
     public Mobile _commandIssuer;
+
+    private Mobile _lkpTarget;
+    private Point3D _lkpLocation;
+    private IPoint3D _lkpGoal; // boxed _lkpLocation handed to the PathFollower
+    private long _lkpExpireTick;
+    private long _guardStopTick;
+    private long _investigateStopTick;
+    private bool _investigating;
 
     public PathFollower Path { get; protected set; }
     public AITimer AITimer { get; }
@@ -64,6 +78,7 @@ public abstract partial class BaseAI
         {
             if (_action != value)
             {
+
                 _action = value;
                 OnActionChanged();
             }
@@ -233,6 +248,15 @@ public abstract partial class BaseAI
             return true;
         }
 
+        if (_action == ActionType.Combat)
+        {
+            UpdateLastKnownLocation();
+        }
+        else if (_action is ActionType.Wander or ActionType.Guard)
+        {
+            TryReengageLastKnown();
+        }
+
         switch (Action)
         {
             case ActionType.Wander:
@@ -323,6 +347,16 @@ public abstract partial class BaseAI
     {
         Mobile.Warmode = true;
         Mobile.Combatant = null;
+
+        // Investigate a fresh last-seen position that is not already in view; the guard
+        // grace period begins once the investigation ends.
+        _investigating = _lkpTarget != null && Core.TickCount - _lkpExpireTick < 0 &&
+                         !(Mobile.InRange(_lkpLocation, 1) ||
+                           Mobile.InLOS(_lkpLocation) && Mobile.InRange(_lkpLocation, Mobile.RangePerception));
+        _investigateStopTick = Core.TickCount + InvestigateDuration;
+        _guardStopTick = Core.TickCount + GuardGraceDuration;
+        _lkpGoal = null;
+
     }
 
     private void HandleFleeAction()
@@ -453,16 +487,117 @@ public abstract partial class BaseAI
 
     public virtual bool DoActionGuard()
     {
-        if (Mobile.Combatant == null)
+        if (_investigating)
         {
-            DebugSay("No threats found. Going home...");
-            Action = ActionType.Wander;
+            if (InvestigateLastKnown())
+            {
+                return true;
+            }
+
+            _investigating = false;
+            _guardStopTick = Core.TickCount + GuardGraceDuration;
+
         }
 
-        DebugSay("I stopped being on guard.");
+        if (Core.TickCount - _guardStopTick < 0)
+        {
+            DebugSay("I am on guard.");
+
+            if (Utility.Random(8) == 0)
+            {
+                Mobile.Direction = (Direction)Utility.Random(8);
+            }
+
+            return true;
+        }
+
+        DebugSay("I stopped being on guard. Going home...");
         Action = ActionType.Wander;
 
         return true;
+    }
+
+    /// <summary>
+    /// Records the combatant's position while it is visible and in line of sight.
+    /// </summary>
+    private void UpdateLastKnownLocation()
+    {
+        var combatant = Mobile.Combatant;
+
+        if (combatant?.Deleted == false && combatant.Map == Mobile.Map &&
+            Mobile.CanSee(combatant) && Mobile.InLOS(combatant))
+        {
+            _lkpTarget = combatant;
+            _lkpLocation = combatant.Location;
+            _lkpExpireTick = Core.TickCount + LkpFreshDuration;
+        }
+    }
+
+    /// <summary>
+    /// Re-engages the last-seen target when it returns to view within perception range,
+    /// bypassing the reacquire throttle.
+    /// </summary>
+    private bool TryReengageLastKnown()
+    {
+        var target = _lkpTarget;
+
+        if (target == null)
+        {
+            return false;
+        }
+
+        if (target.Deleted || !target.Alive || target.Map != Mobile.Map ||
+            target is BaseCreature { IsDeadPet: true } || Core.TickCount - _lkpExpireTick >= 0)
+        {
+            ClearLastKnown();
+            return false;
+        }
+
+        if (Mobile.Controlled || Mobile.BardPacified || Mobile.BardProvoked || Mobile.FightMode == FightMode.None)
+        {
+            return false;
+        }
+
+        if (!Mobile.InRange(target, Mobile.RangePerception) || !Mobile.CanSee(target) ||
+            !Mobile.InLOS(target) || !Mobile.CanBeHarmful(target, false))
+        {
+            return false;
+        }
+
+        DebugSay("There you are!");
+        Mobile.Combatant = target;
+        Mobile.FocusMob = null;
+        Action = ActionType.Combat;
+        return true;
+    }
+
+    /// <summary>
+    /// Walks toward the last-seen position until it is in view, reached, timed out, or
+    /// unreachable. Returns false when the investigation is finished.
+    /// </summary>
+    private bool InvestigateLastKnown()
+    {
+        if (_lkpTarget == null || Core.TickCount - _investigateStopTick >= 0)
+        {
+            return false;
+        }
+
+        if (Mobile.InRange(_lkpLocation, 1) ||
+            Mobile.InLOS(_lkpLocation) && Mobile.InRange(_lkpLocation, Mobile.RangePerception))
+        {
+            DebugSay("They truly disappeared...");
+            return false;
+        }
+
+        _lkpGoal ??= _lkpLocation;
+        return MoveToPoint(_lkpGoal, false);
+    }
+
+    private void ClearLastKnown()
+    {
+        _lkpTarget = null;
+        _lkpGoal = null;
+        _investigating = false;
     }
 
     public virtual bool DoActionFlee()
@@ -705,6 +840,7 @@ public abstract partial class BaseAI
 
         if (Core.TickCount - Mobile.NextReacquireTime < 0)
         {
+
             Mobile.FocusMob = null;
             return false;
         }
@@ -829,6 +965,7 @@ public abstract partial class BaseAI
         }
 
         Mobile.FocusMob = newFocusMob ?? enemySummonMob;
+
         return Mobile.FocusMob != null;
     }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -964,7 +964,6 @@ public abstract partial class BaseAI
         }
 
         Mobile.FocusMob = newFocusMob ?? enemySummonMob;
-
         return Mobile.FocusMob != null;
     }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -496,7 +496,6 @@ public abstract partial class BaseAI
 
             _investigating = false;
             _guardStopTick = Core.TickCount + GuardGraceDuration;
-
         }
 
         if (Core.TickCount - _guardStopTick < 0)

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -837,7 +837,6 @@ public abstract partial class BaseAI
 
         if (Core.TickCount - Mobile.NextReacquireTime < 0)
         {
-
             Mobile.FocusMob = null;
             return false;
         }

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -78,7 +78,6 @@ public abstract partial class BaseAI
         {
             if (_action != value)
             {
-
                 _action = value;
                 OnActionChanged();
             }

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -356,7 +356,6 @@ public abstract partial class BaseAI
         _investigateStopTick = Core.TickCount + InvestigateDuration;
         _guardStopTick = Core.TickCount + GuardGraceDuration;
         _lkpGoal = null;
-
     }
 
     private void HandleFleeAction()

--- a/Projects/UOContent/Mobiles/AI/MageAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MageAI.cs
@@ -679,7 +679,7 @@ public class MageAI : BaseAI
                 Mobile.Combatant = Mobile.FocusMob;
                 Mobile.FocusMob = null;
             }
-            else if (!Mobile.InRange(c, Mobile.RangePerception * 3))
+            else if (!Mobile.InRange(c, Mobile.ChaseLeashRange))
             {
                 Mobile.Combatant = null;
             }
@@ -693,6 +693,23 @@ public class MageAI : BaseAI
                 Action = ActionType.Guard;
                 return true;
             }
+        }
+
+        // Geometry (not hiding — CanSee passed above) is blocking the shot: close in until
+        // line of sight returns. Poisoned mages still fall through to cure.
+        if (!Mobile.Poisoned && Mobile.Spell?.IsCasting != true && !Mobile.InLOS(c))
+        {
+            DebugSay("I cannot see my target, moving to regain line of sight");
+
+            if (!MoveTo(c, false, 1))
+            {
+                OnFailedMove();
+            }
+
+            _lastTarget = c;
+            _lastTargetLoc = c.Location;
+
+            return true;
         }
 
         if (Mobile.TriggerAbility(MonsterAbilityTrigger.CombatAction, c))
@@ -1018,7 +1035,16 @@ public class MageAI : BaseAI
 
             if (toTarget != null)
             {
-                RunTo(toTarget);
+                // Without line of sight the stand-off is pointless — close in so the held
+                // target can be invoked.
+                if (!Mobile.InLOS(toTarget))
+                {
+                    MoveTo(toTarget, true, 1);
+                }
+                else
+                {
+                    RunTo(toTarget);
+                }
             }
         }
 

--- a/Projects/UOContent/Mobiles/AI/MeleeAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MeleeAI.cs
@@ -84,7 +84,6 @@ public class MeleeAI : BaseAI
 
         if (!Mobile.InRange(combatant, Mobile.ChaseLeashRange))
         {
-
             Mobile.Combatant = null;
         }
 

--- a/Projects/UOContent/Mobiles/AI/MeleeAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MeleeAI.cs
@@ -114,7 +114,6 @@ public class MeleeAI : BaseAI
 
         if (Mobile.GetDistanceToSqrt(combatant) > Mobile.RangePerception + 1)
         {
-
             this.DebugSayFormatted($"I cannot find {combatant.Name}, so my guard is up.");
             Action = ActionType.Guard;
             return false;

--- a/Projects/UOContent/Mobiles/AI/MeleeAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MeleeAI.cs
@@ -82,8 +82,9 @@ public class MeleeAI : BaseAI
             return true;
         }
 
-        if (!Mobile.InRange(combatant, Mobile.RangePerception * 3))
+        if (!Mobile.InRange(combatant, Mobile.ChaseLeashRange))
         {
+
             Mobile.Combatant = null;
         }
 
@@ -114,6 +115,7 @@ public class MeleeAI : BaseAI
 
         if (Mobile.GetDistanceToSqrt(combatant) > Mobile.RangePerception + 1)
         {
+
             this.DebugSayFormatted($"I cannot find {combatant.Name}, so my guard is up.");
             Action = ActionType.Guard;
             return false;

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -660,6 +660,13 @@ namespace Server.Mobiles
         [CommandProperty(AccessLevel.GameMaster)]
         public int RangePerception { get; set; }
 
+        /// <summary>
+        /// How far a chase may stretch before the creature gives up its combatant. Between
+        /// RangePerception and this leash it keeps chasing but may switch to closer targets.
+        /// </summary>
+        [CommandProperty(AccessLevel.GameMaster)]
+        public virtual int ChaseLeashRange => RangePerception * 2;
+
         [CommandProperty(AccessLevel.GameMaster)]
         public int RangeFight { get; set; }
 


### PR DESCRIPTION
### Summary

Fixes the long-standing reports of monsters losing track of players who run around a corner ("Is monster AI not using pathfinding? It seems to be LOS blocked by statics"). Root-cause investigation compared current behavior against RunUO line-by-line and traced the regressions through the AI overhaul era (#2232, #2246, #2379, #2401, #2461).

### Root causes and fixes

1. **Movement contract** — `MoveTo`/`ApproachTarget` returned false on every healthy mid-chase tick (true only on arrival), so MeleeAI's RunUO-inherited *"move failed and beyond RangePerception+1 → Guard"* clause — which RunUO only evaluated on genuine blockage — fired **every tick of every chase**. A mounted player trivially opens 17 tiles at a corner, the monster guards, Guard nulls the combatant, and re-acquisition is LOS-gated — unrecoverable through a wall. Movement now reports failure only on genuine failure (no step taken with no working path, or approach give-up). ArcherAI's equivalent clause moves to the hard leash.

2. **Last-known-position pursuit** — while a combatant is in LOS its position is recorded each think tick. When the target vanishes (corner, hiding, recall), the creature walks to the last-seen spot, stands guard there ~10s (restoring RunUO's guard grace, which had decayed to a single tick since #2246), and **re-engages instantly** if the same target re-enters view — bypassing the 10s reacquire throttle.

3. **`ChaseLeashRange`** — new virtual on BaseCreature (default `RangePerception * 2` = 32 tiles) replaces the inline `RangePerception * 3` (48) in Melee/Mage/Archer AI. Per-creature tunable via `[props`.

4. **Group movement demoted to a crowding refinement** — previously any uncontrolled creature with one ally within 8 tiles on the same target used greedy ring-stepping for the *entire* chase, with wall-slides counted as success, never invoking the pathfinder — the "aggroed but won't come around the corner" symptom for spawn groups. It now engages only near the target when allies actually contest the ring, and blocked/wall-slid steps escalate to the pathfinding approach primitive.

5. **Mages close distance on broken LOS** — a mage within casting range but LOS-blocked by geometry stood at the wall holding a spell target until the 60s combatant expiry (ProcessTarget short-circuits Think and its RunTo stands off at RangeFight). Geometry-blocked mages now close in until LOS returns, both pre-cast and while holding a target. Hidden targets (CanSee) and poison-cure priority unchanged. The new movement contract also stops the constant spurious `OnFailedMove` teleport rolls mid-chase.

6. **Move budget: one actual step per AI tick** — nothing advanced `NextMove` on a normal step (RunUO's `m_NextMove` budget was lost), so code paths attempting several moves in one think tick could cross multiple tiles at once — visible as "warping" when crowded creatures jockey for position. A successful step now consumes a half-step budget (floor 50ms): blocks intra-tick double moves, stays safely below the timer interval so legitimate next-tick moves are never jitter-throttled, and does not reintroduce `TransformMoveDelay` inflation. Blocked attempts consume nothing, so retry ladders (repath-and-step, the collision fan) are unaffected. `CanMoveNow` is also wraparound-safe now.

### Reference behavior

RunUO requires LOS to *acquire* a target and to *land* a hit or spell — never to *continue* a chase (its MeleeAI LOS bail-out is literally commented out in stock code). Chases drop only on: target hidden, target dead/off-map, beyond `RangePerception * 3`, 60s without combat interaction, or blocked movement while far away. This PR restores those semantics while adding the last-known-position investigation on top. NPC run flags are untouched — pace is AI-timer-driven and most NPC art has no run animation.

### Testing

- Full suite passes (837 Server + 708 UOContent, including the `ApproachTargetTests` from #2461 — `UnreachableTarget_GivesUp_AndIdles` caught a real edge in the move budget where wall-slide ticks stopped counting toward stall give-up; fixed by sampling move-eligibility before the attempt).
- In-game verification on live repro scenarios (dungeon corridor chases, mounted flight, group aggro at corners, LOS-blocked mage standoffs, crowded positioning).