### PR TITLE
fix: respect active region MountsAllowed for players

### DIFF
--- a/Projects/UOContent.Tests/Tests/Mobiles/MountRegionTests.cs
+++ b/Projects/UOContent.Tests/Tests/Mobiles/MountRegionTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Server;
+using Server.Mobiles;
+using Server.Items;
+using Server.Regions;
+using Xunit;
+
+namespace UOContent.Tests.Mobiles;
+
+[Collection("Sequential UOContent Tests")]
+public class MountRegionTests
+{
+    public static IEnumerable<object[]> MountCases()
+    {
+        foreach (var era in Enum.GetValues<Expansion>())
+        {
+            foreach (var allowed in new[] { false, true })
+            {
+                yield return new object[] { era, allowed, false };
+                yield return new object[] { era, allowed, true };
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(MountCases))]
+    public void Mounting_RespectsActiveRegion(Expansion era, bool allowed, bool ethereal)
+    {
+        var previous = Core.Expansion;
+        var region = new MountTestRegion(allowed);
+        PlayerMobile player = null;
+        TestHorse horse = null;
+        EtherealHorse statue = null;
+        try
+        {
+            Core.Expansion = era;
+            region.Register();
+            player = new PlayerMobile(World.NewMobile);
+            player.DefaultMobileInit();
+            player.Race = Race.Human;
+            player.AddItem(new Backpack());
+            player.MoveToWorld(new Point3D(1000, 1000, 0), Map.Felucca);
+            Assert.Same(region, player.Region);
+
+            if (ethereal)
+            {
+                statue = new EtherealHorse { IsRewardItem = false };
+                player.Backpack.DropItem(statue);
+                Assert.Same(player.Backpack, statue.Parent);
+                Assert.Equal(allowed, statue.Validate(player));
+            }
+            else
+            {
+                horse = new TestHorse();
+                horse.MoveToWorld(player.Location, player.Map);
+                horse.SetControlMaster(player);
+                horse.OnDoubleClick(player);
+                Assert.Equal(allowed, horse.Rider == player);
+                Assert.Equal(allowed, player.Mounted);
+            }
+        }
+        finally
+        {
+            horse?.Delete();
+            statue?.Delete();
+            player?.Delete();
+            region.Unregister();
+            Core.Expansion = previous;
+        }
+    }
+
+    private class MountTestRegion : BaseRegion
+    {
+        private readonly bool _allowed;
+
+        public MountTestRegion(bool allowed)
+            : base("MountRegionTest", Map.Felucca, 100,
+                new Rectangle3D(990, 990, -128, 20, 20, 256))
+        {
+            _allowed = allowed;
+        }
+
+        public override bool MountsAllowed => _allowed;
+    }
+
+    // The test fixture does not configure NPCSpeeds.
+    private class TestHorse : Horse
+    {
+        public override void GetSpeeds(out double activeSpeed, out double passiveSpeed)
+        {
+            activeSpeed = 0.2;
+            passiveSpeed = 0.4;
+        }
+    }
+}

--- a/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
@@ -1,7 +1,8 @@
 using ModernUO.Serialization;
 using System;
 using Server.Items;
-using Server.Misc;using Server.Multis;
+using Server.Misc;
+using Server.Multis;
 using Server.Regions;
 using Server.Targeting;
 

--- a/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
+++ b/Projects/UOContent/Mobiles/Animals/Mounts/BaseMount.cs
@@ -1,8 +1,8 @@
 using ModernUO.Serialization;
 using System;
 using Server.Items;
-using Server.Misc;
-using Server.Multis;
+using Server.Misc;using Server.Multis;
+using Server.Regions;
 using Server.Targeting;
 
 namespace Server.Mobiles;
@@ -286,6 +286,12 @@ public abstract partial class BaseMount : BaseCreature, IMount
 
         if (mob is PlayerMobile mobile)
         {
+            if (mobile.Region is BaseRegion { MountsAllowed: false })
+            {
+                mobile.SendLocalizedMessage(1042317); // You may not ride at this time
+                result = false;
+            }
+
             if (mobile.MountBlockReason != BlockMountType.None)
             {
                 mobile.SendLocalizedMessage((int)mobile.MountBlockReason);


### PR DESCRIPTION
A player can mount a horse or validate an ethereal mount inside a BaseRegion that overrides MountsAllowed to false because CheckMountAllowed never consults that property. This adds the missing check in the shared player permission path, using existing localized message 1042317.

Related to #2628; based on the reporter's proposed check. This makes an existing customization option effective. It does not assert an OSI-wide dungeon mount ban, change any standard region defaults, or add dismount/stable/remount behavior.

@kamronbatman — would you be comfortable with this narrow approach? It checks the active region only, matching the reporter's snippet. An allowed child region will not automatically inherit a parent's restriction. Should parent-region inheritance be part of this fix, or handled separately? The check is scoped to PlayerMobile like the existing restrictions; no GM exemption is added. Leaving this as a draft for that policy discussion.

Validation on isolated Ubuntu/.NET 10 checkouts at c9831b968:

- 48 regression cases: all 12 Expansion enum values × allowed/restricted region × normal/ethereal path.
- Pristine upstream with the same tests: all 24 restricted cases fail; all 24 allowed cases pass.
- With this change: full UOContent suite passes, 1,024 passed / 0 failed / 0 skipped, including all 48 new cases.
- Normal mount tests call Horse.OnDoubleClick and check Rider/Mounted. The test horse only overrides speeds because NPCSpeeds is not configured by the fixture.
- Ethereal tests call EtherealHorse.Validate with a statuette in an equipped backpack; they do not simulate the full summon timer or client interaction. Reward-account eligibility is disabled in the test to isolate region permission.
- Both uploaded files match the tested files by Git blob hash. No live shard changes.

Run from the checkout root with MODERNUO_TEST_DATA_DIR pointing to static client files:
```sh
dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj -c Release -p:SolutionDir="$PWD/" --filter FullyQualifiedName~MountRegionTests
dotnet test Projects/UOContent.Tests/UOContent.Tests.csproj -c Release --no-build
```
