### PR TITLE
feat: event-driven target acquisition with a reaction-time gradient

### DIFF
--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace UOContent.Tests.Mobiles.AI;
 
-// Pins the reacquire gate: an empty scan retries quickly, a successful acquire holds its
-// target for the full ReacquireDelay (stickiness). Re-arming the long delay on failure
-// left creatures blind for the whole delay to a player walking up.
+// Pins the reacquire gate and the AcquireOnApproachDelay intelligence gradient: every scan
+// re-arms the full ReacquireDelay; enemy movement clamps the deadline to the approach
+// delay (Zero = instant paragon engage); an illegal deadline self-heals.
 [Collection("Sequential Pathfinding Tests")]
 public class AcquisitionTests : IDisposable
 {
@@ -85,10 +85,10 @@ public class AcquisitionTests : IDisposable
     }
 
     [Theory]
-    [InlineData(true, 5, true)]   // player moving inside perception clamps the deadline
-    [InlineData(false, 5, false)] // non-player movement is ignored
-    [InlineData(true, 20, false)] // outside perception (16) is ignored
-    public void MovementClampsScanDeadlineToNoticeDelay(bool player, int distance, bool notices)
+    [InlineData(false, 5, true)]  // an enemy moving inside notice range clamps the deadline
+    [InlineData(true, 5, false)]  // a same-team wild creature is not an enemy — ignored
+    [InlineData(false, 20, false)] // outside notice range (16) is ignored
+    public void MovementClampsScanDeadlineOnlyForEnemiesInRange(bool wildMover, int distance, bool notices)
     {
         var map = Map.Maps[1];
         Assert.NotNull(map);
@@ -97,10 +97,18 @@ public class AcquisitionTests : IDisposable
         var bc = Spawn(map, new Point3D(1500, 1600, (sbyte)z));
         bc.NextReacquireTime = Core.TickCount + 8000;
 
-        var mover = new TargetStub { Player = player };
-        mover.DefaultMobileInit();
-        mover.MoveToWorld(new Point3D(1500 - distance, 1600, (sbyte)z), map);
-        _created.Add(mover);
+        Mobile mover;
+        if (wildMover)
+        {
+            mover = Spawn(map, new Point3D(1500 - distance, 1600, (sbyte)z));
+        }
+        else
+        {
+            mover = new TargetStub { Player = true };
+            mover.DefaultMobileInit();
+            mover.MoveToWorld(new Point3D(1500 - distance, 1600, (sbyte)z), map);
+            _created.Add(mover);
+        }
 
         bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
 
@@ -109,7 +117,7 @@ public class AcquisitionTests : IDisposable
         if (notices)
         {
             // Clamped to the notice delay (2s), never opened outright.
-            Assert.InRange(remaining, 1, (long)bc.NoticeMovementDelay.TotalMilliseconds);
+            Assert.InRange(remaining, 1, (long)bc.AcquireOnApproachDelay.TotalMilliseconds);
         }
         else
         {
@@ -117,8 +125,44 @@ public class AcquisitionTests : IDisposable
         }
     }
 
+    private sealed class InstantStub : BaseCreature
+    {
+        public InstantStub() : base(AIType.AI_Melee, FightMode.Closest, 16, 1) => Body = 0xC9;
+
+        public override TimeSpan AcquireOnApproachDelay => TimeSpan.Zero;
+
+        public override void GetSpeeds(out double activeSpeed, out double passiveSpeed)
+        {
+            activeSpeed = 0.3;
+            passiveSpeed = 0.6;
+        }
+    }
+
     [Fact]
-    public void RepeatedMovement_DoesNotShortenBelowNoticeDelay()
+    public void ZeroApproachDelay_EngagesInstantly()
+    {
+        var map = Map.Maps[1];
+        Assert.NotNull(map);
+        map.GetAverageZ(1500, 1600, out _, out var z, out _);
+
+        var bc = new InstantStub();
+        bc.MoveToWorld(new Point3D(1500, 1600, (sbyte)z), map);
+        bc.AIObject.AITimer?.Stop();
+        _created.Add(bc);
+        bc.NextReacquireTime = Core.TickCount + 8000;
+
+        var mover = new TargetStub { Player = true };
+        mover.DefaultMobileInit();
+        mover.MoveToWorld(new Point3D(1495, 1600, (sbyte)z), map);
+        _created.Add(mover);
+
+        bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
+
+        Assert.Equal(mover, bc.Combatant);
+    }
+
+    [Fact]
+    public void RepeatedMovement_DoesNotShortenBelowApproachDelay()
     {
         var map = Map.Maps[1];
         Assert.NotNull(map);

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Mobiles;
+using Xunit;
+
+namespace UOContent.Tests.Mobiles.AI;
+
+// Pins the reacquire gate: an empty scan retries quickly, a successful acquire holds its
+// target for the full ReacquireDelay (stickiness). Re-arming the long delay on failure
+// left creatures blind for the whole delay to a player walking up.
+[Collection("Sequential Pathfinding Tests")]
+public class AcquisitionTests : IDisposable
+{
+    private readonly List<Mobile> _created = new();
+
+    public void Dispose()
+    {
+        foreach (var m in _created)
+        {
+            m?.Delete();
+        }
+
+        _created.Clear();
+    }
+
+    private sealed class WildStub : BaseCreature
+    {
+        public WildStub() : base(AIType.AI_Melee, FightMode.Closest, 16, 1) => Body = 0xC9;
+
+        public override void GetSpeeds(out double activeSpeed, out double passiveSpeed)
+        {
+            activeSpeed = 0.3;
+            passiveSpeed = 0.6;
+        }
+    }
+
+    private sealed class TargetStub : Mobile
+    {
+        public TargetStub() => Body = 0x190;
+    }
+
+    private WildStub Spawn(Map map, Point3D loc)
+    {
+        var bc = new WildStub();
+        bc.MoveToWorld(loc, map);
+        bc.AIObject.AITimer?.Stop();
+        _created.Add(bc);
+        return bc;
+    }
+
+    [Fact]
+    public void EmptyScan_RetriesQuickly()
+    {
+        var map = Map.Maps[1];
+        Assert.NotNull(map);
+        map.GetAverageZ(1500, 1600, out _, out var z, out _);
+
+        var bc = Spawn(map, new Point3D(1500, 1600, (sbyte)z));
+        bc.NextReacquireTime = Core.TickCount;
+
+        Assert.False(bc.AIObject.AcquireFocusMob(bc.RangePerception, FightMode.Closest, false, false, true));
+        Assert.InRange(bc.NextReacquireTime - Core.TickCount, 1, 5000);
+    }
+
+    [Fact]
+    public void SuccessfulAcquire_HoldsFullDelay()
+    {
+        var map = Map.Maps[1];
+        Assert.NotNull(map);
+        map.GetAverageZ(1500, 1600, out _, out var z, out _);
+
+        var bc = Spawn(map, new Point3D(1500, 1600, (sbyte)z));
+
+        var target = new TargetStub();
+        target.DefaultMobileInit();
+        target.MoveToWorld(new Point3D(1497, 1600, (sbyte)z), map);
+        _created.Add(target);
+
+        bc.NextReacquireTime = Core.TickCount;
+
+        Assert.True(bc.AIObject.AcquireFocusMob(bc.RangePerception, FightMode.Closest, false, false, true));
+        Assert.Equal(target, bc.FocusMob);
+        Assert.True(bc.NextReacquireTime - Core.TickCount > 5000);
+    }
+}

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -139,7 +139,7 @@ public class AcquisitionTests : IDisposable
     }
 
     [Fact]
-    public void ZeroApproachDelay_EngagesInstantly()
+    public void ZeroApproachDelay_OpensGateImmediately()
     {
         var map = Map.Maps[1];
         Assert.NotNull(map);
@@ -158,7 +158,9 @@ public class AcquisitionTests : IDisposable
 
         bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
 
-        Assert.Equal(mover, bc.Combatant);
+        // Zero = scan on the very next think: the gate is open, no direct engage.
+        Assert.True(Core.TickCount - bc.NextReacquireTime >= 0);
+        Assert.Null(bc.Combatant);
     }
 
     [Fact]

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 
 namespace UOContent.Tests.Mobiles.AI;
 
-// Pins the reacquire gate and the AcquireOnApproachDelay intelligence gradient: every scan
-// re-arms the full ReacquireDelay; enemy movement clamps the deadline to the approach
-// delay (Zero = instant paragon engage); an illegal deadline self-heals.
+// Pins the reacquire gate and the AcquireOnApproachDelay gradient: every scan re-arms the
+// full ReacquireDelay; enemy movement clamps the deadline to the approach delay (Zero =
+// prodded scan); an illegal deadline self-heals.
 [Collection("Sequential Pathfinding Tests")]
 public class AcquisitionTests : IDisposable
 {
@@ -116,7 +116,7 @@ public class AcquisitionTests : IDisposable
 
         if (notices)
         {
-            // Clamped to the notice delay (2s), never opened outright.
+            // Clamped to the approach delay (2s), never opened outright.
             Assert.InRange(remaining, 1, (long)bc.AcquireOnApproachDelay.TotalMilliseconds);
         }
         else

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -158,9 +158,10 @@ public class AcquisitionTests : IDisposable
 
         bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
 
-        // Zero = scan on the very next think: the gate is open, no direct engage.
+        // Zero = the gate opens and the AI is prodded to think now; no direct engage.
         Assert.True(Core.TickCount - bc.NextReacquireTime >= 0);
         Assert.Null(bc.Combatant);
+        Assert.True(bc.AIObject.AITimer.Running);
     }
 
     [Fact]

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -85,9 +85,10 @@ public class AcquisitionTests : IDisposable
     }
 
     [Theory]
-    [InlineData(false, 5, true)]  // an enemy moving inside notice range clamps the deadline
+    [InlineData(false, 5, true)]  // an enemy moving inside approach range (10) clamps the deadline
     [InlineData(true, 5, false)]  // a same-team wild creature is not an enemy — ignored
-    [InlineData(false, 20, false)] // outside notice range (16) is ignored
+    [InlineData(false, 12, false)] // inside RangePerception but outside approach range — poll only
+    [InlineData(false, 20, false)] // outside approach range (10) is ignored
     public void MovementClampsScanDeadlineOnlyForEnemiesInRange(bool wildMover, int distance, bool notices)
     {
         var map = Map.Maps[1];

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -63,6 +63,29 @@ public class AcquisitionTests : IDisposable
         Assert.InRange(bc.NextReacquireTime - Core.TickCount, 1, 5000);
     }
 
+    [Theory]
+    [InlineData(true, 5, true)]   // player moving inside perception opens the gate
+    [InlineData(false, 5, false)] // non-player movement is ignored
+    [InlineData(true, 20, false)] // outside perception (16) is ignored
+    public void MovementOpensGateOnlyForPlayersInPerception(bool player, int distance, bool opens)
+    {
+        var map = Map.Maps[1];
+        Assert.NotNull(map);
+        map.GetAverageZ(1500, 1600, out _, out var z, out _);
+
+        var bc = Spawn(map, new Point3D(1500, 1600, (sbyte)z));
+        bc.NextReacquireTime = Core.TickCount + 8000;
+
+        var mover = new TargetStub { Player = player };
+        mover.DefaultMobileInit();
+        mover.MoveToWorld(new Point3D(1500 - distance, 1600, (sbyte)z), map);
+        _created.Add(mover);
+
+        bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
+
+        Assert.Equal(opens, Core.TickCount - bc.NextReacquireTime >= 0);
+    }
+
     [Fact]
     public void SuccessfulAcquire_HoldsFullDelay()
     {

--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AcquisitionTests.cs
@@ -50,7 +50,7 @@ public class AcquisitionTests : IDisposable
     }
 
     [Fact]
-    public void EmptyScan_RetriesQuickly()
+    public void EmptyScan_HonorsReacquireDelay()
     {
         var map = Map.Maps[1];
         Assert.NotNull(map);
@@ -60,14 +60,35 @@ public class AcquisitionTests : IDisposable
         bc.NextReacquireTime = Core.TickCount;
 
         Assert.False(bc.AIObject.AcquireFocusMob(bc.RangePerception, FightMode.Closest, false, false, true));
-        Assert.InRange(bc.NextReacquireTime - Core.TickCount, 1, 5000);
+        Assert.InRange(bc.NextReacquireTime - Core.TickCount, 5000, 10000);
+    }
+
+    [Fact]
+    public void WedgedGate_SelfHeals()
+    {
+        var map = Map.Maps[1];
+        Assert.NotNull(map);
+        map.GetAverageZ(1500, 1600, out _, out var z, out _);
+
+        var bc = Spawn(map, new Point3D(1500, 1600, (sbyte)z));
+
+        var target = new TargetStub();
+        target.DefaultMobileInit();
+        target.MoveToWorld(new Point3D(1497, 1600, (sbyte)z), map);
+        _created.Add(target);
+
+        // Illegal deadline (beyond ReacquireDelay): must read as open, not block forever.
+        bc.NextReacquireTime = Core.TickCount + 60000;
+
+        Assert.True(bc.AIObject.AcquireFocusMob(bc.RangePerception, FightMode.Closest, false, false, true));
+        Assert.Equal(target, bc.FocusMob);
     }
 
     [Theory]
-    [InlineData(true, 5, true)]   // player moving inside perception opens the gate
+    [InlineData(true, 5, true)]   // player moving inside perception clamps the deadline
     [InlineData(false, 5, false)] // non-player movement is ignored
     [InlineData(true, 20, false)] // outside perception (16) is ignored
-    public void MovementOpensGateOnlyForPlayersInPerception(bool player, int distance, bool opens)
+    public void MovementClampsScanDeadlineToNoticeDelay(bool player, int distance, bool notices)
     {
         var map = Map.Maps[1];
         Assert.NotNull(map);
@@ -83,7 +104,40 @@ public class AcquisitionTests : IDisposable
 
         bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
 
-        Assert.Equal(opens, Core.TickCount - bc.NextReacquireTime >= 0);
+        var remaining = bc.NextReacquireTime - Core.TickCount;
+
+        if (notices)
+        {
+            // Clamped to the notice delay (2s), never opened outright.
+            Assert.InRange(remaining, 1, (long)bc.NoticeMovementDelay.TotalMilliseconds);
+        }
+        else
+        {
+            Assert.True(remaining > 5000);
+        }
+    }
+
+    [Fact]
+    public void RepeatedMovement_DoesNotShortenBelowNoticeDelay()
+    {
+        var map = Map.Maps[1];
+        Assert.NotNull(map);
+        map.GetAverageZ(1500, 1600, out _, out var z, out _);
+
+        var bc = Spawn(map, new Point3D(1500, 1600, (sbyte)z));
+        bc.NextReacquireTime = Core.TickCount + 8000;
+
+        var mover = new TargetStub { Player = true };
+        mover.DefaultMobileInit();
+        mover.MoveToWorld(new Point3D(1495, 1600, (sbyte)z), map);
+        _created.Add(mover);
+
+        bc.OnMovement(mover, new Point3D(1400, 1600, (sbyte)z));
+        var afterFirst = bc.NextReacquireTime;
+
+        bc.OnMovement(mover, new Point3D(1496, 1600, (sbyte)z));
+
+        Assert.Equal(afterFirst, bc.NextReacquireTime);
     }
 
     [Fact]

--- a/Projects/UOContent/Mobiles/AI/ArcherAI.cs
+++ b/Projects/UOContent/Mobiles/AI/ArcherAI.cs
@@ -17,7 +17,7 @@ public class ArcherAI : BaseAI
 
         if (AcquireFocusMob(Mobile.RangePerception, Mobile.FightMode, false, false, true))
         {
-            this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name} and I will attack");
+            this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name}, attacking");
 
             Mobile.Combatant = Mobile.FocusMob;
             Action = ActionType.Combat;

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
@@ -31,7 +31,7 @@ public sealed class AITimer : Timer
     private int _detectHiddenMinDelay;
     private int _detectHiddenMaxDelay;
 
-    public AITimer(BaseAI owner) : base(TimeSpan.FromMilliseconds(Utility.Random(3000)),
+    public AITimer(BaseAI owner) : base(TimeSpan.FromMilliseconds(Utility.Random(256)),
         TimeSpan.FromSeconds(owner.Mobile.CurrentSpeed))
     {
         _owner = owner;
@@ -48,7 +48,11 @@ public sealed class AITimer : Timer
             return;
         }
 
-        Start(); // keeps the stagger Delay
+        // Activation is player-visible (sector wake, spawn, resurrection): a short random
+        // spread wakes the creature within a think while a sector's worth of timers still
+        // avoids a same-tick burst. The construction stagger (up to 3s) read as lag.
+        Delay = TimeSpan.FromMilliseconds(Utility.Random(256));
+        Start();
         _nextWake = Core.TickCount + (long)Delay.TotalMilliseconds;
     }
 

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
@@ -28,6 +28,7 @@ public sealed class AITimer : Timer
     private long _nextThink;
     private long _nextWake; // when the pending wheel entry fires
     private bool _inTick;
+    private bool _spreadPhase;
     private int _detectHiddenMinDelay;
     private int _detectHiddenMaxDelay;
 
@@ -37,11 +38,13 @@ public sealed class AITimer : Timer
         _owner = owner;
         _owner._nextDetectHidden = Core.TickCount;
         _nextThink = Core.TickCount;
+        _spreadPhase = true;
     }
 
     public void Activate()
     {
         _nextThink = Core.TickCount;
+        _spreadPhase = true;
 
         if (Running)
         {
@@ -50,7 +53,8 @@ public sealed class AITimer : Timer
 
         // Activation is player-visible (sector wake, spawn, resurrection): a short random
         // spread wakes the creature within a think while a sector's worth of timers still
-        // avoids a same-tick burst. The construction stagger (up to 3s) read as lag.
+        // avoids a same-tick burst. Cohort desync happens after the first think (see
+        // _spreadPhase) — a long first-wake delay here read as lag.
         Delay = TimeSpan.FromMilliseconds(Utility.Random(256));
         Start();
         _nextWake = Core.TickCount + (long)Delay.TotalMilliseconds;
@@ -152,7 +156,19 @@ public sealed class AITimer : Timer
             }
 
             // Cadence from the post-decision speed (decisions may flip active/passive).
-            _nextThink = Core.TickCount + (long)(_owner.Mobile.CurrentSpeed * 1000);
+            var period = (long)(_owner.Mobile.CurrentSpeed * 1000);
+            _nextThink = Core.TickCount + period;
+
+            if (_spreadPhase)
+            {
+                // One-time desync after a wake: a cohort activated by the same player step
+                // (sector wake, world load) shares a think phase and would move in
+                // lock-step forever — the RunUO town artifact. A random fraction of one
+                // period spreads each creature's cadence without delaying the first,
+                // player-visible think.
+                _spreadPhase = false;
+                _nextThink += Utility.Random((int)Math.Max(1, period));
+            }
         }
         else
         {

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
@@ -28,23 +28,20 @@ public sealed class AITimer : Timer
     private long _nextThink;
     private long _nextWake; // when the pending wheel entry fires
     private bool _inTick;
-    private bool _spreadPhase;
     private int _detectHiddenMinDelay;
     private int _detectHiddenMaxDelay;
 
-    public AITimer(BaseAI owner) : base(TimeSpan.FromMilliseconds(Utility.Random(256)),
-        TimeSpan.FromSeconds(owner.Mobile.CurrentSpeed))
+    // The initial delay is irrelevant: Activate is the only start path and sets its own.
+    public AITimer(BaseAI owner) : base(TimeSpan.Zero, TimeSpan.FromSeconds(owner.Mobile.CurrentSpeed))
     {
         _owner = owner;
         _owner._nextDetectHidden = Core.TickCount;
         _nextThink = Core.TickCount;
-        _spreadPhase = true;
     }
 
     public void Activate()
     {
         _nextThink = Core.TickCount;
-        _spreadPhase = true;
 
         if (Running)
         {
@@ -52,8 +49,8 @@ public sealed class AITimer : Timer
         }
 
         // Short random spread: the creature responds within a think while a sector's
-        // worth of timers avoids a same-tick burst; cohort desync happens after the
-        // first think (see _spreadPhase).
+        // worth of timers avoids a same-tick burst; the idle think jitter keeps the
+        // cohort apart from there.
         Delay = TimeSpan.FromMilliseconds(Utility.Random(256));
         Start();
         _nextWake = Core.TickCount + (long)Delay.TotalMilliseconds;
@@ -158,14 +155,14 @@ public sealed class AITimer : Timer
             var period = (long)(_owner.Mobile.CurrentSpeed * 1000);
             _nextThink = Core.TickCount + period;
 
-            if (_spreadPhase)
+            // Idle cadence drifts: a zero-mean jitter random-walks think phases apart, so
+            // creatures spawned or woken together cannot stay in lock-step (a one-shot
+            // spread can collide and identical periods never separate). Engaged cadence
+            // stays exact — pursuit timing anchors to real step times.
+            if (_owner.Mobile.CurrentSpeed == _owner.Mobile.PassiveSpeed)
             {
-                // One-time desync after a wake: cohorts activated together (sector wake,
-                // world load) share a think phase and would move in lock-step forever. A
-                // random fraction of one period spreads the cadence without delaying the
-                // first think.
-                _spreadPhase = false;
-                _nextThink += Utility.Random((int)Math.Max(1, period));
+                var jitter = (int)(period >> 3);
+                _nextThink += Utility.RandomMinMax(-jitter, jitter);
             }
         }
         else

--- a/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/AITimer.cs
@@ -51,10 +51,9 @@ public sealed class AITimer : Timer
             return;
         }
 
-        // Activation is player-visible (sector wake, spawn, resurrection): a short random
-        // spread wakes the creature within a think while a sector's worth of timers still
-        // avoids a same-tick burst. Cohort desync happens after the first think (see
-        // _spreadPhase) — a long first-wake delay here read as lag.
+        // Short random spread: the creature responds within a think while a sector's
+        // worth of timers avoids a same-tick burst; cohort desync happens after the
+        // first think (see _spreadPhase).
         Delay = TimeSpan.FromMilliseconds(Utility.Random(256));
         Start();
         _nextWake = Core.TickCount + (long)Delay.TotalMilliseconds;
@@ -161,11 +160,10 @@ public sealed class AITimer : Timer
 
             if (_spreadPhase)
             {
-                // One-time desync after a wake: a cohort activated by the same player step
-                // (sector wake, world load) shares a think phase and would move in
-                // lock-step forever — the RunUO town artifact. A random fraction of one
-                // period spreads each creature's cadence without delaying the first,
-                // player-visible think.
+                // One-time desync after a wake: cohorts activated together (sector wake,
+                // world load) share a think phase and would move in lock-step forever. A
+                // random fraction of one period spreads the cadence without delaying the
+                // first think.
                 _spreadPhase = false;
                 _nextThink += Utility.Random((int)Math.Max(1, period));
             }

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -853,9 +853,8 @@ public abstract partial class BaseAI
         var reacquireDelay = (long)Mobile.ReacquireDelay.TotalMilliseconds;
         var gateRemaining = Mobile.NextReacquireTime - Core.TickCount;
 
-        // Self-healing gate: nothing may legally arm the deadline further out than
-        // ReacquireDelay, so a wedged or wrapped value cannot silence acquisition —
-        // it reads as open and the scan below re-arms it sanely.
+        // Nothing may legally arm the deadline further out than ReacquireDelay: a wedged
+        // or wrapped value reads as open instead of silencing acquisition.
         if (gateRemaining > 0 && gateRemaining <= reacquireDelay)
         {
             Mobile.FocusMob = null;

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -861,8 +861,6 @@ public abstract partial class BaseAI
             return false;
         }
 
-        // No cooldown re-arm: this precedes every AI's "detected X" transition message,
-        // which a re-arm here would swallow.
         DebugSay("Acquiring new target...", 0);
 
         var acquired = AcquireNewFocusMob(Mobile.Map, iRange, acqType, bPlayerOnly, bFacFriend, bFacFoe);

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -868,8 +868,8 @@ public abstract partial class BaseAI
 
         var acquired = AcquireNewFocusMob(Mobile.Map, iRange, acqType, bPlayerOnly, bFacFriend, bFacFoe);
 
-        // Reaction time is the movement-notice path (BaseCreature.NoticeMovement), not
-        // this poll — every scan honors the full delay.
+        // Reaction time is the approach path (BaseCreature.ScheduleAcquireOnApproach),
+        // not this poll — every scan honors the full delay.
         Mobile.NextReacquireTime = Core.TickCount + reacquireDelay;
 
         return acquired;

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -856,16 +856,17 @@ public abstract partial class BaseAI
             return false;
         }
 
-        Mobile.NextReacquireTime = Core.TickCount + (int)Mobile.ReacquireDelay.TotalMilliseconds;
-
         DebugSay("Acquiring new target...");
 
-        if (Mobile.Map == null)
-        {
-            return Mobile.FocusMob != null;
-        }
+        var acquired = AcquireNewFocusMob(Mobile.Map, iRange, acqType, bPlayerOnly, bFacFriend, bFacFoe);
 
-        return AcquireNewFocusMob(Mobile.Map, iRange, acqType, bPlayerOnly, bFacFriend, bFacFoe);
+        // A successful acquire holds for the full delay; an empty scan retries quickly.
+        // Re-arming the long delay on failure left a creature blind for the whole delay
+        // to a player walking up (walk-up aggro latency uniform in 0..ReacquireDelay).
+        Mobile.NextReacquireTime = Core.TickCount +
+            (int)(acquired ? Mobile.ReacquireDelay : Mobile.FailedReacquireDelay).TotalMilliseconds;
+
+        return acquired;
     }
 
     private bool HandleBardProvoked()

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -856,7 +856,9 @@ public abstract partial class BaseAI
             return false;
         }
 
-        DebugSay("Acquiring new target...");
+        // No cooldown re-arm: this precedes every AI's "detected X" transition message,
+        // which a re-arm here would swallow.
+        DebugSay("Acquiring new target...", 0);
 
         var acquired = AcquireNewFocusMob(Mobile.Map, iRange, acqType, bPlayerOnly, bFacFriend, bFacFoe);
 
@@ -942,8 +944,10 @@ public abstract partial class BaseAI
 
     private bool AcquireNewFocusMob(Map map, int iRange, FightMode acqType, bool bPlayerOnly, bool bFacFriend, bool bFacFoe)
     {
-        Mobile newFocusMob = null, enemySummonMob = null;
-        double val = double.MinValue, enemySummonVal = double.MinValue;
+        Mobile newFocusMob = null;
+        Mobile enemySummonMob = null;
+        var val = double.MinValue;
+        var enemySummonVal = double.MinValue;
 
         foreach (var m in map.GetMobilesInRange(Mobile.Location, iRange))
         {

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -853,8 +853,6 @@ public abstract partial class BaseAI
         var reacquireDelay = (long)Mobile.ReacquireDelay.TotalMilliseconds;
         var gateRemaining = Mobile.NextReacquireTime - Core.TickCount;
 
-        // Nothing may legally arm the deadline further out than ReacquireDelay: a wedged
-        // or wrapped value reads as open instead of silencing acquisition.
         if (gateRemaining > 0 && gateRemaining <= reacquireDelay)
         {
             Mobile.FocusMob = null;

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -850,7 +850,13 @@ public abstract partial class BaseAI
             return false;
         }
 
-        if (Core.TickCount - Mobile.NextReacquireTime < 0)
+        var reacquireDelay = (long)Mobile.ReacquireDelay.TotalMilliseconds;
+        var gateRemaining = Mobile.NextReacquireTime - Core.TickCount;
+
+        // Self-healing gate: nothing may legally arm the deadline further out than
+        // ReacquireDelay, so a wedged or wrapped value cannot silence acquisition —
+        // it reads as open and the scan below re-arms it sanely.
+        if (gateRemaining > 0 && gateRemaining <= reacquireDelay)
         {
             Mobile.FocusMob = null;
             return false;
@@ -862,11 +868,9 @@ public abstract partial class BaseAI
 
         var acquired = AcquireNewFocusMob(Mobile.Map, iRange, acqType, bPlayerOnly, bFacFriend, bFacFoe);
 
-        // A successful acquire holds for the full delay; an empty scan retries quickly.
-        // Re-arming the long delay on failure left a creature blind for the whole delay
-        // to a player walking up (walk-up aggro latency uniform in 0..ReacquireDelay).
-        Mobile.NextReacquireTime = Core.TickCount +
-            (int)(acquired ? Mobile.ReacquireDelay : Mobile.FailedReacquireDelay).TotalMilliseconds;
+        // Reaction time is the movement-notice path (BaseCreature.NoticeMovement), not
+        // this poll — every scan honors the full delay.
+        Mobile.NextReacquireTime = Core.TickCount + reacquireDelay;
 
         return acquired;
     }

--- a/Projects/UOContent/Mobiles/AI/BerserkAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BerserkAI.cs
@@ -12,7 +12,7 @@ public class BerserkAI : BaseAI
 
         if (AcquireFocusMob(Mobile.RangePerception, FightMode.Closest, false, true, true))
         {
-            this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name} and I will attack");
+            this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name}, attacking");
 
             Mobile.Combatant = Mobile.FocusMob;
             Action = ActionType.Combat;

--- a/Projects/UOContent/Mobiles/AI/MeleeAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MeleeAI.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Server.Mobiles;
 
 public class MeleeAI : BaseAI
@@ -14,6 +16,7 @@ public class MeleeAI : BaseAI
         if (AcquireFocusMob(Mobile.RangePerception, Mobile.FightMode, false, false, true))
         {
             this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name}, attacking");
+
             Mobile.Combatant = Mobile.FocusMob;
             Action = ActionType.Combat;
         }
@@ -65,13 +68,9 @@ public class MeleeAI : BaseAI
         return true;
     }
 
-    private bool IsValidCombatant(Mobile combatant)
-    {
-        return combatant?.Deleted == false 
-               && combatant.Map == Mobile.Map 
-               && combatant.Alive 
-               && !combatant.IsDeadBondedPet;
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsValidCombatant(Mobile combatant) =>
+        combatant?.Deleted == false && combatant.Map == Mobile.Map && combatant.Alive && !combatant.IsDeadBondedPet;
 
     private bool HandleOutOfRangeCombatant(Mobile combatant)
     {
@@ -127,7 +126,8 @@ public class MeleeAI : BaseAI
     {
         if (AcquireFocusMob(Mobile.RangePerception, Mobile.FightMode, false, false, true))
         {
-            this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name}, attacking.");
+            this.DebugSayFormatted($"I have detected {Mobile.FocusMob.Name}, attacking");
+
             Mobile.Combatant = Mobile.FocusMob;
             Action = ActionType.Combat;
         }

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -2053,8 +2053,6 @@ namespace Server.Mobiles
         {
             base.Deserialize(reader);
 
-            // Not serialized; the 0 default blocks acquisition on hosts whose tick counter
-            // starts negative (tick fields must seed from a live tick, never rely on 0).
             NextReacquireTime = Core.TickCount;
 
             var version = reader.ReadInt();

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -953,7 +953,9 @@ namespace Server.Mobiles
         // think; larger is dumber; pure ReacquireDelay is the oblivious floor.
         public virtual TimeSpan AcquireOnApproachDelay => m_Paragon ? TimeSpan.Zero : TimeSpan.FromSeconds(2.0);
 
-        public virtual int AcquireOnApproachRange => m_Paragon ? 10 : RangePerception;
+        // Reactive range is tighter than the periodic scan's RangePerception: approach
+        // aggro starts on-screen; the ReacquireDelay poll keeps the wide ambient sweep.
+        public virtual int AcquireOnApproachRange => 10;
 
         // Clamps the scan deadline rather than opening the gate: repeated steps cannot
         // shorten it further, so an armed creature scans once per delay period.

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -961,11 +961,20 @@ namespace Server.Mobiles
         // creature yields one scan per delay period, not one per think.
         private void ScheduleAcquireOnApproach()
         {
-            var deadline = Core.TickCount + (long)AcquireOnApproachDelay.TotalMilliseconds;
+            var delay = (long)AcquireOnApproachDelay.TotalMilliseconds;
+            var deadline = Core.TickCount + delay;
 
             if (deadline - NextReacquireTime < 0)
             {
                 NextReacquireTime = deadline;
+            }
+
+            if (delay <= 0)
+            {
+                // Zero-delay (paragon snap): think now — the ranked scan engages within a
+                // wheel turn instead of waiting out the think cadence. Prod is spam-safe
+                // and the Combatant == null guard ends it once engaged.
+                AIObject?.AITimer?.Prod();
             }
         }
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -948,21 +948,31 @@ namespace Server.Mobiles
 
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);
 
-        // Retry pace after a scan that found nothing; the full ReacquireDelay applies only
-        // after a successful acquire, as target stickiness. Walk-up aggro does not wait on
-        // this — a player moving inside perception opens the gate (ShouldNoticeMovement);
-        // this is the fallback for what movement cannot signal (reveals, doors, summons).
-        public virtual TimeSpan FailedReacquireDelay => TimeSpan.FromSeconds(4.0);
+        // Reaction-time knob: a player moving inside perception pulls the next scan to at
+        // most this far away (see NoticeMovement). The intelligence ladder:
+        // AcquireOnApproach (instant, forced engage) > ReacquireOnMovement (scan next
+        // think) > this bounded notice (default) > pure ReacquireDelay (oblivious).
+        public virtual TimeSpan NoticeMovementDelay => TimeSpan.FromSeconds(2.0);
 
-        // A gate-blocked creature notices a player moving inside its perception and scans
-        // on its next think — walk-up aggro without per-second polling. Not the paragon
-        // insta-acquire (AcquireOnApproach): the think cadence keeps the reaction unhurried.
+        // Bounded notice: clamp the scan deadline instead of opening the gate — repeated
+        // steps cannot shorten it further, so a player moving beside an armed creature
+        // yields one scan per notice period, not one per think.
+        private void NoticeMovement()
+        {
+            var notice = Core.TickCount + (long)NoticeMovementDelay.TotalMilliseconds;
+
+            if (notice - NextReacquireTime < 0)
+            {
+                NextReacquireTime = notice;
+            }
+        }
+
         private bool ShouldNoticeMovement(Mobile m) =>
             Combatant == null && m.Player && !m.Hidden &&
-            Core.TickCount - NextReacquireTime < 0 &&
             !Controlled && !Summoned && !BardPacified &&
             FightMode != FightMode.None && FightMode != FightMode.Aggressor &&
             InRange(m.Location, RangePerception);
+
         public virtual bool ReacquireOnMovement => false;
         public virtual bool AcquireOnApproach => m_Paragon;
         public virtual int AcquireOnApproachRange => 10;
@@ -2885,9 +2895,13 @@ namespace Server.Mobiles
                     DoHarmful(m);
                 }
             }
-            else if (ReacquireOnMovement || ShouldNoticeMovement(m))
+            else if (ReacquireOnMovement)
             {
                 ForceReacquire();
+            }
+            else if (ShouldNoticeMovement(m))
+            {
+                NoticeMovement();
             }
 
             SpeechType?.OnMovement(this, m, oldLocation);

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -949,10 +949,9 @@ namespace Server.Mobiles
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);
 
         // The intelligence gradient (formerly the AcquireOnApproach bool): an enemy moving
-        // inside AcquireOnApproachRange pulls the next scan to at most this far away. Zero
-        // engages instantly on movement — the old paragon behavior. Ladder: Zero (instant,
-        // forced engage) > ReacquireOnMovement (scan next think) > bounded delay (default)
-        // > pure ReacquireDelay (oblivious).
+        // inside AcquireOnApproachRange pulls the next scan to at most this far away —
+        // Zero (paragons) scans on the very next think, larger is dumber, and pure
+        // ReacquireDelay (no approach reaction) is the oblivious floor.
         public virtual TimeSpan AcquireOnApproachDelay => m_Paragon ? TimeSpan.Zero : TimeSpan.FromSeconds(2.0);
 
         public virtual int AcquireOnApproachRange => m_Paragon ? 10 : RangePerception;
@@ -2890,22 +2889,13 @@ namespace Server.Mobiles
 
         public override void OnMovement(Mobile m, Point3D oldLocation)
         {
-            var acquireOnApproach = ShouldAcquireOnApproach(m);
-
-            if (acquireOnApproach && AcquireOnApproachDelay <= TimeSpan.Zero)
+            if (ShouldAcquireOnApproach(m))
             {
-                // The gradient's floor: instant engage (the old paragon behavior).
-                Combatant = FocusMob = m;
-                AIObject?.MoveTo(m, 1);
-                DoHarmful(m);
+                ScheduleAcquireOnApproach();
             }
             else if (ReacquireOnMovement)
             {
                 ForceReacquire();
-            }
-            else if (acquireOnApproach)
-            {
-                ScheduleAcquireOnApproach();
             }
 
             SpeechType?.OnMovement(this, m, oldLocation);

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -936,14 +936,6 @@ namespace Server.Mobiles
 
         public virtual bool GivesMLMinorArtifact => false;
 
-        /* To save on cpu usage, RunUO creatures only reacquire creatures under the following circumstances:
-         *  - 10 seconds have elapsed since the last time it tried
-         *  - The creature was attacked
-         *  - Some creatures, like dragons, will reacquire when they see someone move
-         *
-         * This functionality appears to be implemented on OSI as well
-         */
-
         public long NextReacquireTime { get; set; }
 
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -948,34 +948,39 @@ namespace Server.Mobiles
 
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);
 
-        // Reaction-time knob: a player moving inside perception pulls the next scan to at
-        // most this far away (see NoticeMovement). The intelligence ladder:
-        // AcquireOnApproach (instant, forced engage) > ReacquireOnMovement (scan next
-        // think) > this bounded notice (default) > pure ReacquireDelay (oblivious).
-        public virtual TimeSpan NoticeMovementDelay => TimeSpan.FromSeconds(2.0);
+        // The intelligence gradient (formerly the AcquireOnApproach bool): an enemy moving
+        // inside AcquireOnApproachRange pulls the next scan to at most this far away. Zero
+        // engages instantly on movement — the old paragon behavior. Ladder: Zero (instant,
+        // forced engage) > ReacquireOnMovement (scan next think) > bounded delay (default)
+        // > pure ReacquireDelay (oblivious).
+        public virtual TimeSpan AcquireOnApproachDelay => m_Paragon ? TimeSpan.Zero : TimeSpan.FromSeconds(2.0);
 
-        // Bounded notice: clamp the scan deadline instead of opening the gate — repeated
-        // steps cannot shorten it further, so a player moving beside an armed creature
-        // yields one scan per notice period, not one per think.
-        private void NoticeMovement()
+        public virtual int AcquireOnApproachRange => m_Paragon ? 10 : RangePerception;
+
+        // Bounded approach-acquire: clamp the scan deadline instead of opening the gate —
+        // repeated steps cannot shorten it further, so an enemy moving beside an armed
+        // creature yields one scan per delay period, not one per think.
+        private void ScheduleAcquireOnApproach()
         {
-            var notice = Core.TickCount + (long)NoticeMovementDelay.TotalMilliseconds;
+            var deadline = Core.TickCount + (long)AcquireOnApproachDelay.TotalMilliseconds;
 
-            if (notice - NextReacquireTime < 0)
+            if (deadline - NextReacquireTime < 0)
             {
-                NextReacquireTime = notice;
+                NextReacquireTime = deadline;
             }
         }
 
-        private bool ShouldNoticeMovement(Mobile m) =>
-            Combatant == null && m.Player && !m.Hidden &&
+        // IsEnemy first: it cheaply rejects the common case (a same-team wild creature
+        // wandering past another) before CanBeHarmful's notoriety work; CanBeHarmful also
+        // covers hidden movers via CanSee.
+        private bool ShouldAcquireOnApproach(Mobile m) =>
+            Combatant == null &&
             !Controlled && !Summoned && !BardPacified &&
             FightMode != FightMode.None && FightMode != FightMode.Aggressor &&
-            InRange(m.Location, RangePerception);
+            InRange(m.Location, AcquireOnApproachRange) &&
+            IsEnemy(m) && CanBeHarmful(m, false);
 
         public virtual bool ReacquireOnMovement => false;
-        public virtual bool AcquireOnApproach => m_Paragon;
-        public virtual int AcquireOnApproachRange => 10;
 
         public static bool Summoning { get; set; }
 
@@ -2885,23 +2890,22 @@ namespace Server.Mobiles
 
         public override void OnMovement(Mobile m, Point3D oldLocation)
         {
-            if (AcquireOnApproach && !Controlled && !Summoned && !BardPacified && FightMode != FightMode.Aggressor)
+            var acquireOnApproach = ShouldAcquireOnApproach(m);
+
+            if (acquireOnApproach && AcquireOnApproachDelay <= TimeSpan.Zero)
             {
-                if (InRange(m.Location, AcquireOnApproachRange) && !InRange(oldLocation, AcquireOnApproachRange) &&
-                    CanBeHarmful(m) && IsEnemy(m))
-                {
-                    Combatant = FocusMob = m;
-                    AIObject?.MoveTo(m, 1);
-                    DoHarmful(m);
-                }
+                // The gradient's floor: instant engage (the old paragon behavior).
+                Combatant = FocusMob = m;
+                AIObject?.MoveTo(m, 1);
+                DoHarmful(m);
             }
             else if (ReacquireOnMovement)
             {
                 ForceReacquire();
             }
-            else if (ShouldNoticeMovement(m))
+            else if (acquireOnApproach)
             {
-                NoticeMovement();
+                ScheduleAcquireOnApproach();
             }
 
             SpeechType?.OnMovement(this, m, oldLocation);

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -947,6 +947,10 @@ namespace Server.Mobiles
         public long NextReacquireTime { get; set; }
 
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);
+
+        // Retry pace after a scan that found nothing; the full ReacquireDelay applies only
+        // after a successful acquire, as target stickiness.
+        public virtual TimeSpan FailedReacquireDelay => TimeSpan.FromSeconds(1.0);
         public virtual bool ReacquireOnMovement => false;
         public virtual bool AcquireOnApproach => m_Paragon;
         public virtual int AcquireOnApproachRange => 10;
@@ -2023,6 +2027,10 @@ namespace Server.Mobiles
         public override void Deserialize(IGenericReader reader)
         {
             base.Deserialize(reader);
+
+            // Not serialized; the 0 default blocks acquisition on hosts whose tick counter
+            // starts negative (tick fields must seed from a live tick, never rely on 0).
+            NextReacquireTime = Core.TickCount;
 
             var version = reader.ReadInt();
 

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -948,17 +948,15 @@ namespace Server.Mobiles
 
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);
 
-        // The intelligence gradient (formerly the AcquireOnApproach bool): an enemy moving
-        // inside AcquireOnApproachRange pulls the next scan to at most this far away —
-        // Zero (paragons) scans on the very next think, larger is dumber, and pure
-        // ReacquireDelay (no approach reaction) is the oblivious floor.
+        // Reaction-time gradient: an enemy moving inside AcquireOnApproachRange pulls the
+        // next scan to at most this far away. Zero (paragons) scans on the very next
+        // think; larger is dumber; pure ReacquireDelay is the oblivious floor.
         public virtual TimeSpan AcquireOnApproachDelay => m_Paragon ? TimeSpan.Zero : TimeSpan.FromSeconds(2.0);
 
         public virtual int AcquireOnApproachRange => m_Paragon ? 10 : RangePerception;
 
-        // Bounded approach-acquire: clamp the scan deadline instead of opening the gate —
-        // repeated steps cannot shorten it further, so an enemy moving beside an armed
-        // creature yields one scan per delay period, not one per think.
+        // Clamps the scan deadline rather than opening the gate: repeated steps cannot
+        // shorten it further, so an armed creature scans once per delay period.
         private void ScheduleAcquireOnApproach()
         {
             var delay = (long)AcquireOnApproachDelay.TotalMilliseconds;
@@ -971,16 +969,14 @@ namespace Server.Mobiles
 
             if (delay <= 0)
             {
-                // Zero-delay (paragon snap): think now — the ranked scan engages within a
-                // wheel turn instead of waiting out the think cadence. Prod is spam-safe
-                // and the Combatant == null guard ends it once engaged.
+                // Zero: think now — the ranked scan engages within a wheel turn. Prod is
+                // spam-safe; the Combatant == null guard stops the prods once engaged.
                 AIObject?.AITimer?.Prod();
             }
         }
 
-        // IsEnemy first: it cheaply rejects the common case (a same-team wild creature
-        // wandering past another) before CanBeHarmful's notoriety work; CanBeHarmful also
-        // covers hidden movers via CanSee.
+        // IsEnemy first — it cheaply rejects the common case (a same-team wild creature
+        // wandering past); CanBeHarmful covers hidden movers via CanSee.
         private bool ShouldAcquireOnApproach(Mobile m) =>
             Combatant == null &&
             !Controlled && !Summoned && !BardPacified &&

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -949,8 +949,20 @@ namespace Server.Mobiles
         public virtual TimeSpan ReacquireDelay => TimeSpan.FromSeconds(10.0);
 
         // Retry pace after a scan that found nothing; the full ReacquireDelay applies only
-        // after a successful acquire, as target stickiness.
-        public virtual TimeSpan FailedReacquireDelay => TimeSpan.FromSeconds(1.0);
+        // after a successful acquire, as target stickiness. Walk-up aggro does not wait on
+        // this — a player moving inside perception opens the gate (ShouldNoticeMovement);
+        // this is the fallback for what movement cannot signal (reveals, doors, summons).
+        public virtual TimeSpan FailedReacquireDelay => TimeSpan.FromSeconds(4.0);
+
+        // A gate-blocked creature notices a player moving inside its perception and scans
+        // on its next think — walk-up aggro without per-second polling. Not the paragon
+        // insta-acquire (AcquireOnApproach): the think cadence keeps the reaction unhurried.
+        private bool ShouldNoticeMovement(Mobile m) =>
+            Combatant == null && m.Player && !m.Hidden &&
+            Core.TickCount - NextReacquireTime < 0 &&
+            !Controlled && !Summoned && !BardPacified &&
+            FightMode != FightMode.None && FightMode != FightMode.Aggressor &&
+            InRange(m.Location, RangePerception);
         public virtual bool ReacquireOnMovement => false;
         public virtual bool AcquireOnApproach => m_Paragon;
         public virtual int AcquireOnApproachRange => 10;
@@ -2873,7 +2885,7 @@ namespace Server.Mobiles
                     DoHarmful(m);
                 }
             }
-            else if (ReacquireOnMovement)
+            else if (ReacquireOnMovement || ShouldNoticeMovement(m))
             {
                 ForceReacquire();
             }

--- a/dev-docs/claude-skills/migrate-from-runuo/migrate-items-mobiles.md
+++ b/dev-docs/claude-skills/migrate-from-runuo/migrate-items-mobiles.md
@@ -30,6 +30,7 @@ description: >
 - `Name = "text"` -> `public override string DefaultName => "text";`
 - Expression-bodied overrides: `public override int Meat { get { return 1; } }` -> `public override int Meat => 1;`
 - AI movement calls lose the `run` flag: `MoveTo(m, true, range)` -> `MoveTo(m, range)` (also `WalkMobileRange`, `ApproachTarget`, `MoveToPoint`, `PathFollower.Follow`); the Running bit is derived from step pace -> `dev-docs/runuo-migration-docs/09-items-mobiles-creatures.md` § AI Movement
+- `AcquireOnApproach` (bool) -> `AcquireOnApproachDelay` (TimeSpan; `Zero` = old instant behavior) -> same doc § Target Acquisition
 
 ## Anti-Patterns
 - Using `_field--` instead of `Property--` (bypasses MarkDirty tracking)

--- a/dev-docs/claude-skills/modernuo-content-patterns.md
+++ b/dev-docs/claude-skills/modernuo-content-patterns.md
@@ -29,7 +29,9 @@ description: >
    overridden). Prefer `npc-speeds.json` buckets (`SpeedClass`); `SetSpeed()` sets think
    AND clears move overrides, `SetMoveSpeed()` sets move only. The client `Running` bit is
    derived from the step pace (`BaseAI.ShouldRun`); movement APIs take no run argument --
-   see `dev-docs/content-patterns.md` § Creature Speeds
+   see `dev-docs/content-patterns.md` § Creature Speeds. Reaction time to approaching
+   enemies is `AcquireOnApproachDelay` (TimeSpan gradient; `Zero` = paragon snap, 2s
+   default, `ReacquireDelay`-only = oblivious) -- see § Target Acquisition
 8. **`OnThink` overrides must be excess-call tolerant** -- it fires more often than the
    think cadence (player commands prod it; speed-ups reschedule it). Gate consequential
    work on a tick-count deadline (subtraction form) or make it idempotent; bare per-call

--- a/dev-docs/content-patterns.md
+++ b/dev-docs/content-patterns.md
@@ -295,6 +295,23 @@ flood the client's step queue. Movement APIs (`MoveTo`, `WalkMobileRange`,
 fast. Creatures step at most once per `CurrentMoveSpeed` period, paced from the step just
 taken — a stall never banks catch-up steps, so a resumed chase restarts at full pace.
 
+### Target Acquisition: the reaction-time gradient
+
+Acquisition is event-driven, not polled. The periodic scan (`AcquireFocusMob`) is gated by
+`ReacquireDelay` (10 s default) and every scan re-arms it in full, success or failure — it
+is target stickiness plus the fallback for what movement cannot signal (reveals, doors,
+summons). Reaction time comes from `BaseCreature.OnMovement`: an enemy moving inside
+`AcquireOnApproachRange` (paragons 10, default `RangePerception`) clamps the next scan to
+at most **`AcquireOnApproachDelay`** — the intelligence gradient. `TimeSpan.Zero`
+(paragons) also prods the AI, so the ranked scan engages within a timer-wheel turn; the
+2 s default reads as "took a beat to notice you"; larger is dumber; a creature that
+overrides the delay above `ReacquireDelay` is effectively oblivious to approach. Repeated
+steps cannot shorten the clamp, so an armed creature scans once per delay period, not once
+per step or think. `ReacquireOnMovement` remains the broader hook (any mover, no enemy
+check, scan next think). The gate self-heals: a deadline further out than `ReacquireDelay`
+is illegal and reads as open, so no wedged or wrapped value can silence acquisition beyond
+one delay period.
+
 ### OnThink: the excess-call contract
 
 `OnThink()` is a scheduler pass, not an action. The AI timer calls it *at least* at the

--- a/dev-docs/content-patterns.md
+++ b/dev-docs/content-patterns.md
@@ -301,7 +301,8 @@ Acquisition is event-driven, not polled. The periodic scan (`AcquireFocusMob`) i
 `ReacquireDelay` (10 s default) and every scan re-arms it in full, success or failure — it
 is target stickiness plus the fallback for what movement cannot signal (reveals, doors,
 summons). Reaction time comes from `BaseCreature.OnMovement`: an enemy moving inside
-`AcquireOnApproachRange` (paragons 10, default `RangePerception`) clamps the next scan to
+`AcquireOnApproachRange` (10 — on-screen; the periodic scan keeps the wider
+`RangePerception`) clamps the next scan to
 at most **`AcquireOnApproachDelay`** — the intelligence gradient. `TimeSpan.Zero`
 (paragons) also prods the AI, so the ranked scan engages within a timer-wheel turn; the
 2 s default reads as "took a beat to notice you"; larger is dumber; a creature that

--- a/dev-docs/runuo-migration-docs/09-items-mobiles-creatures.md
+++ b/dev-docs/runuo-migration-docs/09-items-mobiles-creatures.md
@@ -512,7 +512,8 @@ public override bool AcquireOnApproach => true;
 public override TimeSpan AcquireOnApproachDelay => TimeSpan.Zero;
 ```
 
-`AcquireOnApproachRange` now defaults to `RangePerception` (paragons keep 10). The
+`AcquireOnApproachRange` stays 10 for all creatures (reactive aggro is on-screen; the
+periodic `ReacquireDelay` scan still sweeps the full `RangePerception`). The
 acquired target comes from the normal FightMode-ranked scan, not from whichever mobile
 happened to move. See `content-patterns.md` § Target Acquisition.
 

--- a/dev-docs/runuo-migration-docs/09-items-mobiles-creatures.md
+++ b/dev-docs/runuo-migration-docs/09-items-mobiles-creatures.md
@@ -497,6 +497,25 @@ An isolated step (after the creature stood for at least a walk interval) goes ou
 walk regardless of pace — only a continuing cadence, or a pace faster than the run
 interpolation, flags run.
 
+## Target Acquisition: `AcquireOnApproach` Is a Delay
+
+RunUO's `AcquireOnApproach` bool (paragon insta-aggro on approach) is now
+`AcquireOnApproachDelay`, a `TimeSpan` reaction-time gradient that applies to every
+creature — enemy movement inside `AcquireOnApproachRange` schedules a scan within the
+delay instead of waiting out the 10 s `ReacquireDelay` poll:
+
+```csharp
+// RunUO
+public override bool AcquireOnApproach => true;
+
+// ModernUO — Zero is the old instant behavior; larger values are dumber
+public override TimeSpan AcquireOnApproachDelay => TimeSpan.Zero;
+```
+
+`AcquireOnApproachRange` now defaults to `RangePerception` (paragons keep 10). The
+acquired target comes from the normal FightMode-ranked scan, not from whichever mobile
+happened to move. See `content-patterns.md` § Target Acquisition.
+
 ## Item Name Changes
 
 ```csharp

--- a/dev-docs/runuo-migration-docs/11-api-reference.md
+++ b/dev-docs/runuo-migration-docs/11-api-reference.md
@@ -133,6 +133,7 @@ Alphabetical by RunUO API name. Use Ctrl+F / Cmd+F to search.
 | `MoveTo(m, run, range)` | `MoveTo(m, range)` | `run` removed; the Running bit is derived from the step pace (`BaseAI.ShouldRun`) |
 | `WalkMobileRange(m, steps, run, min, max)` | `WalkMobileRange(m, steps, min, max)` | Same |
 | `PathFollower.Follow(run, range)` | `Follow(range)` | Same |
+| `AcquireOnApproach` (bool) | `AcquireOnApproachDelay` (TimeSpan) | Reaction-time gradient; `Zero` = old instant behavior |
 
 ## Networking
 


### PR DESCRIPTION
Fixes walk-up aggro latency (up to a full 10 s of obliviousness) and hardens the reacquire gate so no state can silence acquisition, while turning `AcquireOnApproach` into the reaction-time knob for future per-creature intelligence tuning.

### Why

`AcquireFocusMob` re-armed the 10 s `ReacquireDelay` **before** scanning, success or failure. A creature that scanned an empty room was blind for 10 s to a player walking up — walk-up aggro latency was uniform in 0..10 s. Waking from sector sleep stacked the AI timer's 0–3 s construction stagger on top. And `NextReacquireTime` is not serialized: on hosts whose tick counter starts negative (GCP pass-through), the 0 default blocked **all** acquisition shard-wide after a restart until the counter crossed zero.

### What

**Event-driven reaction — `AcquireOnApproachDelay` (the intelligence gradient)**
- The paragon `AcquireOnApproach` bool becomes a `TimeSpan` on every creature: an enemy moving inside `AcquireOnApproachRange` (10 for all creatures — on-screen reactive aggro; the periodic scan keeps the wide `RangePerception` sweep) *clamps* the next scan to at most the delay. Repeated steps cannot shorten it further — one scan per delay period, not per step or think.
- `Zero` (paragons) also prods the AI timer: the ranked scan engages within a wheel turn — the old snap, minus the special-cased engage path. The target now comes from the normal FightMode ranking instead of whichever mobile happened to move, and the `Combatant == null` guard stops re-engage spam.
- The 2 s default reads as "took a beat to notice you"; larger values are dumber; `ReacquireDelay` alone is the oblivious floor. Mover checks are the approach logic's `IsEnemy` + `CanBeHarmful` (so pets count and hidden movers are excluded via `CanSee`), with `IsEnemy` first to cheaply reject same-team wild creatures wandering past. The check rides the `OnMovement` callback every step already pays for — no polling added.

**Gate correctness**
- Every scan re-arms the full `ReacquireDelay`, success or failure (classic semantics; reaction time is the approach path, not the poll).
- Self-healing by construction: a deadline further out than `ReacquireDelay` is an illegal state and reads as open — no wedged or wrapped value can silence acquisition beyond one delay period.
- `NextReacquireTime` is seeded from a live tick on deserialize (the GCP negative-tick blackout).

**AI timer wake**
- Activation (sector wake, spawn, resurrection) starts within a 0–256 ms spread instead of the 0–3 s construction stagger, which read as lag.
- The stagger's real job — keeping same-speed cohorts out of lock-step (the RunUO town artifact) — is now a zero-mean ±period/8 jitter on each **idle** think, so phases random-walk apart within seconds and can never re-lock. Instrumentation showed why a one-shot spread can't do this job: the timer wheel fires within ±1 ms, so with 10 creatures on a 500 ms period some pair collides on nearly the same phase ~75% of the time (birthday paradox) and then steps in the same loop iteration *forever*. Jitter is scoped to passive speed: engaged cadence stays exact, since pursuit timing anchors to real step times.

**Debug**
- The `AcquireFocusMob` scan message no longer re-arms the shared 5 s debug cooldown, which swallowed every AI's "I have detected X" transition line.

**API change** for custom scripts: `AcquireOnApproach` (bool) → `AcquireOnApproachDelay` (TimeSpan). Documented in `content-patterns.md` § Target Acquisition, `runuo-migration-docs/09` + `11`, and the migration skill checklist.

### Tests

`AcquisitionTests`: both scan outcomes honor `ReacquireDelay`; a 60 s-wedged gate still acquires; enemy movement clamps the deadline (same-team wild movers and out-of-range movers ignored); repeated movement cannot shorten below the delay; `Zero` opens the gate and prods without a direct engage. Full suite: 755 UOContent green.