### PR TITLE
feat(skills): SkillEvents.SkillUsed for cross-assembly subscribers; InternalsVisibleTo ModernSpawner.Tests

### DIFF
--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -50,5 +50,8 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>UOContent.Tests</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>ModernSpawner.Tests</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 </Project>

--- a/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
+++ b/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
@@ -1,7 +1,5 @@
-using System;
 using Server;
 using Server.Misc;
-using Server.Tests;
 using Xunit;
 
 namespace UOContent.Tests;
@@ -81,8 +79,22 @@ public class SkillEventsTests
         var from = new Mobile();
         var skill = from.Skills[SkillName.Mining];
 
-        Assert.True(SkillCheck.CheckSkill(from, skill, null, 1.0));
+        var calls = 0;
 
-        from.Delete();
+        void Handler(Mobile m, Skill s, bool ok) => calls++;
+
+        try
+        {
+            // Subscribe and detach again so the invocation list is provably back to empty without reflection.
+            SkillEvents.SkillChecked += Handler;
+            SkillEvents.SkillChecked -= Handler;
+
+            Assert.True(SkillCheck.CheckSkill(from, skill, null, 1.0));
+            Assert.Equal(0, calls);
+        }
+        finally
+        {
+            from.Delete();
+        }
     }
 }

--- a/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
+++ b/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
@@ -1,0 +1,88 @@
+using System;
+using Server;
+using Server.Misc;
+using Server.Tests;
+using Xunit;
+
+namespace UOContent.Tests;
+
+[Collection("Sequential UOContent Tests")]
+public class SkillEventsTests
+{
+    [Fact]
+    public void CheckSkill_RaisesSkillChecked_WithFromSkillAndOutcome()
+    {
+        var from = new Mobile();
+        var skill = from.Skills[SkillName.Mining];
+
+        Mobile seenFrom = null;
+        Skill seenSkill = null;
+        var seenSuccess = false;
+        var calls = 0;
+
+        void Handler(Mobile m, Skill s, bool ok)
+        {
+            seenFrom = m;
+            seenSkill = s;
+            seenSuccess = ok;
+            calls++;
+        }
+
+        SkillEvents.SkillChecked += Handler;
+        try
+        {
+            // Utility.RandomDouble() is in [0, 1), so a chance of 1.0 always succeeds and 0.0 always fails.
+            var guaranteed = SkillCheck.CheckSkill(from, skill, null, 1.0);
+            Assert.True(guaranteed);
+            Assert.Equal(1, calls);
+            Assert.Same(from, seenFrom);
+            Assert.Same(skill, seenSkill);
+            Assert.True(seenSuccess);
+
+            var impossible = SkillCheck.CheckSkill(from, skill, null, 0.0);
+            Assert.False(impossible);
+            Assert.Equal(2, calls);
+            Assert.False(seenSuccess);
+        }
+        finally
+        {
+            SkillEvents.SkillChecked -= Handler;
+            from.Delete();
+        }
+    }
+
+    [Fact]
+    public void CheckSkill_WithZeroSkillCap_DoesNotRaiseSkillChecked()
+    {
+        var from = new Mobile();
+        var skill = from.Skills[SkillName.Mining];
+        from.Skills.Cap = 0;
+
+        var calls = 0;
+
+        void Handler(Mobile m, Skill s, bool ok) => calls++;
+
+        SkillEvents.SkillChecked += Handler;
+        try
+        {
+            Assert.False(SkillCheck.CheckSkill(from, skill, null, 1.0));
+            Assert.Equal(0, calls);
+        }
+        finally
+        {
+            SkillEvents.SkillChecked -= Handler;
+            from.Delete();
+        }
+    }
+
+    [Fact]
+    public void CheckSkill_WithNoSubscriber_DoesNotThrow()
+    {
+        var from = new Mobile();
+        var skill = from.Skills[SkillName.Mining];
+
+        Assert.True(SkillCheck.CheckSkill(from, skill, null, 1.0));
+
+        from.Delete();
+    }
+}

--- a/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
+++ b/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
@@ -29,7 +29,6 @@ public class SkillEventsTests
         SkillEvents.SkillChecked += Handler;
         try
         {
-            // Utility.RandomDouble() is in [0, 1), so a chance of 1.0 always succeeds and 0.0 always fails.
             var guaranteed = SkillCheck.CheckSkill(from, skill, null, 1.0);
             Assert.True(guaranteed);
             Assert.Equal(1, calls);
@@ -85,7 +84,6 @@ public class SkillEventsTests
 
         try
         {
-            // Subscribe and detach again so the invocation list is provably back to empty without reflection.
             SkillEvents.SkillChecked += Handler;
             SkillEvents.SkillChecked -= Handler;
 

--- a/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
+++ b/Projects/UOContent.Tests/Tests/Skills/SkillEventsTests.cs
@@ -7,88 +7,114 @@ namespace UOContent.Tests;
 [Collection("Sequential UOContent Tests")]
 public class SkillEventsTests
 {
+    private sealed class Recorder
+    {
+        public Mobile From;
+        public Skill Skill;
+        public bool Success;
+        public int Calls;
+
+        public void Handle(Mobile from, Skill skill, bool success)
+        {
+            From = from;
+            Skill = skill;
+            Success = success;
+            Calls++;
+        }
+    }
+
     [Fact]
-    public void CheckSkill_RaisesSkillChecked_WithFromSkillAndOutcome()
+    public void DirectTarget_RolledAttempt_RaisesOnceWithTheReturnedOutcome()
     {
         var from = new Mobile();
         var skill = from.Skills[SkillName.Mining];
+        var recorder = new Recorder();
 
-        Mobile seenFrom = null;
-        Skill seenSkill = null;
-        var seenSuccess = false;
-        var calls = 0;
-
-        void Handler(Mobile m, Skill s, bool ok)
-        {
-            seenFrom = m;
-            seenSkill = s;
-            seenSuccess = ok;
-            calls++;
-        }
-
-        SkillEvents.SkillChecked += Handler;
+        SkillEvents.SkillUsed += recorder.Handle;
         try
         {
-            var guaranteed = SkillCheck.CheckSkill(from, skill, null, 1.0);
-            Assert.True(guaranteed);
-            Assert.Equal(1, calls);
-            Assert.Same(from, seenFrom);
-            Assert.Same(skill, seenSkill);
-            Assert.True(seenSuccess);
+            var rolled = SkillCheck.Mobile_SkillCheckDirectTarget(from, SkillName.Mining, null, 0.5);
+            Assert.Equal(1, recorder.Calls);
+            Assert.Same(from, recorder.From);
+            Assert.Same(skill, recorder.Skill);
+            Assert.Equal(rolled, recorder.Success);
 
-            var impossible = SkillCheck.CheckSkill(from, skill, null, 0.0);
-            Assert.False(impossible);
-            Assert.Equal(2, calls);
-            Assert.False(seenSuccess);
+            Assert.False(SkillCheck.Mobile_SkillCheckDirectTarget(from, SkillName.Mining, null, 0.0));
+            Assert.Equal(2, recorder.Calls);
+            Assert.False(recorder.Success);
         }
         finally
         {
-            SkillEvents.SkillChecked -= Handler;
+            SkillEvents.SkillUsed -= recorder.Handle;
             from.Delete();
         }
     }
 
     [Fact]
-    public void CheckSkill_WithZeroSkillCap_DoesNotRaiseSkillChecked()
+    public void ShortCircuits_StillRaise_WithTheHandlerOutcome()
     {
         var from = new Mobile();
-        var skill = from.Skills[SkillName.Mining];
-        from.Skills.Cap = 0;
+        var recorder = new Recorder();
 
-        var calls = 0;
-
-        void Handler(Mobile m, Skill s, bool ok) => calls++;
-
-        SkillEvents.SkillChecked += Handler;
+        SkillEvents.SkillUsed += recorder.Handle;
         try
         {
-            Assert.False(SkillCheck.CheckSkill(from, skill, null, 1.0));
-            Assert.Equal(0, calls);
+            Assert.True(SkillCheck.Mobile_SkillCheckDirectLocation(from, SkillName.Mining, 1.0));
+            Assert.Equal(1, recorder.Calls);
+            Assert.True(recorder.Success);
+
+            Assert.False(SkillCheck.Mobile_SkillCheckDirectTarget(from, SkillName.Mining, null, -0.1));
+            Assert.Equal(2, recorder.Calls);
+            Assert.False(recorder.Success);
+
+            Assert.False(SkillCheck.Mobile_SkillCheckLocation(from, SkillName.Mining, 50.0, 100.0));
+            Assert.Equal(3, recorder.Calls);
+            Assert.False(recorder.Success);
+
+            Assert.True(SkillCheck.Mobile_SkillCheckTarget(from, SkillName.Mining, null, 0.0, 0.0));
+            Assert.Equal(4, recorder.Calls);
+            Assert.True(recorder.Success);
         }
         finally
         {
-            SkillEvents.SkillChecked -= Handler;
+            SkillEvents.SkillUsed -= recorder.Handle;
             from.Delete();
         }
     }
 
     [Fact]
-    public void CheckSkill_WithNoSubscriber_DoesNotThrow()
+    public void CheckSkill_Direct_DoesNotRaise()
     {
         var from = new Mobile();
         var skill = from.Skills[SkillName.Mining];
+        var recorder = new Recorder();
 
-        var calls = 0;
+        SkillEvents.SkillUsed += recorder.Handle;
+        try
+        {
+            SkillCheck.CheckSkill(from, skill, null, 1.0);
+            Assert.Equal(0, recorder.Calls);
+        }
+        finally
+        {
+            SkillEvents.SkillUsed -= recorder.Handle;
+            from.Delete();
+        }
+    }
 
-        void Handler(Mobile m, Skill s, bool ok) => calls++;
+    [Fact]
+    public void NoSubscriber_DoesNotThrow()
+    {
+        var from = new Mobile();
+        var recorder = new Recorder();
 
         try
         {
-            SkillEvents.SkillChecked += Handler;
-            SkillEvents.SkillChecked -= Handler;
+            SkillEvents.SkillUsed += recorder.Handle;
+            SkillEvents.SkillUsed -= recorder.Handle;
 
-            Assert.True(SkillCheck.CheckSkill(from, skill, null, 1.0));
-            Assert.Equal(0, calls);
+            Assert.True(SkillCheck.Mobile_SkillCheckDirectLocation(from, SkillName.Mining, 1.0));
+            Assert.Equal(0, recorder.Calls);
         }
         finally
         {

--- a/Projects/UOContent/Skills/SkillCheck.cs
+++ b/Projects/UOContent/Skills/SkillCheck.cs
@@ -141,6 +141,7 @@ public static class SkillCheck
             }
         }
 
+        SkillEvents.InvokeSkillChecked(from, skill, success);
         return success;
     }
 

--- a/Projects/UOContent/Skills/SkillCheck.cs
+++ b/Projects/UOContent/Skills/SkillCheck.cs
@@ -48,6 +48,13 @@ public static class SkillCheck
             return false;
         }
 
+        var success = CheckLocation(from, skill, minSkill, maxSkill);
+        SkillEvents.InvokeSkillUsed(from, skill, success);
+        return success;
+    }
+
+    private static bool CheckLocation(Mobile from, Skill skill, double minSkill, double maxSkill)
+    {
         var value = skill.Value;
 
         if (value < minSkill)
@@ -76,6 +83,13 @@ public static class SkillCheck
             return false;
         }
 
+        var success = CheckDirectLocation(from, skill, chance);
+        SkillEvents.InvokeSkillUsed(from, skill, success);
+        return success;
+    }
+
+    private static bool CheckDirectLocation(Mobile from, Skill skill, double chance)
+    {
         if (chance < 0.0)
         {
             return false; // Too difficult
@@ -141,7 +155,6 @@ public static class SkillCheck
             }
         }
 
-        SkillEvents.InvokeSkillChecked(from, skill, success);
         return success;
     }
 
@@ -157,6 +170,13 @@ public static class SkillCheck
             return false;
         }
 
+        var success = CheckTarget(from, skill, target, minSkill, maxSkill);
+        SkillEvents.InvokeSkillUsed(from, skill, success);
+        return success;
+    }
+
+    private static bool CheckTarget(Mobile from, Skill skill, object target, double minSkill, double maxSkill)
+    {
         var value = skill.Value;
 
         if (value < minSkill)
@@ -183,6 +203,13 @@ public static class SkillCheck
             return false;
         }
 
+        var success = CheckDirectTarget(from, skill, target, chance);
+        SkillEvents.InvokeSkillUsed(from, skill, success);
+        return success;
+    }
+
+    private static bool CheckDirectTarget(Mobile from, Skill skill, object target, double chance)
+    {
         if (chance < 0.0)
         {
             return false; // Too difficult

--- a/Projects/UOContent/Skills/SkillEvents.cs
+++ b/Projects/UOContent/Skills/SkillEvents.cs
@@ -11,11 +11,31 @@ namespace Server.Misc;
 public static class SkillEvents
 {
     /// <summary>
-    /// Raised once per <see cref="SkillCheck.CheckSkill(Mobile, Skill, object, double)" /> call, after
-    /// gains are applied, with the outcome of the check. Not raised when the check is skipped because
-    /// the mobile has a skill cap of zero. Runs on the game thread; subscribers must not block and
-    /// should not allocate.
+    /// Raised once per <see cref="SkillCheck.CheckSkill(Mobile, Skill, object, double)" /> call, after gains
+    /// are applied, with the outcome of the check.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Not every skill check reaches <c>CheckSkill</c>, so this event does not observe them all. The four
+    /// <c>Mobile_SkillCheck*</c> wrappers that <see cref="Mobile" /> dispatches through return before calling
+    /// it when the mobile has no such skill, when the check is too difficult
+    /// (<c>value &lt; minSkill</c>, or <c>chance &lt; 0.0</c>) and when the check is no challenge
+    /// (<c>value &gt;= maxSkill</c>, <c>minSkill &gt;= maxSkill</c>, or <c>chance &gt;= 1.0</c>). A
+    /// trivially successful check by a high-skill mobile therefore never raises this event even though it
+    /// returns <c>true</c>. Every skill check in this assembly reaches <c>CheckSkill</c> through one of those
+    /// wrappers, combat included. A caller that invokes <c>CheckSkill</c> directly always raises the event,
+    /// except for the <c>Skills.Cap == 0</c> early return, where no check is rolled.
+    /// </para>
+    /// <para>
+    /// Raised for every <see cref="Mobile" />, not only players: pets and monsters roll skill checks in
+    /// combat too, so a subscriber that only cares about players should filter on <c>PlayerMobile</c>.
+    /// <c>CheckSkill</c> does not test <see cref="Mobile.Deleted" />, so a subscriber must not assume
+    /// <c>from</c> is still in the world.
+    /// </para>
+    /// <para>
+    /// Runs on the game thread; subscribers must not block and should not allocate.
+    /// </para>
+    /// </remarks>
     public static event Action<Mobile, Skill, bool> SkillChecked;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Projects/UOContent/Skills/SkillEvents.cs
+++ b/Projects/UOContent/Skills/SkillEvents.cs
@@ -4,38 +4,17 @@ using System.Runtime.CompilerServices;
 namespace Server.Misc;
 
 /// <summary>
-/// Plain C# events raised by the skill system. These are deliberately not
-/// <c>CodeGeneratedEvents</c>: generated events dispatch statically inside this assembly, so
-/// content in another assembly (external spawners, quest systems) cannot subscribe to them.
+/// Skill system events. Plain C# events so other assemblies can subscribe; generated events cannot be
+/// subscribed across assemblies.
 /// </summary>
 public static class SkillEvents
 {
     /// <summary>
-    /// Raised once per <see cref="SkillCheck.CheckSkill(Mobile, Skill, object, double)" /> call, after gains
-    /// are applied, with the outcome of the check.
+    /// Raised once per <see cref="SkillCheck.CheckSkill(Mobile, Skill, object, double)" /> after gains are
+    /// applied. Not raised when the skill cap is zero, or when a <c>Mobile_SkillCheck*</c> wrapper
+    /// short-circuits (missing skill, too difficult, or no challenge) before reaching <c>CheckSkill</c>.
+    /// Fires for every <see cref="Mobile" />, including creatures. Subscribers must not block or allocate.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Not every skill check reaches <c>CheckSkill</c>, so this event does not observe them all. The four
-    /// <c>Mobile_SkillCheck*</c> wrappers that <see cref="Mobile" /> dispatches through return before calling
-    /// it when the mobile has no such skill, when the check is too difficult
-    /// (<c>value &lt; minSkill</c>, or <c>chance &lt; 0.0</c>) and when the check is no challenge
-    /// (<c>value &gt;= maxSkill</c>, <c>minSkill &gt;= maxSkill</c>, or <c>chance &gt;= 1.0</c>). A
-    /// trivially successful check by a high-skill mobile therefore never raises this event even though it
-    /// returns <c>true</c>. Every skill check in this assembly reaches <c>CheckSkill</c> through one of those
-    /// wrappers, combat included. A caller that invokes <c>CheckSkill</c> directly always raises the event,
-    /// except for the <c>Skills.Cap == 0</c> early return, where no check is rolled.
-    /// </para>
-    /// <para>
-    /// Raised for every <see cref="Mobile" />, not only players: pets and monsters roll skill checks in
-    /// combat too, so a subscriber that only cares about players should filter on <c>PlayerMobile</c>.
-    /// <c>CheckSkill</c> does not test <see cref="Mobile.Deleted" />, so a subscriber must not assume
-    /// <c>from</c> is still in the world.
-    /// </para>
-    /// <para>
-    /// Runs on the game thread; subscribers must not block and should not allocate.
-    /// </para>
-    /// </remarks>
     public static event Action<Mobile, Skill, bool> SkillChecked;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Projects/UOContent/Skills/SkillEvents.cs
+++ b/Projects/UOContent/Skills/SkillEvents.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Server.Misc;
+
+/// <summary>
+/// Plain C# events raised by the skill system. These are deliberately not
+/// <c>CodeGeneratedEvents</c>: generated events dispatch statically inside this assembly, so
+/// content in another assembly (external spawners, quest systems) cannot subscribe to them.
+/// </summary>
+public static class SkillEvents
+{
+    /// <summary>
+    /// Raised once per <see cref="SkillCheck.CheckSkill(Mobile, Skill, object, double)" /> call, after
+    /// gains are applied, with the outcome of the check. Not raised when the check is skipped because
+    /// the mobile has a skill cap of zero. Runs on the game thread; subscribers must not block and
+    /// should not allocate.
+    /// </summary>
+    public static event Action<Mobile, Skill, bool> SkillChecked;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void InvokeSkillChecked(Mobile from, Skill skill, bool success) =>
+        SkillChecked?.Invoke(from, skill, success);
+}

--- a/Projects/UOContent/Skills/SkillEvents.cs
+++ b/Projects/UOContent/Skills/SkillEvents.cs
@@ -10,14 +10,14 @@ namespace Server.Misc;
 public static class SkillEvents
 {
     /// <summary>
-    /// Raised once per <see cref="SkillCheck.CheckSkill(Mobile, Skill, object, double)" /> after gains are
-    /// applied. Not raised when the skill cap is zero, or when a <c>Mobile_SkillCheck*</c> wrapper
-    /// short-circuits (missing skill, too difficult, or no challenge) before reaching <c>CheckSkill</c>.
-    /// Fires for every <see cref="Mobile" />, including creatures. Subscribers must not block or allocate.
+    /// Raised once per skill attempt from the four <c>Mobile_SkillCheck*</c> handlers with the attempt's
+    /// outcome, including attempts the handler resolves without a roll (too difficult, no challenge).
+    /// Not raised when the mobile lacks the skill. Fires for every <see cref="Mobile" />, including
+    /// creatures. Subscribers must not block or allocate.
     /// </summary>
-    public static event Action<Mobile, Skill, bool> SkillChecked;
+    public static event Action<Mobile, Skill, bool> SkillUsed;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void InvokeSkillChecked(Mobile from, Skill skill, bool success) =>
-        SkillChecked?.Invoke(from, skill, success);
+    public static void InvokeSkillUsed(Mobile from, Skill skill, bool success) =>
+        SkillUsed?.Invoke(from, skill, success);
 }

--- a/dev-docs/events.md
+++ b/dev-docs/events.md
@@ -247,9 +247,9 @@ public static void HandlePlayerLogin(PlayerMobile player)
 Generated events dispatch statically inside `UOContent`; content that other assemblies must observe exposes a
 plain `static event` instead (shape: `Projects/UOContent/Engines/Help/HelpEvents.cs`).
 
-- `SkillEvents.SkillChecked` -- `Action<Mobile, Skill, bool success>`, raised once per `SkillCheck.CheckSkill`
-  after gains. Not raised when the skill cap is zero or when a `Mobile_SkillCheck*` wrapper short-circuits
-  (missing skill, too difficult, no challenge) before reaching `CheckSkill`. Fires for every `Mobile`.
+- `SkillEvents.SkillUsed` -- `Action<Mobile, Skill, bool success>`, raised once per skill attempt from the
+  four `Mobile_SkillCheck*` handlers with the attempt's outcome, including attempts resolved without a roll
+  (too difficult, no challenge). Not raised when the mobile lacks the skill. Fires for every `Mobile`.
 
 ---
 

--- a/dev-docs/events.md
+++ b/dev-docs/events.md
@@ -240,6 +240,16 @@ public static void HandlePlayerLogin(PlayerMobile player)
 - `PlayerMobile.PlayerDeathEvent` -- Player dies
 - `BaseCreature.CreatureDeathEvent` -- Creature dies
 
+### Static content events (subscribable from any assembly)
+
+Generated events dispatch statically inside `UOContent`, so code in another assembly cannot subscribe to
+them. Content that must be observable across assemblies exposes a plain `static event` instead (see
+`Projects/UOContent/Engines/Help/HelpEvents.cs` for the shape).
+
+- `SkillEvents.SkillChecked` -- `Action<Mobile, Skill, bool success>`, raised once per
+  `SkillCheck.CheckSkill` after gains are applied. Not raised when the mobile's skill cap is zero and the
+  check returns early.
+
 ---
 
 ## Event Args Pooling Pattern

--- a/dev-docs/events.md
+++ b/dev-docs/events.md
@@ -244,24 +244,12 @@ public static void HandlePlayerLogin(PlayerMobile player)
 
 ## Static Content Events
 
-Generated events dispatch statically inside `UOContent`, so code in another assembly cannot subscribe to
-them. Content that must be observable across assemblies exposes a plain `static event` instead (see
-`Projects/UOContent/Engines/Help/HelpEvents.cs` for the shape).
+Generated events dispatch statically inside `UOContent`; content that other assemblies must observe exposes a
+plain `static event` instead (shape: `Projects/UOContent/Engines/Help/HelpEvents.cs`).
 
-- `SkillEvents.SkillChecked` -- `Action<Mobile, Skill, bool success>`, raised once per
-  `SkillCheck.CheckSkill` after gains are applied. Not raised when the mobile's skill cap is zero and the
-  check returns early.
-
-  **It does not observe every skill check.** The four `Mobile_SkillCheck*` wrappers that `Mobile` dispatches
-  through return before reaching `CheckSkill` when the mobile has no such skill, when the check is too
-  difficult (`value < minSkill`, or `chance < 0.0`) and when it is no challenge (`value >= maxSkill`,
-  `minSkill >= maxSkill`, or `chance >= 1.0`) -- so a trivially successful check by a high-skill mobile
-  returns `true` without raising. Every skill check in `UOContent` goes through those wrappers, combat
-  included; a caller that invokes `CheckSkill` directly always raises.
-
-  It fires for every `Mobile`, not only players -- pets and monsters roll skill checks in combat too, so
-  subscribers usually filter on `PlayerMobile`. `CheckSkill` does not test `from.Deleted`, so a subscriber
-  must not assume the mobile is still in the world.
+- `SkillEvents.SkillChecked` -- `Action<Mobile, Skill, bool success>`, raised once per `SkillCheck.CheckSkill`
+  after gains. Not raised when the skill cap is zero or when a `Mobile_SkillCheck*` wrapper short-circuits
+  (missing skill, too difficult, no challenge) before reaching `CheckSkill`. Fires for every `Mobile`.
 
 ---
 

--- a/dev-docs/events.md
+++ b/dev-docs/events.md
@@ -240,7 +240,9 @@ public static void HandlePlayerLogin(PlayerMobile player)
 - `PlayerMobile.PlayerDeathEvent` -- Player dies
 - `BaseCreature.CreatureDeathEvent` -- Creature dies
 
-### Static content events (subscribable from any assembly)
+---
+
+## Static Content Events
 
 Generated events dispatch statically inside `UOContent`, so code in another assembly cannot subscribe to
 them. Content that must be observable across assemblies exposes a plain `static event` instead (see
@@ -249,6 +251,17 @@ them. Content that must be observable across assemblies exposes a plain `static 
 - `SkillEvents.SkillChecked` -- `Action<Mobile, Skill, bool success>`, raised once per
   `SkillCheck.CheckSkill` after gains are applied. Not raised when the mobile's skill cap is zero and the
   check returns early.
+
+  **It does not observe every skill check.** The four `Mobile_SkillCheck*` wrappers that `Mobile` dispatches
+  through return before reaching `CheckSkill` when the mobile has no such skill, when the check is too
+  difficult (`value < minSkill`, or `chance < 0.0`) and when it is no challenge (`value >= maxSkill`,
+  `minSkill >= maxSkill`, or `chance >= 1.0`) -- so a trivially successful check by a high-skill mobile
+  returns `true` without raising. Every skill check in `UOContent` goes through those wrappers, combat
+  included; a caller that invokes `CheckSkill` directly always raises.
+
+  It fires for every `Mobile`, not only players -- pets and monsters roll skill checks in combat too, so
+  subscribers usually filter on `PlayerMobile`. `CheckSkill` does not test `from.Deleted`, so a subscriber
+  must not assume the mobile is still in the world.
 
 ---
 


### PR DESCRIPTION
## Summary

Two small additive changes that an external content assembly (ModernSpawner) needs, as separable commits.

**1. `SkillEvents.SkillUsed`** (`Projects/UOContent/Skills/SkillEvents.cs`, namespace `Server.Misc`): a plain C# event `Action<Mobile, Skill, bool success>` raised once per skill attempt from each of the four `Mobile_SkillCheck*` handlers, with the handler's own result. Attempts the handler resolves without a roll (too difficult, no challenge) raise too, so a grandmaster's trivial success and a guaranteed combat roll are observable. Not raised when the mobile lacks the skill. Each handler keeps its logic in a private core method and raises on the way out, so there is exactly one raise per attempt and `CheckSkill` itself is unchanged.

- **Why a plain event and not a `[GeneratedEvent]`:** generated events are compile-time static dispatch inside the UOContent compilation, so a subscriber in another assembly cannot use `[OnEvent]`. Shape follows `HelpEvents`.
- **Why "used", not "gained":** this is the XmlSpawner skill-trigger semantic (it wrapped the same four handlers and passed their result as `success`; its grammar was `Skill[+/-]` for success-only or failure-only). Gains are already observable through the existing skill-change notification on `Mobile`.
- **Cost:** one delegate null-check per attempt when nothing is subscribed; no boxing, no closure, no allocation. The handlers sit on the combat swing path.
- **Exception contract:** subscriber exceptions propagate, matching `EventSink`/`HelpEvents`; no try/catch by design.

**2. `InternalsVisibleTo("ModernSpawner.Tests")`** on `Server.csproj`, beside the existing `Server.Tests`/`UOContent.Tests` entries, so an external test host can seed `Core._now` the way the engine's own test initializers do. Separable; a public test seam on `Core` would serve the same need without naming a downstream assembly.

## Open question

The payload is the `Skill` object plus a positional `bool`. A `readonly struct` args type passed `in` would leave room to add `chance` or the target later without breaking subscribers. Happy to change before merge.

## Test plan

- [x] `UOContent.Tests`: 4 tests — a rolled attempt raises once with the returned outcome; each short-circuit path (no challenge, too difficult, on both the direct and value-window handlers) raises with the handler's result; a direct `CheckSkill` call does not raise; no subscriber does not throw. Full suite green.
- [x] `Server` and `UOContent` build clean with `TreatWarningsAsErrors`.
- [ ] CI