### PR TITLE
Fix BaseRegion.InitRectangles using X coordinate as upper Z bound

### DIFF
--- a/Projects/UOContent/Regions/BaseRegion.cs
+++ b/Projects/UOContent/Regions/BaseRegion.cs
@@ -113,7 +113,7 @@ public class BaseRegion : Region
                         m_RectBuffer2.RemoveAt(k);
 
                         var sz = rect.Start.Z;
-                        var ez = rect.End.X;
+                        var ez = rect.End.Z;
 
                         if (l1 < l2)
                         {


### PR DESCRIPTION

### **Fix BaseRegion.InitRectangles using X coordinate as upper Z bound**

 `BaseRegion.InitRectangles()` currently initializes the ending Z coordinate with `rect.End.X`:

 ```csharp
 var ez = rect.End.X;
 ```

 `ez` is subsequently used with `sz` when constructing the Z extent of split `Rectangle3D` bounds, so this appears to be a coordinate-axis typo. It should use:

 ```csharp
 var ez = rect.End.Z;
 ```

 For example, given a source area with `X=[1000,1200)` and `Z=[-20,20)`, the current implementation can produce split bounds whose upper Z becomes `1200` rather than `20`.

 This corrupts the vertical extent of the rectangles generated by `InitRectangles()`. `RegionSpawner` uses these generated rectangles as spawn bounds, so the issue is particularly relevant to Z-constrained or vertically overlapping regions.

 Broad/default-Z surface regions can mask the problem because an erroneously large upper-Z bound may still include all normal surface positions.

 The regression test verifies that splitting overlapping areas preserves the original source rectangle's Z interval when `End.X != End.Z`.

------

The defect itself is extremely clear:

```csharp
var sx = rect.Start.X;
var sy = rect.Start.Y;
var sz = rect.Start.Z;

var ex = rect.End.X;
var ey = rect.End.Y;
var ez = rect.End.X; // <- wrong axis
```

and subsequently:

```csharp
new Rectangle3D(
    ...,
    ez - sz
);
```

`ez` can only sensibly be:

```csharp
var ez = rect.End.Z;
```

Consider a perfectly normal UO region:

```text
X: 1000 .. 1200
Y: 2000 .. 2200
Z:  -20 ..   20
```

Correct values:

```text
sz = -20
ez =  20

Z height = 20 - (-20)
         = 40
```

Current bug:

```text
sz = -20
ez = rect.End.X
   = 1200

Z height = 1200 - (-20)
         = 1220
```

So a rectangle intended to cover:

```text
Z -20 .. 20
```

can become a generated split rectangle effectively covering:

```text
Z -20 .. 1200
```

That is **genuine coordinate-axis corruption**.
