### PR TITLE
feat: publish a knowledge graph of the codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,10 @@
 # Ignore everything under tools/ except the operator scripts checked in below.
 /tools/*
 !/tools/Export-IpBlocklist.ps1
+!/tools/knowledge-graph/
+
+# graphify knowledge-graph build output (regenerate with /graphify; see
+# dev-docs/knowledge-graph.md). The graph is a derived artifact -- tens of MB
+# and stale the moment main moves -- so it is hosted, not committed.
+/graphify-out
+/tools/knowledge-graph/dist

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,35 @@
+# graphify corpus definition for ModernUO
+#
+# Anything matched here is kept OUT of the knowledge graph built by /graphify.
+# Patterns use gitignore syntax and are merged on top of .gitignore, so this
+# file only ever narrows the corpus further.
+#
+# The goal: the graph should contain the shipped source of the server and its
+# game content -- nothing generated, nothing vendored, nothing local-only.
+#
+# Keep every pattern rooted with a leading "/". Unrooted gitignore patterns
+# match at any depth, so a bare "tools/" would also swallow
+# Projects/UOContent/Items/Skill Items/Tools/ and silently drop 31 crafting
+# tool files from the graph. Rooted patterns match only the top-level directory
+# they name.
+
+# Generated serialization migration snapshots (~3,850 JSON files, machine-written)
+/Projects/*/Migrations/
+
+# Prose that documents the code rather than being the code. dev-docs/ is a
+# large hand-written corpus about ModernUO internals; catalog it separately
+# if you ever want a docs graph, but it drowns the code graph when merged in.
+/dev-docs/
+
+# Runtime data, decorations, and vendored third-party material
+/Distribution/
+/THIRD-PARTY-NOTICES/
+/branding/
+/tools/
+
+# Local-only and agent scratch directories (untracked or developer-specific)
+/docs/
+/.claude/
+/.superpowers/
+/.wt-*/
+/ModernUO.sln.DotSettings.user

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ Apply these when writing or reviewing `.cs` files under `Projects/`.
 
 | Topic | File |
 |---|---|
+| Knowledge graph (hosted codebase map: what calls what, impact analysis) | `dev-docs/knowledge-graph.md` |
 | Code standards & LINQ tiers | `dev-docs/code-standards.md` |
 | Serialization system | `dev-docs/serialization.md` |
 | Content patterns (Items, Mobiles, Creatures) | `dev-docs/content-patterns.md` |
@@ -87,6 +88,7 @@ Then copy only the relevant skill files based on the task:
 | String building / formatting | `modernuo-string-handling` |
 | Code review / audit | `modernuo-code-audit` |
 | Any `.cs` file edit | `modernuo-code-audit` (always offer for code changes) |
+| Orienting in unfamiliar code, "what calls X", impact analysis | `modernuo-knowledge-graph` |
 | **RunUO Migration** | |
 | Migrate any RunUO script | `migrate-from-runuo/migrate-foundation` (always), plus system-specific skills below |
 | Migrate Item/Mobile/Creature | `migrate-from-runuo/migrate-foundation`, `migrate-from-runuo/migrate-serialization`, `migrate-from-runuo/migrate-items-mobiles` |

--- a/dev-docs/claude-skills/modernuo-knowledge-graph.md
+++ b/dev-docs/claude-skills/modernuo-knowledge-graph.md
@@ -1,0 +1,118 @@
+---
+name: modernuo-knowledge-graph
+description: >
+  Trigger when orienting in unfamiliar parts of the codebase, tracing what calls or depends on a
+  type, assessing the blast radius of a change, or answering "where does X live / what touches Y".
+  Use the hosted knowledge graph before fanning out greps across 4,000+ files.
+---
+
+# ModernUO Knowledge Graph
+
+A prebuilt map of the codebase: 30,892 nodes and 64,845 directed edges over
+every `.cs` file in `Projects/`, clustered into roughly 1,640 subsystems.
+
+Full documentation: `dev-docs/knowledge-graph.md`.
+
+## When This Activates
+- Orienting in a subsystem you have not read yet
+- "What calls this?" / "What does this depend on?" / "What breaks if I change it?"
+- Finding where a feature lives without knowing its filenames
+- Checking whether two systems are coupled before refactoring across them
+
+## When NOT to use it
+- **Anything you can answer by reading one known file.** Just read the file.
+- **Verifying current behaviour.** The graph lags `main` — see below.
+- **Runtime wiring.** Reflection, `[Constructible]` discovery, event
+  registration and serialization migrations are invisible to a structural
+  parse. ModernUO uses all of them heavily.
+
+## Rule 1: Check freshness first
+
+```sh
+curl -s https://graph.muo.gg/manifest.json
+```
+
+`built_at_commit` is the commit the graph was extracted from. Compare it to
+`main`. If the code you care about changed since, **read the source instead** —
+the graph is refreshed manually and is a map, not ground truth. Say so plainly
+rather than reporting stale structure as fact.
+
+## Rule 2: Prefer the wiki for orientation
+
+The per-community articles are plain markdown, need no tooling, and name real
+file paths:
+
+```sh
+curl -s https://graph.muo.gg/wiki.tar.gz | tar xz
+# then read wiki/index.md and follow the community you need
+```
+
+Each article lists the community's key types with paths, and the communities it
+shares edges with. This is usually the fastest way to go from "I know nothing
+about the crafting system" to "here are the eight files that matter".
+
+## Rule 3: Query the graph for relationships
+
+If the graph is built locally (`graphify update .` from the repo root, a few
+minutes, no LLM) or `graph.json.gz` is unpacked into `graphify-out/`:
+
+```sh
+graphify affected "BaseHouse" --depth 1   # what breaks if I change this
+graphify query "how does spell damage reach a Mobile"
+graphify path "BaseHouse" "Item"          # shortest path between two types
+graphify explain "MonsterAbility"         # plain-language summary of a node
+```
+
+`affected` is the one to reach for before a refactor. It walks edges in reverse
+and reports every dependent with a `file.cs:Lnnn` location, so the output is
+directly openable:
+
+```
+- ConfirmDemolishHouseGump [references] Projects/UOContent/Gumps/Houses/ConfirmDemolishHouseGump.cs:L8
+- .ClearCoOwners_Callback() [references] Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs:L720
+```
+
+Edges are directed, so caller and callee are distinguishable — "what calls
+`SpellHelper.Damage`" and "what does it call" give different answers.
+
+## Rule 4: Never present the graph as complete
+
+Three limits change how you must phrase conclusions:
+
+1. **~12% of edges are dropped** because they point at BCL types, generic
+   parameters or symbols outside the corpus. **Absence of an edge is not
+   evidence of no relationship.** Never say "nothing calls X" on graph evidence
+   alone — confirm with a grep before making that claim.
+2. **Multiplicity is lost.** Forty calls on forty lines collapse to one edge.
+   The graph answers *whether*, never *how often*.
+3. **Communities are statistical.** Clusters come from connectivity and their
+   names are generated from the dominant directory. A community boundary is a
+   hint, not an architectural statement.
+
+Use the graph to find candidates fast, then verify in the source before acting
+on what you found.
+
+## God Nodes
+
+The most connected types, worth knowing because a change to any of them has
+wide reach:
+
+| Type | Edges |
+|---|---|
+| `BaseCreature` | 889 |
+| `PlayerMobile` | 558 |
+| `Mobile` | 420 |
+| `IGenericReader` | 314 |
+| `IPropertyList` | 289 |
+| `MLQuest` | 277 |
+| `CommandEventArgs` | 231 |
+| `IEntity` | 226 |
+| `Item` | 219 |
+| `BaseHouse` | 209 |
+
+Touching one of these is a signal to widen review, not a reason to stop.
+
+## Rebuilding
+
+See `tools/knowledge-graph/README.md`. The corpus is pinned by `.graphifyignore`
+at the repo root, so everyone who rebuilds gets the same file set.

--- a/dev-docs/knowledge-graph.md
+++ b/dev-docs/knowledge-graph.md
@@ -1,0 +1,164 @@
+# Knowledge Graph
+
+A queryable map of the ModernUO codebase: every type, method and file in
+`Projects/`, the edges between them, and 1,600-odd clusters grouping them into
+subsystems. It exists so that a question like *"what actually touches
+`BaseHouse` when a house is demolished?"* can be answered by traversing
+relationships instead of grepping and guessing.
+
+It is built with [graphify](https://github.com/safishamsi/graphify), which
+parses C# structurally and clusters the result.
+
+## What is in it
+
+Built from `main` at `e52d54b7d`:
+
+| | |
+|---|---|
+| Nodes | 30,892 |
+| Edges | 64,845 (directed) |
+| Communities | 1,643 |
+| Corpus | 4,190 files — all 4,160 tracked `.cs` files, plus project files, top-level docs and CI workflows |
+
+The most connected types are the ones you would expect, which is a decent
+sanity check on the extraction:
+
+`BaseCreature` (889 edges) · `PlayerMobile` (558) · `Mobile` (420) ·
+`IGenericReader` (314) · `IPropertyList` (289) · `MLQuest` (277) ·
+`CommandEventArgs` (231) · `IEntity` (226) · `Item` (219) · `BaseHouse` (209)
+
+Edges are **directed**, so a caller is distinguishable from a callee: "what
+calls `SpellHelper.Damage`" and "what does `SpellHelper.Damage` call" are
+different questions with different answers.
+
+## Where it lives
+
+The graph is **not committed**. It is ~34 MB of derived JSON that is stale the
+moment `main` moves, and git would keep every version of it forever — against a
+repository whose largest tracked file is 768 KB. It is hosted instead:
+
+| Artifact | URL | What it is |
+|---|---|---|
+| Interactive viewer | `https://graph.muo.gg` | Pan/zoom map of the community structure |
+| `graph.json.gz` | `https://graph.muo.gg/graph.json.gz` | Full graph (~1.4 MB) for tooling |
+| `wiki.tar.gz` | `https://graph.muo.gg/wiki.tar.gz` | One markdown article per community |
+| `manifest.json` | `https://graph.muo.gg/manifest.json` | Source commit, counts, sizes |
+
+**Always check `manifest.json` first.** Its `built_at_commit` says which commit
+the hosted graph was extracted from. If that commit is far behind `main`,
+anything the graph says about recently changed code may be wrong, and you
+should fall back to reading the source. The graph is refreshed manually, not on
+every merge — treat it as a map, not as ground truth.
+
+## Using it
+
+### The wiki (best for agents)
+
+The per-community articles are plain markdown and need no tooling. Each one
+lists the community's key types with their file paths, and links to the
+communities it shares edges with:
+
+```
+# Housing System - BaseHouse
+> 200 nodes · cohesion 0.02
+
+## Key Concepts
+- **BaseHouse** (209 connections) — `Projects/UOContent/Multis/Houses/BaseHouse.cs`
+- **HouseGumpAOS** (22 connections) — `Projects/UOContent/Gumps/Houses/HouseGumpAOS.cs`
+...
+## Relationships
+- [[Server: Regions]] (110 shared connections)
+- [[Items / Misc - GlassItems.cs]] (24 shared connections)
+```
+
+Key Concepts is ordered by raw connection count, so a language primitive such
+as `bool` can head the list ahead of the types you actually want. Skip past the
+entries with no file path.
+
+`wiki/index.md` is the entry point: communities sorted by size, each a link.
+Start there, read the article for the subsystem you care about, then open the
+files it names.
+
+### Querying locally
+
+With the graph built (see below) or `graph.json.gz` downloaded and unpacked:
+
+```sh
+graphify affected "BaseHouse" --depth 1                 # what depends on this
+graphify query "how does spell damage reach a Mobile"   # BFS, broad context
+graphify query "..." --dfs                              # trace one path
+graphify path "BaseHouse" "Item"                        # shortest path
+graphify explain "MonsterAbility"                       # plain-language summary
+```
+
+`affected` is the most useful of these before a refactor: it walks edges in
+reverse and prints each dependent with a `file.cs:Lnnn` location, so the result
+is a list you can open rather than a list you have to go find.
+
+### As an MCP server
+
+Exposes `query_graph`, `get_node`, `get_neighbors`, `get_community`,
+`god_nodes`, `graph_stats` and `shortest_path` to any MCP-capable agent:
+
+```sh
+python -m graphify.serve graphify-out/graph.json
+```
+
+## Rebuilding it
+
+Two paths, depending on whether you want the prose layer refreshed too.
+
+**Code only** — no LLM, no agent, fully scriptable, a few minutes:
+
+```sh
+graphify update .                                   # re-extract C#, re-cluster
+python tools/knowledge-graph/label_communities.py   # re-derive community names
+graphify export html && graphify export wiki
+python tools/knowledge-graph/package_artifacts.py
+```
+
+**Everything**, including the ~53 nodes extracted from `README.md`,
+`CONTRIBUTING.md`, `CLAUDE.md` and the CI workflows: run `/graphify` from
+Claude Code (it drives the LLM pass), then the same last three commands.
+
+Run `label_communities.py` **after every rebuild**. Both paths re-cluster, and
+clustering renumbers communities — labels from a previous run will not line up.
+
+Full instructions, including the Cloudflare deploy, are in
+[`tools/knowledge-graph/README.md`](../tools/knowledge-graph/README.md).
+
+The corpus is pinned by `.graphifyignore` at the repo root, which graphify reads
+automatically, so a rebuild covers the same files for everyone. It deliberately
+excludes generated migration snapshots, `dev-docs/`, vendored material and
+local-only directories.
+
+Cost is low: the structural pass is deterministic C# parsing, and only the 16
+prose/CI files reach an LLM (well under 100k tokens for a full rebuild).
+
+## Known limitations
+
+Be aware of these before trusting an answer:
+
+- **Unresolved references are dropped.** About 12% of extracted edges point at
+  something with no node — BCL types, generic parameters like `T`, and symbols
+  outside the corpus. Those edges do not appear in the graph. Absence of an
+  edge is therefore not proof that no relationship exists.
+- **Edge multiplicity is lost.** A method that calls another forty times on
+  forty lines yields one edge, not forty. Edges answer *whether*, never *how
+  often*.
+- **Communities are statistical, not architectural.** Clustering is run on
+  connectivity, so a cluster can straddle what a developer would call two
+  systems, or split one. Community names are generated from the dominant
+  source directory — useful labels, not a design document.
+- **Clustering is not deterministic.** The same corpus produces a different
+  number of communities from run to run (1,621, 1,643 and 1,700 across three
+  builds of the same commit), and members shift between them. Node and edge
+  counts are stable; community structure is approximate. This is why community
+  names are regenerated from content after every rebuild rather than written
+  down once.
+- **Nothing runtime is modelled.** Reflection, `[Constructible]` discovery,
+  event wiring resolved at startup, serialization migrations and anything
+  driven by config are invisible to a structural parse. ModernUO leans on all
+  of these, so the graph understates coupling in exactly the places the engine
+  is most dynamic.
+- **The graph lags `main`.** See `manifest.json`.

--- a/tools/knowledge-graph/README.md
+++ b/tools/knowledge-graph/README.md
@@ -1,0 +1,116 @@
+# ModernUO knowledge graph — build & deploy
+
+Tooling that turns the ModernUO source tree into a queryable knowledge graph and
+publishes it. For what the graph *is* and how to use it, read
+[`dev-docs/knowledge-graph.md`](../../dev-docs/knowledge-graph.md).
+
+The graph is a **derived artifact**. It is never committed: it is tens of
+megabytes, and it goes stale the moment `main` moves. It is rebuilt on demand
+and hosted, and `manifest.json` records the commit it came from so anyone can
+tell how far behind the hosted copy has drifted.
+
+## What lives here
+
+| File | Purpose |
+|---|---|
+| `label_communities.py` | Names each community from its contents, deterministically |
+| `package_artifacts.py` | Compresses the build into `dist/` for upload |
+| `README.md` | This file |
+
+`dist/` and `graphify-out/` are both gitignored.
+
+## Rebuilding
+
+Requires [graphify](https://github.com/safishamsi/graphify) (0.8.49+) and Python 3.10+:
+
+```sh
+uv tool install graphifyy     # or: pip install graphifyy
+```
+
+From the repository root:
+
+```sh
+graphify update .                                   # re-extract C#, rebuild, re-cluster
+python tools/knowledge-graph/label_communities.py   # stable community names
+graphify export html                                # interactive viewer
+graphify export wiki                                # per-community articles
+python tools/knowledge-graph/package_artifacts.py   # -> tools/knowledge-graph/dist/
+```
+
+`graphify update` is structural only: it re-parses C# with no LLM and no agent,
+which makes it the path to script. It does **not** refresh the ~53 nodes
+extracted from the prose and CI files — for those, run `/graphify` from Claude
+Code, which drives the LLM pass, and then the same last three commands.
+
+Two things about `update` are easy to get wrong:
+
+- **It re-clusters.** Communities are renumbered on every run, so
+  `label_communities.py` must run after it or the names will not line up with
+  the communities they describe.
+- **It skips `graph.html`** because the graph is far above graphify's 5,000-node
+  viz limit. `graphify export html` handles that by aggregating to a
+  community-level view, so run it explicitly.
+
+The corpus is defined by [`.graphifyignore`](../../.graphifyignore) at the repo
+root, which graphify reads automatically — no flags needed, and everyone who
+rebuilds gets the same file set. It currently resolves to ~4,190 files: every
+`.cs` file tracked in `Projects/`, the solution and project files, and the
+top-level docs and CI workflows.
+
+Expect roughly 5 minutes on a modern machine. The structural pass is pure C#
+AST parsing — parallel, free, and identical run to run, so the `update` path
+above costs no tokens at all. The full `/graphify` path adds only the 16
+prose/CI files, which lands well under 100k tokens.
+
+### Why labels are generated, not hand-written
+
+graphify numbers communities arbitrarily; the same corpus can yield different
+integer IDs run to run. Names written against those IDs would be wrong the
+first time anyone regenerated the graph. `label_communities.py` therefore
+derives every name from the community's dominant source directory plus its
+most-connected member, so rebuilds reproduce the same names and the wiki stays
+diffable. Names that would otherwise be unhelpfully generic are corrected
+through the `OVERRIDES` table, keyed by directory rather than by ID.
+
+## Deploying to Cloudflare
+
+`package_artifacts.py` writes one self-contained directory, `dist/site/`:
+
+```
+index.html        the interactive graph
+graph.json.gz     full graph, ~1.4 MB compressed
+wiki.tar.gz       per-community articles
+GRAPH_REPORT.md   audit report
+manifest.json     source commit, counts, artifact sizes
+_headers          content types, and no-cache on manifest.json
+```
+
+That is the whole deploy. With
+[wrangler](https://developers.cloudflare.com/workers/wrangler/) authenticated:
+
+```sh
+wrangler pages deploy tools/knowledge-graph/dist/site --project-name modernuo-knowledge-graph
+```
+
+Then point the Pages project's custom domain at `graph.muo.gg`, the hostname
+`dev-docs/knowledge-graph.md` and the skill send agents to. Keep the three in
+sync if it ever changes.
+
+### Why Pages and not R2
+
+The full artifact set is a few MB, and the largest single file is the 2.3 MB
+`index.html` — comfortably inside Pages' 25 MB per-file limit. Serving it all
+from Pages means one command, one hostname, and no bucket to make public; R2
+objects are private by default, which is an easy way to hand agents a 401
+instead of a graph. Reach for R2 only if an artifact outgrows the per-file
+limit or you want versioned history of past graphs.
+
+### Serving notes
+
+- `_headers` marks the `.gz` files `application/gzip` so they are served as
+  opaque downloads. Consumers decompress them (`| tar xz`, `gunzip`) rather
+  than relying on transparent decoding.
+- `manifest.json` is served `no-cache`, so a freshness check never reads a
+  stale commit. Everything else is cached for an hour.
+- Deploys are atomic, so there is no window where `manifest.json` advertises a
+  commit whose artifacts have not landed yet.

--- a/tools/knowledge-graph/label_communities.py
+++ b/tools/knowledge-graph/label_communities.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Assign stable, human-readable names to the communities in a graphify graph.
+
+graphify's clusterer numbers communities arbitrarily -- the same corpus can
+produce different integer IDs on different runs. Naming them by hand against
+those IDs would therefore go stale the first time anyone regenerates the graph.
+
+Instead every name here is a pure function of the community's *contents*:
+its dominant source directory, plus its most-connected member when two
+communities would otherwise collide. Regenerating the graph reproduces the
+same names, so the wiki and report stay diffable across rebuilds.
+
+Usage:
+    python label_communities.py [--out graphify-out/.graphify_labels.json]
+
+Reads graphify-out/graph.json and graphify-out/.graphify_analysis.json.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+from pathlib import Path
+
+# Directories whose derived name would be unhelpfully generic or misleading.
+# Keyed by dominant source directory, which is stable across rebuilds.
+OVERRIDES = {
+    "Projects/Server/Items": "Server Item Core",
+    "Projects/Server/Mobiles": "Server Mobile Core",
+    "Projects/Server/Collections": "Pooled Collections & Array Pools",
+    "Projects/Server/Serialization": "Serialization Core",
+    "Projects/Server/Network/Packets": "Server Network Packets",
+    "Projects/Server/Json/Converters": "JSON Converters",
+    "Projects/UOContent/Network/Packets": "Content Network Packets",
+    "Projects/UOContent/Items/Weapons": "BaseWeapon Combat",
+    "Projects/UOContent/Items/Weapons/Abilities": "Weapon Special Abilities",
+    "Projects/UOContent/Multis/Houses": "Housing System",
+    "Projects/UOContent/Engines/Craft/Core": "Crafting System Core",
+    "Projects/UOContent/Engines/ML Quests/Definitions": "ML Quest Definitions",
+    "Projects/UOContent/Mobiles/Vendors/SBInfo": "Vendor Stock Definitions",
+    "Projects/UOContent/Mobiles/Abilities": "Monster Ability Framework",
+    "Projects/UOContent/Commands": "Command Handlers",
+    "Projects/UOContent/Gumps/Base": "Gump Builders",
+    "Projects/UOContent/Spells/Base": "Spell Core",
+}
+
+PROJECTS = {
+    "UOContent", "Server", "Server.Tests", "UOContent.Tests",
+    "BuildTool", "Logger", "Application",
+}
+
+
+def dominant_dir(members, nodes):
+    """Most common parent directory among a community's file-backed members."""
+    dirs = collections.Counter()
+    for m in members:
+        node = nodes.get(m)
+        if not node:
+            continue
+        src = (node.get("source_file") or "").replace("\\", "/")
+        if "/" in src:
+            dirs["/".join(src.split("/")[:-1])] += 1
+    return dirs.most_common(1)[0][0] if dirs else None
+
+
+def derive(path):
+    """Turn 'Projects/UOContent/Items/Weapons' into 'Items / Weapons'."""
+    parts = [p for p in path.split("/") if p and p != "Projects"]
+    if parts and parts[0] in PROJECTS:
+        project, rest = parts[0], parts[1:]
+    else:
+        project, rest = "", parts
+    tail = " / ".join(rest[-2:]) if rest else project
+    # Content lives in UOContent by default; name the other projects explicitly
+    # so a test or engine community is never mistaken for game content.
+    if project and project != "UOContent":
+        tail = f"{project}: {tail}" if tail else project
+    return tail or "Unclassified"
+
+
+# Language primitives, ubiquitous BCL generics and test attributes. These are
+# the most-connected node in many communities but say nothing about what the
+# community *is*, so they never get to name one.
+STOPLIST = {
+    "bool", "byte", "sbyte", "char", "short", "ushort", "int", "uint", "long",
+    "ulong", "float", "double", "decimal", "string", "object", "void", "var",
+    "Type", "Types", "Array", "List", "IList", "Dictionary", "IDictionary",
+    "HashSet", "IEnumerable", "ICollection", "IComparer", "IComparable",
+    "Span", "ReadOnlySpan", "Memory", "Nullable", "Func", "Action", "Predicate",
+    "DateTime", "TimeSpan", "Guid", "Exception", "Task", "Enum", "Struct",
+    "Fact", "Theory", "InlineData", "MethodImpl", "Description", "Usage",
+    "Aliases", "Serial", "T", "T1", "T2", "T3", "TKey", "TValue",
+}
+
+
+def hub(members, nodes, degree, scope=None):
+    """Most-connected member that actually names the community.
+
+    Prefers, in order: a type defined inside the community's own directory,
+    any type outside the stoplist, then anything at all. Methods (labels
+    starting with ".") are a last resort -- ".OnHit()" identifies a community
+    far less well than "BaseWeapon" does.
+    """
+    ranked = sorted(members, key=lambda m: -degree[m])
+
+    def candidates(in_scope, allow_stopped, allow_method):
+        for m in ranked:
+            node = nodes.get(m)
+            if not node:
+                continue
+            label = (node.get("label") or "").strip()
+            if not label:
+                continue
+            if not allow_method and label.startswith("."):
+                continue
+            if not allow_stopped and label.lstrip(".") in STOPLIST:
+                continue
+            if in_scope:
+                src = (node.get("source_file") or "").replace("\\", "/")
+                if not scope or not src.startswith(scope):
+                    continue
+            yield label
+
+    for in_scope, allow_stopped, allow_method in (
+        (True, False, False),    # a local type -- the best case
+        (False, False, False),   # any meaningful type
+        (True, False, True),     # a local method
+        (False, True, True),     # anything, including primitives
+    ):
+        for label in candidates(in_scope, allow_stopped, allow_method):
+            return label
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graph", default="graphify-out/graph.json")
+    ap.add_argument("--analysis", default="graphify-out/.graphify_analysis.json")
+    ap.add_argument("--out", default="graphify-out/.graphify_labels.json")
+    args = ap.parse_args()
+
+    graph = json.loads(Path(args.graph).read_text(encoding="utf-8"))
+    analysis = json.loads(Path(args.analysis).read_text(encoding="utf-8"))
+    nodes = {n["id"]: n for n in graph["nodes"]}
+
+    degree = collections.Counter()
+    for link in graph["links"]:
+        degree[link["source"]] += 1
+        degree[link["target"]] += 1
+
+    communities = analysis["communities"]
+
+    # Pass 1: base name from the dominant directory.
+    base = {}
+    for cid, members in communities.items():
+        path = dominant_dir(members, nodes)
+        if path is None:
+            label = hub(members, nodes, degree) or "Unclassified"
+        else:
+            label = OVERRIDES.get(path) or derive(path)
+        base[cid] = label
+
+    # Pass 2: several communities can share a directory. Disambiguate the
+    # collisions with each one's hub so every name points somewhere distinct.
+    counts = collections.Counter(base.values())
+    labels = {}
+    for cid, label in base.items():
+        if counts[label] == 1:
+            labels[cid] = label
+            continue
+        h = hub(communities[cid], nodes, degree,
+                scope=dominant_dir(communities[cid], nodes))
+        labels[cid] = f"{label} - {h}" if h else label
+
+    Path(args.out).write_text(
+        json.dumps(labels, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    distinct = len(set(labels.values()))
+    print(f"Labelled {len(labels)} communities ({distinct} distinct) -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/knowledge-graph/package_artifacts.py
+++ b/tools/knowledge-graph/package_artifacts.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Package a built graphify graph for hosting on Cloudflare Pages.
+
+Everything lands in one directory, tools/knowledge-graph/dist/site/ (gitignored),
+so publishing is a single `wrangler pages deploy` with no bucket to configure:
+
+    index.html        the interactive graph
+    graph.json.gz     the full graph for agents and tooling (~24x smaller)
+    wiki.tar.gz       the per-community wiki articles
+    GRAPH_REPORT.md   the audit report
+    manifest.json     what commit this was built from, and how big it is
+    _headers          content types, and no-cache on manifest.json
+
+The whole set is a few MB and the largest file is well inside Pages' 25 MB
+per-file limit, so R2 buys nothing here.
+
+manifest.json is the staleness signal: it records the commit the graph was
+extracted from, so a consumer can compare it against origin/main and know
+how far behind the hosted copy has drifted. It is served no-cache so a
+freshness check never reads a stale answer.
+
+Usage:
+    python package_artifacts.py [--graphify-out graphify-out] [--dist dist]
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import shutil
+import subprocess
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def human(n):
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.1f}{unit}" if unit != "B" else f"{n}B"
+        n /= 1024
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--graphify-out", default=None,
+                    help="graphify output dir (default: <repo>/graphify-out)")
+    ap.add_argument("--dist", default=None,
+                    help="output dir (default: alongside this script)")
+    args = ap.parse_args()
+
+    repo = HERE.parent.parent
+    out = Path(args.graphify_out) if args.graphify_out else repo / "graphify-out"
+    dist = Path(args.dist) if args.dist else HERE / "dist"
+
+    graph_json = out / "graph.json"
+    if not graph_json.exists():
+        raise SystemExit(f"{graph_json} not found - run /graphify first")
+
+    if dist.exists():
+        shutil.rmtree(dist)
+    site = dist / "site"
+    site.mkdir(parents=True)
+
+    graph = json.loads(graph_json.read_text(encoding="utf-8"))
+    commit = graph.get("built_at_commit")
+
+    # graph.json.gz -- the payload agents actually fetch
+    raw = graph_json.read_bytes()
+    gz_path = site / "graph.json.gz"
+    gz_path.write_bytes(gzip.compress(raw, 9))
+
+    # site/index.html -- Cloudflare Pages serves index.html at the root
+    html = out / "graph.html"
+    if html.exists():
+        shutil.copyfile(html, site / "index.html")
+
+    # wiki.tar.gz -- thousands of small files, so archive rather than upload each
+    wiki = out / "wiki"
+    wiki_files = 0
+    wiki_path = site / "wiki.tar.gz"
+    if wiki.is_dir():
+        with tarfile.open(wiki_path, "w:gz", compresslevel=9) as tar:
+            tar.add(wiki, arcname="wiki")
+        wiki_files = sum(1 for _ in wiki.rglob("*") if _.is_file())
+
+    # The report is small enough to serve uncompressed next to the site.
+    report = out / "GRAPH_REPORT.md"
+    if report.exists():
+        shutil.copyfile(report, site / "GRAPH_REPORT.md")
+
+    describe = None
+    try:
+        describe = subprocess.run(
+            ["git", "-C", str(repo), "describe", "--tags", "--always"],
+            capture_output=True, text=True, check=False).stdout.strip() or None
+    except OSError:
+        pass
+
+    manifest = {
+        "built_at_commit": commit,
+        "built_at_describe": describe,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "directed": graph.get("directed"),
+        "nodes": len(graph.get("nodes", [])),
+        "edges": len(graph.get("links", [])),
+        "communities": len({n.get("community") for n in graph.get("nodes", [])
+                            if n.get("community") is not None}),
+        "artifacts": {
+            "graph.json.gz": gz_path.stat().st_size,
+            "wiki.tar.gz": wiki_path.stat().st_size if wiki_path.exists() else None,
+            "index.html": (site / "index.html").stat().st_size
+                          if (site / "index.html").exists() else None,
+        },
+        "wiki_articles": wiki_files or None,
+    }
+    (site / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    # Cloudflare Pages reads _headers at the site root. The .gz files must be
+    # served as opaque downloads rather than transparently re-encoded, and the
+    # freshness manifest must never be answered from cache.
+    (site / "_headers").write_text(
+        "/graph.json.gz\n"
+        "  Content-Type: application/gzip\n"
+        "  Cache-Control: public, max-age=3600\n"
+        "/wiki.tar.gz\n"
+        "  Content-Type: application/gzip\n"
+        "  Cache-Control: public, max-age=3600\n"
+        "/manifest.json\n"
+        "  Content-Type: application/json\n"
+        "  Cache-Control: no-cache\n"
+        "/GRAPH_REPORT.md\n"
+        "  Content-Type: text/markdown; charset=utf-8\n",
+        encoding="utf-8")
+
+    print(f"Packaged into {site}")
+    print(f"  commit      {commit}")
+    print(f"  graph       {manifest['nodes']:,} nodes / {manifest['edges']:,} edges "
+          f"/ {manifest['communities']:,} communities")
+    for name, size in manifest["artifacts"].items():
+        if size:
+            print(f"  {name:<18} {human(size)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds tooling and docs for a queryable map of the codebase: **30,892 nodes and 64,845 directed edges** over every tracked `.cs` file in `Projects/`, clustered into subsystems. It exists to answer "what calls this", "what breaks if I change it" and "where does this feature live" by traversal instead of by grep across 4,000+ files.

Built with [graphify](https://github.com/safishamsi/graphify). The most connected types come out as you'd hope, which is a reasonable sanity check on the extraction:

`BaseCreature` (889) · `PlayerMobile` (558) · `Mobile` (420) · `IGenericReader` (314) · `IPropertyList` (289) · `MLQuest` (277) · `CommandEventArgs` (231) · `IEntity` (226) · `Item` (219) · `BaseHouse` (209)

## The graph itself is not committed

It's ~34 MB of derived JSON that is stale the moment `main` moves, and git keeps every version forever — in a repo whose largest tracked file is 768 KB. So this PR is **docs and tooling only** (~770 lines, no `.cs` touched). The artifacts are built on demand and hosted on Cloudflare Pages; `manifest.json` records the commit they came from so anyone can see how far the hosted copy has drifted.

The full artifact set is a few MB with a 2.3 MB largest file, so it all fits in a single Pages deploy — no R2 bucket, one `wrangler pages deploy`, one hostname.

## What's here

- **`.graphifyignore`** pins the corpus so every rebuild covers the same files, and graphify reads it automatically (a plain rebuild needs no flags). It resolves to exactly the 4,160 tracked `.cs` files plus project files, top-level docs and CI workflows — verified against `git ls-files`. Patterns are rooted deliberately: an unrooted `tools/` also matches `Items/Skill Items/Tools/` and silently drops 31 crafting files.
- **`tools/knowledge-graph/label_communities.py`** names communities from their contents instead of by hand. Clustering renumbers communities every run — three builds of the same commit gave 1,621, 1,643 and 1,700 — so hand-written names would break the first time anyone regenerated.
- **`tools/knowledge-graph/package_artifacts.py`** packages a build into one directory that deploys with a single command.
- **`dev-docs/knowledge-graph.md`** and a **`modernuo-knowledge-graph` skill**, wired into the `CLAUDE.md` tables.

## Both docs lead with the limits

This is a map, not ground truth, and the docs say so up front:

- **~12% of extracted edges are dropped** as unresolved (BCL types, generic params, symbols outside the corpus). **Absence of an edge is not evidence of absence** — the skill tells agents to confirm with a grep before ever claiming "nothing calls X".
- **Edge multiplicity is lost** — forty calls collapse to one edge. It answers *whether*, never *how often*.
- **Nothing resolved at runtime is modelled** — reflection, `[Constructible]` discovery, event wiring, serialization migrations. The graph understates coupling exactly where the engine is most dynamic.
- **Communities are statistical and non-deterministic**, and the graph lags `main`.

## Before merging

The docs point agents at `https://graph.muo.gg`. That hostname needs to exist (Pages custom domain) or the links are dead — happy to swap it if you'd rather use something else.

## Regenerating

```sh
graphify update .                                   # no LLM, no agent, scriptable
python tools/knowledge-graph/label_communities.py
graphify export html && graphify export wiki
python tools/knowledge-graph/package_artifacts.py
wrangler pages deploy tools/knowledge-graph/dist/site --project-name modernuo-knowledge-graph
```

The structural pass is pure C# AST parsing — parallel, free, no tokens. Only the full `/graphify` path touches an LLM, for the 16 prose/CI files, and lands under 100k tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
