### PR TITLE
feat(network): grow the send buffer on demand instead of disconnecting

### DIFF
--- a/Projects/Server.Tests/Tests/Network/NetStateDisconnectTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateDisconnectTests.cs
@@ -225,12 +225,10 @@ public class NetStateDisconnectTests
 
         try
         {
-            var capacity = ns._socket.SendBuffer.PhysicalSize;
+            ns.Send(new byte[NetState.MaxSendBufferSize + 1]); // cannot fit; queues the disconnect
+            ns.Send(new byte[NetState.MaxSendBufferSize + 2]); // same tick; must not re-report
 
-            ns.Send(new byte[capacity + 1]); // cannot fit; queues the disconnect
-            ns.Send(new byte[capacity + 2]); // same tick; must not re-report
-
-            Assert.Contains($"needed {capacity + 1}", ns._disconnectReason);
+            Assert.Contains($"needed {NetState.MaxSendBufferSize + 1}", ns._disconnectReason);
         }
         finally
         {

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -26,8 +26,7 @@ public class NetStateSendBufferTests
         return data;
     }
 
-    // Compressed length is only knowable by compressing; a short random prefix lands under the
-    // target, then appending zeros (2 bits each) walks it up one byte at a time without overshooting.
+    // A random prefix lands under the target; zeros (2 bits each) walk it up a byte at a time
     private static byte[] CompressesToExactly(int compressedLength, int seed)
     {
         var randomLength = compressedLength * 5 / 8;
@@ -71,8 +70,7 @@ public class NetStateSendBufferTests
         return received;
     }
 
-    // The peer having read everything is not the same as the send buffer being free: the completion
-    // that releases the bytes still has to land on the loop.
+    // Peer receipt does not free the buffer; the completion must land first
     private static void WaitForDrain(NetState ns)
     {
         var deadline = Stopwatch.StartNew();
@@ -100,7 +98,7 @@ public class NetStateSendBufferTests
 
         try
         {
-            // No Slice() between sends: nothing drains, so the base buffer overflows on its own
+            // No Slice(): nothing drains, so the base buffer overflows
             var chunk = baseSize / 4;
             var expected = new byte[chunk * 6];
             for (var i = 0; i < 6; i++)
@@ -133,7 +131,7 @@ public class NetStateSendBufferTests
 
         try
         {
-            // No Slice() between sends: compressed output accumulates until the base buffer overflows.
+            // No Slice(): compressed output accumulates until the base overflows
             var chunkLength = baseSize / 4;
             var expected = new byte[(chunkLength * 2 + 4) * 6];
             var scratch = new byte[chunkLength * 2 + 4];
@@ -182,9 +180,7 @@ public class NetStateSendBufferTests
 
         try
         {
-            // No Slice() between sends, so nothing drains; each chunk is sized off what's left (worst
-            // Huffman ratio 11/8, plus headroom) since random bytes never compress smaller than
-            // themselves, so the fill cannot overflow before it's full.
+            // Chunks sized so the fill cannot overflow (random bytes never compress; ratio at most 11/8)
             var seed = 600;
             while (ns._socket.SendBuffer.WritableBytes > 4096)
             {
@@ -192,13 +188,12 @@ public class NetStateSendBufferTests
                 SendAndRecord(Pattern(Math.Min(baseSize / 8, (writable - 2048) * 8 / 11), seed++));
             }
 
-            // Buffer now full: Send() has no span to compress into.
+            // Full; no span to compress into
             SendAndRecord(CompressesToExactly(ns._socket.SendBuffer.WritableBytes, seed));
             Assert.Equal(0, ns._socket.SendBuffer.WritableBytes);
             Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
 
-            // Raw, this exceeds what's left; compressed it is a quarter of that, so one tier suffices -
-            // growing against the raw length instead would demand the whole packet's worth of space.
+            // Raw exceeds the remainder; compressed fits in one tier
             SendAndRecord(new byte[Math.Min(baseSize * 3 / 4, NetworkCompression.DefiniteOverflow)]);
 
             Assert.True(ns.Running);
@@ -229,7 +224,7 @@ public class NetStateSendBufferTests
             first.CopyTo(expected, 0);
             second.CopyTo(expected, first.Length);
 
-            // The first send leaves a non-empty remainder that is too small for the second send.
+            // Remainder too small for the second send
             ns.Send(first);
             ns.Send(second);
 
@@ -255,15 +250,14 @@ public class NetStateSendBufferTests
 
         try
         {
-            // Shrinking the peer's receive buffer stalls the transfer: the first send stays in flight,
-            // so the second write has to grow around bytes in flight, not merely queued.
+            // A small peer buffer keeps the first send in flight through the growth
             client.ReceiveBufferSize = 4096;
 
             var first = Pattern(baseSize / 2, 300);
             var second = Pattern(baseSize / 2 + 1, 301);
 
             ns.Send(first);
-            NetState.Slice(); // posts the first send; loopback stalls once the peer's buffer fills
+            NetState.Slice(); // posts the first send
             Assert.True(ns._socket.SendBuffer.InFlightBytes > 0);
 
             ns.Send(second);
@@ -336,8 +330,7 @@ public class NetStateSendBufferTests
             ReadAll(client, chunk * 6);
             WaitForDrain(ns);
 
-            // The sweep is the only thing that shrinks an idle connection in production; nothing here
-            // calls TryShrinkSendBuffer itself.
+            // The sweep shrinks; nothing here calls TryShrinkSendBuffer
             Core._tickCount = ns._sendBufferGrewAt + NetState.SendBufferHoldMs;
             NetState.CheckAllAlive();
 
@@ -414,10 +407,9 @@ public class NetStateSendBufferTests
         try
         {
             ns.Disconnect("test");
-            NetState.Slice(); // hands the disconnect to the socket; it is draining from here
+            NetState.Slice(); // handoff
 
-            // CannotSendPackets short-circuits before any growth; keeping the buffer from draining is
-            // the last thing a closing connection needs.
+            // CannotSendPackets short-circuits before any growth
             ns.Send(Pattern(baseSize * 2, 500));
 
             Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
@@ -447,13 +439,13 @@ public class NetStateSendBufferTests
 
         Assert.Equal(0L, NetState.CoerceSendBufferGrowthBudget(-1, sendBufferSize, maxSendBufferSize));
 
-        // Zero is a deliberate "never grow", not a too-small budget
+        // zero means never grow
         Assert.Equal(0L, NetState.CoerceSendBufferGrowthBudget(0, sendBufferSize, maxSendBufferSize));
 
         Assert.Equal(minimum, NetState.CoerceSendBufferGrowthBudget(1, sendBufferSize, maxSendBufferSize));
         Assert.Equal(minimum * 4, NetState.CoerceSendBufferGrowthBudget(minimum * 4, sendBufferSize, maxSendBufferSize));
 
-        // Growth is off when the maximum is the base size, so the budget is taken as configured
+        // growth off; budget untouched
         Assert.Equal(1L, NetState.CoerceSendBufferGrowthBudget(1, sendBufferSize, sendBufferSize));
     }
 }

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Net.Sockets;
+using System.Network;
+using System.Threading;
 using Server.Network;
 using Xunit;
 
@@ -31,7 +33,9 @@ public class NetStateSendBufferTests
         while (total < length && deadline.ElapsedMilliseconds < 10000)
         {
             NetState.Slice();
-            if (client.Poll(1000, SelectMode.SelectRead))
+
+            // Poll takes microseconds, not milliseconds
+            if (client.Poll(50_000, SelectMode.SelectRead))
             {
                 var read = client.Receive(received, total, length - total, SocketFlags.None);
                 Assert.NotEqual(0, read);
@@ -41,6 +45,27 @@ public class NetStateSendBufferTests
 
         Assert.Equal(length, total);
         return received;
+    }
+
+    // The peer having read everything is not the same as the send buffer being free: the completion
+    // that releases the bytes still has to land on the loop.
+    private static void WaitForDrain(NetState ns)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (deadline.ElapsedMilliseconds < 10000)
+        {
+            NetState.Slice();
+
+            if (ns._socket.SendBuffer.ReadableBytes == 0 && ns._socket.SendBuffer.InFlightBytes == 0)
+            {
+                break;
+            }
+
+            Thread.Sleep(5);
+        }
+
+        Assert.Equal(0, ns._socket.SendBuffer.ReadableBytes);
+        Assert.Equal(0, ns._socket.SendBuffer.InFlightBytes);
     }
 
     [Fact]
@@ -147,6 +172,46 @@ public class NetStateSendBufferTests
     }
 
     [Fact]
+    public void Send_WithSendInFlight_GrowsAndStreamStaysIntact()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            // Shrinking the peer's receive buffer and never reading stalls the transfer: the posted
+            // send stays outstanding, so the second write has to grow around bytes still in flight
+            // rather than around bytes merely queued.
+            client.ReceiveBufferSize = 4096;
+
+            var first = Pattern(baseSize / 2, 300);
+            var second = Pattern(baseSize / 2 + 1, 301);
+
+            ns.Send(first);
+            NetState.Slice(); // posts the first send; loopback stalls once the peer's buffer fills
+            Assert.True(ns._socket.SendBuffer.InFlightBytes > 0);
+
+            ns.Send(second);
+
+            Assert.True(ns.Running);
+            Assert.Equal(string.Empty, ns._disconnectReason);
+            Assert.True(ns._socket.SendBuffer.PhysicalSize > baseSize);
+            Assert.True(ns._sendBufferGrown);
+
+            var expected = new byte[first.Length + second.Length];
+            first.CopyTo(expected, 0);
+            second.CopyTo(expected, first.Length);
+
+            Assert.Equal(expected, ReadAll(client, expected.Length));
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
     public void Shrink_AfterDrainAndHold_ReturnsToBase()
     {
         var ns = CreateAuthenticatedNetState(out var client);
@@ -162,13 +227,7 @@ public class NetStateSendBufferTests
 
             Assert.True(ns._sendBufferGrown);
             ReadAll(client, chunk * 6);
-
-            // Let the last send completion land before judging the drain
-            for (var i = 0; i < 20; i++)
-            {
-                NetState.Slice();
-                System.Threading.Thread.Sleep(5);
-            }
+            WaitForDrain(ns);
 
             var grewAt = ns._sendBufferGrewAt;
             Assert.False(ns.TryShrinkSendBuffer(grewAt + NetState.SendBufferHoldMs - 1));
@@ -178,6 +237,41 @@ public class NetStateSendBufferTests
         }
         finally
         {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
+    public void Shrink_ThroughAliveSweep_ReturnsToBase()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+        var previousTicks = Core._tickCount;
+
+        try
+        {
+            var chunk = baseSize / 4;
+            for (var i = 0; i < 6; i++)
+            {
+                ns.Send(Pattern(chunk, i + 400));
+            }
+
+            Assert.True(ns._sendBufferGrown);
+            ReadAll(client, chunk * 6);
+            WaitForDrain(ns);
+
+            // The sweep is the only thing that shrinks an idle connection in production; nothing here
+            // calls TryShrinkSendBuffer itself.
+            Core._tickCount = ns._sendBufferGrewAt + NetState.SendBufferHoldMs;
+            NetState.CheckAllAlive();
+
+            Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
+            Assert.False(ns._sendBufferGrown);
+        }
+        finally
+        {
+            Core._tickCount = previousTicks;
             ns.Dispose();
             client.Close();
         }
@@ -211,12 +305,15 @@ public class NetStateSendBufferTests
     public void Send_AboveMemoryCeiling_DoesNotGrow()
     {
         var previous = NetState.UnderMemoryCeiling;
-        NetState.UnderMemoryCeiling = static () => false;
-        var ns = CreateAuthenticatedNetState(out var client);
-        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+        NetState ns = null;
+        Socket client = null;
 
         try
         {
+            ns = CreateAuthenticatedNetState(out client);
+            var baseSize = ns._socket.SendBuffer.PhysicalSize;
+            NetState.UnderMemoryCeiling = static () => false;
+
             for (var i = 0; i < 6; i++)
             {
                 ns.Send(Pattern(baseSize / 4, i));
@@ -228,8 +325,60 @@ public class NetStateSendBufferTests
         finally
         {
             NetState.UnderMemoryCeiling = previous;
+            ns?.Dispose();
+            client?.Close();
+        }
+    }
+
+    [Fact]
+    public void Send_OnClosingSocket_DoesNotGrow()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            ns.Disconnect("test");
+            NetState.Slice(); // hands the disconnect to the socket; it is draining from here
+
+            // CannotSendPackets short-circuits before any growth; keeping the buffer from draining is
+            // the last thing a closing connection needs.
+            ns.Send(Pattern(baseSize * 2, 500));
+
+            Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
+            Assert.False(ns._sendBufferGrown);
+        }
+        finally
+        {
             ns.Dispose();
             client.Close();
         }
+    }
+
+    [Theory]
+    [InlineData(3 * 1024 * 1024, 4 * 1024 * 1024)]   // not a power of two; rounded up
+    [InlineData(512 * 1024 * 1024, 256 * 1024 * 1024)] // above the transport ceiling; capped
+    [InlineData(1024, 64 * 1024)]                     // below the minimum; raised
+    [InlineData(2 * 1024 * 1024, 2 * 1024 * 1024)]   // already valid; untouched
+    public void CoercePowerOfTwoSetting_CoercesToATierTheTransportAccepts(int configured, int expected) =>
+        Assert.Equal(expected, NetState.CoercePowerOfTwoSetting("network.sendBufferMaxSize", configured, 64 * 1024));
+
+    [Fact]
+    public void CoerceSendBufferGrowthBudget_ClampsNegativeAndRaisesBelowOneSlab()
+    {
+        const int sendBufferSize = 256 * 1024;
+        const int maxSendBufferSize = 2 * 1024 * 1024;
+        var minimum = RingSocketManager.MinimumSendBufferGrowthBudget(sendBufferSize);
+
+        Assert.Equal(0L, NetState.CoerceSendBufferGrowthBudget(-1, sendBufferSize, maxSendBufferSize));
+
+        // Zero is a deliberate "never grow", not a too-small budget
+        Assert.Equal(0L, NetState.CoerceSendBufferGrowthBudget(0, sendBufferSize, maxSendBufferSize));
+
+        Assert.Equal(minimum, NetState.CoerceSendBufferGrowthBudget(1, sendBufferSize, maxSendBufferSize));
+        Assert.Equal(minimum * 4, NetState.CoerceSendBufferGrowthBudget(minimum * 4, sendBufferSize, maxSendBufferSize));
+
+        // Growth is off when the maximum is the base size, so the budget is taken as configured
+        Assert.Equal(1L, NetState.CoerceSendBufferGrowthBudget(1, sendBufferSize, sendBufferSize));
     }
 }

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Network;
@@ -23,6 +24,30 @@ public class NetStateSendBufferTests
         var data = new byte[length];
         new System.Random(seed).NextBytes(data);
         return data;
+    }
+
+    // A chunk's compressed length is only knowable by compressing it. Random bytes inflate, so a
+    // short random prefix lands under the target; a zero costs two bits, so appending zeros walks the
+    // compressed length up one byte at a time and cannot step over the target.
+    private static byte[] CompressesToExactly(int compressedLength, int seed)
+    {
+        var randomLength = compressedLength * 5 / 8;
+        var data = new byte[compressedLength * 8];
+        Pattern(randomLength, seed).CopyTo(data, 0);
+
+        var scratch = new byte[compressedLength * 2 + 16];
+        for (var length = randomLength; length < data.Length; length++)
+        {
+            var compressed = NetworkCompression.Compress(data.AsSpan(0, length), scratch);
+            Assert.InRange(compressed, 1, compressedLength);
+
+            if (compressed == compressedLength)
+            {
+                return data[..length];
+            }
+        }
+
+        throw new InvalidOperationException($"No chunk compresses to exactly {compressedLength} bytes");
     }
 
     private static byte[] ReadAll(Socket client, int length)
@@ -131,6 +156,60 @@ public class NetStateSendBufferTests
 
             Array.Resize(ref expected, expectedLength);
             Assert.Equal(expected, ReadAll(client, expected.Length));
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
+    public void Send_CompressedGrowth_FullBuffer_GrowsOneTierAndFits()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        ns.CompressionEnabled = true;
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+        var expected = new List<byte>(baseSize * 2);
+
+        void SendAndRecord(byte[] data)
+        {
+            var scratch = new byte[data.Length * 2 + 4];
+            var compressedLength = NetworkCompression.Compress(data, scratch);
+            Assert.True(compressedLength > 0);
+            expected.AddRange(scratch.AsSpan(0, compressedLength));
+            ns.Send(data);
+        }
+
+        try
+        {
+            // No Slice() between sends: nothing drains, so the fill lands in the base buffer as written.
+            // Random bytes never compress smaller than themselves, and every chunk is sized off what is
+            // left (worst Huffman ratio 11/8, plus headroom), so the fill cannot overflow on its own.
+            var seed = 600;
+            while (ns._socket.SendBuffer.WritableBytes > 4096)
+            {
+                var writable = ns._socket.SendBuffer.WritableBytes;
+                SendAndRecord(Pattern(Math.Min(baseSize / 8, (writable - 2048) * 8 / 11), seed++));
+            }
+
+            // Completely full, which is the branch under test: Send() has no span to compress into.
+            SendAndRecord(CompressesToExactly(ns._socket.SendBuffer.WritableBytes, seed));
+            Assert.Equal(0, ns._socket.SendBuffer.WritableBytes);
+            Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
+
+            // Raw, this is larger than everything the full buffer has left; compressed it is a quarter
+            // of its size, so one tier is all it needs. Growing against the raw length instead demands
+            // the whole packet's worth of writable space, which refuses at the maximum on a shard whose
+            // maximum is near its base size.
+            SendAndRecord(new byte[Math.Min(baseSize * 3 / 4, NetworkCompression.DefiniteOverflow)]);
+
+            Assert.True(ns.Running);
+            Assert.Equal(string.Empty, ns._disconnectReason);
+            Assert.Equal(baseSize * 2, ns._socket.SendBuffer.PhysicalSize);
+            Assert.True(ns._sendBufferGrown);
+
+            Assert.Equal(expected.ToArray(), ReadAll(client, expected.Count));
         }
         finally
         {

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -26,9 +26,8 @@ public class NetStateSendBufferTests
         return data;
     }
 
-    // A chunk's compressed length is only knowable by compressing it. Random bytes inflate, so a
-    // short random prefix lands under the target; a zero costs two bits, so appending zeros walks the
-    // compressed length up one byte at a time and cannot step over the target.
+    // Compressed length is only knowable by compressing; a short random prefix lands under the
+    // target, then appending zeros (2 bits each) walks it up one byte at a time without overshooting.
     private static byte[] CompressesToExactly(int compressedLength, int seed)
     {
         var randomLength = compressedLength * 5 / 8;
@@ -183,9 +182,9 @@ public class NetStateSendBufferTests
 
         try
         {
-            // No Slice() between sends: nothing drains, so the fill lands in the base buffer as written.
-            // Random bytes never compress smaller than themselves, and every chunk is sized off what is
-            // left (worst Huffman ratio 11/8, plus headroom), so the fill cannot overflow on its own.
+            // No Slice() between sends, so nothing drains; each chunk is sized off what's left (worst
+            // Huffman ratio 11/8, plus headroom) since random bytes never compress smaller than
+            // themselves, so the fill cannot overflow before it's full.
             var seed = 600;
             while (ns._socket.SendBuffer.WritableBytes > 4096)
             {
@@ -193,15 +192,13 @@ public class NetStateSendBufferTests
                 SendAndRecord(Pattern(Math.Min(baseSize / 8, (writable - 2048) * 8 / 11), seed++));
             }
 
-            // Completely full, which is the branch under test: Send() has no span to compress into.
+            // Buffer now full: Send() has no span to compress into.
             SendAndRecord(CompressesToExactly(ns._socket.SendBuffer.WritableBytes, seed));
             Assert.Equal(0, ns._socket.SendBuffer.WritableBytes);
             Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
 
-            // Raw, this is larger than everything the full buffer has left; compressed it is a quarter
-            // of its size, so one tier is all it needs. Growing against the raw length instead demands
-            // the whole packet's worth of writable space, which refuses at the maximum on a shard whose
-            // maximum is near its base size.
+            // Raw, this exceeds what's left; compressed it is a quarter of that, so one tier suffices -
+            // growing against the raw length instead would demand the whole packet's worth of space.
             SendAndRecord(new byte[Math.Min(baseSize * 3 / 4, NetworkCompression.DefiniteOverflow)]);
 
             Assert.True(ns.Running);
@@ -258,9 +255,8 @@ public class NetStateSendBufferTests
 
         try
         {
-            // Shrinking the peer's receive buffer and never reading stalls the transfer: the posted
-            // send stays outstanding, so the second write has to grow around bytes still in flight
-            // rather than around bytes merely queued.
+            // Shrinking the peer's receive buffer stalls the transfer: the first send stays in flight,
+            // so the second write has to grow around bytes in flight, not merely queued.
             client.ReceiveBufferSize = 4096;
 
             var first = Pattern(baseSize / 2, 300);

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -76,6 +76,77 @@ public class NetStateSendBufferTests
     }
 
     [Fact]
+    public void Send_CompressedGrowth_RetriesAndStreamStaysIntact()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        ns.CompressionEnabled = true;
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            // No Slice() between sends: compressed output accumulates until the base buffer overflows.
+            var chunkLength = baseSize / 4;
+            var expected = new byte[(chunkLength * 2 + 4) * 6];
+            var scratch = new byte[chunkLength * 2 + 4];
+            var expectedLength = 0;
+            for (var i = 0; i < 6; i++)
+            {
+                var data = Pattern(chunkLength, i + 100);
+                var compressedLength = NetworkCompression.Compress(data, scratch);
+                Assert.True(compressedLength > 0);
+                scratch.AsSpan(0, compressedLength).CopyTo(expected.AsSpan(expectedLength));
+                expectedLength += compressedLength;
+                ns.Send(data);
+            }
+
+            Assert.True(ns.Running);
+            Assert.Equal(string.Empty, ns._disconnectReason);
+            Assert.True(ns._socket.SendBuffer.PhysicalSize > baseSize);
+            Assert.True(ns._sendBufferGrown);
+
+            Array.Resize(ref expected, expectedLength);
+            Assert.Equal(expected, ReadAll(client, expected.Length));
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
+    public void Send_WithPartialRemainder_GrowsAndCopiesFullPayload()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            var first = Pattern(baseSize / 2, 200);
+            var second = Pattern(baseSize / 2 + 1, 201);
+            var expected = new byte[first.Length + second.Length];
+            first.CopyTo(expected, 0);
+            second.CopyTo(expected, first.Length);
+
+            // The first send leaves a non-empty remainder that is too small for the second send.
+            ns.Send(first);
+            ns.Send(second);
+
+            Assert.True(ns.Running);
+            Assert.Equal(string.Empty, ns._disconnectReason);
+            Assert.True(ns._socket.SendBuffer.PhysicalSize > baseSize);
+            Assert.True(ns._sendBufferGrown);
+
+            Assert.Equal(expected, ReadAll(client, expected.Length));
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
     public void Send_PastTheMaximum_FallsBackToExhaustion()
     {
         var ns = CreateAuthenticatedNetState(out var client);

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -304,7 +304,7 @@ public class NetStateSendBufferTests
     [Fact]
     public void Send_AboveMemoryCeiling_DoesNotGrow()
     {
-        var previous = NetState.UnderMemoryCeiling;
+        var previous = NetState._availableMemoryBytes;
         NetState ns = null;
         Socket client = null;
 
@@ -312,7 +312,7 @@ public class NetStateSendBufferTests
         {
             ns = CreateAuthenticatedNetState(out client);
             var baseSize = ns._socket.SendBuffer.PhysicalSize;
-            NetState.UnderMemoryCeiling = static () => false;
+            NetState._availableMemoryBytes = 1; // any working set is above 80% of one byte
 
             for (var i = 0; i < 6; i++)
             {
@@ -324,7 +324,7 @@ public class NetStateSendBufferTests
         }
         finally
         {
-            NetState.UnderMemoryCeiling = previous;
+            NetState._availableMemoryBytes = previous;
             ns?.Dispose();
             client?.Close();
         }

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -147,6 +147,43 @@ public class NetStateSendBufferTests
     }
 
     [Fact]
+    public void Shrink_AfterDrainAndHold_ReturnsToBase()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            var chunk = baseSize / 4;
+            for (var i = 0; i < 6; i++)
+            {
+                ns.Send(Pattern(chunk, i));
+            }
+
+            Assert.True(ns._sendBufferGrown);
+            ReadAll(client, chunk * 6);
+
+            // Let the last send completion land before judging the drain
+            for (var i = 0; i < 20; i++)
+            {
+                NetState.Slice();
+                System.Threading.Thread.Sleep(5);
+            }
+
+            var grewAt = ns._sendBufferGrewAt;
+            Assert.False(ns.TryShrinkSendBuffer(grewAt + NetState.SendBufferHoldMs - 1));
+            Assert.True(ns.TryShrinkSendBuffer(grewAt + NetState.SendBufferHoldMs));
+            Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
+            Assert.False(ns._sendBufferGrown);
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
     public void Send_PastTheMaximum_FallsBackToExhaustion()
     {
         var ns = CreateAuthenticatedNetState(out var client);

--- a/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
+++ b/Projects/Server.Tests/Tests/Network/NetStateSendBufferTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Diagnostics;
+using System.Net.Sockets;
+using Server.Network;
+using Xunit;
+
+namespace Server.Tests.Network;
+
+[Collection("Sequential Server Tests")]
+public class NetStateSendBufferTests
+{
+    private static NetState CreateAuthenticatedNetState(out Socket client)
+    {
+        var ns = PacketTestUtilities.CreateTestNetState(out client);
+        ns.Account = new MockAccount();
+        return ns;
+    }
+
+    private static byte[] Pattern(int length, int seed)
+    {
+        var data = new byte[length];
+        new System.Random(seed).NextBytes(data);
+        return data;
+    }
+
+    private static byte[] ReadAll(Socket client, int length)
+    {
+        var received = new byte[length];
+        var total = 0;
+        var deadline = Stopwatch.StartNew();
+        while (total < length && deadline.ElapsedMilliseconds < 10000)
+        {
+            NetState.Slice();
+            if (client.Poll(1000, SelectMode.SelectRead))
+            {
+                var read = client.Receive(received, total, length - total, SocketFlags.None);
+                Assert.NotEqual(0, read);
+                total += read;
+            }
+        }
+
+        Assert.Equal(length, total);
+        return received;
+    }
+
+    [Fact]
+    public void Send_GrowsInsteadOfDisconnecting_AndStreamStaysIntact()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            // No Slice() between sends: nothing drains, so the base buffer overflows on its own
+            var chunk = baseSize / 4;
+            var expected = new byte[chunk * 6];
+            for (var i = 0; i < 6; i++)
+            {
+                var data = Pattern(chunk, i);
+                data.CopyTo(expected, i * chunk);
+                ns.Send(data);
+            }
+
+            Assert.True(ns.Running);
+            Assert.Equal(string.Empty, ns._disconnectReason);
+            Assert.True(ns._socket.SendBuffer.PhysicalSize > baseSize);
+            Assert.True(ns._sendBufferGrown);
+
+            Assert.Equal(expected, ReadAll(client, expected.Length));
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
+    public void Send_PastTheMaximum_FallsBackToExhaustion()
+    {
+        var ns = CreateAuthenticatedNetState(out var client);
+
+        try
+        {
+            var chunk = 64 * 1024;
+            var writes = NetState.MaxSendBufferSize / chunk + 1;
+            for (var i = 0; i < writes; i++)
+            {
+                ns.Send(Pattern(chunk, i));
+            }
+
+            Assert.Contains("Send buffer exhausted", ns._disconnectReason);
+            Assert.Equal(NetState.MaxSendBufferSize, ns._socket.SendBuffer.PhysicalSize);
+        }
+        finally
+        {
+            ns.Dispose();
+            client.Close();
+        }
+    }
+
+    [Fact]
+    public void Send_AboveMemoryCeiling_DoesNotGrow()
+    {
+        var previous = NetState.UnderMemoryCeiling;
+        NetState.UnderMemoryCeiling = static () => false;
+        var ns = CreateAuthenticatedNetState(out var client);
+        var baseSize = ns._socket.SendBuffer.PhysicalSize;
+
+        try
+        {
+            for (var i = 0; i < 6; i++)
+            {
+                ns.Send(Pattern(baseSize / 4, i));
+            }
+
+            Assert.Equal(baseSize, ns._socket.SendBuffer.PhysicalSize);
+            Assert.Contains("Send buffer exhausted", ns._disconnectReason);
+        }
+        finally
+        {
+            NetState.UnderMemoryCeiling = previous;
+            ns.Dispose();
+            client.Close();
+        }
+    }
+}

--- a/Projects/Server/Network/NetState/DumpNetStates.cs
+++ b/Projects/Server/Network/NetState/DumpNetStates.cs
@@ -28,11 +28,11 @@ public static class DumpNetStates
     {
         using var file = new StreamWriter($"netstatedump-{Core.Now:yyyy-M-d-HH-mm-ss}_{Core.TickCount}.csv");
 
-        file.WriteLine("NetState, ConnectedOn, NextActivityCheck, SocketConnected, ProtocolState, ParserState");
+        file.WriteLine("NetState, ConnectedOn, NextActivityCheck, SocketConnected, ProtocolState, ParserState, SendBufferSize");
 
         foreach (var ns in NetState.Instances)
         {
-            file.WriteLine($"{ns}, {ns.ConnectedOn}, {ns.NextActivityCheck}, {ns.IsConnected}, {ns._protocolState}, {ns._parserState}");
+            file.WriteLine($"{ns}, {ns.ConnectedOn}, {ns.NextActivityCheck}, {ns.IsConnected}, {ns._protocolState}, {ns._parserState}, {ns._socket?.SendBuffer.PhysicalSize ?? 0}");
         }
     }
 }

--- a/Projects/Server/Network/NetState/NetState.Network.cs
+++ b/Projects/Server/Network/NetState/NetState.Network.cs
@@ -170,6 +170,33 @@ public partial class NetState
             maxSendBufferSize: MaxSendBufferSize,
             sendBufferGrowthBudget: _sendBufferGrowthBudget
         );
+
+        Timer.DelayCall(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), MaintainSendBuffers);
+    }
+
+    internal static void MaintainSendBuffers()
+    {
+        if (_socketManager == null)
+        {
+            return;
+        }
+
+        var stats = _socketManager.Maintain();
+        if (stats.BuffersReleased > 0 || stats.GrowthRefusals > 0)
+        {
+            logger.Information(
+                "Send buffer tiers: {Capacity} bytes, {InUse} in use, floor {Floor}, released {Released}, growth refused {Refused}",
+                stats.TierCapacityBytes,
+                stats.TierInUse,
+                stats.TierRetainFloor,
+                stats.BuffersReleased,
+                stats.GrowthRefusals
+            );
+        }
+        else
+        {
+            logger.Debug("Send buffer tiers: {Capacity} bytes, {InUse} in use, floor {Floor}", stats.TierCapacityBytes, stats.TierInUse, stats.TierRetainFloor);
+        }
     }
 
     /// <summary>
@@ -527,6 +554,7 @@ public partial class NetState
                         {
                             // Update activity check on successful send
                             nsSend.NextActivityCheck = curTicks + 30000;
+                            nsSend.TryShrinkSendBuffer(curTicks);
                         }
                         break;
                     }
@@ -658,6 +686,7 @@ public partial class NetState
             foreach (var ns in Instances)
             {
                 ns.CheckAlive(curTicks);
+                ns.TryShrinkSendBuffer(curTicks);
             }
         }
         catch (Exception ex)

--- a/Projects/Server/Network/NetState/NetState.Network.cs
+++ b/Projects/Server/Network/NetState/NetState.Network.cs
@@ -36,8 +36,7 @@ public partial class NetState
     private const long DefaultSendBufferGrowthBudget = 1024L * 1024 * 256; // 256 MB
     private const int DefaultMemoryCeilingPercent = 80;
 
-    // Transport tiers run from the base size up to this; a larger configured maximum is capped here
-    // instead of overflowing that enumeration at socket creation.
+    // Transport ceiling; larger values overflow its tier enumeration
     private const int TransportMaxSendBufferSize = 1024 * 1024 * 256; // 256 MB
     private const int MaxConnections = 4096;         // Max concurrent connections
 
@@ -45,7 +44,7 @@ public partial class NetState
     private static long _sendBufferGrowthBudget;
     private static int _memoryCeilingPercent;
 
-    // Sampled at configure, refreshed by the maintenance sweep; internal so a test can force it.
+    // Refreshed by the maintenance sweep; internal for tests
     internal static long _availableMemoryBytes;
 
     private static Timer.DelayCallTimer _maintenanceTimer;
@@ -180,7 +179,7 @@ public partial class NetState
             return;
         }
 
-        // Cheap, and the container's limit can change out from under it.
+        // Container limits can change
         _availableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
 
         var ceilingRefusals = _ceilingRefusals;
@@ -225,8 +224,7 @@ public partial class NetState
         CoercePowerOfTwoSetting(key, ServerConfiguration.GetOrUpdateSetting(key, defaultValue), minimum);
 
     /// <summary>
-    /// Clamps to a power of two between <paramref name="minimum"/> and the transport ceiling; split
-    /// from the setting read so tests can exercise it on values directly.
+    /// Clamps to a power of two between <paramref name="minimum"/> and the transport ceiling.
     /// </summary>
     internal static int CoercePowerOfTwoSetting(string key, int configured, int minimum)
     {
@@ -260,7 +258,7 @@ public partial class NetState
 
         if (!BitOperations.IsPow2(size))
         {
-            // The ceiling is itself a power of two, so rounding up can never cross it.
+            // Rounding up cannot cross the ceiling, itself a power of two
             var rounded = (int)BitOperations.RoundUpToPowerOf2((uint)size);
 
             logger.Warning("{Key} {Configured} is not a power of two; using {Adjusted}", key, configured, rounded);
@@ -271,8 +269,7 @@ public partial class NetState
     }
 
     /// <summary>
-    /// A negative budget disables growth; a budget under one tier slab is raised to the minimum,
-    /// since it could never grow anything.
+    /// Negative disables growth; below one tier slab is raised to the minimum.
     /// </summary>
     internal static long CoerceSendBufferGrowthBudget(long configured, int sendBufferSize, int maxSendBufferSize)
     {

--- a/Projects/Server/Network/NetState/NetState.Network.cs
+++ b/Projects/Server/Network/NetState/NetState.Network.cs
@@ -35,11 +35,20 @@ public partial class NetState
     private const int DefaultMaxSendBufferSize = 1024 * 1024 * 2;          // 2 MB
     private const long DefaultSendBufferGrowthBudget = 1024L * 1024 * 256; // 256 MB
     private const int DefaultMemoryCeilingPercent = 80;
+
+    // The transport enumerates its tiers from the base size up to this; larger values overflow that
+    // enumeration, so a configured maximum is capped here rather than failing at socket creation.
+    private const int TransportMaxSendBufferSize = 1024 * 1024 * 256; // 256 MB
     private const int MaxConnections = 4096;         // Max concurrent connections
 
     internal static int MaxSendBufferSize { get; private set; }
     private static long _sendBufferGrowthBudget;
     private static int _memoryCeilingPercent;
+
+    // Sampled once at configure and refreshed by the maintenance sweep; see UnderMemoryCeiling.
+    private static long _availableMemoryBytes;
+
+    private static Timer.DelayCallTimer _maintenanceTimer;
 
     private static readonly Queue<NetState> _disposed = [];
     private static readonly TimeSpan ConnectingSocketIdleLimit = TimeSpan.FromMilliseconds(5000); // 5 seconds
@@ -132,24 +141,13 @@ public partial class NetState
         // per-connection memory ceiling.
         var sendBufferSize = GetSendBufferSize();
         MaxSendBufferSize = GetPowerOfTwoSetting("network.sendBufferMaxSize", DefaultMaxSendBufferSize, sendBufferSize);
-        _sendBufferGrowthBudget = ServerConfiguration.GetOrUpdateSetting("network.sendBufferGrowthBudget", DefaultSendBufferGrowthBudget);
+        _sendBufferGrowthBudget = CoerceSendBufferGrowthBudget(
+            ServerConfiguration.GetOrUpdateSetting("network.sendBufferGrowthBudget", DefaultSendBufferGrowthBudget),
+            sendBufferSize,
+            MaxSendBufferSize
+        );
         _memoryCeilingPercent = Math.Clamp(ServerConfiguration.GetOrUpdateSetting("network.memoryCeilingPercent", DefaultMemoryCeilingPercent), 1, 100);
-
-        // The transport allocates tier buffers a slab at a time; a positive budget below one slab
-        // could never grow anything, so raise it to the minimum rather than fail at startup.
-        if (MaxSendBufferSize > sendBufferSize && _sendBufferGrowthBudget > 0)
-        {
-            var minimumBudget = RingSocketManager.MinimumSendBufferGrowthBudget(sendBufferSize);
-            if (_sendBufferGrowthBudget < minimumBudget)
-            {
-                logger.Warning(
-                    "network.sendBufferGrowthBudget {Configured} is below one tier slab; using {Minimum}",
-                    _sendBufferGrowthBudget,
-                    minimumBudget
-                );
-                _sendBufferGrowthBudget = minimumBudget;
-            }
-        }
+        _availableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
 
         const int maxBufferSlabs = 32;
         var ring = IORingGroup.Create(
@@ -171,7 +169,7 @@ public partial class NetState
             sendBufferGrowthBudget: _sendBufferGrowthBudget
         );
 
-        Timer.DelayCall(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), MaintainSendBuffers);
+        _maintenanceTimer = Timer.DelayCall(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1), MaintainSendBuffers);
     }
 
     internal static void MaintainSendBuffers()
@@ -181,21 +179,36 @@ public partial class NetState
             return;
         }
 
+        // Cheap, and the figure moves when the container's limit is resized under us.
+        _availableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+
+        var ceilingRefusals = _ceilingRefusals;
+        var capRefusals = _capRefusals;
+        _ceilingRefusals = 0;
+        _capRefusals = 0;
+
         var stats = _socketManager.Maintain();
-        if (stats.BuffersReleased > 0 || stats.GrowthRefusals > 0)
+        if (stats.BuffersReleased > 0 || stats.GrowthRefusals > 0 || capRefusals > 0 || ceilingRefusals > 0)
         {
             logger.Information(
-                "Send buffer tiers: {Capacity} bytes, {InUse} in use, floor {Floor}, released {Released}, growth refused {Refused}",
+                "Send buffer tiers: {Capacity} bytes of tier capacity, {InUse} buffers in use, floor {Floor} buffers, released {Released}, refused: budget {BudgetRefusals}, at max {CapRefusals}, ceiling {CeilingRefusals}",
                 stats.TierCapacityBytes,
                 stats.TierInUse,
                 stats.TierRetainFloor,
                 stats.BuffersReleased,
-                stats.GrowthRefusals
+                stats.GrowthRefusals,
+                capRefusals,
+                ceilingRefusals
             );
         }
         else
         {
-            logger.Debug("Send buffer tiers: {Capacity} bytes, {InUse} in use, floor {Floor}", stats.TierCapacityBytes, stats.TierInUse, stats.TierRetainFloor);
+            logger.Debug(
+                "Send buffer tiers: {Capacity} bytes of tier capacity, {InUse} buffers in use, floor {Floor} buffers",
+                stats.TierCapacityBytes,
+                stats.TierInUse,
+                stats.TierRetainFloor
+            );
         }
     }
 
@@ -207,28 +220,87 @@ public partial class NetState
     private static int GetSendBufferSize() =>
         GetPowerOfTwoSetting("network.sendBufferSize", DefaultSendBufferSize, MinSendBufferSize);
 
-    private static int GetPowerOfTwoSetting(string key, int defaultValue, int minimum)
+    private static int GetPowerOfTwoSetting(string key, int defaultValue, int minimum) =>
+        CoercePowerOfTwoSetting(key, ServerConfiguration.GetOrUpdateSetting(key, defaultValue), minimum);
+
+    /// <summary>
+    /// Coerces a buffer-size setting to a power of two between <paramref name="minimum"/> and the
+    /// transport's hard ceiling. Split from the setting read so it can be exercised on values.
+    /// </summary>
+    internal static int CoercePowerOfTwoSetting(string key, int configured, int minimum)
     {
-        var configured = ServerConfiguration.GetOrUpdateSetting(key, defaultValue);
-        var size = Math.Max(minimum, configured);
+        var size = configured;
 
-        if (!BitOperations.IsPow2(size))
-        {
-            size = (int)BitOperations.RoundUpToPowerOf2((uint)size);
-        }
-
-        if (size != configured)
+        if (size > TransportMaxSendBufferSize)
         {
             logger.Warning(
-                "{Key} {Configured} is not a power of two of at least {Minimum}; using {Adjusted}",
+                "{Key} {Configured} is above the transport maximum {Maximum} (capped); using {Adjusted}",
+                key,
+                configured,
+                TransportMaxSendBufferSize,
+                TransportMaxSendBufferSize
+            );
+
+            size = TransportMaxSendBufferSize;
+        }
+
+        if (size < minimum)
+        {
+            logger.Warning(
+                "{Key} {Configured} is below the minimum {Minimum} (raised); using {Adjusted}",
                 key,
                 configured,
                 minimum,
-                size
+                minimum
             );
+
+            size = minimum;
+        }
+
+        if (!BitOperations.IsPow2(size))
+        {
+            // The ceiling is itself a power of two, so rounding up can never cross it.
+            var rounded = (int)BitOperations.RoundUpToPowerOf2((uint)size);
+
+            logger.Warning("{Key} {Configured} is not a power of two; using {Adjusted}", key, configured, rounded);
+            size = rounded;
         }
 
         return size;
+    }
+
+    /// <summary>
+    /// Coerces the shared growth budget: a negative budget is meaningless, and a positive budget
+    /// below one tier slab could never grow anything.
+    /// </summary>
+    internal static long CoerceSendBufferGrowthBudget(long configured, int sendBufferSize, int maxSendBufferSize)
+    {
+        if (configured < 0)
+        {
+            logger.Warning("network.sendBufferGrowthBudget {Configured} is negative; using 0 (growth disabled)", configured);
+            return 0;
+        }
+
+        if (configured == 0 || maxSendBufferSize <= sendBufferSize)
+        {
+            return configured;
+        }
+
+        // The transport allocates tier buffers a slab at a time; raise a too-small budget to the
+        // minimum rather than fail at startup.
+        var minimumBudget = RingSocketManager.MinimumSendBufferGrowthBudget(sendBufferSize);
+        if (configured < minimumBudget)
+        {
+            logger.Warning(
+                "network.sendBufferGrowthBudget {Configured} is below one tier slab; using {Minimum}",
+                configured,
+                minimumBudget
+            );
+
+            return minimumBudget;
+        }
+
+        return configured;
     }
 
     /// <summary>

--- a/Projects/Server/Network/NetState/NetState.Network.cs
+++ b/Projects/Server/Network/NetState/NetState.Network.cs
@@ -36,8 +36,8 @@ public partial class NetState
     private const long DefaultSendBufferGrowthBudget = 1024L * 1024 * 256; // 256 MB
     private const int DefaultMemoryCeilingPercent = 80;
 
-    // The transport enumerates its tiers from the base size up to this; larger values overflow that
-    // enumeration, so a configured maximum is capped here rather than failing at socket creation.
+    // Transport tiers run from the base size up to this; a larger configured maximum is capped here
+    // instead of overflowing that enumeration at socket creation.
     private const int TransportMaxSendBufferSize = 1024 * 1024 * 256; // 256 MB
     private const int MaxConnections = 4096;         // Max concurrent connections
 
@@ -45,8 +45,7 @@ public partial class NetState
     private static long _sendBufferGrowthBudget;
     private static int _memoryCeilingPercent;
 
-    // Sampled once at configure and refreshed by the maintenance sweep; see UnderMemoryCeiling.
-    // Internal so a test can force the ceiling.
+    // Sampled at configure, refreshed by the maintenance sweep; internal so a test can force it.
     internal static long _availableMemoryBytes;
 
     private static Timer.DelayCallTimer _maintenanceTimer;
@@ -181,7 +180,7 @@ public partial class NetState
             return;
         }
 
-        // Cheap, and the figure moves when the container's limit is resized under us.
+        // Cheap, and the container's limit can change out from under it.
         _availableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
 
         var ceilingRefusals = _ceilingRefusals;
@@ -226,8 +225,8 @@ public partial class NetState
         CoercePowerOfTwoSetting(key, ServerConfiguration.GetOrUpdateSetting(key, defaultValue), minimum);
 
     /// <summary>
-    /// Coerces a buffer-size setting to a power of two between <paramref name="minimum"/> and the
-    /// transport's hard ceiling. Split from the setting read so it can be exercised on values.
+    /// Clamps to a power of two between <paramref name="minimum"/> and the transport ceiling; split
+    /// from the setting read so tests can exercise it on values directly.
     /// </summary>
     internal static int CoercePowerOfTwoSetting(string key, int configured, int minimum)
     {
@@ -272,8 +271,8 @@ public partial class NetState
     }
 
     /// <summary>
-    /// Coerces the shared growth budget: a negative budget is meaningless, and a positive budget
-    /// below one tier slab could never grow anything.
+    /// A negative budget disables growth; a budget under one tier slab is raised to the minimum,
+    /// since it could never grow anything.
     /// </summary>
     internal static long CoerceSendBufferGrowthBudget(long configured, int sendBufferSize, int maxSendBufferSize)
     {
@@ -288,8 +287,7 @@ public partial class NetState
             return configured;
         }
 
-        // The transport allocates tier buffers a slab at a time; raise a too-small budget to the
-        // minimum rather than fail at startup.
+        // Tier buffers are allocated a slab at a time.
         var minimumBudget = RingSocketManager.MinimumSendBufferGrowthBudget(sendBufferSize);
         if (configured < minimumBudget)
         {

--- a/Projects/Server/Network/NetState/NetState.Network.cs
+++ b/Projects/Server/Network/NetState/NetState.Network.cs
@@ -46,7 +46,8 @@ public partial class NetState
     private static int _memoryCeilingPercent;
 
     // Sampled once at configure and refreshed by the maintenance sweep; see UnderMemoryCeiling.
-    private static long _availableMemoryBytes;
+    // Internal so a test can force the ceiling.
+    internal static long _availableMemoryBytes;
 
     private static Timer.DelayCallTimer _maintenanceTimer;
 
@@ -146,7 +147,8 @@ public partial class NetState
             sendBufferSize,
             MaxSendBufferSize
         );
-        _memoryCeilingPercent = Math.Clamp(ServerConfiguration.GetOrUpdateSetting("network.memoryCeilingPercent", DefaultMemoryCeilingPercent), 1, 100);
+        // 0 disables the ceiling
+        _memoryCeilingPercent = Math.Clamp(ServerConfiguration.GetOrUpdateSetting("network.memoryCeilingPercent", DefaultMemoryCeilingPercent), 0, 100);
         _availableMemoryBytes = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
 
         const int maxBufferSlabs = 32;

--- a/Projects/Server/Network/NetState/NetState.Network.cs
+++ b/Projects/Server/Network/NetState/NetState.Network.cs
@@ -32,7 +32,14 @@ public partial class NetState
     private const int RecvBufferSize = 1024 * 64;    // 64KB recv buffers
     private const int DefaultSendBufferSize = 1024 * 256;  // 256KB send buffers
     private const int MinSendBufferSize = 1024 * 64;       // Platform allocation granularity
+    private const int DefaultMaxSendBufferSize = 1024 * 1024 * 2;          // 2 MB
+    private const long DefaultSendBufferGrowthBudget = 1024L * 1024 * 256; // 256 MB
+    private const int DefaultMemoryCeilingPercent = 80;
     private const int MaxConnections = 4096;         // Max concurrent connections
+
+    internal static int MaxSendBufferSize { get; private set; }
+    private static long _sendBufferGrowthBudget;
+    private static int _memoryCeilingPercent;
 
     private static readonly Queue<NetState> _disposed = [];
     private static readonly TimeSpan ConnectingSocketIdleLimit = TimeSpan.FromMilliseconds(5000); // 5 seconds
@@ -121,16 +128,36 @@ public partial class NetState
         // latency is roughly completion RTT / this value.
         var maxOutstandingSends = ServerConfiguration.GetOrUpdateSetting("network.maxOutstandingSends", 32);
 
-        // Initialize IORingGroup
-        var ring = IORingGroup.Create(
-            queueSize: MaxConnections * 2,
-            maxConnections: MaxConnections,
-            maxOutstandingSends: maxOutstandingSends
-        );
-
         // Per-connection send buffer: the lever for "send buffer exhausted" disconnects, and the
         // per-connection memory ceiling.
         var sendBufferSize = GetSendBufferSize();
+        MaxSendBufferSize = GetPowerOfTwoSetting("network.sendBufferMaxSize", DefaultMaxSendBufferSize, sendBufferSize);
+        _sendBufferGrowthBudget = ServerConfiguration.GetOrUpdateSetting("network.sendBufferGrowthBudget", DefaultSendBufferGrowthBudget);
+        _memoryCeilingPercent = Math.Clamp(ServerConfiguration.GetOrUpdateSetting("network.memoryCeilingPercent", DefaultMemoryCeilingPercent), 1, 100);
+
+        // The transport allocates tier buffers a slab at a time; a positive budget below one slab
+        // could never grow anything, so raise it to the minimum rather than fail at startup.
+        if (MaxSendBufferSize > sendBufferSize && _sendBufferGrowthBudget > 0)
+        {
+            var minimumBudget = RingSocketManager.MinimumSendBufferGrowthBudget(sendBufferSize);
+            if (_sendBufferGrowthBudget < minimumBudget)
+            {
+                logger.Warning(
+                    "network.sendBufferGrowthBudget {Configured} is below one tier slab; using {Minimum}",
+                    _sendBufferGrowthBudget,
+                    minimumBudget
+                );
+                _sendBufferGrowthBudget = minimumBudget;
+            }
+        }
+
+        const int maxBufferSlabs = 32;
+        var ring = IORingGroup.Create(
+            queueSize: MaxConnections * 2,
+            maxConnections: MaxConnections,
+            maxOutstandingSends: maxOutstandingSends,
+            maxRegisteredBuffers: RingSocketManager.RequiredRegisteredBuffers(MaxConnections, sendBufferSize, MaxSendBufferSize, _sendBufferGrowthBudget, maxBufferSlabs)
+        );
 
         // Create socket manager which handles buffer pools and socket lifecycle
         _socketManager = new RingSocketManager(
@@ -139,7 +166,9 @@ public partial class NetState
             recvBufferSize: RecvBufferSize,
             sendBufferSize: sendBufferSize,
             initialBufferSlabs: 8,
-            maxBufferSlabs: 32
+            maxBufferSlabs: maxBufferSlabs,
+            maxSendBufferSize: MaxSendBufferSize,
+            sendBufferGrowthBudget: _sendBufferGrowthBudget
         );
     }
 
@@ -148,10 +177,13 @@ public partial class NetState
     /// allocation granularity. IORingBuffer requires this and would otherwise throw at socket
     /// creation rather than at startup.
     /// </summary>
-    private static int GetSendBufferSize()
+    private static int GetSendBufferSize() =>
+        GetPowerOfTwoSetting("network.sendBufferSize", DefaultSendBufferSize, MinSendBufferSize);
+
+    private static int GetPowerOfTwoSetting(string key, int defaultValue, int minimum)
     {
-        var configured = ServerConfiguration.GetOrUpdateSetting("network.sendBufferSize", DefaultSendBufferSize);
-        var size = Math.Max(MinSendBufferSize, configured);
+        var configured = ServerConfiguration.GetOrUpdateSetting(key, defaultValue);
+        var size = Math.Max(minimum, configured);
 
         if (!BitOperations.IsPow2(size))
         {
@@ -161,9 +193,10 @@ public partial class NetState
         if (size != configured)
         {
             logger.Warning(
-                "network.sendBufferSize {Configured} is not a power of two of at least {Minimum}; using {Adjusted}",
+                "{Key} {Configured} is not a power of two of at least {Minimum}; using {Adjusted}",
+                key,
                 configured,
-                MinSendBufferSize,
+                minimum,
                 size
             );
         }

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -56,7 +56,9 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     // therefore a heuristic guard against starving the host, not a hard bound on the process. An
     // unpopulated figure (<= 0) fails open: refusing growth on a number we do not have would
     // disconnect players for no reason.
-    internal static Func<bool> UnderMemoryCeiling = static () =>
+    // network.memoryCeilingPercent 0 turns the check off; an unpopulated GC figure fails open.
+    private static bool UnderMemoryCeiling() =>
+        _memoryCeilingPercent <= 0 ||
         _availableMemoryBytes <= 0 ||
         Environment.WorkingSet < _availableMemoryBytes / 100 * _memoryCeilingPercent;
 

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -527,6 +527,25 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return true;
     }
 
+    // Demotes a drained socket once the hold since its last growth has passed. The pool keeps the
+    // larger buffer on hand; the socket only needs to stop occupying it.
+    internal bool TryShrinkSendBuffer(long curTicks)
+    {
+        if (!_sendBufferGrown || _socket == null || curTicks - (_sendBufferGrewAt + SendBufferHoldMs) < 0)
+        {
+            return false;
+        }
+
+        if (!_socketManager.TryShrinkSendBuffer(_socket))
+        {
+            return false;
+        }
+
+        _sendBufferGrown = false;
+        logger.Debug("{NetState}: send buffer returned to {Size}", this, _socket.SendBuffer.PhysicalSize);
+        return true;
+    }
+
     public void Send(ReadOnlySpan<byte> span)
     {
         if (span == ReadOnlySpan<byte>.Empty || this.CannotSendPackets())

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -546,18 +546,18 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             return;
         }
 
-        // Never drop silently: the client would stay connected while missing game state.
-        if (!GetSendBuffer(out var buffer))
-        {
-            if (!TryGrowSendBuffer(length) || !GetSendBuffer(out buffer))
-            {
-                SendBufferExhausted(length, buffer.Length);
-                return;
-            }
-        }
-
         try
         {
+            // Never drop silently: the client would stay connected while missing game state.
+            if (!GetSendBuffer(out var buffer))
+            {
+                if (!TryGrowSendBuffer(length) || !GetSendBuffer(out buffer))
+                {
+                    SendBufferExhausted(length, buffer.Length);
+                    return;
+                }
+            }
+
             // Apply encoding first (e.g., compression from UOContent)
             if (CompressionEnabled)
             {

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -47,6 +47,13 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     private static readonly HashSet<NetState> _instances = new(2048);
     public static HashSet<NetState> Instances => _instances;
 
+    // Replaced by tests. Working set against the container-aware available memory.
+    internal static Func<bool> UnderMemoryCeiling = static () =>
+        Environment.WorkingSet < GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 100 * _memoryCeilingPercent;
+
+    private static long _memoryCeilingWarnedAt;
+    private static bool _memoryCeilingWarned;
+
     private readonly string _toString;
     private ClientVersion _version;
     private bool _running = true;
@@ -58,6 +65,10 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     internal string _disconnectReason = string.Empty;
     private long _drainDeadline;
     private bool _drainDeadlineArmed;
+
+    internal bool _sendBufferGrown;
+    internal long _sendBufferGrewAt;
+    internal const long SendBufferHoldMs = 30000;
 
     internal ParserState _parserState = ParserState.AwaitingNextPacket;
     internal ProtocolState _protocolState = ProtocolState.AwaitingSeed;
@@ -480,6 +491,42 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return buffer.Length > 0;
     }
 
+    // Grows until `needed` fits or growth is refused. Refusal leaves the caller on today's path.
+    internal bool TryGrowSendBuffer(int needed)
+    {
+        if (_socket == null)
+        {
+            return false;
+        }
+
+        while (_socket.SendBuffer.WritableBytes < needed)
+        {
+            if (!UnderMemoryCeiling())
+            {
+                var now = Core.TickCount;
+                if (!_memoryCeilingWarned || now - _memoryCeilingWarnedAt >= 60000)
+                {
+                    _memoryCeilingWarned = true;
+                    _memoryCeilingWarnedAt = now;
+                    logger.Warning("Send buffer growth refused: process is above {Percent}% of available memory", _memoryCeilingPercent);
+                }
+
+                return false;
+            }
+
+            if (!_socketManager.TryGrowSendBuffer(_socket))
+            {
+                return false;
+            }
+
+            _sendBufferGrown = true;
+            _sendBufferGrewAt = Core.TickCount;
+            logger.Debug("{NetState}: send buffer grown to {Size}", this, _socket.SendBuffer.PhysicalSize);
+        }
+
+        return true;
+    }
+
     public void Send(ReadOnlySpan<byte> span)
     {
         if (span == ReadOnlySpan<byte>.Empty || this.CannotSendPackets())
@@ -502,8 +549,11 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         // Never drop silently: the client would stay connected while missing game state.
         if (!GetSendBuffer(out var buffer))
         {
-            SendBufferExhausted(length, 0);
-            return;
+            if (!TryGrowSendBuffer(length) || !GetSendBuffer(out buffer))
+            {
+                SendBufferExhausted(length, buffer.Length);
+                return;
+            }
         }
 
         try
@@ -513,17 +563,31 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             {
                 length = NetworkCompression.Compress(span, buffer);
 
-                // 0 means nothing was written, whether it did not fit or the input was too large.
                 if (length <= 0)
                 {
-                    SendBufferExhausted(span.Length, buffer.Length);
-                    return;
+                    if (!TryGrowSendBuffer(span.Length * 2 + 4) || !GetSendBuffer(out buffer))
+                    {
+                        SendBufferExhausted(span.Length, buffer.Length);
+                        return;
+                    }
+
+                    length = NetworkCompression.Compress(span, buffer);
+                    if (length <= 0)
+                    {
+                        SendBufferExhausted(span.Length, buffer.Length);
+                        return;
+                    }
                 }
             }
             else if (span.Length > buffer.Length)
             {
-                SendBufferExhausted(span.Length, buffer.Length);
-                return;
+                if (!TryGrowSendBuffer(span.Length) || !GetSendBuffer(out buffer))
+                {
+                    SendBufferExhausted(span.Length, buffer.Length);
+                    return;
+                }
+
+                span.CopyTo(buffer);
             }
             else
             {

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -47,16 +47,8 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     private static readonly HashSet<NetState> _instances = new(2048);
     public static HashSet<NetState> Instances => _instances;
 
-    // Replaced by tests. Working set against the container-aware available memory sampled by
-    // ConfigureNetwork and refreshed by MaintainSendBuffers.
-    //
-    // TotalAvailableMemoryBytes is container-aware (it reports the cgroup/job-object limit where one
-    // exists) but equals the GC heap hard limit only when a hard limit is configured, and ModernUO
-    // configures none. Environment.WorkingSet is resident memory, not managed heap size. The two are
-    // therefore a heuristic guard against starving the host, not a hard bound on the process. An
-    // unpopulated figure (<= 0) fails open: refusing growth on a number we do not have would
-    // disconnect players for no reason.
-    // network.memoryCeilingPercent 0 turns the check off; an unpopulated GC figure fails open.
+    // _availableMemoryBytes is the GC's container-aware available-memory figure, a heuristic against
+    // starving the host rather than a hard process bound; it fails open when 0 or unpopulated.
     private static bool UnderMemoryCeiling() =>
         _memoryCeilingPercent <= 0 ||
         _availableMemoryBytes <= 0 ||
@@ -66,8 +58,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     private static long _memoryCeilingWarnedAt;
     private static bool _memoryCeilingWarned;
 
-    // ModernUO-side growth refusals, drained and reset by MaintainSendBuffers. Budget refusals are
-    // counted by the transport itself and reported through its maintenance stats.
+    // Drained and reset by MaintainSendBuffers; budget refusals are counted by the transport instead.
     private static int _ceilingRefusals;
     private static int _capRefusals;
 
@@ -508,7 +499,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return buffer.Length > 0;
     }
 
-    // Grows until `needed` fits or growth is refused. Refusal leaves the caller on today's path.
+    // Grows tier by tier until `needed` fits or a tier is refused.
     internal bool TryGrowSendBuffer(int needed)
     {
         if (_socket == null)
@@ -527,8 +518,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return true;
     }
 
-    // One tier step, ceiling-checked. For callers that cannot state how much they need up front
-    // (compression), the only way to find out is to grow and try again.
+    // For compression, which can't know its output size up front except by growing and retrying.
     internal bool TryGrowSendBufferOneTier()
     {
         if (_socket == null)
@@ -553,8 +543,8 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
         if (!_socketManager.TryGrowSendBuffer(_socket))
         {
-            // Already at the per-connection maximum; anything else the transport refused came out of
-            // the shared growth budget, which the transport counts for itself.
+            // At the per-connection cap; any other refusal came from the shared budget, which the
+            // transport counts itself.
             if (_socket.SendBuffer.PhysicalSize >= MaxSendBufferSize)
             {
                 _capRefusals++;
@@ -569,8 +559,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return true;
     }
 
-    // Demotes a drained socket once the hold since its last growth has passed. The pool keeps the
-    // larger buffer on hand; the socket only needs to stop occupying it.
+    // The pool keeps the larger buffer on hand; shrinking here only stops the socket occupying it.
     internal bool TryShrinkSendBuffer(long curTicks)
     {
         if (!_sendBufferGrown || _socket == null || curTicks - (_sendBufferGrewAt + SendBufferHoldMs) < 0)
@@ -612,11 +601,8 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             // Never drop silently: the client would stay connected while missing game state.
             if (!GetSendBuffer(out var buffer))
             {
-                // The buffer is completely full, so there is no span to compress into yet. With
-                // compression on the raw length is the wrong target - the packet may compress to a
-                // fraction of it, and demanding the raw length manufactures exhaustion at the
-                // maximum for a packet that would have fit. Take one tier to get a span, then let
-                // the compression path below grow per tier for as long as Compress refuses.
+                // No span to compress into yet; compression may shrink the payload, so growing to the
+                // raw length would over-commit. Grow one tier and let the retry loop below finish it.
                 var grown = CompressionEnabled ? TryGrowSendBufferOneTier() : TryGrowSendBuffer(length);
 
                 if (!grown || !GetSendBuffer(out buffer))
@@ -640,9 +626,8 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
                         return;
                     }
 
-                    // The compressed length is only known by compressing, and the worst Huffman ratio
-                    // is 11/8 - a 2N + 4 target over-states the need and manufactures exhaustion at the
-                    // maximum. Grow a tier at a time and retry instead.
+                    // Compressed length is unknown until compressed; a 2N+4 target (worst Huffman
+                    // ratio 11/8) over-states it, so grow a tier at a time and retry instead.
                     while (length <= 0 && TryGrowSendBufferOneTier() && GetSendBuffer(out buffer))
                     {
                         length = NetworkCompression.Compress(span, buffer);
@@ -708,8 +693,8 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             return;
         }
 
-        // Read writable alongside unacked and capacity: a caller that grew a tier and was then
-        // refused still holds the pre-growth span, and reporting its length contradicts the capacity.
+        // Read fresh: a caller that grew a tier and was then refused still holds the pre-growth span,
+        // which would contradict the reported capacity.
         var sendBuffer = _socket?.SendBuffer;
         var writable = sendBuffer?.WritableBytes ?? 0;
         var unacked = sendBuffer?.InFlightBytes ?? 0;

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -612,7 +612,14 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             // Never drop silently: the client would stay connected while missing game state.
             if (!GetSendBuffer(out var buffer))
             {
-                if (!TryGrowSendBuffer(length) || !GetSendBuffer(out buffer))
+                // The buffer is completely full, so there is no span to compress into yet. With
+                // compression on the raw length is the wrong target - the packet may compress to a
+                // fraction of it, and demanding the raw length manufactures exhaustion at the
+                // maximum for a packet that would have fit. Take one tier to get a span, then let
+                // the compression path below grow per tier for as long as Compress refuses.
+                var grown = CompressionEnabled ? TryGrowSendBufferOneTier() : TryGrowSendBuffer(length);
+
+                if (!grown || !GetSendBuffer(out buffer))
                 {
                     SendBufferExhausted(length);
                     return;

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -47,8 +47,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     private static readonly HashSet<NetState> _instances = new(2048);
     public static HashSet<NetState> Instances => _instances;
 
-    // _availableMemoryBytes is the GC's container-aware available-memory figure, a heuristic against
-    // starving the host rather than a hard process bound; it fails open when 0 or unpopulated.
+    // GC's container-aware figure: a heuristic, not a hard bound; fails open when unpopulated
     private static bool UnderMemoryCeiling() =>
         _memoryCeilingPercent <= 0 ||
         _availableMemoryBytes <= 0 ||
@@ -58,7 +57,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     private static long _memoryCeilingWarnedAt;
     private static bool _memoryCeilingWarned;
 
-    // Drained and reset by MaintainSendBuffers; budget refusals are counted by the transport instead.
+    // Reset by MaintainSendBuffers; the transport counts budget refusals
     private static int _ceilingRefusals;
     private static int _capRefusals;
 
@@ -518,7 +517,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return true;
     }
 
-    // For compression, which can't know its output size up front except by growing and retrying.
+    // One tier; compression learns its output size by retrying
     internal bool TryGrowSendBufferOneTier()
     {
         if (_socket == null)
@@ -543,8 +542,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
         if (!_socketManager.TryGrowSendBuffer(_socket))
         {
-            // At the per-connection cap; any other refusal came from the shared budget, which the
-            // transport counts itself.
+            // At the cap; the transport counts budget refusals
             if (_socket.SendBuffer.PhysicalSize >= MaxSendBufferSize)
             {
                 _capRefusals++;
@@ -559,7 +557,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
         return true;
     }
 
-    // The pool keeps the larger buffer on hand; shrinking here only stops the socket occupying it.
+    // The pool retains the larger buffer
     internal bool TryShrinkSendBuffer(long curTicks)
     {
         if (!_sendBufferGrown || _socket == null || curTicks - (_sendBufferGrewAt + SendBufferHoldMs) < 0)
@@ -601,8 +599,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             // Never drop silently: the client would stay connected while missing game state.
             if (!GetSendBuffer(out var buffer))
             {
-                // No span to compress into yet; compression may shrink the payload, so growing to the
-                // raw length would over-commit. Grow one tier and let the retry loop below finish it.
+                // Full; the compressed size is unknown, so grow one tier and let the retry loop finish
                 var grown = CompressionEnabled ? TryGrowSendBufferOneTier() : TryGrowSendBuffer(length);
 
                 if (!grown || !GetSendBuffer(out buffer))
@@ -619,15 +616,14 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
                 if (length <= 0)
                 {
-                    // Past this input length Compress refuses unconditionally, so growth cannot help.
+                    // Compress refuses this length outright; growth cannot help
                     if (span.Length > NetworkCompression.DefiniteOverflow)
                     {
                         SendBufferExhausted(span.Length);
                         return;
                     }
 
-                    // Compressed length is unknown until compressed; a 2N+4 target (worst Huffman
-                    // ratio 11/8) over-states it, so grow a tier at a time and retry instead.
+                    // Output size is unknown until compressed; grow a tier and retry
                     while (length <= 0 && TryGrowSendBufferOneTier() && GetSendBuffer(out buffer))
                     {
                         length = NetworkCompression.Compress(span, buffer);
@@ -693,8 +689,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             return;
         }
 
-        // Read fresh: a caller that grew a tier and was then refused still holds the pre-growth span,
-        // which would contradict the reported capacity.
+        // Read fresh; the caller's span may predate a growth
         var sendBuffer = _socket?.SendBuffer;
         var writable = sendBuffer?.WritableBytes ?? 0;
         var unacked = sendBuffer?.InFlightBytes ?? 0;

--- a/Projects/Server/Network/NetState/NetState.cs
+++ b/Projects/Server/Network/NetState/NetState.cs
@@ -47,12 +47,27 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     private static readonly HashSet<NetState> _instances = new(2048);
     public static HashSet<NetState> Instances => _instances;
 
-    // Replaced by tests. Working set against the container-aware available memory.
+    // Replaced by tests. Working set against the container-aware available memory sampled by
+    // ConfigureNetwork and refreshed by MaintainSendBuffers.
+    //
+    // TotalAvailableMemoryBytes is container-aware (it reports the cgroup/job-object limit where one
+    // exists) but equals the GC heap hard limit only when a hard limit is configured, and ModernUO
+    // configures none. Environment.WorkingSet is resident memory, not managed heap size. The two are
+    // therefore a heuristic guard against starving the host, not a hard bound on the process. An
+    // unpopulated figure (<= 0) fails open: refusing growth on a number we do not have would
+    // disconnect players for no reason.
     internal static Func<bool> UnderMemoryCeiling = static () =>
-        Environment.WorkingSet < GC.GetGCMemoryInfo().TotalAvailableMemoryBytes / 100 * _memoryCeilingPercent;
+        _availableMemoryBytes <= 0 ||
+        Environment.WorkingSet < _availableMemoryBytes / 100 * _memoryCeilingPercent;
 
+    private const long MemoryCeilingWarnIntervalMs = 60000;
     private static long _memoryCeilingWarnedAt;
     private static bool _memoryCeilingWarned;
+
+    // ModernUO-side growth refusals, drained and reset by MaintainSendBuffers. Budget refusals are
+    // counted by the transport itself and reported through its maintenance stats.
+    private static int _ceilingRefusals;
+    private static int _capRefusals;
 
     private readonly string _toString;
     private ClientVersion _version;
@@ -501,29 +516,54 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
         while (_socket.SendBuffer.WritableBytes < needed)
         {
-            if (!UnderMemoryCeiling())
-            {
-                var now = Core.TickCount;
-                if (!_memoryCeilingWarned || now - _memoryCeilingWarnedAt >= 60000)
-                {
-                    _memoryCeilingWarned = true;
-                    _memoryCeilingWarnedAt = now;
-                    logger.Warning("Send buffer growth refused: process is above {Percent}% of available memory", _memoryCeilingPercent);
-                }
-
-                return false;
-            }
-
-            if (!_socketManager.TryGrowSendBuffer(_socket))
+            if (!TryGrowSendBufferOneTier())
             {
                 return false;
             }
-
-            _sendBufferGrown = true;
-            _sendBufferGrewAt = Core.TickCount;
-            logger.Debug("{NetState}: send buffer grown to {Size}", this, _socket.SendBuffer.PhysicalSize);
         }
 
+        return true;
+    }
+
+    // One tier step, ceiling-checked. For callers that cannot state how much they need up front
+    // (compression), the only way to find out is to grow and try again.
+    internal bool TryGrowSendBufferOneTier()
+    {
+        if (_socket == null)
+        {
+            return false;
+        }
+
+        if (!UnderMemoryCeiling())
+        {
+            _ceilingRefusals++;
+
+            var now = Core.TickCount;
+            if (!_memoryCeilingWarned || now - (_memoryCeilingWarnedAt + MemoryCeilingWarnIntervalMs) >= 0)
+            {
+                _memoryCeilingWarned = true;
+                _memoryCeilingWarnedAt = now;
+                logger.Warning("Send buffer growth refused: process is above {Percent}% of available memory", _memoryCeilingPercent);
+            }
+
+            return false;
+        }
+
+        if (!_socketManager.TryGrowSendBuffer(_socket))
+        {
+            // Already at the per-connection maximum; anything else the transport refused came out of
+            // the shared growth budget, which the transport counts for itself.
+            if (_socket.SendBuffer.PhysicalSize >= MaxSendBufferSize)
+            {
+                _capRefusals++;
+            }
+
+            return false;
+        }
+
+        _sendBufferGrown = true;
+        _sendBufferGrewAt = Core.TickCount;
+        logger.Debug("{NetState}: send buffer grown to {Size}", this, _socket.SendBuffer.PhysicalSize);
         return true;
     }
 
@@ -572,7 +612,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             {
                 if (!TryGrowSendBuffer(length) || !GetSendBuffer(out buffer))
                 {
-                    SendBufferExhausted(length, buffer.Length);
+                    SendBufferExhausted(length);
                     return;
                 }
             }
@@ -584,16 +624,24 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
 
                 if (length <= 0)
                 {
-                    if (!TryGrowSendBuffer(span.Length * 2 + 4) || !GetSendBuffer(out buffer))
+                    // Past this input length Compress refuses unconditionally, so growth cannot help.
+                    if (span.Length > NetworkCompression.DefiniteOverflow)
                     {
-                        SendBufferExhausted(span.Length, buffer.Length);
+                        SendBufferExhausted(span.Length);
                         return;
                     }
 
-                    length = NetworkCompression.Compress(span, buffer);
+                    // The compressed length is only known by compressing, and the worst Huffman ratio
+                    // is 11/8 - a 2N + 4 target over-states the need and manufactures exhaustion at the
+                    // maximum. Grow a tier at a time and retry instead.
+                    while (length <= 0 && TryGrowSendBufferOneTier() && GetSendBuffer(out buffer))
+                    {
+                        length = NetworkCompression.Compress(span, buffer);
+                    }
+
                     if (length <= 0)
                     {
-                        SendBufferExhausted(span.Length, buffer.Length);
+                        SendBufferExhausted(span.Length);
                         return;
                     }
                 }
@@ -602,7 +650,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             {
                 if (!TryGrowSendBuffer(span.Length) || !GetSendBuffer(out buffer))
                 {
-                    SendBufferExhausted(span.Length, buffer.Length);
+                    SendBufferExhausted(span.Length);
                     return;
                 }
 
@@ -643,7 +691,7 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
     /// High unacked means a slow client holding the buffer; needed approaching capacity means the
     /// buffer is too small for this shard and network.sendBufferSize should be raised.
     /// </remarks>
-    private void SendBufferExhausted(int needed, int writable)
+    private void SendBufferExhausted(int needed)
     {
         // One report per disconnect; the first reason wins
         if (_disconnectQueued)
@@ -651,7 +699,10 @@ public partial class NetState : IComparable<NetState>, IValueLinkListNode<NetSta
             return;
         }
 
+        // Read writable alongside unacked and capacity: a caller that grew a tier and was then
+        // refused still holds the pre-growth span, and reporting its length contradicts the capacity.
         var sendBuffer = _socket?.SendBuffer;
+        var writable = sendBuffer?.WritableBytes ?? 0;
         var unacked = sendBuffer?.InFlightBytes ?? 0;
         var capacity = sendBuffer?.PhysicalSize ?? 0;
 

--- a/Projects/Server/Network/NetworkCompression.cs
+++ b/Projects/Server/Network/NetworkCompression.cs
@@ -19,8 +19,9 @@ public static class NetworkCompression
     // Fixed overhead, in bits, per compression call
     private const int TerminalCodeLength = 4;
 
-    // If our input exceeds this length, we cannot possibly compress it within the buffer
-    private const int DefiniteOverflow = (BufferSize * 8 - TerminalCodeLength) / MinimalCodeLength;
+    // If our input exceeds this length, we cannot possibly compress it within the buffer, no matter
+    // how large the output span is. Callers that grow their buffer on a refusal check this first.
+    internal const int DefiniteOverflow = (BufferSize * 8 - TerminalCodeLength) / MinimalCodeLength;
 
     // Packed Table: High 16 bits = Length, Low 16 bits = Value
     private static readonly uint[] _packedHuffmanTable = new uint[257];

--- a/Projects/Server/Network/NetworkCompression.cs
+++ b/Projects/Server/Network/NetworkCompression.cs
@@ -19,7 +19,7 @@ public static class NetworkCompression
     // Fixed overhead, in bits, per compression call
     private const int TerminalCodeLength = 4;
 
-    // Past this input length, no output span is large enough; Compress returns 0 unconditionally.
+    // Compress returns 0 for longer input regardless of the output span
     internal const int DefiniteOverflow = (BufferSize * 8 - TerminalCodeLength) / MinimalCodeLength;
 
     // Packed Table: High 16 bits = Length, Low 16 bits = Value

--- a/Projects/Server/Network/NetworkCompression.cs
+++ b/Projects/Server/Network/NetworkCompression.cs
@@ -19,8 +19,7 @@ public static class NetworkCompression
     // Fixed overhead, in bits, per compression call
     private const int TerminalCodeLength = 4;
 
-    // If our input exceeds this length, we cannot possibly compress it within the buffer, no matter
-    // how large the output span is. Callers that grow their buffer on a refusal check this first.
+    // Past this input length, no output span is large enough; Compress returns 0 unconditionally.
     internal const int DefiniteOverflow = (BufferSize * 8 - TerminalCodeLength) / MinimalCodeLength;
 
     // Packed Table: High 16 bits = Length, Low 16 bits = Value

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,7 +34,7 @@
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Logger\Logger.csproj" />
-        <PackageReference Include="IORingGroup" Version="1.0.12-preview.1" />
+        <PackageReference Include="IORingGroup" Version="1.0.12-preview.2" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.4" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.12" />

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,7 +34,7 @@
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Logger\Logger.csproj" />
-        <PackageReference Include="IORingGroup" Version="1.0.12-preview.3" />
+        <PackageReference Include="IORingGroup" Version="1.0.12-rc.1" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.4" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.12" />

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,7 +34,7 @@
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Logger\Logger.csproj" />
-        <PackageReference Include="IORingGroup" Version="1.0.12-preview.2" />
+        <PackageReference Include="IORingGroup" Version="1.0.12-preview.3" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.4" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.12" />

--- a/Projects/Server/Server.csproj
+++ b/Projects/Server/Server.csproj
@@ -34,7 +34,7 @@
     </Target>
     <ItemGroup>
         <ProjectReference Include="..\Logger\Logger.csproj" />
-        <PackageReference Include="IORingGroup" Version="1.0.11" />
+        <PackageReference Include="IORingGroup" Version="1.0.12-preview.1" />
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="LibDeflate.Bindings" Version="1.0.4" />
         <PackageReference Include="System.IO.Hashing" Version="10.0.12" />

--- a/dev-docs/server-requirements.md
+++ b/dev-docs/server-requirements.md
@@ -68,12 +68,13 @@ Optional systems can add substantially more. The pathfinding prebake
 (`pathfinding.prebakeMaps`) peaks above 1 GB of heap while baking. Budget for it or leave it off on
 small hosts.
 
-Network buffers are minor by comparison: 64 KB receive plus a configurable send buffer per
-connection. Send memory is `network.sendBufferSize` at rest and can grow to
-`network.sendBufferMaxSize` under load. Shared send-buffer tier memory is capped by
-`network.sendBufferGrowthBudget`, and growth is refused when process memory exceeds
-`network.memoryCeilingPercent` of available memory. The worst case is the base send-buffer size
-times the connection count, plus the shared growth budget.
+Network buffers are 64 KB receive plus a configurable send buffer per connection. Send memory is
+`network.sendBufferSize` at rest and can grow to `network.sendBufferMaxSize` under load. Shared
+send-buffer tier memory is capped by `network.sendBufferGrowthBudget`, and growth is refused when
+process memory exceeds `network.memoryCeilingPercent` of available memory. The worst case is the
+base send-buffer size times the connection count, plus the shared growth budget: at the defaults,
+100 players is roughly 32 MB at rest, and the growth budget can add up to another 256 MB under
+load.
 
 ModernUO runs **Workstation GC**, which is the right default for small hosts. Do not switch to
 Server GC on a 2-core box.
@@ -114,9 +115,9 @@ See the README for the full supported list. Two things are worth calling out:
 | `world.useMultithreadedSaves` | `true` | Set `false` on 2-core hosts so saves do not contend with the game loop. |
 | `pathfinding.prebakeMaps` | varies | Leave off on memory-constrained hosts; it peaks above 1 GB while baking. |
 | `network.sendBufferSize` | 256 KB | Lower it if you are memory-bound with many connections. |
-| `network.sendBufferMaxSize` | 2097152 | Maximum send-buffer size for a connection under load. |
-| `network.sendBufferGrowthBudget` | 268435456 | Cap shared memory used by the larger send-buffer tiers. |
-| `network.memoryCeilingPercent` | 80 | Refuse send-buffer growth above this percentage of available memory. |
+| `network.sendBufferMaxSize` | 2 MB (`2097152`) | Ceiling a single connection's send buffer can grow to under load. Lower it on memory-constrained hosts; raise it if slow clients are disconnected with "send buffer exhausted". |
+| `network.sendBufferGrowthBudget` | 256 MB (`268435456`) | Cap on the shared memory the larger send-buffer tiers may use. Lower it on memory-constrained hosts. |
+| `network.memoryCeilingPercent` | 80% | Refuse send-buffer growth once the process is above this share of available memory. |
 | `autoArchive.*` retention | 24h/30d/12m | Reduce if disk is tight. |
 
 ## Am I undersized?

--- a/dev-docs/server-requirements.md
+++ b/dev-docs/server-requirements.md
@@ -117,7 +117,7 @@ See the README for the full supported list. Two things are worth calling out:
 | `network.sendBufferSize` | 256 KB | Lower it if you are memory-bound with many connections. |
 | `network.sendBufferMaxSize` | 2 MB (`2097152`) | Ceiling a single connection's send buffer can grow to under load. Lower it on memory-constrained hosts; raise it if slow clients are disconnected with "send buffer exhausted". |
 | `network.sendBufferGrowthBudget` | 256 MB (`268435456`) | Cap on the shared memory the larger send-buffer tiers may use. Lower it on memory-constrained hosts. |
-| `network.memoryCeilingPercent` | 80% | Refuse send-buffer growth once the process is above this share of available memory. |
+| `network.memoryCeilingPercent` | 80% | Refuse send-buffer growth once the process is above this share of available memory; 0 turns the check off. |
 | `autoArchive.*` retention | 24h/30d/12m | Reduce if disk is tight. |
 
 ## Am I undersized?

--- a/dev-docs/server-requirements.md
+++ b/dev-docs/server-requirements.md
@@ -68,8 +68,12 @@ Optional systems can add substantially more. The pathfinding prebake
 (`pathfinding.prebakeMaps`) peaks above 1 GB of heap while baking. Budget for it or leave it off on
 small hosts.
 
-Network buffers are minor by comparison: 64 KB receive plus a configurable 256 KB send
-(`network.sendBufferSize`) per connection, so 100 players is roughly 32 MB.
+Network buffers are minor by comparison: 64 KB receive plus a configurable send buffer per
+connection. Send memory is `network.sendBufferSize` at rest and can grow to
+`network.sendBufferMaxSize` under load. Shared send-buffer tier memory is capped by
+`network.sendBufferGrowthBudget`, and growth is refused when process memory exceeds
+`network.memoryCeilingPercent` of available memory. The worst case is the base send-buffer size
+times the connection count, plus the shared growth budget.
 
 ModernUO runs **Workstation GC**, which is the right default for small hosts. Do not switch to
 Server GC on a 2-core box.
@@ -110,6 +114,9 @@ See the README for the full supported list. Two things are worth calling out:
 | `world.useMultithreadedSaves` | `true` | Set `false` on 2-core hosts so saves do not contend with the game loop. |
 | `pathfinding.prebakeMaps` | varies | Leave off on memory-constrained hosts; it peaks above 1 GB while baking. |
 | `network.sendBufferSize` | 256 KB | Lower it if you are memory-bound with many connections. |
+| `network.sendBufferMaxSize` | 2097152 | Maximum send-buffer size for a connection under load. |
+| `network.sendBufferGrowthBudget` | 268435456 | Cap shared memory used by the larger send-buffer tiers. |
+| `network.memoryCeilingPercent` | 80 | Refuse send-buffer growth above this percentage of available memory. |
 | `autoArchive.*` retention | 24h/30d/12m | Reduce if disk is tight. |
 
 ## Am I undersized?


### PR DESCRIPTION
## Problem

A connection's send buffer is a fixed 256 KB. A burst of world traffic (a crowded area, a mass spawn, a war) that outruns the client's acknowledgements fills it, `NetState.Send()` reports "send buffer exhausted", and the player is disconnected. Raising the size for everyone multiplies the per-connection footprint (4096 × 256 KB is already 1 GB at full occupancy, page-locked on Windows).

## What changes

- **Growth.** When a packet does not fit (the write span is too small, the packet is larger than the span, or compression returns 0), `Send()` asks the transport to grow the buffer to the next power-of-two tier and retries, up to `network.sendBufferMaxSize` (2 MB). Compression retries once per tier since its output size is not known in advance, including when the buffer is completely full. Only when growth is refused does the existing exhaustion disconnect run. The success path is unchanged.
- **Memory ceiling.** Growth is refused (with a once-a-minute warning) when the process working set exceeds `network.memoryCeilingPercent` (80) of the memory available to the process (container-aware; `0` turns the check off). The figure is sampled at startup and refreshed each maintenance tick.
- **Shrink.** A grown socket returns to the base buffer once it is drained and 30 s have passed since its last growth, attempted from the `DataSent` handler and from the 5 s alive sweep.
- **Retention.** Every minute a timer calls the transport's `Maintain()`, which trims idle tier slabs down to the peak concurrent usage of the last 15 minutes, so recurring bursts reuse buffers without allocation while rare ones give the memory back. The line logs at Debug, and only when capacity, usage, or the floor changed or a growth was refused (budget, at max, or ceiling), so an idle shard logs nothing.
- **Budget.** `network.sendBufferGrowthBudget` (256 MB) caps the tier pools' capacity; a positive value below one tier slab is raised with a warning, a negative one is clamped to 0 (growth off). Worst case is base × connections plus the budget.
- Settings are coerced with accurate warnings (power of two, minimum, 256 MB transport ceiling). `[dumpnetstates` gains the send buffer size. `dev-docs/server-requirements.md` describes the new memory story.

## Tests

`NetStateSendBufferTests` (real loopback sockets): growth instead of disconnect with a byte-exact stream, compressed growth against the compressor's own output, the grow-then-copy path, growth with a send genuinely in flight, refusal past the maximum, refusal under the ceiling, refusal on a closing socket, shrink after the hold (direct and through the alive sweep), and the setting coercions. Server.Tests 891 passed, UOContent.Tests 1052 passed against the published 1.0.12.

Reviewed per task, whole-branch, and adversarially by a second model (twice, the second time jointly with the transport branch); all findings addressed.