### PR TITLE
feat: Adds independent think/move clocks for creature AI to fix speed

### DIFF
--- a/Distribution/Data/npc-speeds.json
+++ b/Distribution/Data/npc-speeds.json
@@ -3,12 +3,16 @@
     "level": "VerySlow",
     "active": 0.4,
     "passive": 0.8,
+    "activeMove": 0.9,
+    "passiveMove": 1.5,
     "types": []
   },
   {
     "level": "Slow",
     "active": 0.3,
     "passive": 0.6,
+    "activeMove": 0.6,
+    "passiveMove": 1.2,
     "types": [
       "AntLion", "ArcticOgreLord", "BogThing",
       "Bogle", "BoneKnight", "EarthElemental",
@@ -28,6 +32,8 @@
     "level": "Medium",
     "active": 0.25,
     "passive": 0.5,
+    "activeMove": 0.45,
+    "passiveMove": 1.05,
     "types": [
       "AcidElemental", "AgapiteElemental", "Alligator",
       "AncientLich", "Betrayer", "Bird",
@@ -108,6 +114,8 @@
     "level": "Fast",
     "active": 0.2,
     "passive": 0.4,
+    "activeMove": 0.3,
+    "passiveMove": 0.9,
     "types": [
       "LordOaks", "Silvani", "AirElemental",
       "AncientWyrm", "Balron", "BladeSpirits",
@@ -139,6 +147,8 @@
     "level": "VeryFast",
     "active": 0.125,
     "passive": 0.30,
+    "activeMove": 0.125,
+    "passiveMove": 0.6,
     "types": [
       "Barracoon", "Mephitis", "Neira",
       "Rikktor", "Semidar", "EnergyVortex",

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
@@ -125,6 +125,21 @@ public class MoveSpeedTests : IDisposable
     }
 
     [Fact]
+    public void Herding_DrivesMoveClock_ThinkUntouched()
+    {
+        var bc = NewCreature(); // think 0.3/0.6, passive
+        bc.SetMoveSpeed(0.45, 1.05);
+
+        bc.TargetLocation = new Point2D(10, 10);
+
+        Assert.Equal(0.6, bc.CurrentSpeed);     // think clock unaffected by herding
+        Assert.Equal(0.3, bc.CurrentMoveSpeed); // fixed herding pace, not 1.05
+
+        bc.TargetLocation = null;
+        Assert.Equal(1.05, bc.CurrentMoveSpeed);
+    }
+
+    [Fact]
     public void SnapSpeedsToTable_UndoesScalingDrift_KeepsTunedValues()
     {
         var bc = NewCreature();

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
@@ -24,15 +24,24 @@ public class MoveSpeedTests : IDisposable
 
     private sealed class SpeedStub : BaseCreature
     {
+        // Stands in for the npc-speeds table (unconfigured in the test fixture).
+        public double TableActiveMove;
+        public double TablePassiveMove;
+
         public SpeedStub() : base(AIType.AI_Animal) => Body = 0xC9;
 
         public SpeedStub(Serial serial) : base(serial) => Body = 0xC9;
 
-        // NPCSpeeds isn't configured in the test fixture; provide fixed think speeds.
         public override void GetSpeeds(out double activeSpeed, out double passiveSpeed)
         {
             activeSpeed = 0.3;
             passiveSpeed = 0.6;
+        }
+
+        public override void GetMoveSpeeds(out double activeMoveSpeed, out double passiveMoveSpeed)
+        {
+            activeMoveSpeed = TableActiveMove;
+            passiveMoveSpeed = TablePassiveMove;
         }
     }
 
@@ -101,6 +110,33 @@ public class MoveSpeedTests : IDisposable
 
         Assert.Equal(0.3, bc.ActiveMoveSpeed);  // inheriting again
         Assert.Equal(0.9, bc.PassiveMoveSpeed); // other override untouched
+    }
+
+    [Fact]
+    public void Migration_MatchingThinkSpeeds_AdoptTableMoveValues()
+    {
+        var bc = NewCreature(); // think 0.3/0.6, matching its table entry
+        bc.TableActiveMove = 0.45;
+        bc.TablePassiveMove = 0.9;
+
+        bc.MigrateMoveSpeeds();
+
+        Assert.Equal(0.45, bc.ActiveMoveSpeed);
+        Assert.Equal(0.9, bc.PassiveMoveSpeed);
+    }
+
+    [Fact]
+    public void Migration_TunedThinkSpeeds_KeepInheriting()
+    {
+        var bc = NewCreature();
+        bc.SetSpeed(0.35, 0.6); // hand-tuned: no longer matches the table entry
+        bc.TableActiveMove = 0.45;
+        bc.TablePassiveMove = 0.9;
+
+        bc.MigrateMoveSpeeds();
+
+        Assert.Equal(0.35, bc.ActiveMoveSpeed);
+        Assert.Equal(0.6, bc.PassiveMoveSpeed);
     }
 
     [Theory]

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
@@ -125,6 +125,29 @@ public class MoveSpeedTests : IDisposable
     }
 
     [Fact]
+    public void SnapSpeedsToTable_UndoesScalingDrift_KeepsTunedValues()
+    {
+        var bc = NewCreature();
+        bc.TableActiveMove = 0.45;
+        bc.TablePassiveMove = 0.9;
+        bc.SetMoveSpeed(0.45, 0.9);
+
+        // 0.45 and 0.9 do not survive /1.2 then *1.2 bit-exactly.
+        bc.ScaleMoveSpeed(1.0 / 1.2);
+        bc.ScaleMoveSpeed(1.2);
+        Assert.NotEqual(0.45, bc.ActiveMoveSpeed);
+
+        bc.SnapSpeedsToTable();
+        Assert.Equal(0.45, bc.ActiveMoveSpeed);
+        Assert.Equal(0.9, bc.PassiveMoveSpeed);
+
+        // A hand-tuned value is nowhere near the epsilon and must keep.
+        bc.SetMoveSpeed(0.7, 0.9);
+        bc.SnapSpeedsToTable();
+        Assert.Equal(0.7, bc.ActiveMoveSpeed);
+    }
+
+    [Fact]
     public void Migration_MatchingThinkSpeeds_AdoptTableMoveValues()
     {
         var bc = NewCreature(); // think 0.3/0.6, matching its table entry

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Mobiles;
+using Xunit;
+
+namespace UOContent.Tests.Mobiles.AI;
+
+// Pins the CurrentMoveSpeed classification (verbatim active/passive maps to the matching
+// move value; bespoke stays fused), SetSpeed's one-clock guarantee, and the v22 tail.
+[Collection("Sequential UOContent Tests")]
+public class MoveSpeedTests : IDisposable
+{
+    // Delete spawned stubs so they don't linger in the shared static World.
+    private readonly List<Mobile> _created = new();
+
+    public void Dispose()
+    {
+        for (var i = 0; i < _created.Count; i++)
+        {
+            _created[i].Delete();
+        }
+    }
+
+    private sealed class SpeedStub : BaseCreature
+    {
+        public SpeedStub() : base(AIType.AI_Animal) => Body = 0xC9;
+
+        public SpeedStub(Serial serial) : base(serial) => Body = 0xC9;
+
+        // NPCSpeeds isn't configured in the test fixture; provide fixed think speeds.
+        public override void GetSpeeds(out double activeSpeed, out double passiveSpeed)
+        {
+            activeSpeed = 0.3;
+            passiveSpeed = 0.6;
+        }
+    }
+
+    private SpeedStub NewCreature()
+    {
+        var bc = new SpeedStub();
+        _created.Add(bc);
+        return bc;
+    }
+
+    [Fact]
+    public void MoveSpeeds_InheritThinkValues_ByDefault()
+    {
+        var bc = NewCreature();
+
+        Assert.Equal(0.3, bc.ActiveMoveSpeed);
+        Assert.Equal(0.6, bc.PassiveMoveSpeed);
+        Assert.Equal(bc.CurrentSpeed, bc.CurrentMoveSpeed);
+    }
+
+    [Fact]
+    public void CurrentMoveSpeed_ResolvesPerMode_WhenOverridden()
+    {
+        var bc = NewCreature();
+        bc.SetMoveSpeed(0.45, 0.9);
+
+        // SetSpeed left the creature passive; the think clock is untouched.
+        Assert.Equal(0.6, bc.CurrentSpeed);
+        Assert.Equal(0.9, bc.CurrentMoveSpeed);
+
+        bc.SetCurrentSpeedToActive();
+        Assert.Equal(0.3, bc.CurrentSpeed);
+        Assert.Equal(0.45, bc.CurrentMoveSpeed);
+    }
+
+    [Fact]
+    public void CurrentMoveSpeed_BespokePace_StaysFused()
+    {
+        var bc = NewCreature();
+        bc.SetMoveSpeed(0.45, 0.9);
+
+        // Neither think value verbatim, so both clocks run it.
+        bc.CurrentSpeed = 0.11;
+        Assert.Equal(0.11, bc.CurrentMoveSpeed);
+    }
+
+    [Fact]
+    public void SetSpeed_ClearsMoveOverrides()
+    {
+        var bc = NewCreature();
+        bc.SetMoveSpeed(0.45, 0.9);
+
+        bc.SetSpeed(0.2, 0.4);
+
+        Assert.Equal(0.2, bc.ActiveMoveSpeed);
+        Assert.Equal(0.4, bc.PassiveMoveSpeed);
+    }
+
+    [Fact]
+    public void NonPositiveMoveSpeed_ClearsThatOverride()
+    {
+        var bc = NewCreature();
+        bc.SetMoveSpeed(0.45, 0.9);
+
+        bc.ActiveMoveSpeed = 0;
+
+        Assert.Equal(0.3, bc.ActiveMoveSpeed);  // inheriting again
+        Assert.Equal(0.9, bc.PassiveMoveSpeed); // other override untouched
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void MoveSpeedOverrides_SurviveSerialization(bool overridden)
+    {
+        var bc = NewCreature();
+        if (overridden)
+        {
+            bc.SetMoveSpeed(0.45, 0.9);
+        }
+
+        var writer = new BufferWriter(true);
+        bc.Serialize(writer);
+
+        var buffer = new byte[writer.Position];
+        writer.Buffer.AsSpan(0, (int)writer.Position).CopyTo(buffer);
+
+        var copy = new SpeedStub(World.NewMobile);
+        _created.Add(copy);
+        var reader = new BufferReader(buffer);
+        copy.Deserialize(reader);
+
+        // The v22 tail is the last block; exact consumption catches any offset mistake.
+        Assert.Equal(buffer.Length, reader.Position);
+        Assert.Equal(overridden ? 0.45 : 0.3, copy.ActiveMoveSpeed);
+        Assert.Equal(overridden ? 0.9 : 0.6, copy.PassiveMoveSpeed);
+    }
+}

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/MoveSpeedTests.cs
@@ -113,6 +113,18 @@ public class MoveSpeedTests : IDisposable
     }
 
     [Fact]
+    public void ScaleMoveSpeed_ScalesOverrides_LeavesInheritAlone()
+    {
+        var bc = NewCreature();
+        bc.ActiveMoveSpeed = 0.6; // passive left inheriting
+
+        bc.ScaleMoveSpeed(1.0 / 1.2);
+
+        Assert.Equal(0.5, bc.ActiveMoveSpeed);
+        Assert.Equal(bc.PassiveSpeed, bc.PassiveMoveSpeed); // still inheriting, not 0 * scalar
+    }
+
+    [Fact]
     public void Migration_MatchingThinkSpeeds_AdoptTableMoveValues()
     {
         var bc = NewCreature(); // think 0.3/0.6, matching its table entry

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AIMovement.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AIMovement.cs
@@ -38,7 +38,18 @@ public abstract partial class BaseAI
     private bool _approachGaveUp;
     private Point3D _approachGaveUpGoalLoc;
 
-    public static double BadlyHurtMoveDelay(BaseCreature bc)
+    // --- Move intent (see ContinueMove) ------------------------------------------------
+    // Durable movement goal renewed by en-route ApproachTarget/MoveToPoint calls; while
+    // live, the AITimer wakes at NextMove between think ticks to advance the step.
+    private Mobile _moveIntentTarget;
+    private IPoint3D _moveIntentPoint;
+    private bool _moveIntentRun;
+    private int _moveIntentRange;
+    private long _moveIntentExpire;
+
+    // Inflates a step delay while badly hurt; computed from the passed base so it cannot
+    // compound across steps. Damage slows steps, never decisions.
+    public static double BadlyHurtMoveDelay(BaseCreature bc, double delay)
     {
         var statMin = Core.HS ? bc.Stam : bc.Hits;
         var statMax = Core.HS ? bc.StamMax : bc.HitsMax;
@@ -46,14 +57,15 @@ public abstract partial class BaseAI
         if (!bc.IsDeadPet && (bc.ReduceSpeedWithDamage || bc.IsSubdued)
                           && statMax > 0 && statMin < statMax * 0.3)
         {
-            var hits = (double)statMin / statMax;
+            var stat = (double)statMin / statMax;
 
-            if (hits < 0.1) { return bc.CurrentSpeed + 0.15; }
-            if (hits < 0.2) { return bc.CurrentSpeed + 0.1; }
-            if (hits < 0.3) { return bc.CurrentSpeed + 0.05; }
+            if (stat < 0.1) { return delay + 0.15; }
+            if (stat < 0.2) { return delay + 0.1; }
+
+            return delay + 0.05;
         }
 
-        return bc.CurrentSpeed;
+        return delay;
     }
 
     public bool CanMoveNow(out double delay)
@@ -62,12 +74,23 @@ public abstract partial class BaseAI
         return Core.TickCount - NextMove >= 0;
     }
 
-    // Caps movement at one actual step per AI think tick; pacing itself is the timer's
-    // cadence. Half a step keeps the budget below the timer interval so a legitimate
-    // next-tick move is never jitter-throttled.
+    // Accumulative full-step budget: long-run pacing averages CurrentMoveSpeed exactly
+    // regardless of timer-grid jitter; snap-to-now caps stall catch-up at one step.
     private void ConsumeMoveBudget()
     {
-        NextMove = Core.TickCount + Math.Max(50, (int)(Mobile.CurrentSpeed * 500));
+        var stepDelay = Mobile.CurrentMoveSpeed;
+
+        if (!(Core.AOS && IsFollowingMaster()))
+        {
+            stepDelay = BadlyHurtMoveDelay(Mobile, stepDelay);
+        }
+
+        NextMove += Math.Max(50, (long)(stepDelay * 1000));
+
+        if (Core.TickCount - NextMove > 0)
+        {
+            NextMove = Core.TickCount;
+        }
     }
 
     public virtual bool CheckMove() => !(Mobile.Deleted || Mobile.DisallowAllMoves);
@@ -95,21 +118,18 @@ public abstract partial class BaseAI
 
         if (TryMove(d))
         {
+            // Writes the think clock only; hurt slowdown applies in ConsumeMoveBudget.
             if (Core.AOS && IsFollowingMaster())
             {
                 Mobile.CurrentSpeed = 0.1;
             }
-            else if (Mobile.Hits < Mobile.HitsMax * 0.3)
-            {
-                Mobile.CurrentSpeed = BadlyHurtMoveDelay(Mobile);
-            }
             else if (Mobile.Warmode || Mobile.Combatant != null)
             {
-                Mobile.CurrentSpeed = Mobile.ActiveSpeed;
+                Mobile.SetCurrentSpeedToActive();
             }
             else
             {
-                Mobile.CurrentSpeed = Mobile.PassiveSpeed;
+                Mobile.SetCurrentSpeedToPassive();
             }
 
             ConsumeMoveBudget();
@@ -319,12 +339,14 @@ public abstract partial class BaseAI
     {
         if (Mobile.Deleted || Mobile.DisallowAllMoves || target?.Deleted != false)
         {
+            ClearMoveIntent();
             return false;
         }
 
         if (Mobile.InRange(target, range))
         {
             ResetApproach();
+            ClearMoveIntent();
             return true;
         }
 
@@ -333,11 +355,14 @@ public abstract partial class BaseAI
         {
             if (target.Location == _approachGaveUpGoalLoc)
             {
+                ClearMoveIntent();
                 return false;
             }
 
             ResetApproach(); // target moved — try again fresh
         }
+
+        RenewMoveIntent(target, null, run, range);
 
         // FAST PATH: greedy step toward the target, counted as success ONLY when the move
         // fully succeeded (not an auto-turn sidestep) and actually got us closer. An
@@ -401,6 +426,7 @@ public abstract partial class BaseAI
     {
         if (Mobile.Deleted || Mobile.DisallowAllMoves || goal == null)
         {
+            ClearMoveIntent();
             return false;
         }
 
@@ -409,16 +435,26 @@ public abstract partial class BaseAI
             Path = new PathFollower(Mobile, goal) { Mover = DoMoveImpl };
         }
 
+        RenewMoveIntent(null, goal, run, 1);
+
         var couldMove = CanMoveNow(out _) && !IsInBadState();
         var locBefore = Mobile.Location;
 
         if (Path.Follow(run, 1))
         {
             Path = null;
+            ClearMoveIntent();
             return false; // arrived
         }
 
-        return Mobile.Location != locBefore || !couldMove;
+        var progressed = Mobile.Location != locBefore || !couldMove;
+
+        if (!progressed)
+        {
+            ClearMoveIntent();
+        }
+
+        return progressed;
     }
 
     /// <summary>
@@ -461,10 +497,10 @@ public abstract partial class BaseAI
 
         if (++_approachStallTicks >= ApproachGiveUpTicks)
         {
-
             _approachGaveUp = true;
             _approachGaveUpGoalLoc = goalLoc;
             Path = null;
+            ClearMoveIntent();
         }
     }
 
@@ -478,6 +514,56 @@ public abstract partial class BaseAI
         _approachBestDist = 0;
         _approachStallTicks = 0;
         _approachGaveUp = false;
+    }
+
+    private void RenewMoveIntent(Mobile target, IPoint3D point, bool run, int range)
+    {
+        _moveIntentTarget = target;
+        _moveIntentPoint = point;
+        _moveIntentRun = run;
+        _moveIntentRange = range;
+
+        // A live pursuit renews every think tick; unrenewed intent dies on its own.
+        _moveIntentExpire = Core.TickCount + (long)(Mobile.CurrentSpeed * 2000) + 250;
+    }
+
+    public void ClearMoveIntent()
+    {
+        _moveIntentTarget = null;
+        _moveIntentPoint = null;
+    }
+
+    /// <summary>
+    /// True while a durable movement goal is live; <paramref name="nextMove"/> is the tick
+    /// the movement budget elapses.
+    /// </summary>
+    public bool TryGetMoveWake(out long nextMove)
+    {
+        nextMove = NextMove;
+
+        return (_moveIntentTarget != null || _moveIntentPoint != null) &&
+               Core.TickCount - _moveIntentExpire < 0;
+    }
+
+    /// <summary>
+    /// Advances the current pursuit/investigation by one step on a movement-clock wake;
+    /// no decisions run.
+    /// </summary>
+    public void ContinueMove()
+    {
+        if (!TryGetMoveWake(out var nextMove) || Core.TickCount - nextMove < 0)
+        {
+            return;
+        }
+
+        if (_moveIntentTarget != null)
+        {
+            ApproachTarget(_moveIntentTarget, _moveIntentRun, _moveIntentRange);
+        }
+        else
+        {
+            MoveToPoint(_moveIntentPoint, _moveIntentRun);
+        }
     }
 
     public virtual bool MoveTo(Mobile m, bool run, int range)

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
@@ -17,9 +17,15 @@ using System;
 
 namespace Server.Mobiles;
 
+/// <summary>
+/// Drives an AI on two clocks: decisions at <see cref="BaseCreature.CurrentSpeed"/>, plus
+/// move-only wakes at <see cref="BaseAI.NextMove"/> while a pursuit is live. Each tick
+/// schedules the earlier of the two deadlines.
+/// </summary>
 public sealed class AITimer : Timer
 {
     private readonly BaseAI _owner;
+    private long _nextThink;
     private int _detectHiddenMinDelay;
     private int _detectHiddenMaxDelay;
 
@@ -28,12 +34,27 @@ public sealed class AITimer : Timer
     {
         _owner = owner;
         _owner._nextDetectHidden = Core.TickCount;
+        _nextThink = Core.TickCount;
     }
 
     public void Activate()
     {
+        _nextThink = Core.TickCount;
         Interval = TimeSpan.FromSeconds(_owner.Mobile.CurrentSpeed);
         Start();
+    }
+
+    // A speed-up must not wait out a stale, longer think deadline.
+    public void OnSpeedChanged()
+    {
+        var candidate = Core.TickCount + (long)(_owner.Mobile.CurrentSpeed * 1000);
+
+        if (candidate - _nextThink < 0)
+        {
+            _nextThink = candidate;
+        }
+
+        Interval = TimeSpan.FromSeconds(_owner.Mobile.CurrentSpeed);
     }
 
     protected override void OnTick()
@@ -44,23 +65,52 @@ public sealed class AITimer : Timer
             return;
         }
 
-        _owner.Mobile.OnThink();
-
-        if (ShouldStop())
+        if (Core.TickCount - _nextThink >= 0)
         {
-            Stop();
-            return;
+            _owner.Mobile.OnThink();
+
+            if (ShouldStop())
+            {
+                Stop();
+                return;
+            }
+
+            HandleBardEffects();
+
+            if (_owner.Mobile.Controlled ? _owner.Obey() : _owner.Think())
+            {
+                HandleDetectHidden();
+            }
+
+            // Cadence from the post-decision speed (decisions may flip active/passive).
+            _nextThink = Core.TickCount + (long)(_owner.Mobile.CurrentSpeed * 1000);
+        }
+        else
+        {
+            _owner.ContinueMove();
         }
 
-        Interval = TimeSpan.FromSeconds(_owner.Mobile.CurrentSpeed);
-        HandleBardEffects();
+        ScheduleNext();
+    }
 
-        if (_owner.Mobile.Controlled ? !_owner.Obey() : !_owner.Think())
+    private void ScheduleNext()
+    {
+        var now = Core.TickCount;
+        var delay = _nextThink - now;
+
+        if (_owner.TryGetMoveWake(out var nextMove))
         {
-            return;
+            var moveDelay = nextMove - now;
+
+            // Only a future budget is a wake — a blocked creature must not spin the timer.
+            if (moveDelay > 0 && moveDelay < delay)
+            {
+                delay = moveDelay;
+            }
         }
 
-        HandleDetectHidden();
+        // The wheel rounds up to its 8ms resolution; a non-positive delay becomes one turn.
+        Interval = TimeSpan.FromMilliseconds(delay);
     }
 
     private bool ShouldStop()

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -40,6 +40,7 @@ public abstract partial class BaseAI
     private Mobile _lkpTarget;
     private Point3D _lkpLocation;
     private IPoint3D _lkpGoal; // boxed _lkpLocation handed to the PathFollower
+    private IPoint3D _herdGoal; // boxed herding goal handed to the PathFollower
     private long _lkpExpireTick;
     private long _guardStopTick;
     private long _investigateStopTick;
@@ -627,6 +628,7 @@ public abstract partial class BaseAI
 
         if (target == null)
         {
+            _herdGoal = null;
             return false;
         }
 
@@ -634,7 +636,15 @@ public abstract partial class BaseAI
 
         if (distance >= 1 && distance <= 15)
         {
-            DoMove(Mobile.GetDirectionTo(target));
+            // A cached boxed goal keeps the PathFollower persistent across ticks; walking
+            // through MoveToPoint paces herding on the movement clock and paths around
+            // obstacles.
+            if (_herdGoal == null || _herdGoal.X != target.X || _herdGoal.Y != target.Y)
+            {
+                _herdGoal = new Point3D(target.X, target.Y, Mobile.Map?.GetAverageZ(target.X, target.Y) ?? Mobile.Z);
+            }
+
+            MoveToPoint(_herdGoal, false);
             return true;
         }
 
@@ -644,6 +654,7 @@ public abstract partial class BaseAI
         }
 
         Mobile.TargetLocation = null;
+        _herdGoal = null;
         return false;
     }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -58,6 +58,7 @@ public abstract partial class BaseAI
     public BaseAI(BaseCreature m)
     {
         Mobile = m;
+        NextMove = Core.TickCount;
         AITimer = new AITimer(this);
 
         if (!m.PlayerRangeSensitive || !World.Loading && m.Map != null && m.Map != Map.Internal && m.Map.GetSector(m.Location).Active)
@@ -295,6 +296,9 @@ public abstract partial class BaseAI
 
     public virtual void OnActionChanged()
     {
+        // A change of course invalidates between-think movement continuation.
+        ClearMoveIntent();
+
         switch (Action)
         {
             case ActionType.Wander:
@@ -1131,6 +1135,6 @@ public abstract partial class BaseAI
 
     public virtual void OnCurrentSpeedChanged()
     {
-        AITimer.Interval = TimeSpan.FromSeconds(Mobile.CurrentSpeed);
+        AITimer.OnSpeedChanged();
     }
 }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -265,6 +265,10 @@ namespace Server.Mobiles
         private double _passiveSpeed;
         private double _currentSpeed;
 
+        // Movement clock (seconds per step); 0 = inherit the matching think value.
+        private double _activeMoveSpeed;
+        private double _passiveMoveSpeed;
+
         // Herding - Overrides the AI to force the mob to move to a specific location
         // Thinking: 0.3s, Movement: 0.6s.
         private IPoint2D _targetLocation;
@@ -342,6 +346,7 @@ namespace Server.Mobiles
             FightMode = mode;
 
             GetSpeeds(out var activeSpeed, out var passiveSpeed);
+            GetMoveSpeeds(out _activeMoveSpeed, out _passiveMoveSpeed);
 
             ActiveSpeed = activeSpeed;
             PassiveSpeed = passiveSpeed;
@@ -673,6 +678,7 @@ namespace Server.Mobiles
         [CommandProperty(AccessLevel.GameMaster)]
         public int RangeHome { get; set; } = 10;
 
+        /// <summary>Seconds per AI decision while engaged; see <see cref="ActiveMoveSpeed"/> for movement pace.</summary>
         [CommandProperty(AccessLevel.GameMaster)]
         public virtual double ActiveSpeed
         {
@@ -686,6 +692,7 @@ namespace Server.Mobiles
             }
         }
 
+        /// <summary>Seconds per AI decision while idle; see <see cref="PassiveMoveSpeed"/> for movement pace.</summary>
         [CommandProperty(AccessLevel.GameMaster)]
         public virtual double PassiveSpeed
         {
@@ -698,6 +705,22 @@ namespace Server.Mobiles
                     _passiveSpeed = value;
                 }
             }
+        }
+
+        /// <summary>Seconds per step while engaged. Inherits <see cref="ActiveSpeed"/>; set 0 to re-inherit.</summary>
+        [CommandProperty(AccessLevel.GameMaster)]
+        public virtual double ActiveMoveSpeed
+        {
+            get => _activeMoveSpeed > 0 ? _activeMoveSpeed : _activeSpeed;
+            set => _activeMoveSpeed = value > 0 ? value : 0;
+        }
+
+        /// <summary>Seconds per step while idle. Inherits <see cref="PassiveSpeed"/>; set 0 to re-inherit.</summary>
+        [CommandProperty(AccessLevel.GameMaster)]
+        public virtual double PassiveMoveSpeed
+        {
+            get => _passiveMoveSpeed > 0 ? _passiveMoveSpeed : _passiveSpeed;
+            set => _passiveMoveSpeed = value > 0 ? value : 0;
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
@@ -722,6 +745,31 @@ namespace Server.Mobiles
                     _currentSpeed = value;
                     AIObject?.OnCurrentSpeedChanged();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Resolved seconds per step: a verbatim active/passive <see cref="CurrentSpeed"/>
+        /// maps to the matching movement value; a bespoke pace stays fused to both clocks.
+        /// </summary>
+        [CommandProperty(AccessLevel.GameMaster)]
+        public double CurrentMoveSpeed
+        {
+            get
+            {
+                var current = CurrentSpeed;
+
+                if (current == _activeSpeed)
+                {
+                    return ActiveMoveSpeed;
+                }
+
+                if (current == _passiveSpeed)
+                {
+                    return PassiveMoveSpeed;
+                }
+
+                return current;
             }
         }
 
@@ -1850,7 +1898,7 @@ namespace Server.Mobiles
         {
             base.Serialize(writer);
 
-            writer.Write(21); // version
+            writer.Write(22); // version
 
             writer.Write((int)m_CurrentAI);
             writer.Write((int)m_DefaultAI);
@@ -1970,6 +2018,10 @@ namespace Server.Mobiles
 
             // Version 19
             writer.Write(HomeMap);
+
+            // Version 22 (0 = inherit the matching think value)
+            writer.Write(_activeMoveSpeed);
+            writer.Write(_passiveMoveSpeed);
         }
 
         public override void Deserialize(IGenericReader reader)
@@ -2171,6 +2223,12 @@ namespace Server.Mobiles
             if (version >= 19)
             {
                 HomeMap = reader.ReadMap();
+            }
+
+            if (version >= 22)
+            {
+                _activeMoveSpeed = reader.ReadDouble();
+                _passiveMoveSpeed = reader.ReadDouble();
             }
 
             if (version <= 14 && m_Paragon && Hue == 0x31)
@@ -4586,11 +4644,30 @@ namespace Server.Mobiles
             return false;
         }
 
+        /// <summary>
+        /// Sets the think clock and clears movement overrides (legacy one-clock semantics);
+        /// use <see cref="SetMoveSpeed"/> for an independent movement pace.
+        /// </summary>
         public void SetSpeed(double active, double passive, bool isPassive = true)
         {
             ActiveSpeed = active;
             PassiveSpeed = passive;
+            ClearMoveSpeed();
             CurrentSpeed = isPassive ? PassiveSpeed : ActiveSpeed;
+        }
+
+        /// <summary>Sets only the movement clock (seconds per step).</summary>
+        public void SetMoveSpeed(double active, double passive)
+        {
+            ActiveMoveSpeed = active;
+            PassiveMoveSpeed = passive;
+        }
+
+        /// <summary>Clears movement overrides; steps pace off the think clock again.</summary>
+        public void ClearMoveSpeed()
+        {
+            _activeMoveSpeed = 0;
+            _passiveMoveSpeed = 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -4904,6 +4981,11 @@ namespace Server.Mobiles
         public virtual void GetSpeeds(out double activeSpeed, out double passiveSpeed)
         {
             NPCSpeeds.GetSpeeds(this, out activeSpeed, out passiveSpeed);
+        }
+
+        public virtual void GetMoveSpeeds(out double activeMoveSpeed, out double passiveMoveSpeed)
+        {
+            NPCSpeeds.GetMoveSpeeds(this, out activeMoveSpeed, out passiveMoveSpeed);
         }
 
         public virtual void DropBackpack()

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -269,8 +269,8 @@ namespace Server.Mobiles
         private double _activeMoveSpeed;
         private double _passiveMoveSpeed;
 
-        // Herding - Overrides the AI to force the mob to move to a specific location
-        // Thinking: 0.3s, Movement: 0.6s.
+        // Herding - forces the mob to walk to a specific location, paced by the movement
+        // clock at HerdingMoveSpeed. Thinking is unaffected.
         private IPoint2D _targetLocation;
 
         private int m_DamageMax = -1;
@@ -723,21 +723,21 @@ namespace Server.Mobiles
             set => _passiveMoveSpeed = value > 0 ? value : 0;
         }
 
+        // Herded creatures walk at a fixed standard pace regardless of their own speed
+        // (RunUO's forced 0.3, without its TransformMoveDelay inflation to 0.6).
+        private const double HerdingMoveSpeed = 0.3;
+
         [CommandProperty(AccessLevel.GameMaster)]
         public IPoint2D TargetLocation
         {
             get => _targetLocation;
-            set
-            {
-                _targetLocation = value;
-                AIObject?.OnCurrentSpeedChanged();
-            }
+            set => _targetLocation = value;
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
         public double CurrentSpeed
         {
-            get => _targetLocation != null ? 0.3 : _currentSpeed;
+            get => _currentSpeed;
             set
             {
                 if (Math.Abs(_currentSpeed - value) > 0.0001)
@@ -751,25 +751,21 @@ namespace Server.Mobiles
         /// <summary>
         /// Resolved seconds per step: a verbatim active/passive <see cref="CurrentSpeed"/>
         /// maps to the matching movement value; a bespoke pace stays fused to both clocks.
+        /// A herded creature is always driven at <see cref="HerdingMoveSpeed"/>.
         /// </summary>
         [CommandProperty(AccessLevel.GameMaster)]
         public double CurrentMoveSpeed
         {
             get
             {
-                var current = CurrentSpeed;
-
-                if (current == _activeSpeed)
+                if (_targetLocation != null)
                 {
-                    return ActiveMoveSpeed;
+                    return HerdingMoveSpeed;
                 }
 
-                if (current == _passiveSpeed)
-                {
-                    return PassiveMoveSpeed;
-                }
-
-                return current;
+                return _currentSpeed == _activeSpeed ? ActiveMoveSpeed
+                    : _currentSpeed == _passiveSpeed ? PassiveMoveSpeed
+                    : _currentSpeed;
             }
         }
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -774,9 +774,6 @@ namespace Server.Mobiles
         }
 
         [CommandProperty(AccessLevel.GameMaster)]
-        public double MoveSpeedMod { get; set; }
-
-        [CommandProperty(AccessLevel.GameMaster)]
         public Point3D Home
         {
             get => m_Home;
@@ -4688,6 +4685,35 @@ namespace Server.Mobiles
             if (_passiveMoveSpeed > 0)
             {
                 _passiveMoveSpeed *= scalar;
+            }
+        }
+
+        /// <summary>
+        /// Snaps speeds within rounding distance of the creature's table values back to
+        /// exact. A scaling buff that divides then multiplies can drift by an ulp (e.g.
+        /// 0.9 and 0.45 through 1.2), which would read as hand-tuned; call after undoing
+        /// such a buff. Genuinely tuned speeds are nowhere near the epsilon and keep.
+        /// </summary>
+        public void SnapSpeedsToTable()
+        {
+            GetSpeeds(out var activeSpeed, out var passiveSpeed);
+
+            if (Math.Abs(_activeSpeed - activeSpeed) < 0.0001 && Math.Abs(_passiveSpeed - passiveSpeed) < 0.0001)
+            {
+                _activeSpeed = activeSpeed;
+                _passiveSpeed = passiveSpeed;
+            }
+
+            GetMoveSpeeds(out var activeMoveSpeed, out var passiveMoveSpeed);
+
+            if (activeMoveSpeed > 0 && Math.Abs(_activeMoveSpeed - activeMoveSpeed) < 0.0001)
+            {
+                _activeMoveSpeed = activeMoveSpeed;
+            }
+
+            if (passiveMoveSpeed > 0 && Math.Abs(_passiveMoveSpeed - passiveMoveSpeed) < 0.0001)
+            {
+                _passiveMoveSpeed = passiveMoveSpeed;
             }
         }
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -4674,6 +4674,23 @@ namespace Server.Mobiles
             _passiveMoveSpeed = 0;
         }
 
+        /// <summary>
+        /// Scales movement overrides (paragon and similar buffs). Inheriting values stay
+        /// inheriting — they already follow the scaled think clock.
+        /// </summary>
+        public void ScaleMoveSpeed(double scalar)
+        {
+            if (_activeMoveSpeed > 0)
+            {
+                _activeMoveSpeed *= scalar;
+            }
+
+            if (_passiveMoveSpeed > 0)
+            {
+                _passiveMoveSpeed *= scalar;
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetCurrentSpeedToActive() => CurrentSpeed = ActiveSpeed;
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -2230,6 +2230,10 @@ namespace Server.Mobiles
                 _activeMoveSpeed = reader.ReadDouble();
                 _passiveMoveSpeed = reader.ReadDouble();
             }
+            else
+            {
+                MigrateMoveSpeeds();
+            }
 
             if (version <= 14 && m_Paragon && Hue == 0x31)
             {
@@ -4986,6 +4990,20 @@ namespace Server.Mobiles
         public virtual void GetMoveSpeeds(out double activeMoveSpeed, out double passiveMoveSpeed)
         {
             NPCSpeeds.GetMoveSpeeds(this, out activeMoveSpeed, out passiveMoveSpeed);
+        }
+
+        // Pre-v22 saves carry no movement clock. A creature whose serialized think speeds
+        // still match what it would spawn with today was never hand-tuned: adopt today's
+        // move values so existing worlds (and pets) pick up npc-speeds pacing without a
+        // respawn. Tuned creatures keep movement inheriting their think clock.
+        internal void MigrateMoveSpeeds()
+        {
+            GetSpeeds(out var activeSpeed, out var passiveSpeed);
+
+            if (_activeSpeed == activeSpeed && _passiveSpeed == passiveSpeed)
+            {
+                GetMoveSpeeds(out _activeMoveSpeed, out _passiveMoveSpeed);
+            }
         }
 
         public virtual void DropBackpack()

--- a/Projects/UOContent/Mobiles/NPCSpeeds.cs
+++ b/Projects/UOContent/Mobiles/NPCSpeeds.cs
@@ -38,6 +38,22 @@ public static class NPCSpeeds
         passiveSpeed = sp.PassiveSpeed;
     }
 
+    // Move speeds are optional (0 = inherit), so this tolerates a missing entry or table.
+    public static void GetMoveSpeeds(BaseCreature bc, out double activeMoveSpeed, out double passiveMoveSpeed)
+    {
+        if ((bc.SpeedClass == SpeedLevel.None || !_speedsByLevel.TryGetValue(bc.SpeedClass, out var sp)) &&
+            !_speedsByType.TryGetValue(bc.GetType(), out sp) &&
+            !_speedsByLevel.TryGetValue(SpeedLevel.Medium, out sp))
+        {
+            activeMoveSpeed = 0;
+            passiveMoveSpeed = 0;
+            return;
+        }
+
+        activeMoveSpeed = sp.ActiveMoveSpeed;
+        passiveMoveSpeed = sp.PassiveMoveSpeed;
+    }
+
     public static void RegisterSpeed(SpeedClassEntry entry)
     {
         _speedsByLevel[entry.Level] = entry;
@@ -77,6 +93,13 @@ public static class NPCSpeeds
 
         [JsonPropertyName("passive")]
         public double PassiveSpeed { get; init; }
+
+        // Movement clock (seconds per step); absent/0 = inherit the matching think value.
+        [JsonPropertyName("activeMove")]
+        public double ActiveMoveSpeed { get; init; }
+
+        [JsonPropertyName("passiveMove")]
+        public double PassiveMoveSpeed { get; init; }
 
         [JsonPropertyName("types")]
         public HashSet<Type> Types { get; init; }

--- a/Projects/UOContent/Mobiles/Special/Paragon.cs
+++ b/Projects/UOContent/Mobiles/Special/Paragon.cs
@@ -79,6 +79,7 @@ public static class Paragon
 
         bc.PassiveSpeed /= SpeedBuff;
         bc.ActiveSpeed /= SpeedBuff;
+        bc.ScaleMoveSpeed(1.0 / SpeedBuff);
         bc.CurrentSpeed = bc.PassiveSpeed;
 
         bc.DamageMin += DamageBuff;
@@ -143,6 +144,7 @@ public static class Paragon
 
         bc.PassiveSpeed *= SpeedBuff;
         bc.ActiveSpeed *= SpeedBuff;
+        bc.ScaleMoveSpeed(SpeedBuff);
         bc.CurrentSpeed = bc.PassiveSpeed;
 
         bc.DamageMin -= DamageBuff;

--- a/Projects/UOContent/Mobiles/Special/Paragon.cs
+++ b/Projects/UOContent/Mobiles/Special/Paragon.cs
@@ -145,6 +145,7 @@ public static class Paragon
         bc.PassiveSpeed *= SpeedBuff;
         bc.ActiveSpeed *= SpeedBuff;
         bc.ScaleMoveSpeed(SpeedBuff);
+        bc.SnapSpeedsToTable(); // an ulp of scaling drift must not read as hand-tuned
         bc.CurrentSpeed = bc.PassiveSpeed;
 
         bc.DamageMin -= DamageBuff;

--- a/dev-docs/claude-skills/modernuo-content-patterns.md
+++ b/dev-docs/claude-skills/modernuo-content-patterns.md
@@ -23,6 +23,12 @@ description: >
 4. **Clean up timers and references in `OnDelete()`/`OnAfterDelete()`**
 5. **No LINQ** in game logic -- use loops and `PooledRefList<T>`
 6. **File placement** matters -- follow the directory conventions below
+7. **Creature speeds are delays in seconds, on two clocks** -- think
+   (`ActiveSpeed`/`PassiveSpeed`, seconds per AI decision) and move
+   (`ActiveMoveSpeed`/`PassiveMoveSpeed`, seconds per step; inherits think until
+   overridden). Prefer `npc-speeds.json` buckets (`SpeedClass`); `SetSpeed()` sets think
+   AND clears move overrides, `SetMoveSpeed()` sets move only -- see
+   `dev-docs/content-patterns.md` § Creature Speeds
 
 ## New Item Template
 

--- a/dev-docs/content-patterns.md
+++ b/dev-docs/content-patterns.md
@@ -254,6 +254,35 @@ public override int TreasureMapLevel => 3;               // Drops treasure map
 public override double WeaponAbilityChance => 0.4;        // Weapon ability chance
 ```
 
+### Creature Speeds (think vs move clocks)
+
+All "speed" values are **delays in seconds** (smaller = faster). A creature runs two clocks:
+
+- **Think clock** — `ActiveSpeed`/`PassiveSpeed`/`CurrentSpeed`: seconds per AI decision
+  (combat decisions, target acquisition, spell timing).
+- **Move clock** — `ActiveMoveSpeed`/`PassiveMoveSpeed`/`CurrentMoveSpeed`: seconds per
+  step. Inherits the matching think value until overridden, so a creature configured with
+  only think speeds behaves as one clock. Any value is legal — steps are scheduled
+  independently of think ticks, so the two need not divide evenly.
+
+Speeds normally come from `Distribution/Data/npc-speeds.json` (via `SpeedClass` or type
+lists); `activeMove`/`passiveMove` are optional per bucket. Prefer data over code:
+
+```csharp
+public override SpeedLevel SpeedClass => SpeedLevel.Slow;  // bucket in npc-speeds.json
+```
+
+Code-level overrides for special cases:
+
+```csharp
+SetSpeed(0.5, 2.0);          // think clock; ALSO clears move overrides (one-clock legacy semantics)
+SetMoveSpeed(0.45, 0.9);     // move clock only — call after SetSpeed if both are wanted
+ClearMoveSpeed();            // back to inheriting the think clock
+```
+
+All four are `[props`-tunable per instance (move values: set `0` to re-inherit); per-instance
+move overrides serialize. Being badly hurt slows steps, never decisions (RunUO parity).
+
 ---
 
 ## New Spell


### PR DESCRIPTION
Splits creature speed into two clocks so movement pace can be tuned without touching reaction time:

- **Think clock** — `ActiveSpeed`/`PassiveSpeed`/`CurrentSpeed`: seconds per AI decision. Unchanged in meaning, storage, and cadence.
- **Move clock** — `ActiveMoveSpeed`/`PassiveMoveSpeed` (+ resolved `CurrentMoveSpeed`): seconds per step. `0` = inherit the matching think value.

### How

- Move speeds come from optional `activeMove`/`passiveMove` in `npc-speeds.json`, are `[props`-tunable per instance (set `0` to re-inherit), and serialize (BaseCreature v22).
- `SetSpeed()` keeps its legacy one-clock semantics — sets the think clock **and clears move overrides** — so existing callers cannot half-configure a creature. `SetMoveSpeed()`/`ClearMoveSpeed()` configure movement explicitly; `ScaleMoveSpeed()` scales overrides for buffs.
- `CurrentMoveSpeed` is derived by classifying `CurrentSpeed`: a verbatim active/passive think value maps to the matching move value; a bespoke pace written directly (mount boosts, follow sprint) stays fused to both clocks. External `CurrentSpeed` writers need no changes.
- `AITimer` schedules the earlier of the two deadlines. Decisions run at the think cadence exactly as before; while a pursuit/investigation is live, the timer also wakes when the movement budget elapses and advances one step with no decisions. Steps no longer snap to the think grid, so any step delay paces smoothly on the 8ms wheel. A blocked creature schedules no move wakes.
- The movement budget is RunUO's `m_NextMove` accumulate-and-clamp at a full step, so long-run pacing averages `CurrentMoveSpeed` exactly.

### Behavior changes

- **`npc-speeds.json` buckets get RunUO `TransformMoveDelay`-parity move values**: creatures step at RunUO pace while thinking/reacting at current speed. The situational +0.1/+0.2 offsets are deliberately omitted.
- **Existing saves migrate on load**: a pre-v22 creature whose think speeds still match its npc-speeds entry (never hand-tuned) adopts the table's move values — worlds and pets pick up the new pacing without a respawn. Tuned creatures keep movement inheriting their think clock.
- **Paragons scale movement by `SpeedBuff` (1.2x)**: RunUO had no deliberate policy here — dividing by 1.2 knocked most speeds off `TransformMoveDelay`'s exact-equality table (raw pass-through, 2x+ faster), while 0.3/0.6 creatures landed back on it for ~1.33x. This applies the uniform 1.2x the buff always claimed. UnConvert snaps speeds back to exact table values within 1e-4 — /1.2 then ×1.2 drifts 0.45 and 0.9 by an ulp, which would read as hand-tuned (and defeat a future skip-table-conformant-values serialization pass); tuned speeds keep.
- **Herding paces the movement clock**: the old `CurrentSpeed` getter hack is gone. A herded creature walks at a fixed 0.3s/step — RunUO's forced pace, without its `TransformMoveDelay` inflation to 0.6 — so herding is never penalized by a slow creature. Thinking is untouched, and `CheckHerding` walks through `MoveToPoint`, so herded creatures path around obstacles.
- **Badly-hurt slowdown now inflates the step delay only** (RunUO parity), computed from the base each step. Previously it wrote `CurrentSpeed = CurrentSpeed + 0.05..0.15` back on every successful step — compounding unboundedly while hurt and slowing decisions too.
- Removes the vestigial `MoveSpeedMod` (never read, written, or serialized).
- With no bucket or per-instance move values, both clocks carry identical values and creatures pace as before.

### Testing

- Full suite passes (1557, including 12 new `MoveSpeedTests`: resolution classes, `SetSpeed` clearing, `0`-re-inherit, v22 round-trip with exact-consumption check, save migration adopt/skip, buff scale/snap, herding).
- In-game verified via local diagnostics build (per-step budget tracing): steady 700ms step cadence on a 0.3s think grid with one-step catch-up after idle, think grid unperturbed by move wakes.