### PR TITLE
fix: handle null maps when deactivating creature AI

### DIFF
--- a/Projects/UOContent.Tests/Tests/Mobiles/AI/AIDeactivationTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/AI/AIDeactivationTests.cs
@@ -1,0 +1,33 @@
+using Server;
+using Xunit;
+
+namespace UOContent.Tests.Mobiles.AI;
+
+[Collection("Sequential UOContent Tests")]
+public class AIDeactivationTests
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Deactivate_WithoutWorldMap_StopsTimer(bool internalMap, bool controlled)
+    {
+        var creature = new PetTestStub();
+        try
+        {
+            creature.Controlled = controlled;
+            creature.Map = internalMap ? Map.Internal : null;
+            creature.AIObject.Activate();
+            Assert.True(creature.AIObject.AITimer.Running);
+
+            creature.AIObject.Deactivate();
+
+            Assert.False(creature.AIObject.AITimer.Running);
+        }
+        finally
+        {
+            creature.Delete();
+        }
+    }
+}

--- a/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
+++ b/Projects/UOContent/Mobiles/AI/BaseAI/BaseAI.cs
@@ -1102,7 +1102,7 @@ public abstract partial class BaseAI
 
     public virtual void Deactivate()
     {
-        if (Mobile.Map == Map.Internal || !Mobile.Controlled && !Mobile.Map.GetSector(Mobile.Location).Active)
+        if (Mobile.Map == null || Mobile.Map == Map.Internal || !Mobile.Controlled && !Mobile.Map.GetSector(Mobile.Location).Active)
         {
             AITimer.Stop();
         }


### PR DESCRIPTION
An uncontrolled creature with `Map == null` throws in `BaseAI.Deactivate()` when the condition reaches `Map.GetSector()`. A controlled creature with a null map avoids the exception but leaves its AI timer running.

Treat a null map like `Map.Internal` in the existing stop condition. This stops the timer without dereferencing the missing map and leaves the existing valid-map condition and return-home scheduling unchanged.

Addresses only the null-map `Deactivate()` item in #2627; the other audit items remain separate. No era-specific rules are changed.

Validation on Ubuntu / .NET 10, in isolated checkouts based on `c9831b968`:

- Added four regression cases covering null/internal maps with controlled/uncontrolled creatures.
- Unmodified upstream: both null-map cases fail (one NullReferenceException, one timer-still-running assertion); both internal-map cases pass.
- With the fix: all four cases pass.
- AI suite: 134 passed, 0 failed, 0 skipped.
- Full UOContent suite: 980 passed, 0 failed, 0 skipped.

The regression activates a real AI timer, calls `Deactivate()`, and verifies it stops. Tests used the existing static UO client data and did not run against a live world.

Commands (set `MODERNUO_TEST_DATA_DIR` to the static client files and `SolutionDir` to the checkout root):
```sh
dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj -c Release -p:SolutionDir="$PWD/" --filter FullyQualifiedName~AIDeactivationTests
dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj -c Release --no-build --filter FullyQualifiedName~UOContent.Tests.Mobiles.AI
dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj -c Release --no-build
```
