### PR TITLE
perf: keep aggressor lists inline in LastCombatTime order

### DIFF
--- a/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
+++ b/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
@@ -134,7 +134,61 @@ public class AggressorListTests
     }
 
     [Fact]
-    public void RemoveAggressor_UnlinksAndEmpties()
+    public void RepeatAggression_RelinksAggressedSideToTail()
+    {
+        var victim = new TestMobile();
+        var a = new TestMobile();
+        var b = new TestMobile();
+        var c = new TestMobile();
+
+        try
+        {
+            a.AggressiveAction(victim, criminal: false);
+            b.AggressiveAction(victim, criminal: false);
+            c.AggressiveAction(victim, criminal: false);
+            b.AggressiveAction(victim, criminal: false); // b was in the middle of the aggressed list
+
+            Assert.Equal(new[] { a, c, b }, Defenders(victim));
+        }
+        finally
+        {
+            victim.Delete();
+            a.Delete();
+            b.Delete();
+            c.Delete();
+        }
+    }
+
+    [Fact]
+    public void MutualCombat_KeepsOnePairedRecord_AndDeleteClearsPeer()
+    {
+        var victim = new TestMobile();
+        var attacker = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(attacker, criminal: false);
+            attacker.AggressiveAction(victim, criminal: false); // fighting back does not add a second pair
+
+            Assert.Equal(1, victim.Aggressors.Count);
+            Assert.Equal(1, attacker.Aggressed.Count);
+            Assert.Equal(0, attacker.Aggressors.Count);
+            Assert.Equal(0, victim.Aggressed.Count);
+
+            attacker.Delete();
+
+            Assert.Equal(0, victim.Aggressors.Count);
+            Assert.False(victim.HasAggressors);
+        }
+        finally
+        {
+            victim.Delete();
+            attacker.Delete(); // deleting twice is a no-op
+        }
+    }
+
+    [Fact]
+    public void RemoveAggression_UnlinksBothHalves()
     {
         var victim = new TestMobile();
         var attacker = new TestMobile();

--- a/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
+++ b/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
@@ -53,38 +53,6 @@ public class AggressorListTests
     }
 
     [Fact]
-    public void AddAggressor_AppendsWithoutDedupe()
-    {
-        var victim = new TestMobile();
-        var attacker = new TestMobile();
-
-        try
-        {
-            victim.AddAggressor(attacker, criminal: true);
-
-            Assert.True(victim.HasAggressors);
-            Assert.Equal(1, victim.Aggressors.Count);
-            Assert.Same(attacker, Attackers(victim)[0]);
-
-            foreach (var info in victim.Aggressors)
-            {
-                Assert.Same(victim, info.Defender);
-                Assert.True(info.CriminalAggression);
-                Assert.True(info.OnLinkList);
-            }
-
-            // Append-only, like the pet-defense path it replaces.
-            victim.AddAggressor(attacker, criminal: false);
-            Assert.Equal(2, victim.Aggressors.Count);
-        }
-        finally
-        {
-            victim.Delete();
-            attacker.Delete();
-        }
-    }
-
-    [Fact]
     public void AggressiveAction_PopulatesBothSides()
     {
         var victim = new TestMobile();
@@ -140,37 +108,6 @@ public class AggressorListTests
     }
 
     [Fact]
-    public void RepeatAggression_RefreshesEveryDuplicateOnce()
-    {
-        var start = Core._now;
-        var victim = new TestMobile();
-        var a = new TestMobile();
-
-        try
-        {
-            // Two one-sided entries for the same attacker, as the pet-defense path produces.
-            victim.AddAggressor(a, criminal: false);
-            victim.AddAggressor(a, criminal: false);
-
-            Core._now = start + TimeSpan.FromSeconds(30);
-            victim.AggressiveAction(a, criminal: false);
-
-            Assert.Equal(2, victim.Aggressors.Count); // refreshed in place, no third entry
-
-            foreach (var info in victim.Aggressors)
-            {
-                Assert.Equal(Core._now, info.LastCombatTime);
-            }
-        }
-        finally
-        {
-            Core._now = start;
-            victim.Delete();
-            a.Delete();
-        }
-    }
-
-    [Fact]
     public void RepeatAggression_RelinksMiddleEntryToTail()
     {
         var victim = new TestMobile();
@@ -211,10 +148,11 @@ public class AggressorListTests
                 entry = info;
             }
 
-            victim.RemoveAggressor(attacker);
+            victim.RemoveAggression(attacker);
 
             Assert.Equal(0, victim.Aggressors.Count);
             Assert.False(victim.HasAggressors);
+            Assert.Equal(0, attacker.Aggressed.Count); // both halves of the pair are gone
 
             // The entry has been returned to the pool; Next/Previous/OnLinkList are the only
             // members safe to read after Free().
@@ -237,8 +175,7 @@ public class AggressorListTests
 
         try
         {
-            m.RemoveAggressor(other);
-            m.RemoveAggressed(other);
+            m.RemoveAggression(other);
 
             Assert.Equal(0, m.Aggressors.Count);
             Assert.Equal(0, m.Aggressed.Count);

--- a/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
+++ b/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
@@ -23,6 +23,17 @@ public class AggressorListTests
         return result;
     }
 
+    private static List<Mobile> Defenders(Mobile attacker)
+    {
+        var result = new List<Mobile>();
+        foreach (var info in attacker.Aggressed)
+        {
+            result.Add(info.Defender);
+        }
+
+        return result;
+    }
+
     [Fact]
     public void FreshMobile_HasEmptyListsAndNoAggression()
     {
@@ -129,6 +140,63 @@ public class AggressorListTests
     }
 
     [Fact]
+    public void RepeatAggression_RefreshesEveryDuplicateOnce()
+    {
+        var start = Core._now;
+        var victim = new TestMobile();
+        var a = new TestMobile();
+
+        try
+        {
+            // Two one-sided entries for the same attacker, as the pet-defense path produces.
+            victim.AddAggressor(a, criminal: false);
+            victim.AddAggressor(a, criminal: false);
+
+            Core._now = start + TimeSpan.FromSeconds(30);
+            victim.AggressiveAction(a, criminal: false);
+
+            Assert.Equal(2, victim.Aggressors.Count); // refreshed in place, no third entry
+
+            foreach (var info in victim.Aggressors)
+            {
+                Assert.Equal(Core._now, info.LastCombatTime);
+            }
+        }
+        finally
+        {
+            Core._now = start;
+            victim.Delete();
+            a.Delete();
+        }
+    }
+
+    [Fact]
+    public void RepeatAggression_RelinksMiddleEntryToTail()
+    {
+        var victim = new TestMobile();
+        var a = new TestMobile();
+        var b = new TestMobile();
+        var c = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(a, criminal: false);
+            victim.AggressiveAction(b, criminal: false);
+            victim.AggressiveAction(c, criminal: false);
+            victim.AggressiveAction(b, criminal: false); // b was in the middle
+
+            Assert.Equal(new[] { a, c, b }, Attackers(victim));
+        }
+        finally
+        {
+            victim.Delete();
+            a.Delete();
+            b.Delete();
+            c.Delete();
+        }
+    }
+
+    [Fact]
     public void RemoveAggressor_UnlinksAndEmpties()
     {
         var victim = new TestMobile();
@@ -147,6 +215,9 @@ public class AggressorListTests
 
             Assert.Equal(0, victim.Aggressors.Count);
             Assert.False(victim.HasAggressors);
+
+            // The entry has been returned to the pool; Next/Previous/OnLinkList are the only
+            // members safe to read after Free().
             Assert.False(entry.OnLinkList);
             Assert.Null(entry.Next);
             Assert.Null(entry.Previous);
@@ -180,27 +251,35 @@ public class AggressorListTests
     }
 
     [Fact]
-    public void Expiry_PopsOnlyTheExpiredHeadPrefix_OnBothSides()
+    public void Expiry_RemovesExpiredEntries_OnBothSides()
     {
         var start = Core._now;
         var victim = new TestMobile();
         var a = new TestMobile();
         var b = new TestMobile();
+        var c = new TestMobile();
+        var d = new TestMobile();
 
         try
         {
-            victim.AggressiveAction(a, criminal: false);
+            victim.AggressiveAction(a, criminal: false); // a attacks victim
+            c.AggressiveAction(victim, criminal: false); // victim attacks c
 
             Core._now = start + TimeSpan.FromMinutes(1);
-            victim.AggressiveAction(b, criminal: false);
+            victim.AggressiveAction(b, criminal: false); // b attacks victim
+            d.AggressiveAction(victim, criminal: false); // victim attacks d
 
-            // a is 2.5 min old (expired at 2 min); b is 1.5 min old (live)
+            // a and c are 2.5 min old (expired at 2 min); b and d are 1.5 min old (live)
             Core._now = start + TimeSpan.FromMinutes(2.5);
             victim.CheckAggrExpire();
 
             Assert.Equal(new[] { b }, Attackers(victim));
-            Assert.Equal(0, a.Aggressed.Count);   // peer entry removed too
+            Assert.Equal(new[] { d }, Defenders(victim));
+
+            Assert.Equal(0, a.Aggressed.Count);    // peer entries removed too
+            Assert.Equal(0, c.Aggressors.Count);
             Assert.Equal(1, b.Aggressed.Count);
+            Assert.Equal(1, d.Aggressors.Count);
         }
         finally
         {
@@ -208,6 +287,8 @@ public class AggressorListTests
             victim.Delete();
             a.Delete();
             b.Delete();
+            c.Delete();
+            d.Delete();
         }
     }
 

--- a/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
+++ b/Projects/Server.Tests/Tests/Mobiles/AggressorListTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using Server.Collections;
+using Xunit;
+
+namespace Server.Tests;
+
+[Collection("Sequential Server Tests")]
+public class AggressorListTests
+{
+    private class TestMobile : Mobile
+    {
+    }
+
+    private static List<Mobile> Attackers(Mobile victim)
+    {
+        var result = new List<Mobile>();
+        foreach (var info in victim.Aggressors)
+        {
+            result.Add(info.Attacker);
+        }
+
+        return result;
+    }
+
+    [Fact]
+    public void FreshMobile_HasEmptyListsAndNoAggression()
+    {
+        var m = new TestMobile();
+
+        try
+        {
+            Assert.Equal(0, m.Aggressors.Count);
+            Assert.Equal(0, m.Aggressed.Count);
+            Assert.False(m.HasAggressors);
+            Assert.False(m.HasAggressed);
+        }
+        finally
+        {
+            m.Delete();
+        }
+    }
+
+    [Fact]
+    public void AddAggressor_AppendsWithoutDedupe()
+    {
+        var victim = new TestMobile();
+        var attacker = new TestMobile();
+
+        try
+        {
+            victim.AddAggressor(attacker, criminal: true);
+
+            Assert.True(victim.HasAggressors);
+            Assert.Equal(1, victim.Aggressors.Count);
+            Assert.Same(attacker, Attackers(victim)[0]);
+
+            foreach (var info in victim.Aggressors)
+            {
+                Assert.Same(victim, info.Defender);
+                Assert.True(info.CriminalAggression);
+                Assert.True(info.OnLinkList);
+            }
+
+            // Append-only, like the pet-defense path it replaces.
+            victim.AddAggressor(attacker, criminal: false);
+            Assert.Equal(2, victim.Aggressors.Count);
+        }
+        finally
+        {
+            victim.Delete();
+            attacker.Delete();
+        }
+    }
+
+    [Fact]
+    public void AggressiveAction_PopulatesBothSides()
+    {
+        var victim = new TestMobile();
+        var attacker = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(attacker, criminal: false);
+
+            Assert.True(victim.HasAggressors);
+            Assert.Equal(1, victim.Aggressors.Count);
+            Assert.Same(attacker, Attackers(victim)[0]);
+
+            Assert.True(attacker.HasAggressed);
+            Assert.Equal(1, attacker.Aggressed.Count);
+            foreach (var info in attacker.Aggressed)
+            {
+                Assert.Same(victim, info.Defender);
+            }
+
+            Assert.False(victim.HasAggressed);
+            Assert.False(attacker.HasAggressors);
+        }
+        finally
+        {
+            victim.Delete();
+            attacker.Delete();
+        }
+    }
+
+    [Fact]
+    public void RepeatAggression_RefreshesAndMovesToTail()
+    {
+        var victim = new TestMobile();
+        var a = new TestMobile();
+        var b = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(a, criminal: false);
+            victim.AggressiveAction(b, criminal: false);
+            victim.AggressiveAction(a, criminal: false); // a refreshed, now most recent
+
+            Assert.Equal(2, victim.Aggressors.Count);
+            Assert.Equal(new[] { b, a }, Attackers(victim));
+        }
+        finally
+        {
+            victim.Delete();
+            a.Delete();
+            b.Delete();
+        }
+    }
+
+    [Fact]
+    public void RemoveAggressor_UnlinksAndEmpties()
+    {
+        var victim = new TestMobile();
+        var attacker = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(attacker, criminal: false);
+            AggressorInfo entry = null;
+            foreach (var info in victim.Aggressors)
+            {
+                entry = info;
+            }
+
+            victim.RemoveAggressor(attacker);
+
+            Assert.Equal(0, victim.Aggressors.Count);
+            Assert.False(victim.HasAggressors);
+            Assert.False(entry.OnLinkList);
+            Assert.Null(entry.Next);
+            Assert.Null(entry.Previous);
+        }
+        finally
+        {
+            victim.Delete();
+            attacker.Delete();
+        }
+    }
+
+    [Fact]
+    public void RemoveOnEmptyLists_IsNoOp()
+    {
+        var m = new TestMobile();
+        var other = new TestMobile();
+
+        try
+        {
+            m.RemoveAggressor(other);
+            m.RemoveAggressed(other);
+
+            Assert.Equal(0, m.Aggressors.Count);
+            Assert.Equal(0, m.Aggressed.Count);
+        }
+        finally
+        {
+            m.Delete();
+            other.Delete();
+        }
+    }
+
+    [Fact]
+    public void Expiry_PopsOnlyTheExpiredHeadPrefix_OnBothSides()
+    {
+        var start = Core._now;
+        var victim = new TestMobile();
+        var a = new TestMobile();
+        var b = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(a, criminal: false);
+
+            Core._now = start + TimeSpan.FromMinutes(1);
+            victim.AggressiveAction(b, criminal: false);
+
+            // a is 2.5 min old (expired at 2 min); b is 1.5 min old (live)
+            Core._now = start + TimeSpan.FromMinutes(2.5);
+            victim.CheckAggrExpire();
+
+            Assert.Equal(new[] { b }, Attackers(victim));
+            Assert.Equal(0, a.Aggressed.Count);   // peer entry removed too
+            Assert.Equal(1, b.Aggressed.Count);
+        }
+        finally
+        {
+            Core._now = start;
+            victim.Delete();
+            a.Delete();
+            b.Delete();
+        }
+    }
+
+    [Fact]
+    public void DeletingAPeer_UnlinksImmediately()
+    {
+        var victim = new TestMobile();
+        var attacker = new TestMobile();
+
+        try
+        {
+            victim.AggressiveAction(attacker, criminal: false);
+            Assert.Equal(1, victim.Aggressors.Count);
+
+            attacker.Delete();
+
+            Assert.Equal(0, victim.Aggressors.Count);
+            Assert.False(victim.HasAggressors);
+        }
+        finally
+        {
+            victim.Delete();
+            attacker.Delete();
+        }
+    }
+}

--- a/Projects/Server/Mobiles/AggressorInfo.cs
+++ b/Projects/Server/Mobiles/AggressorInfo.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Server.Collections;
 
 namespace Server;
 
-public class AggressorInfo
+public class AggressorInfo : IValueLinkListNode<AggressorInfo>
 {
     private static readonly Queue<AggressorInfo> m_Pool = new();
     private Mobile m_Attacker, m_Defender;
@@ -147,6 +148,11 @@ public class AggressorInfo
         }
     }
 
+    // Intrusive links for Mobile._aggressors / _aggressed. Each info is on exactly one list.
+    public AggressorInfo Next { get; set; }
+    public AggressorInfo Previous { get; set; }
+    public bool OnLinkList { get; set; }
+
     public static AggressorInfo Create(Mobile attacker, Mobile defender, bool criminal)
     {
         AggressorInfo info;
@@ -175,6 +181,8 @@ public class AggressorInfo
 
     public void Free()
     {
+        Debug.Assert(!OnLinkList, "AggressorInfo must be unlinked before it is freed.");
+
         if (m_Queued)
         {
             return;

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -707,30 +707,20 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     /// <c>.ByDescending()</c>; use <see cref="HasAggressors"/> for emptiness checks.
     /// Calling a ValueLinkList mutator on this reference compiles, but operates on a defensive
     /// copy while still unlinking the real nodes — it silently corrupts the list. Mutate only
-    /// through <see cref="AggressiveAction(Mobile, bool)"/>, <see cref="AddAggressor"/>, and
-    /// <see cref="RemoveAggressor"/>.
+    /// through <see cref="AggressiveAction(Mobile, bool)"/> and <see cref="RemoveAggression"/>.
     /// </summary>
     public ref readonly ValueLinkList<AggressorInfo> Aggressors => ref _aggressors;
 
     /// <summary>
     /// Mobiles this mobile has attacked, ordered least recent (head) to most recent (tail).
     /// Same rules as <see cref="Aggressors"/>; mutate only through
-    /// <see cref="AggressiveAction(Mobile, bool)"/> and <see cref="RemoveAggressed"/>.
+    /// <see cref="AggressiveAction(Mobile, bool)"/> and <see cref="RemoveAggression"/>.
     /// </summary>
     public ref readonly ValueLinkList<AggressorInfo> Aggressed => ref _aggressed;
 
     public bool HasAggressors => _aggressors.Count > 0;
 
     public bool HasAggressed => _aggressed.Count > 0;
-
-    /// <summary>
-    /// Appends an aggressor record without the dedupe and refresh logic of
-    /// <see cref="AggressiveAction(Mobile, bool)"/>. Used by pets defending their master.
-    /// </summary>
-    public void AddAggressor(Mobile attacker, bool criminal)
-    {
-        _aggressors.AddLast(AggressorInfo.Create(attacker, this, criminal));
-    }
 
     // Refreshes an entry and moves it to the tail so the list stays in LastCombatTime order.
     private static void RefreshAggression(ref ValueLinkList<AggressorInfo> list, AggressorInfo info)
@@ -3453,48 +3443,43 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         _expireAggrTimerToken.Cancel();
     }
 
-    // Both lists are ordered by LastCombatTime (RefreshAggression relinks on every refresh), but
-    // Expired is also true when a party is Deleted and one-sided entries (AddAggressor) can sit
-    // anywhere, so this walks the whole list. n is small; the walk captures Next before unlinking.
+    // Both lists are ordered by LastCombatTime (RefreshAggression relinks on every refresh), so
+    // time-expired entries are a head prefix. Expired is also true when a party is Deleted; that
+    // case is handled by the deleted mobile's own OnAfterDelete expiry pass, which unlinks the
+    // twin record on every peer. Records are always paired (AggressiveAction creates both halves,
+    // RemoveAggression removes both, the one-sided removers are private), so no entry can be
+    // stranded behind a live head.
     internal void CheckAggrExpire()
     {
-        for (var info = _aggressors._first; info != null;)
+        for (var info = _aggressors._first; info != null && info.Expired;)
         {
             var next = info.Next;
+            var attacker = info.Attacker;
 
-            if (info.Expired)
+            attacker.RemoveAggressed(this);
+            _aggressors.Remove(info);
+            info.Free();
+
+            if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
             {
-                var attacker = info.Attacker;
-
-                attacker.RemoveAggressed(this);
-                _aggressors.Remove(info);
-                info.Free();
-
-                if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
-                {
-                    m_NetState.SendMobileIncoming(this, attacker);
-                }
+                m_NetState.SendMobileIncoming(this, attacker);
             }
 
             info = next;
         }
 
-        for (var info = _aggressed._first; info != null;)
+        for (var info = _aggressed._first; info != null && info.Expired;)
         {
             var next = info.Next;
+            var defender = info.Defender;
 
-            if (info.Expired)
+            defender.RemoveAggressor(this);
+            _aggressed.Remove(info);
+            info.Free();
+
+            if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
             {
-                var defender = info.Defender;
-
-                defender.RemoveAggressor(this);
-                _aggressed.Remove(info);
-                info.Free();
-
-                if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
-                {
-                    m_NetState.SendMobileIncoming(this, defender);
-                }
+                m_NetState.SendMobileIncoming(this, defender);
             }
 
             info = next;
@@ -3955,7 +3940,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         Region.OnAggressed(aggressor, this, criminal);
     }
 
-    public void RemoveAggressed(Mobile aggressed)
+    private void RemoveAggressed(Mobile aggressed)
     {
         if (Deleted)
         {
@@ -3985,7 +3970,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         UpdateAggrExpire();
     }
 
-    public void RemoveAggressor(Mobile aggressor)
+    private void RemoveAggressor(Mobile aggressor)
     {
         if (Deleted)
         {
@@ -4013,6 +3998,24 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         }
 
         UpdateAggrExpire();
+    }
+
+    /// <summary>
+    /// Removes every aggression record between this mobile and <paramref name="other"/>, in
+    /// both directions on both mobiles. Records are always paired, so this is the only
+    /// public removal; one-sided removal would strand the twin record.
+    /// </summary>
+    public void RemoveAggression(Mobile other)
+    {
+        if (other == null || other == this)
+        {
+            return;
+        }
+
+        RemoveAggressor(other);
+        RemoveAggressed(other);
+        other.RemoveAggressor(this);
+        other.RemoveAggressed(this);
     }
 
     public virtual int GetTotal(TotalType type) =>

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -379,8 +379,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     {
         m_Region = Map.Internal.DefaultRegion;
         Serial = serial;
-        Aggressors = new List<AggressorInfo>();
-        Aggressed = new List<AggressorInfo>();
         NextSkillTime = Core.TickCount;
     }
 
@@ -700,9 +698,47 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     [CommandProperty(AccessLevel.Administrator)]
     public long NextSkillTime { get; set; }
 
-    public List<AggressorInfo> Aggressors { get; private set; }
+    private ValueLinkList<AggressorInfo> _aggressors;
+    private ValueLinkList<AggressorInfo> _aggressed;
 
-    public List<AggressorInfo> Aggressed { get; private set; }
+    /// <summary>
+    /// Mobiles that have attacked this mobile, ordered least recent (head) to most recent (tail)
+    /// by <see cref="AggressorInfo.LastCombatTime"/>. Enumerate with <c>foreach</c> or
+    /// <c>.ByDescending()</c>; use <see cref="HasAggressors"/> for emptiness checks.
+    /// Calling a ValueLinkList mutator on this reference compiles, but operates on a defensive
+    /// copy while still unlinking the real nodes — it silently corrupts the list. Mutate only
+    /// through <see cref="AggressiveAction(Mobile, bool)"/>, <see cref="AddAggressor"/>, and
+    /// <see cref="RemoveAggressor"/>.
+    /// </summary>
+    public ref readonly ValueLinkList<AggressorInfo> Aggressors => ref _aggressors;
+
+    /// <summary>
+    /// Mobiles this mobile has attacked, ordered least recent (head) to most recent (tail).
+    /// Same rules as <see cref="Aggressors"/>; mutate only through
+    /// <see cref="AggressiveAction(Mobile, bool)"/> and <see cref="RemoveAggressed"/>.
+    /// </summary>
+    public ref readonly ValueLinkList<AggressorInfo> Aggressed => ref _aggressed;
+
+    public bool HasAggressors => _aggressors.Count > 0;
+
+    public bool HasAggressed => _aggressed.Count > 0;
+
+    /// <summary>
+    /// Appends an aggressor record without the dedupe and refresh logic of
+    /// <see cref="AggressiveAction(Mobile, bool)"/>. Used by pets defending their master.
+    /// </summary>
+    public void AddAggressor(Mobile attacker, bool criminal)
+    {
+        _aggressors.AddLast(AggressorInfo.Create(attacker, this, criminal));
+    }
+
+    // Refreshes an entry and moves it to the tail so the list stays in LastCombatTime order.
+    private static void RefreshAggression(ref ValueLinkList<AggressorInfo> list, AggressorInfo info)
+    {
+        info.Refresh();
+        list.Remove(info);
+        list.AddLast(info);
+    }
 
     public bool ChangingCombatant => m_ChangingCombatant > 0;
 
@@ -2035,9 +2071,9 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             {
                 m_HitsTimer?.Stop();
 
-                for (var i = 0; i < Aggressors.Count; i++) // reset reports on full HP
+                for (var info = _aggressors._first; info != null; info = info.Next) // reset reports on full HP
                 {
-                    Aggressors[i].CanReportMurder = false;
+                    info.CanReportMurder = false;
                 }
 
                 ClearDamageEntries(); // reset damage entries on full HP
@@ -2504,6 +2540,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         m_Map?.OnLeave(this);
         m_Map = null;
+
+        ClearAggressions();
 
         m_MountItem = null;
 
@@ -3390,7 +3428,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
     private void UpdateAggrExpire()
     {
-        if (Deleted || Aggressors.Count == 0 && Aggressed.Count == 0)
+        if (Deleted || !HasAggressors && !HasAggressed)
         {
             StopAggrExpire();
         }
@@ -3402,7 +3440,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
     private void ExpireAggr()
     {
-        if (Deleted || Aggressors.Count == 0 && Aggressed.Count == 0)
+        if (Deleted || !HasAggressors && !HasAggressed)
         {
             StopAggrExpire();
         }
@@ -3417,54 +3455,72 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         _expireAggrTimerToken.Cancel();
     }
 
-    private void CheckAggrExpire()
+    // Unlinks this mobile from every peer's aggression list now, instead of leaving entries whose
+    // Expired reports true (Deleted) for the peer's expiry timer to find. Keeps the lists' expired
+    // entries a pure head prefix.
+    private void ClearAggressions()
     {
-        for (var i = Aggressors.Count - 1; i >= 0; --i)
+        for (var info = _aggressors._first; info != null;)
         {
-            if (i >= Aggressors.Count)
-            {
-                continue;
-            }
+            var next = info.Next;
 
-            var info = Aggressors[i];
+            info.Attacker.RemoveAggressed(this);
+            _aggressors.Remove(info);
+            info.Free();
 
-            if (info.Expired)
-            {
-                var attacker = info.Attacker;
-                attacker.RemoveAggressed(this);
-
-                Aggressors.RemoveAt(i);
-                info.Free();
-
-                if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
-                {
-                    m_NetState.SendMobileIncoming(this, attacker);
-                }
-            }
+            info = next;
         }
 
-        for (var i = Aggressed.Count - 1; i >= 0; --i)
+        for (var info = _aggressed._first; info != null;)
         {
-            if (i >= Aggressed.Count)
+            var next = info.Next;
+
+            info.Defender.RemoveAggressor(this);
+            _aggressed.Remove(info);
+            info.Free();
+
+            info = next;
+        }
+
+        StopAggrExpire();
+    }
+
+    // Both lists are ordered by LastCombatTime, so time-expired entries are a head prefix.
+    // A deleted peer is unlinked eagerly by Delete(), so Expired's Deleted case never lingers here.
+    internal void CheckAggrExpire()
+    {
+        for (var info = _aggressors._first; info != null && info.Expired;)
+        {
+            var next = info.Next;
+            var attacker = info.Attacker;
+
+            attacker.RemoveAggressed(this);
+            _aggressors.Remove(info);
+            info.Free();
+
+            if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
             {
-                continue;
+                m_NetState.SendMobileIncoming(this, attacker);
             }
 
-            var info = Aggressed[i];
+            info = next;
+        }
 
-            if (info.Expired)
+        for (var info = _aggressed._first; info != null && info.Expired;)
+        {
+            var next = info.Next;
+            var defender = info.Defender;
+
+            defender.RemoveAggressor(this);
+            _aggressed.Remove(info);
+            info.Free();
+
+            if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
             {
-                var defender = info.Defender;
-                defender.RemoveAggressor(this);
-
-                Aggressed.RemoveAt(i);
-                info.Free();
-
-                if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
-                {
-                    m_NetState.SendMobileIncoming(this, defender);
-                }
+                m_NetState.SendMobileIncoming(this, defender);
             }
+
+            info = next;
         }
 
         UpdateAggrExpire();
@@ -3812,79 +3868,77 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         var addAggressor = true;
 
-        var list = Aggressors;
-
-        for (var i = 0; i < list.Count; ++i)
+        var last = _aggressors._last;
+        for (var info = _aggressors._first; info != null;)
         {
-            var info = list[i];
+            var next = info == last ? null : info.Next;
 
             if (info.Attacker == aggressor)
             {
-                info.Refresh();
+                RefreshAggression(ref _aggressors, info);
                 info.CriminalAggression = criminal;
                 info.CanReportMurder = criminal;
 
                 addAggressor = false;
             }
+
+            info = next;
         }
 
-        list = aggressor.Aggressors;
-
-        for (var i = 0; i < list.Count; ++i)
+        last = aggressor._aggressors._last;
+        for (var info = aggressor._aggressors._first; info != null;)
         {
-            var info = list[i];
+            var next = info == last ? null : info.Next;
 
             if (info.Attacker == this)
             {
-                info.Refresh();
+                RefreshAggression(ref aggressor._aggressors, info);
 
                 addAggressor = false;
             }
+
+            info = next;
         }
 
         var addAggressed = true;
 
-        list = Aggressed;
-
-        for (var i = 0; i < list.Count; ++i)
+        last = _aggressed._last;
+        for (var info = _aggressed._first; info != null;)
         {
-            var info = list[i];
+            var next = info == last ? null : info.Next;
 
             if (info.Defender == aggressor)
             {
-                info.Refresh();
+                RefreshAggression(ref _aggressed, info);
 
                 addAggressed = false;
             }
+
+            info = next;
         }
 
-        list = aggressor.Aggressed;
-
-        for (var i = 0; i < list.Count; ++i)
+        last = aggressor._aggressed._last;
+        for (var info = aggressor._aggressed._first; info != null;)
         {
-            var info = list[i];
+            var next = info == last ? null : info.Next;
 
             if (info.Defender == this)
             {
-                info.Refresh();
+                RefreshAggression(ref aggressor._aggressed, info);
                 info.CriminalAggression = criminal;
                 info.CanReportMurder = criminal;
 
                 addAggressed = false;
             }
+
+            info = next;
         }
 
         var setCombatant = false;
 
         if (addAggressor)
         {
-            Aggressors.Add(
-                AggressorInfo.Create(
-                    aggressor,
-                    this,
-                    criminal
-                )
-            );
+            _aggressors.AddLast(AggressorInfo.Create(aggressor, this, criminal));
 
             if (CanSee(aggressor))
             {
@@ -3901,13 +3955,7 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
         if (addAggressed)
         {
-            aggressor.Aggressed.Add(
-                AggressorInfo.Create(
-                    aggressor,
-                    this,
-                    criminal
-                )
-            );
+            aggressor._aggressed.AddLast(AggressorInfo.Create(aggressor, this, criminal));
 
             if (CanSee(aggressor))
             {
@@ -3937,15 +3985,11 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var list = Aggressed;
-
-        for (var i = 0; i < list.Count; ++i)
+        for (var info = _aggressed._first; info != null; info = info.Next)
         {
-            var info = list[i];
-
             if (info.Defender == aggressed)
             {
-                Aggressed.RemoveAt(i);
+                _aggressed.Remove(info);
                 info.Free();
 
                 if (m_NetState != null && CanSee(aggressed))
@@ -3967,15 +4011,11 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        var list = Aggressors;
-
-        for (var i = 0; i < list.Count; ++i)
+        for (var info = _aggressors._first; info != null; info = info.Next)
         {
-            var info = list[i];
-
             if (info.Attacker == aggressor)
             {
-                Aggressors.RemoveAt(i);
+                _aggressors.Remove(info);
                 info.Free();
 
                 if (m_NetState != null && CanSee(aggressor))
@@ -7829,8 +7869,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         Items = new List<Item>();
         Map = Map.Internal;
         AutoPageNotify = true;
-        Aggressors = new List<AggressorInfo>();
-        Aggressed = new List<AggressorInfo>();
 
         NextSkillTime = Core.TickCount;
     }

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -722,14 +722,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
     public bool HasAggressed => _aggressed.Count > 0;
 
-    // Refreshes an entry and moves it to the tail so the list stays in LastCombatTime order.
-    private static void RefreshAggression(ref ValueLinkList<AggressorInfo> list, AggressorInfo info)
-    {
-        info.Refresh();
-        list.Remove(info);
-        list.AddLast(info);
-    }
-
     public bool ChangingCombatant => m_ChangingCombatant > 0;
 
     private void ExpireCombatant()
@@ -3808,6 +3800,14 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
     }
 
     public virtual void AggressiveAction(Mobile aggressor) => AggressiveAction(aggressor, false);
+
+    // Refreshes an entry and moves it to the tail so the list stays in LastCombatTime order.
+    private static void RefreshAggression(ref ValueLinkList<AggressorInfo> list, AggressorInfo info)
+    {
+        info.Refresh();
+        list.Remove(info);
+        list.AddLast(info);
+    }
 
     public virtual void AggressiveAction(Mobile aggressor, bool criminal)
     {

--- a/Projects/Server/Mobiles/Mobile.cs
+++ b/Projects/Server/Mobiles/Mobile.cs
@@ -2541,8 +2541,6 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         m_Map?.OnLeave(this);
         m_Map = null;
 
-        ClearAggressions();
-
         m_MountItem = null;
 
         World.RemoveEntity(this);
@@ -3455,18 +3453,28 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         _expireAggrTimerToken.Cancel();
     }
 
-    // Unlinks this mobile from every peer's aggression list now, instead of leaving entries whose
-    // Expired reports true (Deleted) for the peer's expiry timer to find. Keeps the lists' expired
-    // entries a pure head prefix.
-    private void ClearAggressions()
+    // Both lists are ordered by LastCombatTime (RefreshAggression relinks on every refresh), but
+    // Expired is also true when a party is Deleted and one-sided entries (AddAggressor) can sit
+    // anywhere, so this walks the whole list. n is small; the walk captures Next before unlinking.
+    internal void CheckAggrExpire()
     {
         for (var info = _aggressors._first; info != null;)
         {
             var next = info.Next;
 
-            info.Attacker.RemoveAggressed(this);
-            _aggressors.Remove(info);
-            info.Free();
+            if (info.Expired)
+            {
+                var attacker = info.Attacker;
+
+                attacker.RemoveAggressed(this);
+                _aggressors.Remove(info);
+                info.Free();
+
+                if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
+                {
+                    m_NetState.SendMobileIncoming(this, attacker);
+                }
+            }
 
             info = next;
         }
@@ -3475,49 +3483,18 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
         {
             var next = info.Next;
 
-            info.Defender.RemoveAggressor(this);
-            _aggressed.Remove(info);
-            info.Free();
-
-            info = next;
-        }
-
-        StopAggrExpire();
-    }
-
-    // Both lists are ordered by LastCombatTime, so time-expired entries are a head prefix.
-    // A deleted peer is unlinked eagerly by Delete(), so Expired's Deleted case never lingers here.
-    internal void CheckAggrExpire()
-    {
-        for (var info = _aggressors._first; info != null && info.Expired;)
-        {
-            var next = info.Next;
-            var attacker = info.Attacker;
-
-            attacker.RemoveAggressed(this);
-            _aggressors.Remove(info);
-            info.Free();
-
-            if (m_NetState != null && CanSee(attacker) && Utility.InUpdateRange(m_Location, attacker.m_Location))
+            if (info.Expired)
             {
-                m_NetState.SendMobileIncoming(this, attacker);
-            }
+                var defender = info.Defender;
 
-            info = next;
-        }
+                defender.RemoveAggressor(this);
+                _aggressed.Remove(info);
+                info.Free();
 
-        for (var info = _aggressed._first; info != null && info.Expired;)
-        {
-            var next = info.Next;
-            var defender = info.Defender;
-
-            defender.RemoveAggressor(this);
-            _aggressed.Remove(info);
-            info.Free();
-
-            if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
-            {
-                m_NetState.SendMobileIncoming(this, defender);
+                if (m_NetState != null && CanSee(defender) && Utility.InUpdateRange(m_Location, defender.m_Location))
+                {
+                    m_NetState.SendMobileIncoming(this, defender);
+                }
             }
 
             info = next;
@@ -3985,8 +3962,10 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        for (var info = _aggressed._first; info != null; info = info.Next)
+        for (var info = _aggressed._first; info != null;)
         {
+            var next = info.Next;
+
             if (info.Defender == aggressed)
             {
                 _aggressed.Remove(info);
@@ -3999,6 +3978,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                 break;
             }
+
+            info = next;
         }
 
         UpdateAggrExpire();
@@ -4011,8 +3992,10 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
             return;
         }
 
-        for (var info = _aggressors._first; info != null; info = info.Next)
+        for (var info = _aggressors._first; info != null;)
         {
+            var next = info.Next;
+
             if (info.Attacker == aggressor)
             {
                 _aggressors.Remove(info);
@@ -4025,6 +4008,8 @@ public partial class Mobile : IHued, IComparable<Mobile>, ISpawnable, IObjectPro
 
                 break;
             }
+
+            info = next;
         }
 
         UpdateAggrExpire();

--- a/Projects/UOContent/Engines/ConPVP/DuelContext.cs
+++ b/Projects/UOContent/Engines/ConPVP/DuelContext.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using ModernUO.CodeGeneratedEvents;
 using ModernUO.Serialization;
+using Server.Collections;
 using Server.Engines.PartySystem;
 using Server.Factions;
 using Server.Gumps;
@@ -2236,10 +2237,7 @@ public partial class DuelContext
                     continue;
                 }
 
-                mob.RemoveAggressed(dp.Mobile);
-                mob.RemoveAggressor(dp.Mobile);
-                dp.Mobile.RemoveAggressed(mob);
-                dp.Mobile.RemoveAggressor(mob);
+                mob.RemoveAggression(dp.Mobile);
             }
         }
     }

--- a/Projects/UOContent/Engines/ConPVP/Games/CTF.cs
+++ b/Projects/UOContent/Engines/ConPVP/Games/CTF.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModernUO.Serialization;
+using Server.Collections;
 using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;

--- a/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/Guards/BaseFactionGuard.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Collections;
 using Server.Factions.AI;
 using Server.Items;
 using Server.Mobiles;
@@ -114,12 +115,8 @@ namespace Server.Factions
                     return true;
                 }
 
-                var list = m.Aggressed;
-
-                for (var i = 0; i < list.Count; ++i)
+                foreach (var ai in m.Aggressed)
                 {
-                    var ai = list[i];
-
                     if (ai.Defender is BaseFactionGuard bf && bf.Faction == ourFaction)
                     {
                         return true;

--- a/Projects/UOContent/Engines/Factions/Mobiles/Guards/GuardAI.cs
+++ b/Projects/UOContent/Engines/Factions/Mobiles/Guards/GuardAI.cs
@@ -241,9 +241,6 @@ namespace Server.Factions
 
             if (activeOnly)
             {
-                var aggressed = Mobile.Aggressed;
-                var aggressors = Mobile.Aggressors;
-
                 Mobile active = null;
                 var activePrio = 0.0;
 
@@ -261,9 +258,8 @@ namespace Server.Factions
                     }
                 }
 
-                for (var i = 0; i < aggressed.Count; ++i)
+                foreach (var info in Mobile.Aggressed)
                 {
-                    var info = aggressed[i];
                     var m = info.Defender;
 
                     if (m != comb && m.Combatant == Mobile && Mobile.InRange(m, 12) && CanDispel(m))
@@ -283,9 +279,8 @@ namespace Server.Factions
                     }
                 }
 
-                for (var i = 0; i < aggressors.Count; ++i)
+                foreach (var info in Mobile.Aggressors)
                 {
-                    var info = aggressors[i];
                     var m = info.Attacker;
 
                     if (m != comb && m.Combatant == Mobile && Mobile.InRange(m, 12) && CanDispel(m))

--- a/Projects/UOContent/Engines/Help/HelpGump.cs
+++ b/Projects/UOContent/Engines/Help/HelpGump.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using Server.Collections;
 using Server.Engines.ConPVP;
 using Server.Factions;
 using Server.Gumps;
@@ -257,10 +258,8 @@ public sealed class HelpGump : DynamicGump
 
     public static bool CheckCombat(Mobile m)
     {
-        for (var i = 0; i < m.Aggressed.Count; ++i)
+        foreach (var info in m.Aggressed)
         {
-            var info = m.Aggressed[i];
-
             if (Core.Now - info.LastCombatTime < TimeSpan.FromSeconds(30.0))
             {
                 return true;

--- a/Projects/UOContent/Engines/Player Murder System/ReportMurdererGump.cs
+++ b/Projects/UOContent/Engines/Player Murder System/ReportMurdererGump.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using ModernUO.CodeGeneratedEvents;
+using Server.Collections;
 using Server.Gumps;
 using Server.Misc;
 using Server.Mobiles;

--- a/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
+++ b/Projects/UOContent/Items/Misc/Corpses/Corpse.cs
@@ -260,10 +260,8 @@ public partial class Corpse : Container, ICarvable
 
         var lastTime = TimeSpan.MaxValue;
 
-        for (var i = 0; i < owner.Aggressors.Count; ++i)
+        foreach (var info in owner.Aggressors)
         {
-            var info = owner.Aggressors[i];
-
             if (Core.Now - info.LastCombatTime < lastTime)
             {
                 _killer = info.Attacker;
@@ -276,10 +274,8 @@ public partial class Corpse : Container, ICarvable
             }
         }
 
-        for (var i = 0; i < owner.Aggressed.Count; ++i)
+        foreach (var info in owner.Aggressed)
         {
-            var info = owner.Aggressed[i];
-
             if (Core.Now - info.LastCombatTime < lastTime)
             {
                 _killer = info.Defender;

--- a/Projects/UOContent/Items/Special/SoulStone.cs
+++ b/Projects/UOContent/Items/Special/SoulStone.cs
@@ -1,5 +1,6 @@
 using System;
 using ModernUO.Serialization;
+using Server.Collections;
 using Server.Engines.VeteranRewards;
 using Server.Factions;
 using Server.Gumps;
@@ -118,10 +119,8 @@ public partial class SoulStone : Item, ISecurable
 
     private static bool CheckCombat(Mobile m, TimeSpan time)
     {
-        for (var i = 0; i < m.Aggressed.Count; ++i)
+        foreach (var info in m.Aggressed)
         {
-            var info = m.Aggressed[i];
-
             if (Core.Now - info.LastCombatTime < time)
             {
                 return true;

--- a/Projects/UOContent/Misc/AttackMessage.cs
+++ b/Projects/UOContent/Misc/AttackMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Collections;
 
 namespace Server.Misc
 {
@@ -42,24 +43,16 @@ namespace Server.Misc
 
         public static bool CheckAggressions(Mobile m1, Mobile m2)
         {
-            var list = m1.Aggressors;
-
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var info in m1.Aggressors)
             {
-                var info = list[i];
-
                 if (info.Attacker == m2 && Core.Now < info.LastCombatTime + Delay)
                 {
                     return true;
                 }
             }
 
-            list = m2.Aggressors;
-
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var info in m2.Aggressors)
             {
-                var info = list[i];
-
                 if (info.Attacker == m1 && Core.Now < info.LastCombatTime + Delay)
                 {
                     return true;

--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Server.Collections;
 using Server.Engines.ConPVP;
 using Server.Engines.PartySystem;
 using Server.Factions;
@@ -413,6 +414,15 @@ namespace Server.Misc
                 return Notoriety.CanBeAttacked;
             }
 
+            // A controlled pet is fair game to anyone who has attacked both the pet and its master:
+            // the pet's own record of the attacker refreshes on every hit, so the pet stays grey
+            // while the attacker keeps hitting it and reverts two minutes after they stop.
+            if (bcTarg?.ControlMaster is { } petMaster && petMaster != source &&
+                CheckAggressor(bcTarg.Aggressors, source) && CheckAggressor(petMaster.Aggressors, source))
+            {
+                return Notoriety.CanBeAttacked;
+            }
+
             if (source.Player && !target.Player && pmFrom != null && bcTarg != null)
             {
                 var master = bcTarg.GetMaster();
@@ -544,11 +554,11 @@ namespace Server.Misc
 
         public static bool IsSummoned(BaseCreature c) => c?.Summoned == true;
 
-        public static bool CheckAggressor(List<AggressorInfo> list, Mobile target)
+        public static bool CheckAggressor(in ValueLinkList<AggressorInfo> list, Mobile target)
         {
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var info in list)
             {
-                if (list[i].Attacker == target)
+                if (info.Attacker == target)
                 {
                     return true;
                 }
@@ -557,12 +567,10 @@ namespace Server.Misc
             return false;
         }
 
-        public static bool CheckAggressed(List<AggressorInfo> list, Mobile target)
+        public static bool CheckAggressed(in ValueLinkList<AggressorInfo> list, Mobile target)
         {
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var info in list)
             {
-                var info = list[i];
-
                 if (!info.CriminalAggression && info.Defender == target)
                 {
                     return true;

--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -427,8 +427,7 @@ namespace Server.Misc
                 if (Core.ML && master != null)
                 {
                     if (source == master && CheckAggressor(bcTarg.Aggressors, source) ||
-                        CheckAggressor(source.Aggressors, bcTarg) ||
-                        (CheckAggressor(bcTarg.Aggressors, source) && CheckAggressor(master.Aggressors, source)))
+                        CheckAggressor(source.Aggressors, bcTarg))
                     {
                         return Notoriety.CanBeAttacked;
                     }
@@ -491,15 +490,6 @@ namespace Server.Misc
                 {
                     return Notoriety.CanBeAttacked;
                 }
-            }
-
-            // A controlled pet is fair game to anyone who has attacked both the pet and its master:
-            // the pet's own record of the attacker refreshes on every hit, so the pet stays grey
-            // while the attacker keeps hitting it and reverts two minutes after they stop.
-            if (bcTarg?.ControlMaster is { } petMaster && petMaster != source &&
-                CheckAggressor(bcTarg.Aggressors, source) && CheckAggressor(petMaster.Aggressors, source))
-            {
-                return Notoriety.CanBeAttacked;
             }
 
             if (CheckAggressor(source.Aggressors, target))

--- a/Projects/UOContent/Misc/Notoriety.cs
+++ b/Projects/UOContent/Misc/Notoriety.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Server.Collections;
 using Server.Engines.ConPVP;
 using Server.Engines.PartySystem;
@@ -381,7 +380,7 @@ namespace Server.Misc
             return Notoriety.Innocent;
         }
 
-        /* Must be thread-safe */
+        // Runs on the game loop only; it walks the aggression lists, which are not safe to read concurrently.
         public static int MobileNotoriety(Mobile source, Mobile target)
         {
             var bcTarg = target as BaseCreature;
@@ -414,15 +413,6 @@ namespace Server.Misc
                 return Notoriety.CanBeAttacked;
             }
 
-            // A controlled pet is fair game to anyone who has attacked both the pet and its master:
-            // the pet's own record of the attacker refreshes on every hit, so the pet stays grey
-            // while the attacker keeps hitting it and reverts two minutes after they stop.
-            if (bcTarg?.ControlMaster is { } petMaster && petMaster != source &&
-                CheckAggressor(bcTarg.Aggressors, source) && CheckAggressor(petMaster.Aggressors, source))
-            {
-                return Notoriety.CanBeAttacked;
-            }
-
             if (source.Player && !target.Player && pmFrom != null && bcTarg != null)
             {
                 var master = bcTarg.GetMaster();
@@ -437,7 +427,8 @@ namespace Server.Misc
                 if (Core.ML && master != null)
                 {
                     if (source == master && CheckAggressor(bcTarg.Aggressors, source) ||
-                        CheckAggressor(source.Aggressors, bcTarg))
+                        CheckAggressor(source.Aggressors, bcTarg) ||
+                        (CheckAggressor(bcTarg.Aggressors, source) && CheckAggressor(master.Aggressors, source)))
                     {
                         return Notoriety.CanBeAttacked;
                     }
@@ -500,6 +491,15 @@ namespace Server.Misc
                 {
                     return Notoriety.CanBeAttacked;
                 }
+            }
+
+            // A controlled pet is fair game to anyone who has attacked both the pet and its master:
+            // the pet's own record of the attacker refreshes on every hit, so the pet stays grey
+            // while the attacker keeps hitting it and reverts two minutes after they stop.
+            if (bcTarg?.ControlMaster is { } petMaster && petMaster != source &&
+                CheckAggressor(bcTarg.Aggressors, source) && CheckAggressor(petMaster.Aggressors, source))
+            {
+                return Notoriety.CanBeAttacked;
             }
 
             if (CheckAggressor(source.Aggressors, target))

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -14,6 +14,7 @@
  ************************************************************************/
 
 using System;
+using Server.Collections;
 using Server.Engines.Quests.Necro;
 using Server.Engines.Spawners;
 using Server.Engines.Virtues;
@@ -1034,7 +1035,39 @@ public abstract partial class BaseAI
         return !valid && (acqType != FightMode.Evil || (bc?.GetMaster()?.Karma ?? m.Karma) >= 0);
     }
 
-    private bool IsHostile(Mobile from) => Mobile.Combatant == from || from.Combatant == Mobile;
+    // "Engaged with us": either of us targets the other now, or an aggression record between us
+    // is still live (refreshed on every exchange, expires AggressorInfo.ExpireDelay after the last).
+    // The record checks survive a player leaving war mode or switching targets; Combatant does not.
+    private bool IsHostile(Mobile from) =>
+        Mobile.Combatant == from || from.Combatant == Mobile || IsAggressor(from) || IsAggressed(from);
+
+    // from attacked us
+    private bool IsAggressor(Mobile from)
+    {
+        foreach (var aggressor in Mobile.Aggressors)
+        {
+            if (aggressor.Attacker == from && !aggressor.Expired)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // we attacked from
+    private bool IsAggressed(Mobile from)
+    {
+        foreach (var aggressed in Mobile.Aggressed)
+        {
+            if (aggressed.Defender == from && !aggressed.Expired)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     public virtual void DetectHidden()
     {

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -14,6 +14,7 @@
  ************************************************************************/
 
 using System;
+using Server.Collections;
 using Server.Engines.Quests.Necro;
 using Server.Engines.Spawners;
 using Server.Engines.Virtues;
@@ -929,8 +930,8 @@ public abstract partial class BaseAI
     private bool HandleAggressor(FightMode acqType)
     {
         if (acqType != FightMode.Aggressor ||
-            Mobile.Aggressors.Count > 0 ||
-            Mobile.Aggressed.Count > 0 ||
+            Mobile.HasAggressors ||
+            Mobile.HasAggressed ||
             Mobile.FactionAllegiance != null ||
             Mobile.EthicAllegiance != null)
         {

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -14,7 +14,6 @@
  ************************************************************************/
 
 using System;
-using Server.Collections;
 using Server.Engines.Quests.Necro;
 using Server.Engines.Spawners;
 using Server.Engines.Virtues;
@@ -1035,33 +1034,7 @@ public abstract partial class BaseAI
         return !valid && (acqType != FightMode.Evil || (bc?.GetMaster()?.Karma ?? m.Karma) >= 0);
     }
 
-    private bool IsHostile(Mobile from) =>
-        Mobile.Combatant == from || from.Combatant == Mobile || IsAggressor(from) || IsAggressed(from);
-
-    private bool IsAggressor(Mobile from)
-    {
-        foreach (var aggressor in Mobile.Aggressors)
-        {
-            if (aggressor.Defender == from)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private bool IsAggressed(Mobile from)
-    {
-        foreach (var aggressed in Mobile.Aggressed)
-        {
-            if (aggressed.Attacker == from)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    private bool IsHostile(Mobile from) => Mobile.Combatant == from || from.Combatant == Mobile;
 
     public virtual void DetectHidden()
     {

--- a/Projects/UOContent/Mobiles/AI/BaseAI/PetOrders.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/PetOrders.cs
@@ -13,6 +13,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.  *
  ************************************************************************/
 
+using Server.Collections;
+
 namespace Server.Mobiles;
 
 public abstract partial class BaseAI
@@ -430,13 +432,11 @@ public abstract partial class BaseAI
             }
         }
 
-        var aggressors = controlMaster?.Aggressors;
-
-        if (aggressors != null)
+        if (controlMaster != null)
         {
-            for (var i = 0; i < aggressors.Count; i++)
+            foreach (var info in controlMaster.Aggressors)
             {
-                var aggressor = aggressors[i].Attacker;
+                var aggressor = info.Attacker;
 
                 if (aggressor == best || aggressor?.Deleted != false || !aggressor.Alive ||
                     aggressor.IsDeadBondedPet || !Mobile.InRange(aggressor, Mobile.RangePerception))
@@ -569,8 +569,8 @@ public abstract partial class BaseAI
                 return true;
             }
 
-            if (Mobile.Combatant != null || Mobile.Aggressors.Count > 0 ||
-                Mobile.Aggressed.Count > 0 || Core.TickCount < Mobile.NextCombatTime)
+            if (Mobile.Combatant != null || Mobile.HasAggressors ||
+                Mobile.HasAggressed || Core.TickCount < Mobile.NextCombatTime)
             {
                 from.SendMessage("You can not transfer a pet while in combat.");
                 to.SendMessage("You can not transfer a pet while in combat.");

--- a/Projects/UOContent/Mobiles/AI/BaseAI/TransferItem.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/TransferItem.cs
@@ -36,7 +36,7 @@ internal sealed partial class TransferItem : Item
 
     public override bool SkipSerialization => true;
 
-    public static bool IsInCombat(BaseCreature creature) => creature?.Aggressors.Count > 0 || creature?.Aggressed.Count > 0;
+    public static bool IsInCombat(BaseCreature creature) => creature?.HasAggressors == true || creature?.HasAggressed == true;
 
     public override void GetProperties(IPropertyList list)
     {

--- a/Projects/UOContent/Mobiles/AI/MageAI.cs
+++ b/Projects/UOContent/Mobiles/AI/MageAI.cs
@@ -1,4 +1,5 @@
 using System;
+using Server.Collections;
 using Server.Items;
 using Server.Spells;
 using Server.Spells.Fifth;
@@ -857,9 +858,6 @@ public class MageAI : BaseAI
 
         if (activeOnly)
         {
-            var aggressed = Mobile.Aggressed;
-            var aggressors = Mobile.Aggressors;
-
             Mobile active = null;
             var activePrio = 0.0;
 
@@ -877,9 +875,8 @@ public class MageAI : BaseAI
                 }
             }
 
-            for (var i = 0; i < aggressed.Count; ++i)
+            foreach (var info in Mobile.Aggressed)
             {
-                var info = aggressed[i];
                 var m = info.Defender;
 
                 if (m != comb && m.Combatant == Mobile && Mobile.InRange(m, Mobile.RangePerception) && CanDispel(m))
@@ -899,9 +896,8 @@ public class MageAI : BaseAI
                 }
             }
 
-            for (var i = 0; i < aggressors.Count; ++i)
+            foreach (var info in Mobile.Aggressors)
             {
-                var info = aggressors[i];
                 var m = info.Attacker;
 
                 if (m != comb && m.Combatant == Mobile && Mobile.InRange(m, Mobile.RangePerception) && CanDispel(m))

--- a/Projects/UOContent/Mobiles/BaseCreature.cs
+++ b/Projects/UOContent/Mobiles/BaseCreature.cs
@@ -2567,11 +2567,6 @@ namespace Server.Mobiles
         {
             base.AggressiveAction(aggressor, criminal);
 
-            if (ControlMaster != null && NotorietyHandlers.CheckAggressor(ControlMaster.Aggressors, aggressor))
-            {
-                aggressor.Aggressors.Add(AggressorInfo.Create(this, aggressor, true));
-            }
-
             var ct = m_ControlOrder;
 
             if (AIObject != null)
@@ -2727,24 +2722,16 @@ namespace Server.Mobiles
                 return;
             }
 
-            var list = Aggressors;
-
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var ai in Aggressors)
             {
-                var ai = list[i];
-
                 if (ai.Attacker == target)
                 {
                     return;
                 }
             }
 
-            list = Aggressed;
-
-            for (var i = 0; i < list.Count; ++i)
+            foreach (var ai in Aggressed)
             {
-                var ai = list[i];
-
                 if (ai.Defender == target)
                 {
                     var master = GetMaster();
@@ -3123,7 +3110,7 @@ namespace Server.Mobiles
             return base.OnBeforeDeath();
         }
 
-        public int ComputeBonusDamage(in ValueLinkList<DamageEntry> list, Mobile m)
+        public static int ComputeBonusDamage(in ValueLinkList<DamageEntry> list, Mobile m)
         {
             var bonus = 0;
 
@@ -3324,24 +3311,16 @@ namespace Server.Mobiles
                 SendIncomingPacket();
 
                 // TODO: This can be done in Parallel if there are lots of them.
-                var aggressors = Aggressors;
-
-                for (var i = 0; i < aggressors.Count; ++i)
+                foreach (var info in Aggressors)
                 {
-                    var info = aggressors[i];
-
                     if (info.Attacker.Combatant == this)
                     {
                         info.Attacker.Combatant = null;
                     }
                 }
 
-                var aggressed = Aggressed;
-
-                for (var i = 0; i < aggressed.Count; ++i)
+                foreach (var info in Aggressed)
                 {
-                    var info = aggressed[i];
-
                     if (info.Defender.Combatant == this)
                     {
                         info.Defender.Combatant = null;

--- a/Projects/UOContent/Mobiles/Familiars/ShadowWisp.cs
+++ b/Projects/UOContent/Mobiles/Familiars/ShadowWisp.cs
@@ -1,5 +1,6 @@
 using System;
 using ModernUO.Serialization;
+using Server.Collections;
 
 namespace Server.Mobiles;
 
@@ -76,14 +77,25 @@ public partial class ShadowWispFamiliar : BaseFamiliar
 
             var friendly = true;
 
-            for (var j = 0; friendly && j < caster.Aggressors.Count; ++j)
+            foreach (var info in caster.Aggressors)
             {
-                friendly = caster.Aggressors[j].Attacker != m;
+                if (info.Attacker == m)
+                {
+                    friendly = false;
+                    break;
+                }
             }
 
-            for (var j = 0; friendly && j < caster.Aggressed.Count; ++j)
+            if (friendly)
             {
-                friendly = caster.Aggressed[j].Defender != m;
+                foreach (var info in caster.Aggressed)
+                {
+                    if (info.Defender == m)
+                    {
+                        friendly = false;
+                        break;
+                    }
+                }
             }
 
             if (friendly)

--- a/Projects/UOContent/Mobiles/Monsters/Humanoid/Melee/KhaldunRevenant.cs
+++ b/Projects/UOContent/Mobiles/Monsters/Humanoid/Melee/KhaldunRevenant.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using ModernUO.CodeGeneratedEvents;
 using ModernUO.Serialization;
+using Server.Collections;
 using Server.Items;
 
 

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -2749,7 +2749,7 @@ namespace Server.Mobiles
                 return false;
             }
 
-            if (bc?.Controlled == true && this == bc.ControlMaster)
+            if (Core.ML && bc?.Controlled == true && this == bc.ControlMaster)
             {
                 return false;
             }

--- a/Projects/UOContent/Mobiles/PlayerMobile.cs
+++ b/Projects/UOContent/Mobiles/PlayerMobile.cs
@@ -2749,7 +2749,7 @@ namespace Server.Mobiles
                 return false;
             }
 
-            if (Core.ML && bc?.Controlled == true && this == bc.ControlMaster)
+            if (bc?.Controlled == true && this == bc.ControlMaster)
             {
                 return false;
             }

--- a/Projects/UOContent/Multis/Houses/BaseHouse.cs
+++ b/Projects/UOContent/Multis/Houses/BaseHouse.cs
@@ -2467,10 +2467,8 @@ namespace Server.Multis
                 return false;
             }
 
-            for (var i = 0; i < m.Aggressed.Count; ++i)
+            foreach (var info in m.Aggressed)
             {
-                var info = m.Aggressed[i];
-
                 if (info.Defender.Player && info.Defender.Alive &&
                     Core.Now - info.LastCombatTime < HouseRegion.CombatHeatDelay &&
                     (m.Guild is not Guild attackerGuild || info.Defender.Guild is not Guild defenderGuild ||

--- a/Projects/UOContent/Regions/BaseRegion.cs
+++ b/Projects/UOContent/Regions/BaseRegion.cs
@@ -69,7 +69,7 @@ public class BaseRegion : Region
     }
 
     public override TimeSpan GetLogoutDelay(Mobile m) =>
-        NoLogoutDelay && m.Aggressors.Count == 0 && m.Aggressed.Count == 0 && !m.Criminal
+        NoLogoutDelay && !m.HasAggressors && !m.HasAggressed && !m.Criminal
             ? TimeSpan.Zero
             : base.GetLogoutDelay(m);
 

--- a/Projects/UOContent/Regions/HouseRegion.cs
+++ b/Projects/UOContent/Regions/HouseRegion.cs
@@ -1,5 +1,6 @@
 using System;
 using ModernUO.CodeGeneratedEvents;
+using Server.Collections;
 using Server.Gumps;
 using Server.Items;
 using Server.Mobiles;

--- a/Projects/UOContent/Spells/Base/SpellHelper.cs
+++ b/Projects/UOContent/Spells/Base/SpellHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Server.Collections;
 using Server.Engines.CannedEvil;
 using Server.Engines.ConPVP;
 using Server.Engines.PartySystem;
@@ -207,10 +208,8 @@ namespace Server.Spells
                 return false;
             }
 
-            for (var i = 0; i < m.Aggressed.Count; ++i)
+            foreach (var info in m.Aggressed)
             {
-                var info = m.Aggressed[i];
-
                 if (info.Defender.Player && Core.Now - info.LastCombatTime < CombatHeatDelay)
                 {
                     return true;
@@ -219,10 +218,8 @@ namespace Server.Spells
 
             if (Core.AOS)
             {
-                for (var i = 0; i < m.Aggressors.Count; ++i)
+                foreach (var info in m.Aggressors)
                 {
-                    var info = m.Aggressors[i];
-
                     if (info.Attacker.Player && info.Attacker == m && Core.Now - info.LastCombatTime < CombatHeatDelay)
                     {
                         return true;


### PR DESCRIPTION
## Summary

`Mobile.Aggressors` and `Mobile.Aggressed` were `List<AggressorInfo>`s allocated for every mobile, including the ~99% that never fight. They are now inline `ValueLinkList<AggressorInfo>` structs (24 bytes each in the `Mobile` object, no separate allocation) ordered least recent → most recent by `LastCombatTime`.

- `AggressorInfo` (already pooled) is the node; every `Refresh()` relinks the entry to the tail in O(1), so both lists stay ordered by `LastCombatTime` and the 5 s expiry pass pops a head prefix instead of scanning both lists for every mobile in combat.
- Records are always paired: `AggressiveAction` creates both halves and the new public `RemoveAggression(Mobile)` removes both; the one-sided `RemoveAggressor` / `RemoveAggressed` are private. A deleted mobile's own expiry pass unlinks every twin, so no delete hook is needed.
- The 2010 pet-defense line in `BaseCreature.AggressiveAction` that fabricated a one-sided "pet attacked you" record in the attacker's `Aggressors` is deleted and not replaced (see Behavior).
- `HasAggressors` / `HasAggressed` replace `Count > 0` / `Count == 0` reads.
- `NotorietyHandlers.CheckAggressor` / `CheckAggressed` take the list by `in`; callers unchanged.
- `BaseCreature.ComputeBonusDamage` is now `static` (follow-up to #2605; it uses no instance state).
- `BaseAI.IsHostile` bug fix (dates back to RunUO): `IsAggressor` compared `Aggressors[i].Defender` and `IsAggressed` compared `Aggressed[i].Attacker` to the candidate, but both of those sides are always the creature itself, so neither ever matched and "hostile" silently meant only "is my combatant right now". The fields are un-swapped (`Attacker` / `Defender`) and guarded with `!Expired`, so a creature stays engaged with whoever exchanged blows with it for `AggressorInfo.ExpireDelay` (2 min) after the last exchange, surviving the player leaving war mode or switching targets.

Removes two objects and 16 bytes per mobile versus `main` (~8 MB and 1M gen2 objects on a 500k world) and allocates nothing for mobiles in combat. Third and last PR from the lazy per-mobile collections design (#2604, #2605).

## Breaking change

- `Mobile.Aggressors` / `Aggressed` are no longer `List<AggressorInfo>`. Indexing, `.Add()`, `.Remove()`, `.RemoveAt()` no longer compile; use `foreach` / `.ByDescending()` (with `using Server.Collections;`), `.Count`, `HasAggressors` / `HasAggressed`, and `AggressiveAction` / `RemoveAggression` to mutate. Calling a `ValueLinkList` mutator on the `ref readonly` property compiles but operates on a copy while still unlinking the real nodes; do not.
- `Mobile.RemoveAggressor` / `RemoveAggressed` are private. Use `RemoveAggression(other)`, which removes both directions on both mobiles (records are always paired).
- `NotorietyHandlers.CheckAggressor` / `CheckAggressed` signatures changed to `(in ValueLinkList<AggressorInfo>, Mobile)`.

Save format is untouched: aggression is not serialized.

## Behavior

Aggression bookkeeping, refresh, expiry timing, and murder reporting are unchanged. Three intentional gameplay changes:

**A victim's passive pet no longer turns grey to the attacker.** Since a 2010 RunUO commit, when B hit A and then hit A's pet P, the pet wrote a fake "P attacked B" record into B's aggressor list, so P showed grey to B and every further hit on P was free while every hit on A stayed criminal. Nothing in that rule reflects a pet actually engaging. Now a pet's notoriety comes only from its own real records and, on ML, from mirroring its master: P stays blue to B as long as A is blue to B, every hit on P is a criminal action exactly like a hit on A, and P turns grey to B only once P itself attacks B (or, on ML, once A does). Pre-ML pets have never mirrored their master and still do not; that is unchanged. Removing the phantom record also stops a pet that never attacked from being treated as if it had:

- The attacker's own corpse can no longer name a defending pet as its killer.
- The attacker no longer inherits a logout delay, dispel-target candidacy (`MageAI` / `GuardAI`), an `AttackMessage` combat state, or the uncontrolled-NPC harmful gate from that phantom record.

**Hitting your own pet is never criminal.** `PlayerMobile.IsHarmfulCriminal` exempted the player's own controlled pet only under `Core.ML` (a 2009 RunUO gate). Pre-ML the first hit on your own blue pet was a criminal action and called the guards in town, even though the pet then turned grey to you and later hits were free, and your pet attacking you was never criminal in any era. The gate is removed: master and pet can always fight each other without either being flagged, and each shows grey to the other from the real record of the first hit.

**Aggressor-mode creatures stay engaged.** `FightMode.Aggressor` and `FightMode.Evil` creatures now keep retaliating against whoever hit them (or whom they hit) for two minutes after the last exchange, instead of dropping the target the moment the player leaves war mode or their combatant link expires; this is the RunUO intent of `BaseAI.IsHostile`, which had never worked.

Covered by the new `AggressorListTests`.

## Testing

- `dotnet build -c Release` clean (Debug build of `Server` also clean; the branch adds a `Debug.Assert`).
- New `AggressorListTests` plus full `Server.Tests` and `UOContent.Tests`.

## Manual QA before merge

Notoriety cannot be unit-tested end to end. On a test shard with blue player A owning pet P, player B, and a guard zone:

- [ ] B attacks A, then hits P (P passive: `stay` / `follow`, A does not fight back): B is criminal, A and P both see B grey. P stays blue to B; every hit on P is a criminal action (criminal timer refreshes, guards called in town) exactly like a hit on A. P never turns grey to B on its own.
- [ ] Same, but A fights back: on ML, P mirrors A and shows grey to B as soon as A hits B; pre-ML, P stays blue until P itself attacks.
- [ ] P retaliates (AI or `all kill`): P's attacks are not criminal, A is not flagged, B shows grey to P, and P now shows grey to B (real record) so B's further hits on P are not criminal.
- [ ] A hits own pet in town, on a pre-ML shard and on an ML shard: not criminal, no guards; P shows grey to A after the first hit, A shows grey to P. A orders P to attack A: neither flagged, no guards, each grey to the other.
- [ ] A and B in warring guilds (or opposing factions), pre-ML shard: after B hits A and P, P still shows orange (enemy) to B, not grey.
- [ ] B dies to A after hitting P: B's corpse names A (or whoever actually hit B) as killer, never P unless P attacked.
- [ ] Duel end clears aggression both ways (no lingering grey, instant logout).
- [ ] Entries expire ~2 min after the last exchange: logout delay instant again, pet transfer allowed again.
- [ ] Killing a monster that attacked you clears your aggressor entry immediately.
- [ ] Murder-report gump lists only real attackers (no phantom pet).
- [ ] Aggressor-mode creature (e.g. a bird or rabbit): hit it once, leave war mode, walk away slowly: it keeps chasing and attacking for up to ~2 min; after 2 min without an exchange it gives up. Same with an Evil-mode creature and a positive-karma character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
