### PR TITLE
fix: delete the bonus item, not the primary yield, when the bonus cannot be placed

### DIFF
--- a/Projects/UOContent/Engines/Harvest/Core/HarvestSystem.cs
+++ b/Projects/UOContent/Engines/Harvest/Core/HarvestSystem.cs
@@ -219,7 +219,7 @@ namespace Server.Engines.Harvest
                             }
                             else
                             {
-                                item.Delete();
+                                bonusItem?.Delete();
                             }
                         }
 


### PR DESCRIPTION
The bonus-resource failure branch deletes the primary yield, which was already given to the player, instead of the bonus item. Practically unreachable today, but the wrong-variable delete is latent and would eat the player's harvested item the moment Give gets a real failure reason, so worth fixing now.