### PR TITLE
fix: world save failure handling — no partial snapshots, no worker crash, staged publication

### DIFF
--- a/Projects/Server.Tests/Tests/Serialization/GenericEntityPersistenceRoundTripTests.cs
+++ b/Projects/Server.Tests/Tests/Serialization/GenericEntityPersistenceRoundTripTests.cs
@@ -20,7 +20,7 @@ internal class RoundTripEntity : ISerializable
     {
     }
 
-    public void Serialize(IGenericWriter writer)
+    public virtual void Serialize(IGenericWriter writer)
     {
         writer.Write(Value);
         writer.Write(Name);
@@ -31,6 +31,15 @@ internal class RoundTripEntity : ISerializable
         Value = reader.ReadInt();
         Name = reader.ReadString();
     }
+}
+
+internal class ThrowingRoundTripEntity : RoundTripEntity
+{
+    public ThrowingRoundTripEntity(Serial serial) : base(serial)
+    {
+    }
+
+    public override void Serialize(IGenericWriter writer) => throw new InvalidOperationException("broken serializer");
 }
 
 [Collection("Sequential Server Tests")]
@@ -158,6 +167,145 @@ public class GenericEntityPersistenceRoundTripTests
 
             World._threadWorkers = previousWorkers;
             AssemblyHandler.Assemblies = previousAssemblies;
+            Directory.Delete(dir, true);
+        }
+    }
+
+    /// <summary>
+    /// A serializer throwing on a worker used to be an unhandled exception on that thread.
+    /// The worker records it, finishes the drain so the handshake completes, and the loop
+    /// fails the save.
+    /// </summary>
+    [Fact]
+    public void SerializerException_IsRecordedOnTheWorker_AndTheDrainCompletes()
+    {
+        var source = new SerializationChunkSource();
+        var workers = new SerializationThreadWorker[2];
+        for (var i = 0; i < workers.Length; i++)
+        {
+            workers[i] = new SerializationThreadWorker(i, source);
+            workers[i].AllocateHeap();
+        }
+
+        var persistence = new RoundTripPersistence(2002);
+
+        try
+        {
+            for (var i = 1; i <= 100; i++)
+            {
+                var serial = (Serial)(uint)i;
+                persistence.EntitiesBySerial[serial] = i == 50
+                    ? new ThrowingRoundTripEntity(serial)
+                    : new RoundTripEntity(serial) { Value = i, Name = $"entity-{i}" };
+            }
+
+            foreach (var worker in workers)
+            {
+                worker.Wake();
+            }
+
+            source.SetOwner(persistence);
+            Assert.True(persistence.TrySnapshotEntries(out var slotCount));
+            source.PushSlotRanges(persistence, slotCount);
+            source.Flush();
+
+            foreach (var worker in workers)
+            {
+                worker.Sleep();
+            }
+
+            Exception error = null;
+            foreach (var worker in workers)
+            {
+                error ??= worker.Error;
+            }
+
+            Assert.IsType<InvalidOperationException>(error);
+            persistence.PostWorldSave();
+
+            // The next drain starts clean.
+            foreach (var worker in workers)
+            {
+                worker.Wake();
+            }
+
+            foreach (var worker in workers)
+            {
+                worker.Sleep();
+                Assert.Null(worker.Error);
+            }
+        }
+        finally
+        {
+            persistence.Unregister();
+
+            foreach (var worker in workers)
+            {
+                worker.Exit();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A segment that cannot be written used to be logged and dropped, publishing a save
+    /// without those entities (the loader then deletes them). It now fails the save.
+    /// </summary>
+    [Fact]
+    public void WriteSnapshot_FailsTheSave_InsteadOfDroppingASegment()
+    {
+        var source = new SerializationChunkSource();
+        var workers = new SerializationThreadWorker[2];
+        for (var i = 0; i < workers.Length; i++)
+        {
+            workers[i] = new SerializationThreadWorker(i, source);
+            workers[i].AllocateHeap();
+        }
+
+        var previousWorkers = World._threadWorkers;
+        World._threadWorkers = workers;
+
+        var persistence = new RoundTripPersistence(2003);
+        var dir = Path.Combine(Path.GetTempPath(), $"muo-segmentfail-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            for (var i = 1; i <= 100; i++)
+            {
+                var serial = (Serial)(uint)i;
+                persistence.EntitiesBySerial[serial] = new RoundTripEntity(serial) { Value = i, Name = $"entity-{i}" };
+            }
+
+            // Deliberately not registered: the writer cannot index the type.
+
+            foreach (var worker in workers)
+            {
+                worker.Wake();
+            }
+
+            source.SetOwner(persistence);
+            Assert.True(persistence.TrySnapshotEntries(out var slotCount));
+            source.PushSlotRanges(persistence, slotCount);
+            source.Flush();
+
+            foreach (var worker in workers)
+            {
+                worker.Sleep();
+            }
+
+            Assert.Throws<InvalidOperationException>(() => persistence.WriteSnapshot(dir));
+            persistence.PostWorldSave();
+        }
+        finally
+        {
+            persistence.Unregister();
+
+            foreach (var worker in workers)
+            {
+                worker.Exit();
+            }
+
+            World._threadWorkers = previousWorkers;
             Directory.Delete(dir, true);
         }
     }

--- a/Projects/Server.Tests/Tests/Serialization/StagedSavePublishTests.cs
+++ b/Projects/Server.Tests/Tests/Serialization/StagedSavePublishTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Server.Tests;
+
+/// <summary>
+/// The publish protocol: a complete snapshot is staged next to Saves/ before the previous
+/// save is touched, and an interrupted publish is finished at the next boot or save.
+/// </summary>
+[Collection("Sequential Server Tests")]
+public class StagedSavePublishTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"muo-staged-{Guid.NewGuid():N}");
+    private readonly string _previousSavePath;
+
+    public StagedSavePublishTests()
+    {
+        Directory.CreateDirectory(_root);
+        _previousSavePath = World.SavePath;
+        World.SetSavePathForTest(Path.Combine(_root, "Saves"));
+    }
+
+    public void Dispose()
+    {
+        World.SetSavePathForTest(_previousSavePath);
+
+        try
+        {
+            Directory.Delete(_root, true);
+        }
+        catch
+        {
+            // best effort
+        }
+    }
+
+    private static void WriteMarker(string dir, string name)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "marker.txt"), name);
+    }
+
+    private static string ReadMarker(string dir) => File.ReadAllText(Path.Combine(dir, "marker.txt"));
+
+    [Fact]
+    public void NothingStaged_RecoveryIsANoOp()
+    {
+        WriteMarker(World.SavePath, "current");
+
+        World.RecoverStagedSave();
+
+        Assert.Equal("current", ReadMarker(World.SavePath));
+        Assert.Single(Directory.GetDirectories(_root));
+    }
+
+    [Fact]
+    public void StagedSave_ReplacesSaves_AndKeepsThePreviousOne()
+    {
+        WriteMarker(World.SavePath, "old");
+        WriteMarker(World.StagedSavePath, "new");
+
+        World.RecoverStagedSave();
+
+        Assert.Equal("new", ReadMarker(World.SavePath));
+        Assert.False(Directory.Exists(World.StagedSavePath));
+
+        var aside = Array.FindAll(Directory.GetDirectories(_root), d => d.Contains(".previous-"));
+        Assert.Single(aside);
+        Assert.Equal("old", ReadMarker(aside[0]));
+    }
+
+    [Fact]
+    public void StagedSave_WithNoSaves_IsPublished()
+    {
+        WriteMarker(World.StagedSavePath, "new");
+
+        World.RecoverStagedSave();
+
+        Assert.Equal("new", ReadMarker(World.SavePath));
+        Assert.Single(Directory.GetDirectories(_root));
+    }
+}

--- a/Projects/Server/Serialization/GenericEntityPersistence.cs
+++ b/Projects/Server/Serialization/GenericEntityPersistence.cs
@@ -206,8 +206,7 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
                 }
                 catch (Exception error)
                 {
-                    // A partial snapshot must never be published: every entity missing from the
-                    // idx is deleted at the next load. Fail the save and keep the previous one.
+                    // Never publish a partial snapshot: entities missing from the idx are deleted on load.
                     logger.Error(
                         error,
                         "Error writing segment: (Thread: {Thread} - {Start}, {Records} records)",
@@ -322,8 +321,7 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
     private ushort GetTypeIndex(T entity)
     {
         // Every path into EntitiesBySerial registers the type first, so this cannot fire.
-        // If it ever does, WriteSnapshot logs it and fails the save (the previous save stays),
-        // so treat any occurrence as a serious bug in an insertion path, not a bad entity.
+        // If it does, the save fails; treat it as a bug in an insertion path, not a bad entity.
         if (!_typeIndexes.TryGetValue(entity.GetType(), out var typeIndex))
         {
             throw new InvalidOperationException(

--- a/Projects/Server/Serialization/GenericEntityPersistence.cs
+++ b/Projects/Server/Serialization/GenericEntityPersistence.cs
@@ -158,6 +158,7 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
                     _selfPosition,
                     _selfLength
                 );
+                throw;
             }
 
             binPosition += _selfLength;
@@ -205,6 +206,8 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
                 }
                 catch (Exception error)
                 {
+                    // A partial snapshot must never be published: every entity missing from the
+                    // idx is deleted at the next load. Fail the save and keep the previous one.
                     logger.Error(
                         error,
                         "Error writing segment: (Thread: {Thread} - {Start}, {Records} records)",
@@ -212,6 +215,7 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
                         segment.HeapStart,
                         segment.RecordCount
                     );
+                    throw;
                 }
             }
         }
@@ -318,8 +322,7 @@ public class GenericEntityPersistence<T> : GenericPersistence, IGenericEntityPer
     private ushort GetTypeIndex(T entity)
     {
         // Every path into EntitiesBySerial registers the type first, so this cannot fire.
-        // If it ever does, the segment-level catch in WriteSnapshot logs it and moves on —
-        // the failed segment's records are dropped from the idx while binPosition rewinds,
+        // If it ever does, WriteSnapshot logs it and fails the save (the previous save stays),
         // so treat any occurrence as a serious bug in an insertion path, not a bad entity.
         if (!_typeIndexes.TryGetValue(entity.GetType(), out var typeIndex))
         {

--- a/Projects/Server/Serialization/SerializationThreadWorker.cs
+++ b/Projects/Server/Serialization/SerializationThreadWorker.cs
@@ -79,6 +79,13 @@ public class SerializationThreadWorker
     internal List<IGenericSerializable> BufferEntities => _bufferEntities;
 
     /// <summary>
+    /// The first exception a serializer threw on this worker during the drain. The drain
+    /// continues so the queue empties and the handshake completes; the loop reads this after
+    /// every worker paused and fails the save instead of letting the worker thread die.
+    /// </summary>
+    public Exception Error { get; private set; }
+
+    /// <summary>
     /// Releases the write logs after the snapshot is written so serialized entity
     /// references don't linger between saves. Capacity is retained: the logs regrow to
     /// the same size every save.
@@ -155,6 +162,25 @@ public class SerializationThreadWorker
 
     private long ProcessChunk(in SerializationChunkSource.Chunk chunk, BufferWriter writer)
     {
+        try
+        {
+            return ProcessChunkCore(in chunk, writer);
+        }
+        catch (Exception ex)
+        {
+            Error ??= ex;
+
+            if (chunk.Buffer != null)
+            {
+                _chunkSource.Return(chunk.Buffer, chunk.Count);
+            }
+
+            return 0;
+        }
+    }
+
+    private long ProcessChunkCore(in SerializationChunkSource.Chunk chunk, BufferWriter writer)
+    {
         if (chunk.Single != null)
         {
             // Self-payloads are written to their own file, so they record placement on the
@@ -213,6 +239,7 @@ public class SerializationThreadWorker
     public void DrainInline()
     {
         ReleaseWriteLogs();
+        Error = null;
 
         var writer = new BufferWriter(_heap, true);
         var entities = 0L;
@@ -238,6 +265,7 @@ public class SerializationThreadWorker
         while (worker._startEvent.WaitOne())
         {
             worker.ReleaseWriteLogs();
+            worker.Error = null;
 
             var writer = new BufferWriter(worker._heap, true);
             var entities = 0L;

--- a/Projects/Server/Serialization/SerializationThreadWorker.cs
+++ b/Projects/Server/Serialization/SerializationThreadWorker.cs
@@ -79,9 +79,8 @@ public class SerializationThreadWorker
     internal List<IGenericSerializable> BufferEntities => _bufferEntities;
 
     /// <summary>
-    /// The first exception a serializer threw on this worker during the drain. The drain
-    /// continues so the queue empties and the handshake completes; the loop reads this after
-    /// every worker paused and fails the save instead of letting the worker thread die.
+    /// First serializer exception during the drain. The drain continues so the handshake
+    /// completes; the loop fails the save once every worker has paused.
     /// </summary>
     public Exception Error { get; private set; }
 

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -197,7 +197,6 @@ public static class World
         logger.Information("Loading world");
         var watch = Stopwatch.StartNew();
 
-        // A complete save left staged by an interrupted publish is newer than Saves/.
         RecoverStagedSave();
 
         Persistence.Load(SavePath);
@@ -276,8 +275,6 @@ public static class World
     {
         try
         {
-            // Finish a publish that failed after its files were complete, before the new
-            // save can overwrite the staging directory. Off-loop: directory work only.
             RecoverStagedSave();
 
             // Allocate the heaps for the GC
@@ -337,8 +334,7 @@ public static class World
             exception = ex;
         }
 
-        // Even a failed publish leaves workers spinning on the queue: always join them, and
-        // treat a serializer failure on any worker (or on the inline drain) as a failed save.
+        // Always join the workers; any serializer exception fails the save.
         try
         {
             PauseSerializationThreads();
@@ -363,7 +359,6 @@ public static class World
             }
             catch (Exception ex)
             {
-                // A save handler failing does not invalidate the serialized snapshot.
                 logger.Error(ex, "A WorldSave handler failed");
                 Persistence.TraceException(ex);
             }
@@ -383,7 +378,6 @@ public static class World
         }
         else
         {
-            // Nothing is written: the previous save stays authoritative.
             logger.Error(exception, "Saving world {Status}", "failed");
             Persistence.TraceException(exception);
 
@@ -421,27 +415,18 @@ public static class World
     }
 
     /// <summary>
-    /// The staging directory next to <see cref="SavePath" />. A snapshot moves here as soon as
-    /// its files are complete, before anything touches the previous save, so whatever fails
-    /// afterwards a complete newest save is on disk and <see cref="RecoverStagedSave" /> can
-    /// finish publishing it.
+    /// A complete snapshot is staged here before the previous save is touched; a staged
+    /// directory is always a complete save newer than <see cref="SavePath" />.
     /// </summary>
     internal static string StagedSavePath => SavePath + ".next";
 
-    /// <summary>
-    /// Publishes a complete snapshot: stage it, let subscribers archive the previous save
-    /// (<see cref="EventSink.WorldSavePostSnapshot" />, which is how the previous Saves/ ends
-    /// up in Backups/), then put the staged save in place. Before this protocol the previous
-    /// save was moved away first, and a subscriber or the final move failing left nothing
-    /// at Saves/ until the next save.
-    /// </summary>
+    // Stage, let subscribers archive the previous save, then rename the staged save into place.
     private static void PublishSnapshot(string snapshotPath)
     {
         var staging = StagedSavePath;
 
         if (Directory.Exists(staging))
         {
-            // Recovery ran before this save and failed to publish it; do not destroy it.
             SetAside(staging, "unpublished");
         }
 
@@ -460,7 +445,6 @@ public static class World
 
         if (Directory.Exists(SavePath))
         {
-            // No subscriber archived the previous save (or it failed part way). Keep it.
             SetAside(SavePath, "previous");
         }
 
@@ -469,9 +453,8 @@ public static class World
     }
 
     /// <summary>
-    /// Finishes an interrupted publish: a staged directory is always a complete save newer than
-    /// <see cref="SavePath" />. Runs at boot (before load, when archive subscribers are not
-    /// wired yet) and before every save. Whatever is at Saves/ is set aside, never deleted.
+    /// Finishes an interrupted publish. Runs at boot (before load) and before every save;
+    /// whatever is at Saves/ is set aside, never deleted.
     /// </summary>
     internal static void RecoverStagedSave()
     {
@@ -497,9 +480,7 @@ public static class World
         logger.Warning("Set aside {Path} as {Aside}; delete or archive it by hand.", path, aside);
     }
 
-    /// <summary>
-    /// Renames a directory when the volume allows it (atomic), otherwise moves its contents.
-    /// </summary>
+    // Atomic rename on one volume, file-by-file move otherwise.
     private static void MoveDirectory(string source, string destination)
     {
         try

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -122,6 +122,8 @@ public static class World
         UseMultiThreadedSaves = ServerConfiguration.GetOrUpdateSetting("world.useMultithreadedSaves", true);
     }
 
+    internal static void SetSavePathForTest(string path) => SavePath = path;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void WaitForWriteCompletion() => _diskWriteHandle.WaitOne();
 
@@ -194,6 +196,9 @@ public static class World
 
         logger.Information("Loading world");
         var watch = Stopwatch.StartNew();
+
+        // A complete save left staged by an interrupted publish is newer than Saves/.
+        RecoverStagedSave();
 
         Persistence.Load(SavePath);
         EventSink.InvokeWorldLoad();
@@ -271,6 +276,10 @@ public static class World
     {
         try
         {
+            // Finish a publish that failed after its files were complete, before the new
+            // save can overwrite the staging directory. Off-loop: directory work only.
+            RecoverStagedSave();
+
             // Allocate the heaps for the GC
             foreach (var worker in _threadWorkers)
             {
@@ -394,17 +403,7 @@ public static class World
             logger.Information("Writing world save snapshot");
 
             Persistence.WriteSnapshotAll(snapshotPath);
-
-            try
-            {
-                EventSink.InvokeWorldSavePostSnapshot(SavePath, snapshotPath);
-                PathUtility.MoveDirectoryContents(snapshotPath, SavePath);
-                Directory.SetLastWriteTimeUtc(SavePath, Core.Now);
-            }
-            catch (Exception ex)
-            {
-                Persistence.TraceException(ex);
-            }
+            PublishSnapshot(snapshotPath);
 
             watch.Stop();
             logger.Information("Writing world save snapshot {Status} ({Duration:F2} seconds)", "done", watch.Elapsed.TotalSeconds);
@@ -419,6 +418,103 @@ public static class World
 
         _diskWriteHandle.Set();
         Core.LoopContext.Post(FinishWorldSave);
+    }
+
+    /// <summary>
+    /// The staging directory next to <see cref="SavePath" />. A snapshot moves here as soon as
+    /// its files are complete, before anything touches the previous save, so whatever fails
+    /// afterwards a complete newest save is on disk and <see cref="RecoverStagedSave" /> can
+    /// finish publishing it.
+    /// </summary>
+    internal static string StagedSavePath => SavePath + ".next";
+
+    /// <summary>
+    /// Publishes a complete snapshot: stage it, let subscribers archive the previous save
+    /// (<see cref="EventSink.WorldSavePostSnapshot" />, which is how the previous Saves/ ends
+    /// up in Backups/), then put the staged save in place. Before this protocol the previous
+    /// save was moved away first, and a subscriber or the final move failing left nothing
+    /// at Saves/ until the next save.
+    /// </summary>
+    private static void PublishSnapshot(string snapshotPath)
+    {
+        var staging = StagedSavePath;
+
+        if (Directory.Exists(staging))
+        {
+            // Recovery ran before this save and failed to publish it; do not destroy it.
+            SetAside(staging, "unpublished");
+        }
+
+        MoveDirectory(snapshotPath, staging);
+        PublishStagedSave(archive: true);
+    }
+
+    private static void PublishStagedSave(bool archive)
+    {
+        var staging = StagedSavePath;
+
+        if (archive)
+        {
+            EventSink.InvokeWorldSavePostSnapshot(SavePath, staging);
+        }
+
+        if (Directory.Exists(SavePath))
+        {
+            // No subscriber archived the previous save (or it failed part way). Keep it.
+            SetAside(SavePath, "previous");
+        }
+
+        MoveDirectory(staging, SavePath);
+        Directory.SetLastWriteTimeUtc(SavePath, Core.Now);
+    }
+
+    /// <summary>
+    /// Finishes an interrupted publish: a staged directory is always a complete save newer than
+    /// <see cref="SavePath" />. Runs at boot (before load, when archive subscribers are not
+    /// wired yet) and before every save. Whatever is at Saves/ is set aside, never deleted.
+    /// </summary>
+    internal static void RecoverStagedSave()
+    {
+        var staging = StagedSavePath;
+
+        if (!Directory.Exists(staging))
+        {
+            return;
+        }
+
+        logger.Warning(
+            "A complete world save was staged at {Staging} but never published; publishing it now.",
+            staging
+        );
+
+        PublishStagedSave(archive: false);
+    }
+
+    private static void SetAside(string path, string reason)
+    {
+        var aside = $"{path}.{reason}-{Core.Now:yyyy-MM-dd-HH-mm-ss-fff}";
+        MoveDirectory(path, aside);
+        logger.Warning("Set aside {Path} as {Aside}; delete or archive it by hand.", path, aside);
+    }
+
+    /// <summary>
+    /// Renames a directory when the volume allows it (atomic), otherwise moves its contents.
+    /// </summary>
+    private static void MoveDirectory(string source, string destination)
+    {
+        try
+        {
+            Directory.Move(source, destination);
+        }
+        catch (IOException)
+        {
+            if (Directory.Exists(destination))
+            {
+                throw;
+            }
+
+            PathUtility.MoveDirectoryContents(source, destination);
+        }
     }
 
     private static void FinishWorldSave()

--- a/Projects/Server/World/World.cs
+++ b/Projects/Server/World/World.cs
@@ -322,22 +322,51 @@ public static class World
             }
 
             Persistence.SerializeAll();
-            PauseSerializationThreads();
-            LogWorkerBalance();
-
-            EventSink.InvokeWorldSave();
         }
         catch (Exception ex)
         {
             exception = ex;
         }
 
-        WorldState = WorldState.WritingSave;
-        ThreadPool.QueueUserWorkItem(WriteFiles, snapshotPath);
+        // Even a failed publish leaves workers spinning on the queue: always join them, and
+        // treat a serializer failure on any worker (or on the inline drain) as a failed save.
+        try
+        {
+            PauseSerializationThreads();
+        }
+        catch (Exception ex)
+        {
+            exception ??= ex;
+        }
+
+        for (var i = 0; i < _threadWorkers.Length; i++)
+        {
+            exception ??= _threadWorkers[i].Error;
+        }
+
+        if (exception == null)
+        {
+            LogWorkerBalance();
+
+            try
+            {
+                EventSink.InvokeWorldSave();
+            }
+            catch (Exception ex)
+            {
+                // A save handler failing does not invalidate the serialized snapshot.
+                logger.Error(ex, "A WorldSave handler failed");
+                Persistence.TraceException(ex);
+            }
+        }
+
         watch.Stop();
 
         if (exception == null)
         {
+            WorldState = WorldState.WritingSave;
+            ThreadPool.QueueUserWorkItem(WriteFiles, snapshotPath);
+
             var duration = watch.Elapsed.TotalSeconds;
             logger.Information("Saving world {Status} ({Duration:F2} seconds)", "done", duration);
 
@@ -345,10 +374,14 @@ public static class World
         }
         else
         {
+            // Nothing is written: the previous save stays authoritative.
             logger.Error(exception, "Saving world {Status}", "failed");
             Persistence.TraceException(exception);
 
             BroadcastStaff(0x35, true, "World save failed! Check the logs!");
+
+            _diskWriteHandle.Set();
+            FinishWorldSave();
         }
     }
 


### PR DESCRIPTION
Three pre-existing world-save failure-handling bugs, found while reviewing the delta-saves engine (#2610), split out so they land and get adopted on their own before the larger change. #2610 will be rebased on top once this merges. Tracked in project Delta Saves (#7).

## 1. A snapshot missing a segment was published

`GenericEntityPersistence.WriteSnapshot` logged a segment (or self-payload) write error and carried on. The save was published without those records, and every entity in the failed segment was deleted at the next load. The error now propagates: `WriteFiles` never moves a partial snapshot over `Saves/`, the previous save stays authoritative, and staff are told.

## 2. A serializer exception killed the process, or published a partial freeze

An entity whose `Serialize` threw on a worker thread was an unhandled exception on that thread, which terminates the process. On the inline (main-thread) drain it was caught, but the snapshot was still queued for writing with whatever the workers had produced. Workers now record the first exception and keep draining so the queue empties and the wake/pause handshake completes; after every worker paused, `Snapshot` treats a recorded error (or a failure of the drain itself) as a failed save: nothing is written, the previous save stays, staff are told, and the world resumes. A `WorldSave` handler throwing is logged but does not invalidate the serialized snapshot.

## 3. Publication was not transactional

Publishing moved the previous `Saves/` away (`AutoArchive` in `WorldSavePostSnapshot`) and only then moved the new files in. A subscriber throwing after the archive, or the final move failing, left nothing at `Saves/` until the next save; a crash in that window lost the newest save at the next boot.

The snapshot now moves to `Saves.next` as soon as its files are complete; only then do subscribers archive the previous save (same event, same `OldSavePath`, so `AutoArchive` and shard subscribers are unchanged), and the staged directory is renamed into place, which is atomic on one volume (file-by-file move across volumes). A staged directory is by construction a complete save newer than `Saves/`, so an interrupted publish is finished at the next boot (before load) or before the next save: whatever sits at `Saves/` is set aside as `Saves.previous-<timestamp>` (never deleted) and the staged save is published, with a warning naming the directory to archive or delete by hand.

## Tests

Server.Tests 860 / UOContent.Tests green. New: a throwing serializer is recorded on the worker and the next drain starts clean; a segment that cannot be indexed fails `WriteSnapshot` instead of dropping records; staged-save recovery with and without an existing `Saves/`, and as a no-op.